### PR TITLE
Fixes apiserver's build generation i.e. https://github.com/openebs/openebs/issues/606

### DIFF
--- a/buildscripts/apiserver/build.sh
+++ b/buildscripts/apiserver/build.sh
@@ -57,7 +57,7 @@ gox \
         -X main.CtlName='${CTLNAME}' \
         -X main.Version='${GIT_TAG}'" \
     -output "bin/apiserver/{{.OS}}_{{.Arch}}/${CTLNAME}" \
-    .
+    ./cmd/apiserver
 
 echo ""
 


### PR DESCRIPTION
1. Why is this change necessary ?

Recent changes due to
https://github.com/openebs/openebs/issues/512 has resulted
in a bug where apiserver binary is not getting
build

2. How does this change address the issue ?

- This fixes the build script with requried changes

3. How to verify this change ?

- `make apiserver` should result in generation of
proper build artifcats

- run `apiserver` which is one of the artifacts of
build & see if it produces apiserver based CLI

4. What side effects does this change have ?

- None

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
