### PR TITLE
Fix: Volume Delete CLI Command

### DIFF
--- a/command/volume_create.go
+++ b/command/volume_create.go
@@ -46,15 +46,15 @@ type VsmSpec struct {
 // Help shows helpText for a particular CLI command
 func (c *VsmCreateCommand) Help() string {
 	helpText := `
-Usage: maya vsm-create [options] <path>
+Usage: maya volume create [options] <path>
 
   Creates a new Openebs volume.
 
 VSM Create Options:
   -volname
-    Name of the vsm
+    Name of the volume
   -size
-    Provisioning size of the vsm(default is 5G)
+    Provisioning size of the volume(default is 5G)
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/volume_create_test.go
+++ b/command/volume_create_test.go
@@ -70,8 +70,8 @@ func TestVsmCreateCommand_Negative(t *testing.T) {
 	if code := cmd.Run([]string{"some", "bad", "args"}); code != 1 {
 		t.Fatalf("expected exit code 1, got: %d", code)
 	}
-	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Usage: maya vsm") {
-		t.Fatalf("expected 'usage: maya vsm', got: %s", out)
+	if out := ui.ErrorWriter.String(); !strings.Contains(out, "Usage: maya volume create") {
+		t.Fatalf("expected 'usage: maya volume create', got: %s", out)
 	}
 	ui.ErrorWriter.Reset()
 

--- a/command/volume_stats.go
+++ b/command/volume_stats.go
@@ -122,7 +122,7 @@ Volume Stats Options:
 
 // Synopsis shows short information related to CLI command
 func (c *VsmStatsCommand) Synopsis() string {
-	return "Display VSM Stats"
+	return "Display Runtime stats of a Volume"
 }
 
 // Run holds the flag values for CLI subcommands

--- a/command/volume_update.go
+++ b/command/volume_update.go
@@ -30,7 +30,7 @@ General Options:
 }
 
 func (c *VsmUpdateCommand) Synopsis() string {
-	return "Updates the vsm with the provided specs"
+	return "Updates the volume with the provided specs"
 }
 
 func (c *VsmUpdateCommand) Run(args []string) int {

--- a/commands.go
+++ b/commands.go
@@ -72,7 +72,7 @@ func Commands(metaPtr *command.Meta) map[string]cli.CommandFactory {
 				M: meta,
 			}, nil
 		},
-		"volume stop": func() (cli.Command, error) {
+		"volume delete": func() (cli.Command, error) {
 			return &command.VsmStopCommand{
 				Meta: meta,
 			}, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit will fix the issue with volume delete with CLI 
command. Now maya cli will sent a request to M-apiserver 
for deletion of a specific volume.
``` maya volume delete -volname <volume> ```

**Which issue this PR fixes** 
fixes #29 

**How to verify this change**
Provisioned the Openebs Volume in K8s enviorment 
and deleted the volume from the maya cli using following command.
``` maya volume delete -volname <volume> ```

```
ubuntu@master01:~$ kubectl get pods 
NAME                                   READY     STATUS    RESTARTS   AGE
maya-apiserver-546443015-0zbhc         1/1       Running   0          5m
openebs-provisioner-3862123968-shvw0   1/1       Running   0          5m
vol1-ctrl-572094131-lx13j              1/1       Running   0          2m
vol1-rep-2514913120-mn54j              1/1       Running   0          2m
vol1-rep-2514913120-x400d              1/1       Running   0          2m
vol2-ctrl-2535471840-67lgh             1/1       Running   0          2m
vol2-rep-2728425310-gpdg1              1/1       Running   0          2m
vol2-rep-2728425310-gqnt2              1/1       Running   0          2m
vol3-ctrl-3046027795-cmk8f             1/1       Running   0          53s
vol3-rep-1075378838-3j2gt              1/1       Running   0          53s
vol3-rep-1075378838-cc2v3              1/1       Running   0          53s
ubuntu@master01:~$ 

$ maya volume list 
Name  Status
vol1  Running
vol2  Running
vol3  Running

$ maya volume delete -volname vol1
Initiated Volume-Delete request for volume: vol1

ubuntu@master01:~$ kubectl get pods 
NAME                                   READY     STATUS        RESTARTS   AGE
maya-apiserver-546443015-0zbhc         1/1       Running       0          5m
openebs-provisioner-3862123968-shvw0   1/1       Running       0          5m
vol1-rep-2514913120-mn54j              0/1       Terminating   0          3m
vol2-ctrl-2535471840-67lgh             1/1       Running       0          2m
vol2-rep-2728425310-gpdg1              1/1       Running       0          2m
vol2-rep-2728425310-gqnt2              1/1       Running       0          2m
vol3-ctrl-3046027795-cmk8f             1/1       Running       0          1m
vol3-rep-1075378838-3j2gt              1/1       Running       0          1m
vol3-rep-1075378838-cc2v3              1/1       Running       0          1m

ubuntu@master01:~$ kubectl get pods 
NAME                                   READY     STATUS    RESTARTS   AGE
maya-apiserver-546443015-0zbhc         1/1       Running   0          5m
openebs-provisioner-3862123968-shvw0   1/1       Running   0          5m
vol2-ctrl-2535471840-67lgh             1/1       Running   0          2m
vol2-rep-2728425310-gpdg1              1/1       Running   0          2m
vol2-rep-2728425310-gqnt2              1/1       Running   0          2m
vol3-ctrl-3046027795-cmk8f             1/1       Running   0          1m
vol3-rep-1075378838-3j2gt              1/1       Running   0          1m
vol3-rep-1075378838-cc2v3              1/1       Running   0          1m

$ maya volume list                
Name  Status
vol2  Running
vol3  Running
```