### PR TITLE
add volume controller and volume replica node level taint toleration

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -88,8 +88,9 @@ bootstrap:
 	done 
 
 image:
-	@cp bin/maya buildscripts/docker/
+	@cp bin/${MAYACTL} buildscripts/docker/
 	@cd buildscripts/docker && sudo docker build -t openebs/maya:ci --build-arg BUILD_DATE=${BUILD_DATE} .
+	@rm buildscripts/docker/${MAYACTL}
 	@sh buildscripts/push
 
 # You might need to use sudo
@@ -116,6 +117,8 @@ apiserver-image: bin apiserver
 	@cp bin/apiserver/${APISERVER} buildscripts/apiserver/
 	@cp bin/${MAYACTL} buildscripts/apiserver/
 	@cd buildscripts/apiserver && sudo docker build -t openebs/m-apiserver:ci --build-arg BUILD_DATE=${BUILD_DATE} .
+	@rm buildscripts/apiserver/${APISERVER}
+	@rm buildscripts/apiserver/${MAYACTL}
 	@sh buildscripts/apiserver/push
 
 .PHONY: all bin cov integ test vet maya-agent test-nodep apiserver apiserver-image

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,7 @@ Vagrant.require_version ">= 1.6.0"
 M_NODES = ENV['M_NODES'] || 1
 
 # Maya Memory & CPUs
-M_MEM = ENV['M_MEM'] || 1024
+M_MEM = ENV['M_MEM'] || 2048
 M_CPUS = ENV['M_CPUS'] || 1
 
 # Generic installer script common for server(s) & client(s)
@@ -75,7 +75,10 @@ def configureVM(vmCfg, hostname, cpus, mem)
     vb.cpus = cpus
     vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
   end
-  
+
+  # ensure docker is installed
+  vmCfg.vm.provision "docker"
+
   # sync your laptop's development with this Vagrant VM
   vmCfg.vm.synced_folder '.', '/opt/gopath/src/github.com/openebs/maya'
 

