### PR TITLE
Fixing #296 and add error handling

### DIFF
--- a/command/volume_stats.go
+++ b/command/volume_stats.go
@@ -153,6 +153,7 @@ func (c *VsmStatsCommand) Run(args []string) int {
 	annotations, err := GetVolAnnotations(args[0])
 
 	if err != nil || annotations == nil {
+		fmt.Println(err)
 		return -1
 	}
 
@@ -283,8 +284,7 @@ func GetStatus(address string, obj interface{}) (error, int) {
 		return err, -1
 	}
 	defer resp.Body.Close()
-	rc := json.NewDecoder(resp.Body).Decode(obj)
-	return rc, 0
+	return json.NewDecoder(resp.Body).Decode(obj), 0
 }
 
 // NewControllerClient create the new replica client

--- a/command/volume_stats.go
+++ b/command/volume_stats.go
@@ -23,7 +23,7 @@ type Status struct {
 }
 
 type VolumeStats struct {
-	Cl              client.Resource
+	Resource        client.Resource
 	RevisionCounter int64         `json:"RevisionCounter"`
 	ReplicaCounter  int64         `json:"ReplicaCounter"`
 	SCSIIOCount     map[int]int64 `json:"SCSIIOCount"`

--- a/command/volume_stats.go
+++ b/command/volume_stats.go
@@ -137,7 +137,7 @@ func (c *VsmStatsCommand) Run(args []string) int {
 	)
 	statusArray := make([]string, 6)
 
-	flags := c.Meta.FlagSet("vsm-stats", FlagSetClient)
+	flags := c.Meta.FlagSet("volume stats", FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
 	flags.StringVar(&c.Json, "json", "", "")
 

--- a/command/volume_stats.go
+++ b/command/volume_stats.go
@@ -2,28 +2,28 @@ package command
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
-
 	"net/http"
 	"net/url"
 	"os"
-
 	"strconv"
 	"strings"
 	"text/tabwriter"
+	"text/template"
 	"time"
 
 	"github.com/rancher/go-rancher/client"
 )
 
 type Status struct {
-	client.Resource
+	Cl              client.Resource
 	ReplicaCounter  int64 `json:"replicacounter"`
 	RevisionCounter int64 `json:"revisioncounter"`
 }
 
 type VolumeStats struct {
-	client.Resource
+	Cl              client.Resource
 	RevisionCounter int64         `json:"RevisionCounter"`
 	ReplicaCounter  int64         `json:"ReplicaCounter"`
 	SCSIIOCount     map[int]int64 `json:"SCSIIOCount"`
@@ -129,11 +129,13 @@ func (c *VsmStatsCommand) Synopsis() string {
 func (c *VsmStatsCommand) Run(args []string) int {
 
 	var (
-		err, err1, err2 error
+		err, err1, err3 error
+		err2, err4      int
 		status          Status
 		stats1, stats2  VolumeStats
-		statusArray     []string
+		repStatus       string
 	)
+	statusArray := make([]string, 6)
 
 	flags := c.Meta.FlagSet("vsm-stats", FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
@@ -149,12 +151,25 @@ func (c *VsmStatsCommand) Run(args []string) int {
 	}
 
 	annotations, err := GetVolAnnotations(args[0])
+
 	if err != nil || annotations == nil {
 		return -1
 	}
+
 	if annotations.ControllerStatus != "Running" {
-		fmt.Println("Volume not reachable")
+		fmt.Printf("Volume not reachable")
 		return -1
+	}
+
+	replicaCount := 0
+	replicaStatus := strings.Split(annotations.ReplicaStatus, ",")
+	for _, repStatus = range replicaStatus {
+		if repStatus == "Pending" {
+			statusArray[replicaCount] = "Unknown"
+			statusArray[replicaCount+1] = "Unknown"
+			statusArray[replicaCount+2] = "Unknown"
+			replicaCount += 3
+		}
 	}
 
 	replicas := strings.Split(annotations.Replicas, ",")
@@ -162,35 +177,46 @@ func (c *VsmStatsCommand) Run(args []string) int {
 		err, errCode1 := GetStatus(replica+":9502", &status)
 		if err != nil {
 			if errCode1 == 500 || strings.Contains(err.Error(), "EOF") {
-				statusArray = append(statusArray, fmt.Sprintf("%s", replica))
-				statusArray = append(statusArray, fmt.Sprintf("%s", "Waiting"))
-				statusArray = append(statusArray, fmt.Sprintf("%s", "Unknown"))
+				statusArray[replicaCount] = replica
+				statusArray[replicaCount+1] = "Waiting"
+				statusArray[replicaCount+2] = "Unknown"
 
 			} else {
-				statusArray = append(statusArray, fmt.Sprintf("%s", replica))
-				statusArray = append(statusArray, fmt.Sprintf("%s", "Offline"))
-				statusArray = append(statusArray, fmt.Sprintf("%s", "Unknown"))
+				statusArray[replicaCount] = replica
+				statusArray[replicaCount+1] = "Offline"
+				statusArray[replicaCount+2] = "Unknown"
+			}
+			replicaCount += 3
+		} else {
+			statusArray[replicaCount] = replica
+			statusArray[replicaCount+1] = "Online"
+			statusArray[replicaCount+2] = strconv.FormatInt(status.RevisionCounter, 10)
+			replicaCount += 3
+		}
+
+	}
+	//GetVolumeStats gets volume stats
+	err1, err2 = GetVolumeStats(annotations.ClusterIP+":9501", &stats1)
+	if err1 != nil {
+		if (err2 == 500) || (err2 == 503) || err1 != nil {
+			fmt.Println("Volume not Reachable\n", err1)
+			return -1
+		}
+	} else {
+		time.Sleep(1 * time.Second)
+		err3, err4 = GetVolumeStats(annotations.ClusterIP+":9501", &stats2)
+		if err3 != nil {
+			if err4 == 500 || err4 == 503 || err3 != nil {
+				fmt.Println("Volume not Reachable\n", err3)
+				return -1
 			}
 		} else {
-			statusArray = append(statusArray, fmt.Sprintf("%s", replica))
-			statusArray = append(statusArray, fmt.Sprintf("%s", "Online"))
-			statusArray = append(statusArray, fmt.Sprintf("%d", status.RevisionCounter))
+
+			//StatsOutput displays output
+			StatsOutput(c, annotations, args, statusArray, stats1, stats2)
 
 		}
 	}
-
-	//GetVolumeStats gets volume stats
-	err1, _ = GetVolumeStats(annotations.ClusterIP+":9501", &stats1)
-	time.Sleep(1 * time.Second)
-	err2, _ = GetVolumeStats(annotations.ClusterIP+":9501", &stats2)
-
-	if (err1 != nil) || (err2 != nil) {
-		fmt.Println("Volume not reachable")
-	}
-
-	//StatsOutput displays output
-	err = StatsOutput(c, annotations, args, statusArray, stats1, stats2)
-
 	return 0
 }
 
@@ -246,19 +272,19 @@ func GetStatus(address string, obj interface{}) (error, int) {
 	resp, err := replica.httpClient.Get(url)
 	if resp != nil {
 		if resp.StatusCode == 500 {
-			return err, 500
+			return errors.New("Internal Server Error"), 500
 		} else if resp.StatusCode == 503 {
-			return err, 503
+			return errors.New("Service Unavailable"), 503
 		}
 	} else {
-		return err, -1
+		return errors.New("Server Not Reachable"), -1
 	}
 	if err != nil {
 		return err, -1
 	}
 	defer resp.Body.Close()
-
-	return json.NewDecoder(resp.Body).Decode(obj), 0
+	rc := json.NewDecoder(resp.Body).Decode(obj)
+	return rc, 0
 }
 
 // NewControllerClient create the new replica client
@@ -307,12 +333,12 @@ func GetVolumeStats(address string, obj interface{}) (error, int) {
 	resp, err := controller.httpClient.Get(url)
 	if resp != nil {
 		if resp.StatusCode == 500 {
-			return err, 500
+			return errors.New("Internal Server Error"), 500
 		} else if resp.StatusCode == 503 {
-			return err, 503
+			return errors.New("Service Unavailable"), 503
 		}
 	} else {
-		return err, -1
+		return errors.New("Server Not Reachable"), -1
 	}
 	if err != nil {
 		return err, -1
@@ -326,8 +352,7 @@ func GetVolumeStats(address string, obj interface{}) (error, int) {
 func StatsOutput(c *VsmStatsCommand, annotations *Annotations, args []string, statusArray []string, stats1 VolumeStats, stats2 VolumeStats) error {
 
 	var (
-		err error
-
+		err          error
 		ReadLatency  int64
 		WriteLatency int64
 
@@ -336,17 +361,17 @@ func StatsOutput(c *VsmStatsCommand, annotations *Annotations, args []string, st
 	)
 
 	// 10 and 64 represents decimal and bits respectively
-	i_riops, _ := strconv.ParseInt(stats1.ReadIOPS, 10, 64) // Initial
-	f_riops, _ := strconv.ParseInt(stats2.ReadIOPS, 10, 64) // Final
-	readIOPS := f_riops - i_riops
+	iReadIOPS, _ := strconv.ParseInt(stats1.ReadIOPS, 10, 64) // Initial
+	fReadIOPS, _ := strconv.ParseInt(stats2.ReadIOPS, 10, 64) // Final
+	readIOPS := fReadIOPS - iReadIOPS
 
-	i_rtps, _ := strconv.ParseInt(stats1.TotalReadTime, 10, 64)
-	f_rtps, _ := strconv.ParseInt(stats2.TotalReadTime, 10, 64)
-	readTimePS := f_rtps - i_rtps
+	iReadTimePS, _ := strconv.ParseInt(stats1.TotalReadTime, 10, 64)
+	fReadTimePS, _ := strconv.ParseInt(stats2.TotalReadTime, 10, 64)
+	readTimePS := fReadTimePS - iReadTimePS
 
-	i_rbps, _ := strconv.ParseInt(stats1.TotalReadBlockCount, 10, 64)
-	f_rbps, _ := strconv.ParseInt(stats2.TotalReadBlockCount, 10, 64)
-	readBlockCountPS := f_rbps - i_rbps
+	iReadBlockCountPS, _ := strconv.ParseInt(stats1.TotalReadBlockCount, 10, 64)
+	fReadBlockCountPS, _ := strconv.ParseInt(stats2.TotalReadBlockCount, 10, 64)
+	readBlockCountPS := fReadBlockCountPS - iReadBlockCountPS
 
 	rThroughput := readBlockCountPS
 	if readIOPS != 0 {
@@ -357,17 +382,17 @@ func StatsOutput(c *VsmStatsCommand, annotations *Annotations, args []string, st
 		AvgReadBlockCountPS = 0
 	}
 
-	i_wiops, _ := strconv.ParseInt(stats1.WriteIOPS, 10, 64)
-	f_wiops, _ := strconv.ParseInt(stats2.WriteIOPS, 10, 64)
-	writeIOPS := f_wiops - i_wiops
+	iWriteIOPS, _ := strconv.ParseInt(stats1.WriteIOPS, 10, 64)
+	fWriteIOPS, _ := strconv.ParseInt(stats2.WriteIOPS, 10, 64)
+	writeIOPS := fWriteIOPS - iWriteIOPS
 
-	i_wtps, _ := strconv.ParseInt(stats1.TotalWriteTime, 10, 64)
-	f_wtps, _ := strconv.ParseInt(stats2.TotalWriteTime, 10, 64)
-	writeTimePS := f_wtps - i_wtps
+	iWriteTimePS, _ := strconv.ParseInt(stats1.TotalWriteTime, 10, 64)
+	fWriteTimePS, _ := strconv.ParseInt(stats2.TotalWriteTime, 10, 64)
+	writeTimePS := fWriteTimePS - iWriteTimePS
 
-	i_wbcps, _ := strconv.ParseInt(stats1.TotalWriteBlockCount, 10, 64)
-	f_wbcps, _ := strconv.ParseInt(stats2.TotalWriteBlockCount, 10, 64)
-	writeBlockCountPS := f_wbcps - i_wbcps
+	iWriteBlockCountPS, _ := strconv.ParseInt(stats1.TotalWriteBlockCount, 10, 64)
+	fWriteBlockCountPS, _ := strconv.ParseInt(stats2.TotalWriteBlockCount, 10, 64)
+	writeBlockCountPS := fWriteBlockCountPS - iWriteBlockCountPS
 
 	wThroughput := writeBlockCountPS
 	if writeIOPS != 0 {
@@ -378,14 +403,14 @@ func StatsOutput(c *VsmStatsCommand, annotations *Annotations, args []string, st
 		AvgWriteBlockCountPS = 0
 	}
 
-	ss, _ := strconv.ParseFloat(stats2.SectorSize, 64) // Sector Size
-	ss = ss / bytesToMB
+	sectorSize, _ := strconv.ParseFloat(stats2.SectorSize, 64) // Sector Size
+	sectorSize = sectorSize / bytesToMB
 
-	ls, _ := strconv.ParseFloat(stats2.UsedBlocks, 64) // Logical Size
-	ls = ls * ss
+	logicalSize, _ := strconv.ParseFloat(stats2.UsedBlocks, 64) // Logical Size
+	logicalSize = logicalSize * sectorSize
 
-	au, _ := strconv.ParseFloat(stats2.UsedLogicalBlocks, 64) // Actual Used
-	au = au * ss
+	actualUsed, _ := strconv.ParseFloat(stats2.UsedLogicalBlocks, 64) // Actual Used
+	actualUsed = actualUsed * sectorSize
 
 	annotation := Annotation{
 		IQN:    annotations.Iqn,
@@ -394,7 +419,6 @@ func StatsOutput(c *VsmStatsCommand, annotations *Annotations, args []string, st
 		Size:   annotations.VolSize,
 	}
 
-	// json formatting and showing default output
 	if c.Json == "json" {
 
 		stat1 := StatsArr{
@@ -416,35 +440,34 @@ func StatsOutput(c *VsmStatsCommand, annotations *Annotations, args []string, st
 			AvgReadBlockSize:  AvgReadBlockCountPS / bytesToKB, // Bytes to KB
 			AvgWriteBlockSize: AvgWriteBlockCountPS / bytesToKB,
 
-			SectorSize:  ss,
-			ActualUsed:  au,
-			LogicalSize: ls,
+			SectorSize:  sectorSize,
+			ActualUsed:  actualUsed,
+			LogicalSize: logicalSize,
 		}
 
 		data, err := json.MarshalIndent(stat1, "", "\t")
 
 		if err != nil {
-
-			panic(err)
+			fmt.Println("Can't Marshal the data ", err)
 		}
 
 		os.Stdout.Write(data)
 
 	} else {
 
-		// Printing in tabular form
-		//	fmt.Printf("%+v\n\n", annotation)
-		data, err := json.MarshalIndent(annotation, "", "\t")
-
+		// Printing using template
+		tmpl, err1 := template.New("test").Parse("IQN     : {{.IQN}}\nVolume  : {{.Volume}}\nPortal  : {{.Portal}}\nSize    : {{.Size}}")
+		err = err1
 		if err != nil {
-
-			panic(err)
+			fmt.Println("Can't Parse the template ", err)
+		}
+		err = tmpl.Execute(os.Stdout, annotation)
+		if err != nil {
+			fmt.Println("Can't execute the template ", err)
 		}
 
-		os.Stdout.Write(data)
-
+		// Printing in tabular form
 		q := tabwriter.NewWriter(os.Stdout, minwidth, maxwidth, padding, ' ', tabwriter.AlignRight|tabwriter.Debug)
-
 		fmt.Fprintf(q, "\n\nReplica\tStatus\tDataUpdateIndex\t\n")
 		fmt.Fprintf(q, "\t\t\t\n")
 		for i := 0; i < 4; i += 3 {
@@ -460,12 +483,11 @@ func StatsOutput(c *VsmStatsCommand, annotations *Annotations, args []string, st
 		fmt.Fprintf(w, "%d\t%d\t%.3f\t%.3f\t%.3f\t%.3f\t\n", readIOPS, writeIOPS, float64(rThroughput)/bytesToMB, float64(wThroughput)/bytesToMB, float64(ReadLatency)/mic_sec, float64(WriteLatency)/mic_sec)
 		w.Flush()
 
-		x := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', tabwriter.AlignRight|tabwriter.Debug)
+		x := tabwriter.NewWriter(os.Stdout, minwidth, maxwidth, padding, ' ', tabwriter.AlignRight|tabwriter.Debug)
 		fmt.Println("\n------------ Capacity Stats -------------\n")
 		fmt.Fprintf(x, "Logical(GB)\tUsed(GB)\t\n")
-		fmt.Fprintf(x, "%f\t%f\t\n", ls, au)
+		fmt.Fprintf(x, "%f\t%f\t\n", logicalSize, actualUsed)
 		x.Flush()
 	}
-
 	return err
 }

--- a/command/volume_stats.go
+++ b/command/volume_stats.go
@@ -17,7 +17,7 @@ import (
 )
 
 type Status struct {
-	Cl              client.Resource
+	Resource        client.Resource
 	ReplicaCounter  int64 `json:"replicacounter"`
 	RevisionCounter int64 `json:"revisioncounter"`
 }
@@ -158,7 +158,7 @@ func (c *VsmStatsCommand) Run(args []string) int {
 	}
 
 	if annotations.ControllerStatus != "Running" {
-		fmt.Printf("Volume not reachable")
+		fmt.Println("Volume not reachable")
 		return -1
 	}
 


### PR DESCRIPTION
1. Why is this change necessary ?
* maya volume stats fails with one replica running.
* Error handling was not there for all the cases.

2. How does this change address the issue ?
* from now on volume stats will query replica status also . Earlier this case was not there in `stats.go`.
* err does not throw proper error on `resp.StatusCode=500` i.e, it throws `nil` for this case. Now it will throw proper error.

3. How to verify this change ?
* Run the new binary with one replica down/pending status and  output will be something like this
```IQN     : iqn.2016-09.com.openebs.jiva:vol1
Volume  : vol1
Portal  : 10.109.27.40:3260
Size    : 1G

     Replica|    Status|   DataUpdateIndex|
            |          |                  |
     Unknown|   Unknown|           Unknown|
   10.44.0.4|    Online|                 0|

----------- Performance Stats -----------

   r/s|   w/s|   r(MB/s)|   w(MB/s)|   rLat(ms)|   wLat(ms)|
     0|     0|     0.000|     0.000|      0.000|      0.000|

------------ Capacity Stats -------------

   Logical(GB)|   Used(GB)|
      0.000000|   0.000000|
```
* Set `resp.StatusCode` to `500` manually in stats.go and run the binary. you should get the proper error like "Server Unavailable" or "Internal Server Error".