### PR TITLE
Discover local block devices using maya-agent #openebs/openebs/545

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -57,7 +57,7 @@ cov:
 
 test: format
 	@echo "--> Running go test" ;
-	@go test $(PACKAGES)
+	@go test -v $(PACKAGES)
 
 cover:
 	go list ./... | grep -v vendor | xargs -n1 go test --cover

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,7 +25,7 @@ AGENT=maya-agent
 # Specify the date o build
 BUILD_DATE = $(shell date +'%Y%m%d%H%M%S')
 
-all: test mayactl apiserver
+all: maya-agent test mayactl apiserver
 
 dev: format
 	@MAYACTL=${MAYACTL} MAYA_DEV=1 sh -c "'$(PWD)/buildscripts/mayactl/build.sh'"

--- a/buildscripts/test.sh
+++ b/buildscripts/test.sh
@@ -13,5 +13,5 @@ go build -o $TEMPDIR/maya || exit 1
 echo "--> Running tests"
 GOBIN="`which go`"
 PATH=$TEMPDIR:$PATH \
-    $GOBIN test ${GOTEST_FLAGS:--cover -timeout=900s} $($GOBIN list ./... | grep -v /vendor/)
+    $GOBIN test  -v ${GOTEST_FLAGS:--cover -timeout=900s} $($GOBIN list ./... | grep -v /vendor/)
 

--- a/cmd/maya-agent/app/maya-agent.go
+++ b/cmd/maya-agent/app/maya-agent.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/openebs/maya/cmd/maya-agent/app/exporter"
+	"github.com/openebs/maya/cmd/maya-agent/storage/block"
 	"github.com/openebs/maya/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -64,6 +65,7 @@ func NewMayaAgent() (*cobra.Command, error) {
 	cmd.Flags().AddGoFlagSet(goflag.CommandLine)
 	goflag.CommandLine.Parse([]string{})
 	cmd.AddCommand(
+		block.NewCmdBlockDevice(), //Add new command on block device
 		exporter.NewCmdVolumeExporter(),
 	)
 	// Define the flags allowed in this command & store each option provided