--- a/buildscripts/apiserver/Dockerfile
+++ b/buildscripts/apiserver/Dockerfile
@@ -1,0 +1,30 @@
+#
+# This Dockerfile builds a recent maya api server using the latest binary from
+# maya api server's releases.
+#
+
+FROM ubuntu:16.04
+
+# TODO: The following env variables should be auto detected. 
+ENV MAYA_API_SERVER_NETWORK="eth0"
+
+RUN apt-get update && apt-get install -y \
+    iproute2 \
+    curl \
+    net-tools \
+    watch \
+ && rm -rf /var/lib/apt/lists/*
+    
+RUN mkdir -p /etc/apiserver/orchprovider
+RUN mkdir -p /etc/apiserver/specs
+
+COPY demo-vol1.yaml /etc/apiserver/specs/
+COPY apiserver /usr/local/bin/
+COPY maya /usr/local/bin/
+
+COPY entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT entrypoint.sh "${MAYA_API_SERVER_NETWORK}"
+
+EXPOSE 5656

--- a/buildscripts/apiserver/Dockerfile
+++ b/buildscripts/apiserver/Dockerfile
@@ -25,6 +25,15 @@ COPY maya /usr/local/bin/
 COPY entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
+ARG BUILD_DATE
+
+LABEL org.label-schema.name="m-apiserver"
+LABEL org.label-schema.description="API server for OpenEBS"
+LABEL org.label-schema.url="http://www.openebs.io/"
+LABEL org.label-schema.vcs-url="https://github.com/openebs/maya"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=$BUILD_DATE
+
 ENTRYPOINT entrypoint.sh "${MAYA_API_SERVER_NETWORK}"
 
 EXPOSE 5656

--- a/buildscripts/apiserver/build.sh
+++ b/buildscripts/apiserver/build.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# This script builds the application from source for multiple platforms.
+set -e
+
+# Get the parent directory of where this script is.
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
+DIR="$( cd -P "$( dirname "$SOURCE" )/../.." && pwd )"
+
+# Change into that directory
+cd "$DIR"
+
+# Get the git commit
+GIT_COMMIT="$(git rev-parse HEAD)"
+GIT_DIRTY="$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)"
+
+# Determine the arch/os combos we're building for
+XC_ARCH=${XC_ARCH:-"386 amd64"}
+XC_OS=${XC_OS:-"linux"}
+XC_EXCLUDE=${XC_EXCLUDE:-"!darwin/arm !darwin/386"}
+
+# Delete the old contents
+echo "==> Removing old bin/apiserver contents..."
+rm -rf bin/apiserver/*
+mkdir -p bin/apiserver/
+
+# Fetch the tags before using git rev-list --tags
+git fetch --tags >/dev/null 2>&1
+GIT_TAG="$(git describe --tags $(git rev-list --tags --max-count=1))"
+
+if [ -z "${GIT_TAG}" ]; 
+then
+    GIT_TAG="0.0.1"
+fi
+
+if [ -z "${CTLNAME}" ]; 
+then
+    CTLNAME="apiserver"
+fi
+
+# If its dev mode, only build for ourself
+if [[ "${M_APISERVER_DEV}" ]]; then
+    XC_OS=$(go env GOOS)
+    XC_ARCH=$(go env GOARCH)
+fi
+
+# Build!
+echo "==> Building ${CTLNAME} ..."
+
+gox \
+    -os="${XC_OS}" \
+    -arch="${XC_ARCH}" \
+    -osarch="${XC_EXCLUDE}" \
+    -ldflags \
+       "-X main.GitCommit='${GIT_COMMIT}${GIT_DIRTY}' \
+        -X main.CtlName='${CTLNAME}' \
+        -X main.Version='${GIT_TAG}'" \
+    -output "bin/apiserver/{{.OS}}_{{.Arch}}/${CTLNAME}" \
+    .
+
+echo ""
+
+# Move all the compiled things to the $GOPATH/bin
+GOPATH=${GOPATH:-$(go env GOPATH)}
+case $(uname) in
+    CYGWIN*)
+        GOPATH="$(cygpath $GOPATH)"
+        ;;
+esac
+OLDIFS=$IFS
+IFS=: MAIN_GOPATH=($GOPATH)
+IFS=$OLDIFS
+
+# Copy our OS/Arch to ${MAIN_GOPATH}/bin/ directory
+DEV_PLATFORM="./bin/apiserver/$(go env GOOS)_$(go env GOARCH)"
+for F in $(find ${DEV_PLATFORM} -mindepth 1 -maxdepth 1 -type f); do
+    cp ${F} bin/apiserver/
+    cp ${F} ${MAIN_GOPATH}/bin/
+done
+
+if [[ "x${M_APISERVER_DEV}" == "x" ]]; then
+    # Zip and copy to the dist dir
+    echo "==> Packaging..."
+    for PLATFORM in $(find ./bin/apiserver -mindepth 1 -maxdepth 1 -type d); do
+        OSARCH=$(basename ${PLATFORM})
+        echo "--> ${OSARCH}"
+
+        pushd $PLATFORM >/dev/null 2>&1
+        zip ../${CTLNAME}-${OSARCH}.zip ./*
+        popd >/dev/null 2>&1
+    done
+fi
+
+# Done!
+echo
+echo "==> Results:"
+ls -hl bin/apiserver/

--- a/buildscripts/apiserver/demo-vol1.yaml
+++ b/buildscripts/apiserver/demo-vol1.yaml
@@ -1,0 +1,6 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: demo-vol1
+  labels:
+    volumeprovisioner.mapi.openebs.io/storage-size: 5G

--- a/buildscripts/apiserver/entrypoint.sh
+++ b/buildscripts/apiserver/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -ex
+
+MAYA_API_SERVER_NETWORK=$1
+
+CONTAINER_IP_ADDR=$(ip -4 addr show scope global dev "${MAYA_API_SERVER_NETWORK}" | grep inet | awk '{print $2}' | cut -d / -f 1)
+
+# Start apiserver service
+exec /usr/local/bin/apiserver up -bind="${CONTAINER_IP_ADDR}" 1>&2

--- a/buildscripts/apiserver/push
+++ b/buildscripts/apiserver/push
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+IMAGEID=$( sudo docker images -q openebs/m-apiserver:ci )
+
+if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
+then 
+  sudo docker login -u "${DNAME}" -p "${DPASS}";
+  # Push image to docker hub
+  sudo docker push openebs/m-apiserver:ci ;
+  if [ ! -z "${TRAVIS_TAG}" ] ; 
+  then
+    # Push with different tags if tagged as a release
+    # When github is tagged with a release, then Travis will 
+    # set the release tag in env TRAVIS_TAG
+    sudo docker tag ${IMAGEID} openebs/m-apiserver:${TRAVIS_TAG}
+    sudo docker push openebs/m-apiserver:${TRAVIS_TAG}; 
+    sudo docker tag ${IMAGEID} openebs/m-apiserver:latest
+    sudo docker push openebs/m-apiserver:latest; 
+  fi;
+else
+  echo "No docker credentials provided. Skip uploading openebs/m-apiserver:ci to docker hub"; 
+fi;

--- a/orchprovider/k8s/v1/k8s_test.go
+++ b/orchprovider/k8s/v1/k8s_test.go
@@ -410,6 +410,11 @@ func (e *okVsmNameVolumeProfile) VSMName() (string, error) {
 	return "ok-vsm-name", nil
 }
 
+// ControllerImage does not return any error
+func (e *okVsmNameVolumeProfile) IsReplicaNodeTaintTolerations() ([]string, bool, error) {
+	return []string{"k=v:NoSchedule"}, true, nil
+}
+
 // okCtrlImgVolumeProfile focusses on not returning any error during invocation
 // of ControllerImage() method
 type okCtrlImgVolumeProfile struct {
@@ -419,6 +424,11 @@ type okCtrlImgVolumeProfile struct {
 // ControllerImage does not return any error
 func (e *okCtrlImgVolumeProfile) ControllerImage() (string, bool, error) {
 	return "ok-ctrl-img", true, nil
+}
+
+// ControllerImage does not return any error
+func (e *okCtrlImgVolumeProfile) IsReplicaNodeTaintTolerations() ([]string, bool, error) {
+	return []string{"k=v:NoSchedule"}, true, nil
 }
 
 // errVsmNameVolumeProfile focusses on returning error during invocation of

--- a/types/v1/labels.go
+++ b/types/v1/labels.go
@@ -92,6 +92,21 @@ const (
 	// Usage:
 	// <CTX>_REPLICA_TOPOLOGY_KEY = <some value>
 	PVPReplicaTopologyKeyEnvVarKey EnvironmentVariableKey = "_REPLICA_TOPOLOGY_KEY"
+
+	// PVPControllerNodeTaintTolerationEnvVarKey is the environment variable key
+	// for persistent volume provisioner's node taint toleration
+	//
+	// Usage:
+	// <CTX>_CONTROLLER_NODE_TAINT_TOLERATION = <some value>
+	PVPControllerNodeTaintTolerationEnvVarKey EnvironmentVariableKey = "_CONTROLLER_NODE_TAINT_TOLERATION"
+
+	// PVPReplicaNodeTaintTolerationEnvVarKey is the environment variable key for
+	// persistent volume provisioner's node taint toleration
+	//
+	// Usage:
+	// <CTX>__REPLICA_NODE_TAINT_TOLERATION = <some value>
+	PVPReplicaNodeTaintTolerationEnvVarKey EnvironmentVariableKey = "_REPLICA_NODE_TAINT_TOLERATION"
+
 	// OrchestratorNameEnvVarKey is the environment variable key for
 	// orchestration provider's name
 	//
@@ -231,6 +246,10 @@ const (
 	PVPControllerIPsLbl VolumeProvisionerProfileLabel = "volumeprovisioner.mapi.openebs.io/controller-ips"
 	// Label / Tag for a persistent volume provisioner's persistent path
 	PVPPersistentPathLbl VolumeProvisionerProfileLabel = "volumeprovisioner.mapi.openebs.io/persistent-path"
+	// Label / Tag for a persistent volume provisioner's controller node taint toleration
+	PVPControllerNodeTaintTolerationLbl VolumeProvisionerProfileLabel = "volumeprovisioner.mapi.openebs.io/controller-node-taint-toleration"
+	// Label / Tag for a persistent volume provisioner's replica node taint toleration
+	PVPReplicaNodeTaintTolerationLbl VolumeProvisionerProfileLabel = "volumeprovisioner.mapi.openebs.io/replica-node-taint-toleration"
 
 	// PVPReplicaTopologyKeyLbl is the label for a persistent volume provisioner's
 	// VSM replica topology key

--- a/types/v1/util.go
+++ b/types/v1/util.go
@@ -516,6 +516,82 @@ func DefaultControllerImage() string {
 	return string(PVPControllerImageDef)
 }
 
+// GetControllerNodeTaintTolerations gets the node taint tolerations if
+// available
+func GetControllerNodeTaintTolerations(profileMap map[string]string) (string, error) {
+	val, err := ControllerNodeTaintTolerations(profileMap)
+	if err != nil {
+		return "", err
+	}
+
+	if val == "" {
+		val, err = DefaultControllerNodeTaintTolerations()
+	}
+
+	return val, err
+}
+
+// ControllerNodeTaintTolerations extracts the node taint tolerations
+func ControllerNodeTaintTolerations(profileMap map[string]string) (string, error) {
+	val := ""
+	if profileMap != nil {
+		val = strings.TrimSpace(profileMap[string(PVPControllerNodeTaintTolerationLbl)])
+	}
+
+	if val != "" {
+		return val, nil
+	}
+
+	// else get from environment variable
+	return OSGetEnv(string(PVPControllerNodeTaintTolerationEnvVarKey), profileMap), nil
+}
+
+// DefaultControllerNodeTaintTolerations will fetch the default value for node
+// taint tolerations
+func DefaultControllerNodeTaintTolerations() (string, error) {
+	// Controller node taint toleration property is optional. Hence returns blank
+	// (i.e. not required) as default.
+	return "", nil
+}
+
+// GetReplicaNodeTaintTolerations gets the node taint tolerations if
+// available
+func GetReplicaNodeTaintTolerations(profileMap map[string]string) (string, error) {
+	val, err := ReplicaNodeTaintTolerations(profileMap)
+	if err != nil {
+		return "", err
+	}
+
+	if val == "" {
+		val, err = DefaultReplicaNodeTaintTolerations()
+	}
+
+	return val, err
+}
+
+// ReplicaNodeTaintTolerations extracts the node taint tolerations for replica
+func ReplicaNodeTaintTolerations(profileMap map[string]string) (string, error) {
+	val := ""
+	if profileMap != nil {
+		val = strings.TrimSpace(profileMap[string(PVPReplicaNodeTaintTolerationLbl)])
+	}
+
+	if val != "" {
+		return val, nil
+	}
+
+	// else get from environment variable
+	return OSGetEnv(string(PVPReplicaNodeTaintTolerationEnvVarKey), profileMap), nil
+}
+
+// DefaultReplicaNodeTaintTolerations will fetch the default value for node
+// taint tolerations
+func DefaultReplicaNodeTaintTolerations() (string, error) {
+	// Replica node taint toleration property is optional. Hence returns blank
+	// (i.e. not required) as default.
+	return "", nil
+}
+
 // GetOrchestratorNetworkType gets the not nil orchestration provider's network
 // type
 func GetOrchestratorNetworkType(profileMap map[string]string) string {


### PR DESCRIPTION
1. Why is this change necessary ?

It has been seen that a K8s setup might dedicate some
K8s nodes for control plane while some other nodes
for storage plane. This change will be able to handle
such setup needs.

This will fix https://github.com/openebs/openebs/issues/512

2. How does this change address the issue ?

- accepts node taint toleration for volume controller

- accepts node taint toleration for volume replica

- understands ENV variable for above

- modifies buildscripts as apiserver is now under maya
repository.

3. How to verify this change ?

- Refer Issue https://github.com/openebs/openebs/issues/600

- Get a K8s 1.8 or above setup

- Taint the nodes with appropriate taint key & value

- Create volume with node taint toleration enabled for volume
Controller

- Verify if volume controller was placed in the appropriate
tainted node

- Create volume with node taint toleration enabled for
volume Replica

- Verify if volume replica was placed in the appropriate
tainted node

4. What side effects does this change have ?

- The volume controller & replica placement logic is
impacted

- This is an optional feature

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
