### PR TITLE
Set controller and replica images to :latest tag

### DIFF
--- a/types/v1/labels.go
+++ b/types/v1/labels.go
@@ -352,11 +352,11 @@ const (
 	// This should be equal to persistent volume provisioner's replica count
 	PVPPersistentPathCountDef VolumeProvisionerDefaults = PVPReplicaCountDef
 	// Default value for persistent volume provisioner's controller image
-	PVPControllerImageDef VolumeProvisionerDefaults = "openebs/jiva:0.3-RC2"
+	PVPControllerImageDef VolumeProvisionerDefaults = "openebs/jiva:latest"
 	// Default value for persistent volume provisioner's support for replica
 	PVPReqReplicaDef VolumeProvisionerDefaults = "true"
 	// Default value for persistent volume provisioner's replica image
-	PVPReplicaImageDef VolumeProvisionerDefaults = "openebs/jiva:0.3-RC2"
+	PVPReplicaImageDef VolumeProvisionerDefaults = "openebs/jiva:latest"
 	// Default value for persistent volume provisioner's networking support
 	PVPReqNetworkingDef VolumeProvisionerDefaults = "false"
 	// PVPPersistentPathDef is the default value for persistent volume provisioner's


### PR DESCRIPTION
Closes https://github.com/openebs/openebs/issues/632
**What this PR does / why we need it**:
1. The current controller & replica images point to openebs/jiva:0.3-RC2
2. This PR changes it to openebs/jiva:latest