--- a/cmd/maya-agent/main.go
+++ b/cmd/maya-agent/main.go
@@ -1,10 +1,9 @@
 package main
 
 import (
-	"os"
-
 	"github.com/openebs/maya/cmd/maya-agent/app"
 	mayalogger "github.com/openebs/maya/kit/logs"
+	"os"
 )
 
 func main() {

--- a/cmd/maya-agent/storage/block/devices.go
+++ b/cmd/maya-agent/storage/block/devices.go
@@ -1,0 +1,91 @@
+package block
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+
+	"github.com/openebs/maya/cmd/maya-agent/types/v1"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdBlockDevice and its nested children are created
+func NewCmdBlockDevice() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "block",
+		Short: "Operations on block devices",
+		Long: `The block devices on the local machine/minion can be 
+		operated using maya-agent`,
+	}
+	//New sub command to list block device is added
+	cmd.AddCommand(
+		NewSubCmdListBlockDevice(),
+	)
+
+	return cmd
+}
+
+// NewSubCmdListBlockDevice is to list block device is created
+func NewSubCmdListBlockDevice() *cobra.Command {
+	getCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List block devices",
+		Long: `the set of block devices on the local machine/minion
+		can be listed`,
+		Run: func(cmd *cobra.Command, args []string) {
+			//resJsonDecoded is the decoded value of block disk
+			var resJsonDecoded v1.BlockDeviceInfo
+			err := ListBlockExec(&resJsonDecoded)
+			if err != nil {
+				panic(err)
+			}
+			//to print after formatting to end user
+			FormatOutputForUser(&resJsonDecoded)
+
+		},
+	}
+
+	return getCmd
+}
+
+//ListBlockExec is for running os cmds for block disk and json parsing
+func ListBlockExec(resJsonDecoded *v1.BlockDeviceInfo) error {
+	//list block devices in json format
+	ListBlockCommand := v1.OsCommand{"lsblk", "-J"}
+	res, err := exec.Command(ListBlockCommand.Command, ListBlockCommand.Flag).Output()
+	if err != nil {
+		panic(err)
+	}
+
+	//decode the json output
+	err = json.Unmarshal(res, &resJsonDecoded)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+//FormatOutputForUser is to print disk details to end user only with necessary fields
+func FormatOutputForUser(resJsonDecoded *v1.BlockDeviceInfo) {
+	fmt.Printf("%v  %9v  %4v  %4v\n", "Name", "Size", "Type", "Mountpoint")
+	for _, v := range resJsonDecoded.Blockdevices {
+		if v.Children != nil && v.Type == "disk" && (v.Mountpoint == "" || v.Mountpoint == "/") {
+			if v.Mountpoint == "" {
+				v.Mountpoint = "null"
+			}
+			//Print parent details
+			fmt.Printf("%v  %9v  %5v  %5v\n", v.Name, v.Size, v.Type, v.Mountpoint)
+
+			for _, u := range v.Children {
+				if u.Type == "part" {
+					if u.Mountpoint == "" {
+						u.Mountpoint = "null"
+					}
+					//Print children details
+					fmt.Printf("|_%v  %6v  %5v  %5v\n", u.Name, u.Size, u.Type, u.Mountpoint)
+
+				}
+			}
+		}
+	}
+}

--- a/cmd/maya-agent/storage/block/devices_test.go
+++ b/cmd/maya-agent/storage/block/devices_test.go
@@ -1,0 +1,78 @@
+package block_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openebs/maya/cmd/maya-agent/storage/block"
+	"github.com/openebs/maya/cmd/maya-agent/types/v1"
+)
+
+//SampleOutput contains only necessary fields on block disk to validate
+type SampleOutput struct {
+	Name       string
+	Mountpoint string
+	Type       string
+}
+
+//TestListBlockDevice is to check block disks with right samples
+func TestListBlockDevice(t *testing.T) {
+	var resJsonDecoded v1.BlockDeviceInfo
+	sampleParentOutput := SampleOutput{"sda", "", "disk"}
+	sampleChildrenOutput := SampleOutput{"sda1", "", "part"}
+
+	err := block.ListBlockExec(&resJsonDecoded)
+	fmt.Println("err:", err)
+	fmt.Println("resJsonDecoded:", resJsonDecoded)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	flag := ValidateOutput(&resJsonDecoded, &sampleParentOutput, &sampleChildrenOutput)
+	fmt.Println("flag:", flag)
+
+	if flag != true {
+		t.Fatalf("Invalid Output")
+	}
+
+}
+
+//TestListBlockDevice_Negative is to check block disks with wrong samples
+func TestListBlockDevice_Negative(t *testing.T) {
+	var resJsonDecoded v1.BlockDeviceInfo
+	sampleParentOutput := SampleOutput{"abc", "/abc", "loop"}
+	sampleChildrenOutput := SampleOutput{"xyz", "/xyz", "loop"}
+
+	err := block.ListBlockExec(&resJsonDecoded)
+	fmt.Println("err:", err)
+	fmt.Println("resJsonDecoded:", resJsonDecoded)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	flag := ValidateOutput(&resJsonDecoded, &sampleParentOutput, &sampleChildrenOutput)
+	fmt.Println("flag:", flag)
+	if flag == true {
+		t.Fatalf("Invalid Output")
+	}
+
+}
+
+//ValidateOutput is common function to validate samples
+func ValidateOutput(resJsonDecoded *v1.BlockDeviceInfo, sampleParentOutput *SampleOutput,
+	sampleChildrenOutput *SampleOutput) bool {
+	for _, v := range resJsonDecoded.Blockdevices {
+		if v.Type == sampleParentOutput.Type &&
+			v.Mountpoint == sampleParentOutput.Mountpoint &&
+			v.Name[:1] == sampleParentOutput.Name[:1] {
+			return true
+		}
+		if v.Children != nil {
+			for _, u := range v.Children {
+				if u.Type == sampleChildrenOutput.Type &&
+					u.Name[:1] == sampleChildrenOutput.Name[:1] {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/cmd/maya-agent/types/v1/block_device_info.go
+++ b/cmd/maya-agent/types/v1/block_device_info.go
@@ -1,0 +1,24 @@
+package v1
+
+//OsCommand is for operating system related commands for block devices
+type OsCommand struct {
+	Command string
+	Flag    string
+}
+
+//BlockDeviceInfo exposes the json output of lsblk:"blockdevices"
+type BlockDeviceInfo struct {
+	Blockdevices []Blockdevice `json:"blockdevices"`
+}
+
+//Blockdevices has block disk fields
+type Blockdevice struct {
+	Name       string        `json:"name"`               //block device name
+	Majmin     string        `json:"maj:min"`            //major and minor block device number
+	Rm         string        `json:"rm"`                 //is device removable
+	Size       string        `json:"size"`               //size of device
+	Ro         string        `json:"ro"`                 //is device read-only
+	Type       string        `json:"type"`               //is device disk or partition
+	Mountpoint string        `json:"mountpoint"`         //block device mountpoint
+	Children   []Blockdevice `json:"children,omitempty"` //Blockdevice ...
+}


### PR DESCRIPTION
1. Why is this change necessary ?
The feature is necessary to run maya-agent on minions and provide the local block device information

2. How does this change address the issue ?
The commit exposes lsblk command to list local block device info in json format since it will be processed and used later.

3. How to verify this change ?
Run go build maya-agent.go with openebs/maya/cmd/maya-agent as working directory. Run the binary ./maya-agent block list to list the local device info in json format. To verify the unit test, keeping the binary in the working directory, run go test -v app/block_devices_test.go to check two test cases(1.maya-agent block list working fine to list the block devices, 2.maya-agent block ls is invalid command which displays general help info)

Signed-off-by: gkGaneshR <gkganesh126@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
