### PR TITLE
omm-status/osh-status/setup-omm/setup-osh CLI commands are removed

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -24,27 +24,28 @@ func Commands(metaPtr *command.Meta) map[string]cli.CommandFactory {
 	}
 
 	return map[string]cli.CommandFactory{
-		"setup-omm": func() (cli.Command, error) {
-			return &command.InstallMayaCommand{
-				M: meta,
-			}, nil
-		},
-		"setup-osh": func() (cli.Command, error) {
-			return &command.InstallOpenEBSCommand{
-				M: meta,
-			}, nil
-		},
-		"omm-status": func() (cli.Command, error) {
-			return &command.ServerMembersCommand{
-				Meta: meta,
-			}, nil
-		},
-		"osh-status": func() (cli.Command, error) {
-			return &command.NodeStatusCommand{
-				Meta: meta,
-			}, nil
-		},
-
+		/*
+			"setup-omm": func() (cli.Command, error) {
+				return &command.InstallMayaCommand{
+					M: meta,
+				}, nil
+			},
+			"setup-osh": func() (cli.Command, error) {
+				return &command.InstallOpenEBSCommand{
+					M: meta,
+				}, nil
+			},
+			"omm-status": func() (cli.Command, error) {
+				return &command.ServerMembersCommand{
+					Meta: meta,
+				}, nil
+			},
+			"osh-status": func() (cli.Command, error) {
+				return &command.NodeStatusCommand{
+					Meta: meta,
+				}, nil
+			},
+		*/
 		"volume": func() (cli.Command, error) {
 			return &command.VolumeCommand{}, nil
 		},

--- a/commands.go
+++ b/commands.go
@@ -24,6 +24,9 @@ func Commands(metaPtr *command.Meta) map[string]cli.CommandFactory {
 	}
 
 	return map[string]cli.CommandFactory{
+		//the following CLI commands are deprecated with latest implementation.
+		//In kubernetes environment, it is no longer required to setup
+		//openebs master and host.
 		/*
 			"setup-omm": func() (cli.Command, error) {
 				return &command.InstallMayaCommand{


### PR DESCRIPTION
Deprecate setup-omm/setup-osh CLI commands #371 fix dep
Deprecate omm-status/osh-status CLI commands #370 fix dep

**What this PR does / why we need it**:
The above commands are deprecated with the implementation of latest commands.

**Which issue this PR fixes**
fixes openebs/openebs#371, openebs/openebs#370 

**Special notes for your reviewer**:
on terminal, type maya or maya setup-omm etc
Usage: 'maya' [--version] [--help] <command> [<args>]

Available commands are:
```sh
    snapshot    Creates snapshot of a Volume
    version     Prints the Maya version
    volume      Creates a OpenEBS Volume 
```