### PR TITLE
Updated Go to v1.9.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - docker
 language: go
 go:
-  - 1.8
+  - 1.9.1
 install:
   - make bootstrap
 script:


### PR DESCRIPTION
Previous Go version: 1.8
New Go version: 1.9.1

`fixes #539 in openebs repo` [link](https://github.com/openebs/openebs/issues/539)

