### PR TITLE
Modify and Merge Volume struct

### DIFF
--- a/command/volume_create.go
+++ b/command/volume_create.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/openebs/maya/types/v1"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -21,26 +22,6 @@ type VsmCreateCommand struct {
 	Cmd     *exec.Cmd
 	vsmname string
 	size    string
-}
-
-// VsmSpec holds the config for creating a VSM
-type VsmSpec struct {
-	Kind       string `yaml:"kind"`
-	APIVersion string `yaml:"apiVersion"`
-	Metadata   struct {
-		Name   string `yaml:"name"`
-		Labels struct {
-			Storage string `yaml:"volumeprovisioner.mapi.openebs.io/storage-size"`
-		}
-	} `yaml:"metadata"`
-	//Spec struct {
-	//	AccessModes []string `yaml:"accessModes"`
-	//	Resources   struct {
-	//		Requests struct {
-	//			Storage string `yaml:"storage"`
-	//		} `yaml:"requests"`
-	//	} `yaml:"resources"`
-	//} `yaml:"spec"`
 }
 
 // Help shows helpText for a particular CLI command
@@ -136,7 +117,7 @@ func (c *VsmCreateCommand) Run(args []string) int {
 // CreateAPIVsm to create the Vsm through a API call to m-apiserver
 func CreateAPIVsm(vname string, size string) error {
 
-	var vs VsmSpec
+	var vs v1.Volume
 
 	addr := os.Getenv("MAPI_ADDR")
 	if addr == "" {
@@ -154,7 +135,7 @@ func CreateAPIVsm(vname string, size string) error {
 	//Marshal serializes the value provided into a YAML document
 	yamlValue, _ := yaml.Marshal(vs)
 
-	fmt.Printf("Volume Spec Created:\n%v\n", string(yamlValue))
+	//	fmt.Printf("Volume Spec Created:\n%v\n", string(yamlValue))
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(yamlValue))
 	if err != nil {

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -219,7 +219,7 @@ const (
 	VolumeAvailable PersistentVolumePhase = "Available"
 	// used for PersistentVolumes that are bound
 	VolumeBound PersistentVolumePhase = "Bound"
-	// used for PersistentVolumes where the bound PersistentVolumeClaim was deleted
+	// used for PersistentVolumes where the bound PersistentVol:syntime onumeClaim was deleted
 	// released volumes must be recycled before becoming available again
 	// this phase is used by the persistent volume claim binder to signal to another process to reclaim the resource
 	VolumeReleased PersistentVolumePhase = "Released"
@@ -324,27 +324,31 @@ type VsmSpec struct {
 
 // Volume is a command implementation struct
 type Volume struct {
+	Kind       string `yaml:"kind" json:"kind"`
+	APIVersion string `yaml:"api_version" json:"api_version"`
+	Metadata   struct {
+		Annotations       interface{} `yaml:"annotations" json:"annotations"`
+		CreationTimestamp interface{} `yaml:"creation_timestamp" json:"creation_timestamp"`
+		Name              string      `yaml:"name" json:"name"`
+		Labels            struct {
+			Storage string `yaml:"storage" json:"storage"`
+		} `yaml:"labels" json:"labels"`
+	} `yaml:"metadata" json:"metadata"`
 	Spec struct {
-		AccessModes interface{} `json:"AccessModes"`
-		Capacity    interface{} `json:"Capacity"`
-		ClaimRef    interface{} `json:"ClaimRef"`
+		AccessModes interface{} `yaml:"access_modes" json:"access_modes"`
+		Capacity    interface{} `yaml:"capacity" json:"capacity"`
+		ClaimRef    interface{} `yaml:"claim_ref" json:"claim_ref"`
 		OpenEBS     struct {
-			VolumeID string `json:"volumeID"`
-		} `json:"OpenEBS"`
-		PersistentVolumeReclaimPolicy string `json:"PersistentVolumeReclaimPolicy"`
-		StorageClassName              string `json:"StorageClassName"`
-	} `json:"Spec"`
-
+			VolumeID string `yaml:"volume_id" json:"volume_id"`
+		} `yaml:"open_ebs" json:"open_ebs"`
+		PersistentVolumeReclaimPolicy string `yaml:"persistent_volume_reclaim_policy" json:"persistent_volume_reclaim_policy"`
+		StorageClassName              string `yaml:"storage_class_name" json:"storage_class_name"`
+	} `yaml:"spec" json:"spec"`
 	Status struct {
-		Message string `json:"Message"`
-		Phase   string `json:"Phase"`
-		Reason  string `json:"Reason"`
-	} `json:"Status"`
-	Metadata struct {
-		Annotations       interface{} `json:"annotations"`
-		CreationTimestamp interface{} `json:"creationTimestamp"`
-		Name              string      `json:"name"`
-	} `json:"metadata"`
+		Message string `yaml:"message" json:"message"`
+		Phase   string `yaml:"phase" json:"phase"`
+		Reason  string `yaml:"reason" json:"reason"`
+	} `yaml:"status" json:"status"`
 }
 
 // -------------Snapshot Structs ----------


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit will merge VsmSpec and volume struct
which will serve both purposes i.e sending a request
and getting a response to/from m-apiserver.

**Why is this change necessary**:
There is 2 different struct for volume related operations which can be merged to achieve the same.
VsmSpec :  Minimum create volume struct for sending a request to M-apiserver.
Volume : Struct which is response type for volume request , contains some more deep information about the particular volume can be merged into single type struct. 

This change will be  initial commit changes for issue openebs/openebs#420 
