### PR TITLE
Refactor Volume REST API types

### DIFF
--- a/cmd/maya-apiserver/app/server/volume_endpoint.go
+++ b/cmd/maya-apiserver/app/server/volume_endpoint.go
@@ -56,10 +56,10 @@ func (s *HTTPServer) vsmSpecificGetRequest(resp http.ResponseWriter, req *http.R
 // vsmList is the http handler that lists VSMs
 func (s *HTTPServer) vsmList(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 
-	fmt.Println("[DEBUG] Processing VSM list request")
+	fmt.Println("[DEBUG] Processing Volume list request")
 
 	// Create a PVC
-	pvc := &v1.PersistentVolumeClaim{}
+	pvc := &v1.Volume{}
 
 	// Get the persistent volume provisioner instance
 	pvp, err := provisioners.GetVolumeProvisioner(pvc.Labels)
@@ -79,7 +79,7 @@ func (s *HTTPServer) vsmList(resp http.ResponseWriter, req *http.Request) (inter
 	}
 
 	if !ok {
-		return nil, fmt.Errorf("VSM list is not supported by '%s:%s'", pvp.Label(), pvp.Name())
+		return nil, fmt.Errorf("Volume list is not supported by '%s:%s'", pvp.Label(), pvp.Name())
 	}
 
 	l, err := lister.List()
@@ -87,7 +87,7 @@ func (s *HTTPServer) vsmList(resp http.ResponseWriter, req *http.Request) (inter
 		return nil, err
 	}
 
-	fmt.Println("[DEBUG] Processed VSM list request successfully")
+	fmt.Println("[DEBUG] Processed Volume list request successfully")
 
 	return l, nil
 }
@@ -95,14 +95,14 @@ func (s *HTTPServer) vsmList(resp http.ResponseWriter, req *http.Request) (inter
 // vsmRead is the http handler that fetches the details of a VSM
 func (s *HTTPServer) vsmRead(resp http.ResponseWriter, req *http.Request, vsmName string) (interface{}, error) {
 
-	fmt.Println("[DEBUG] Processing VSM read request")
+	fmt.Println("[DEBUG] Processing Volume read request")
 
 	if vsmName == "" {
-		return nil, CodedError(400, fmt.Sprintf("VSM name is missing"))
+		return nil, CodedError(400, fmt.Sprintf("Volume name is missing"))
 	}
 
 	// Create a PVC
-	pvc := &v1.PersistentVolumeClaim{}
+	pvc := &v1.Volume{}
 	pvc.Name = vsmName
 
 	// Get persistent volume provisioner instance
@@ -119,7 +119,7 @@ func (s *HTTPServer) vsmRead(resp http.ResponseWriter, req *http.Request, vsmNam
 
 	reader, ok := pvp.Reader()
 	if !ok {
-		return nil, fmt.Errorf("VSM read is not supported by '%s:%s'", pvp.Label(), pvp.Name())
+		return nil, fmt.Errorf("Volume read is not supported by '%s:%s'", pvp.Label(), pvp.Name())
 	}
 
 	// TODO
@@ -133,7 +133,7 @@ func (s *HTTPServer) vsmRead(resp http.ResponseWriter, req *http.Request, vsmNam
 		return nil, CodedError(404, fmt.Sprintf("VSM '%s' not found", vsmName))
 	}
 
-	fmt.Println("[DEBUG] Processed VSM read request successfully for '" + vsmName + "'")
+	fmt.Println("[DEBUG] Processed Volume read request successfully for '" + vsmName + "'")
 
 	return details, nil
 }
@@ -141,14 +141,14 @@ func (s *HTTPServer) vsmRead(resp http.ResponseWriter, req *http.Request, vsmNam
 // vsmDelete is the http handler that fetches the details of a VSM
 func (s *HTTPServer) vsmDelete(resp http.ResponseWriter, req *http.Request, vsmName string) (interface{}, error) {
 
-	fmt.Println("[DEBUG] Processing VSM delete request")
+	fmt.Println("[DEBUG] Processing Volume delete request")
 
 	if vsmName == "" {
-		return nil, CodedError(400, fmt.Sprintf("VSM name is missing"))
+		return nil, CodedError(400, fmt.Sprintf("Volume name is missing"))
 	}
 
 	// Create a PVC
-	pvc := &v1.PersistentVolumeClaim{}
+	pvc := &v1.Volume{}
 	pvc.Name = vsmName
 
 	// Get the persistent volume provisioner instance
@@ -169,7 +169,7 @@ func (s *HTTPServer) vsmDelete(resp http.ResponseWriter, req *http.Request, vsmN
 	}
 
 	if !ok {
-		return nil, fmt.Errorf("VSM delete is not supported by '%s:%s'", pvp.Label(), pvp.Name())
+		return nil, fmt.Errorf("Volume delete is not supported by '%s:%s'", pvp.Label(), pvp.Name())
 	}
 
 	removed, err := remover.Remove()
@@ -179,20 +179,20 @@ func (s *HTTPServer) vsmDelete(resp http.ResponseWriter, req *http.Request, vsmN
 
 	// If there was not any err & still no removal
 	if !removed {
-		return nil, CodedError(404, fmt.Sprintf("VSM '%s' not found", vsmName))
+		return nil, CodedError(404, fmt.Sprintf("Volume '%s' not found", vsmName))
 	}
 
-	fmt.Println("[DEBUG] Processed VSM delete request successfully for '" + vsmName + "'")
+	fmt.Println("[DEBUG] Processed Volume delete request successfully for '" + vsmName + "'")
 
-	return fmt.Sprintf("VSM '%s' deleted successfully", vsmName), nil
+	return fmt.Sprintf("Volume '%s' deleted successfully", vsmName), nil
 }
 
 // vsmAdd is the http handler that fetches the details of a VSM
 func (s *HTTPServer) vsmAdd(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 
-	fmt.Println("[DEBUG] Processing VSM add request")
+	fmt.Println("[DEBUG] Processing Volume add request")
 
-	pvc := v1.PersistentVolumeClaim{}
+	pvc := v1.Volume{}
 
 	// The yaml/json spec is decoded to pvc struct
 	if err := decodeBody(req, &pvc); err != nil {
@@ -201,7 +201,7 @@ func (s *HTTPServer) vsmAdd(resp http.ResponseWriter, req *http.Request) (interf
 
 	// Name is expected to be available even in the minimalist specs
 	if pvc.Name == "" {
-		return nil, CodedError(400, fmt.Sprintf("VSM name missing in '%v'", pvc))
+		return nil, CodedError(400, fmt.Sprintf("Volume name missing in '%v'", pvc))
 	}
 
 	// Get persistent volume provisioner instance
@@ -218,7 +218,7 @@ func (s *HTTPServer) vsmAdd(resp http.ResponseWriter, req *http.Request) (interf
 
 	adder, ok := pvp.Adder()
 	if !ok {
-		return nil, fmt.Errorf("VSM add is not supported by '%s:%s'", pvp.Label(), pvp.Name())
+		return nil, fmt.Errorf("Volume add operation is not supported by '%s:%s'", pvp.Label(), pvp.Name())
 	}
 
 	// TODO
@@ -228,7 +228,7 @@ func (s *HTTPServer) vsmAdd(resp http.ResponseWriter, req *http.Request) (interf
 		return nil, err
 	}
 
-	fmt.Println("[DEBUG] Processed VSM add request successfully for '" + pvc.Name + "'")
+	fmt.Println("[DEBUG] Processed Volume add request successfully for '" + pvc.Name + "'")
 
 	return details, nil
 }

--- a/command/volume_create.go
+++ b/command/volume_create.go
@@ -117,7 +117,7 @@ func (c *VsmCreateCommand) Run(args []string) int {
 // CreateAPIVsm to create the Vsm through a API call to m-apiserver
 func CreateAPIVsm(vname string, size string) error {
 
-	var vs v1.Volume
+	var vs v1.VolumeSpec
 
 	addr := os.Getenv("MAPI_ADDR")
 	if addr == "" {
@@ -135,7 +135,7 @@ func CreateAPIVsm(vname string, size string) error {
 	//Marshal serializes the value provided into a YAML document
 	yamlValue, _ := yaml.Marshal(vs)
 
-	//	fmt.Printf("Volume Spec Created:\n%v\n", string(yamlValue))
+	fmt.Printf("Volume Spec Created:\n%v\n", string(yamlValue))
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(yamlValue))
 	if err != nil {

--- a/command/volume_create.go
+++ b/command/volume_create.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -117,7 +118,7 @@ func (c *VsmCreateCommand) Run(args []string) int {
 // CreateAPIVsm to create the Vsm through a API call to m-apiserver
 func CreateAPIVsm(vname string, size string) error {
 
-	var vs v1.VolumeSpec
+	var vs v1.VolumeAPISpec
 
 	addr := os.Getenv("MAPI_ADDR")
 	if addr == "" {
@@ -168,7 +169,19 @@ func CreateAPIVsm(vname string, size string) error {
 		os.Exit(1)
 	}
 
-	fmt.Printf("Volume Successfully Created:\n%v\n", string(data))
+	list, _ := getdata(data)
+
+	fmt.Printf("Volume Successfully Created:\n%v\n", list.Annotations)
 
 	return nil
+}
+
+func getdata(body []byte) (*v1.Volume, error) {
+	var list = new(v1.Volume)
+	err := json.Unmarshal(body, &list)
+	if err != nil {
+		fmt.Println("UnMarshling Error:", err)
+		os.Exit(1)
+	}
+	return list, err
 }

--- a/command/volume_create.go
+++ b/command/volume_create.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -169,19 +168,7 @@ func CreateAPIVsm(vname string, size string) error {
 		os.Exit(1)
 	}
 
-	list, _ := getdata(data)
-
-	fmt.Printf("Volume Successfully Created:\n%v\n", list.Annotations)
+	fmt.Printf("Volume Successfully Created:\n%v\n", string(data))
 
 	return nil
-}
-
-func getdata(body []byte) (*v1.Volume, error) {
-	var list = new(v1.Volume)
-	err := json.Unmarshal(body, &list)
-	if err != nil {
-		fmt.Println("UnMarshling Error:", err)
-		os.Exit(1)
-	}
-	return list, err
 }

--- a/orchprovider/k8s/v1/k8s.go
+++ b/orchprovider/k8s/v1/k8s.go
@@ -342,7 +342,7 @@ func (k *k8sOrchestrator) StorageOps() (orchprovider.StorageOps, bool) {
 
 // AddStorage will add persistent volume running as containers. In OpenEBS
 // terms AddStorage will add a VSM.
-func (k *k8sOrchestrator) AddStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.PersistentVolume, error) {
+func (k *k8sOrchestrator) AddStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.Volume, error) {
 
 	// TODO
 	// This is jiva specific
@@ -379,7 +379,7 @@ func (k *k8sOrchestrator) AddStorage(volProProfile volProfile.VolumeProvisionerP
 	// TODO
 	// This is a temporary type that is used
 	// Will move to VSM type
-	pv := &v1.PersistentVolume{}
+	pv := &v1.Volume{}
 	vsm, _ := volProProfile.VSMName()
 	pv.Name = vsm
 
@@ -542,13 +542,13 @@ func (k *k8sOrchestrator) DeleteStorage(volProProfile volProfile.VolumeProvision
 
 // ReadStorage will fetch information about the persistent volume
 //func (k *k8sOrchestrator) ReadStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.PersistentVolumeList, error) {
-func (k *k8sOrchestrator) ReadStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.PersistentVolume, error) {
+func (k *k8sOrchestrator) ReadStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.Volume, error) {
 	// volProProfile is expected to have the VSM name
 	return k.readVSM("", volProProfile)
 }
 
 // readVSM will fetch information about a VSM
-func (k *k8sOrchestrator) readVSM(vsm string, volProProfile volProfile.VolumeProvisionerProfile) (*v1.PersistentVolume, error) {
+func (k *k8sOrchestrator) readVSM(vsm string, volProProfile volProfile.VolumeProvisionerProfile) (*v1.Volume, error) {
 
 	// flag that checks if at-least one child object of VSM exists
 	doesExist := false
@@ -674,7 +674,7 @@ func (k *k8sOrchestrator) readVSM(vsm string, volProProfile volProfile.VolumePro
 	// TODO
 	// This is a temporary type that is used
 	// Will move to VSM type
-	pv := &v1.PersistentVolume{}
+	pv := &v1.Volume{}
 	pv.Name = vsm
 	pv.Annotations = annotations
 
@@ -684,7 +684,7 @@ func (k *k8sOrchestrator) readVSM(vsm string, volProProfile volProfile.VolumePro
 }
 
 // ListStorage will list a collections of VSMs
-func (k *k8sOrchestrator) ListStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.PersistentVolumeList, error) {
+func (k *k8sOrchestrator) ListStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.VolumeList, error) {
 	if volProProfile == nil {
 		return nil, fmt.Errorf("Nil volume provisioner profile provided")
 	}
@@ -700,7 +700,7 @@ func (k *k8sOrchestrator) ListStorage(volProProfile volProfile.VolumeProvisioner
 		return nil, nil
 	}
 
-	pvl := &v1.PersistentVolumeList{}
+	pvl := &v1.VolumeList{}
 
 	for _, d := range dl.Items {
 
@@ -1133,7 +1133,7 @@ func (k *k8sOrchestrator) createControllerService(volProProfile volProfile.Volum
 
 	// TODO
 	// log levels & logging context to be taken care of
-	glog.Infof("Adding service for VSM 'name : %s'", vsm)
+	glog.Infof("Adding service for Volume 'name : %s'", vsm)
 
 	// TODO
 	// Code this like a golang struct template

--- a/orchprovider/k8s/v1/k8s_test.go
+++ b/orchprovider/k8s/v1/k8s_test.go
@@ -118,7 +118,7 @@ func TestAddStorage(t *testing.T) {
 
 	for _, c := range cases {
 
-		pvc := &v1.PersistentVolumeClaim{}
+		pvc := &v1.Volume{}
 		pvc.Name = c.vsmname
 		//pvc.Labels = map[string]string{
 		//	string(v1.PVPVSMNameLbl): c.vsmname,
@@ -579,8 +579,8 @@ type okCreateReplicaPodVolumeProfile struct {
 }
 
 // PVC does not return any error
-func (e *okCreateReplicaPodVolumeProfile) PVC() (*v1.PersistentVolumeClaim, error) {
-	pvc := &v1.PersistentVolumeClaim{}
+func (e *okCreateReplicaPodVolumeProfile) PVC() (*v1.Volume, error) {
+	pvc := &v1.Volume{}
 	pvc.Labels = map[string]string{}
 	return pvc, nil
 }

--- a/orchprovider/k8s/v1/util_test.go
+++ b/orchprovider/k8s/v1/util_test.go
@@ -32,7 +32,7 @@ func TestK8sUtil(t *testing.T) {
 	}
 
 	// a noop pvc that in turn signals use of defaults
-	pvc := &v1.PersistentVolumeClaim{}
+	pvc := &v1.Volume{}
 	pvc.Labels = map[string]string{}
 
 	volP, _ := volProfile.GetDefaultVolProProfile(pvc)
@@ -83,7 +83,7 @@ func TestK8sUtilPods(t *testing.T) {
 	}
 
 	// a noop pvc that in turn signals use of defaults
-	pvc := &v1.PersistentVolumeClaim{}
+	pvc := &v1.Volume{}
 	pvc.Labels = map[string]string{}
 
 	volP, _ := volProfile.GetDefaultVolProProfile(pvc)
@@ -114,7 +114,7 @@ func TestK8sUtilServices(t *testing.T) {
 	}
 
 	// a noop pvc that in turn signals use of defaults
-	pvc := &v1.PersistentVolumeClaim{}
+	pvc := &v1.Volume{}
 	pvc.Labels = map[string]string{}
 
 	volP, _ := volProfile.GetDefaultVolProProfile(pvc)

--- a/orchprovider/nomad/v1/helper_funcs.go
+++ b/orchprovider/nomad/v1/helper_funcs.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Get the job name from a persistent volume claim
-func PvcToJobName(pvc *v1.PersistentVolumeClaim) (string, error) {
+func PvcToJobName(pvc *v1.Volume) (string, error) {
 
 	if pvc == nil {
 		return "", fmt.Errorf("Nil persistent volume claim provided")
@@ -27,7 +27,7 @@ func PvcToJobName(pvc *v1.PersistentVolumeClaim) (string, error) {
 }
 
 // Transform a PersistentVolumeClaim type to Nomad job type
-func PvcToJob(pvc *v1.PersistentVolumeClaim) (*api.Job, error) {
+func PvcToJob(pvc *v1.Volume) (*api.Job, error) {
 
 	if pvc == nil {
 		return nil, fmt.Errorf("Nil persistent volume claim provided")
@@ -274,13 +274,13 @@ func setBEIPs(beEnv, jobMeta map[string]string, jivaBeIPArr []string, iJivaBECou
 }
 
 // Transform the evaluation of a job to a PersistentVolume
-func JobEvalToPv(jobName string, eval *api.Evaluation) (*v1.PersistentVolume, error) {
+func JobEvalToPv(jobName string, eval *api.Evaluation) (*v1.Volume, error) {
 
 	if eval == nil {
 		return nil, fmt.Errorf("Nil job evaluation provided")
 	}
 
-	pv := &v1.PersistentVolume{}
+	pv := &v1.Volume{}
 	pv.Name = jobName
 
 	evalProps := map[string]string{
@@ -294,7 +294,7 @@ func JobEvalToPv(jobName string, eval *api.Evaluation) (*v1.PersistentVolume, er
 	}
 	pv.Annotations = evalProps
 
-	pvs := v1.PersistentVolumeStatus{
+	pvs := v1.VolumeStatus{
 		Message: eval.StatusDescription,
 		Reason:  eval.Status,
 	}
@@ -317,15 +317,15 @@ func MakeJob(name string) (*api.Job, error) {
 }
 
 // Transform a Nomad Job to a PersistentVolume
-func JobToPv(job *api.Job) (*v1.PersistentVolume, error) {
+func JobToPv(job *api.Job) (*v1.Volume, error) {
 	if job == nil {
 		return nil, fmt.Errorf("Nil job provided")
 	}
 
-	pv := &v1.PersistentVolume{}
+	pv := &v1.Volume{}
 	pv.Name = *job.Name
 
-	pvs := v1.PersistentVolumeStatus{
+	pvs := v1.VolumeStatus{
 		Message: *job.StatusDescription,
 		Reason:  *job.Status,
 	}

--- a/orchprovider/nomad/v1/nomad_plug.go
+++ b/orchprovider/nomad/v1/nomad_plug.go
@@ -103,7 +103,7 @@ func (n *NomadOrchestrator) StorageOps() (orchprovider.StorageOps, bool) {
 }
 
 // ReadStorage will fetch information about the persistent volume
-func (n *NomadOrchestrator) ReadStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.PersistentVolume, error) {
+func (n *NomadOrchestrator) ReadStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.Volume, error) {
 	pvc, err := volProProfile.PVC()
 	if err != nil {
 		return nil, err
@@ -124,7 +124,7 @@ func (n *NomadOrchestrator) ReadStorage(volProProfile volProfile.VolumeProvision
 
 // AddStorage will add persistent volume running as containers. In OpenEBS
 // terms AddStorage will add a VSM.
-func (n *NomadOrchestrator) AddStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.PersistentVolume, error) {
+func (n *NomadOrchestrator) AddStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.Volume, error) {
 	// TODO
 	// This is jiva specific
 	// Move this entire logic to a separate package that will couple jiva
@@ -180,6 +180,6 @@ func (n *NomadOrchestrator) DeleteStorage(volProProfile volProfile.VolumeProvisi
 }
 
 // ListStorage will list a collections of VSMs
-func (n *NomadOrchestrator) ListStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.PersistentVolumeList, error) {
+func (n *NomadOrchestrator) ListStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.VolumeList, error) {
 	return nil, fmt.Errorf("ListStorage is not implemented by '%s: %s'", n.Label(), n.Name())
 }

--- a/orchprovider/orchestration.go
+++ b/orchprovider/orchestration.go
@@ -43,7 +43,7 @@ type StorageOps interface {
 	//
 	// TODO
 	//    Use VSM as the return type
-	AddStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.PersistentVolume, error)
+	AddStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.Volume, error)
 
 	// DeleteStorage will remove the persistent volume
 	//
@@ -55,9 +55,9 @@ type StorageOps interface {
 	//
 	// TODO
 	//    Use VSM as the return type
-	ReadStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.PersistentVolume, error)
+	ReadStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.Volume, error)
 
 	// ListStorage will list a collection of VSMs in a given context e.g. namespace
 	// if working in a K8s setup, etc.
-	ListStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.PersistentVolumeList, error)
+	ListStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.VolumeList, error)
 }

--- a/types/v1/profile/orchestrator/profile.go
+++ b/types/v1/profile/orchestrator/profile.go
@@ -22,7 +22,7 @@ type OrchProviderProfile interface {
 	Name() v1.OrchProviderProfileRegistry
 
 	// Get the persistent volume claim associated with this orchestration provider
-	PVC() (*v1.PersistentVolumeClaim, error)
+	PVC() (*v1.Volume, error)
 
 	// Get the network address in CIDR format
 	NetworkAddr() (string, error)
@@ -48,7 +48,7 @@ type OrchProviderProfile interface {
 // TODO
 //  It will decide first based on the provided specifications failing which will
 // ensure a default profile is returned.
-func GetOrchProviderProfile(pvc *v1.PersistentVolumeClaim) (OrchProviderProfile, error) {
+func GetOrchProviderProfile(pvc *v1.Volume) (OrchProviderProfile, error) {
 	var profileMap map[string]string
 
 	if pvc != nil && pvc.Labels != nil {
@@ -95,7 +95,7 @@ func GetOrchProviderProfile(pvc *v1.PersistentVolumeClaim) (OrchProviderProfile,
 // NOTE:
 //    This is a concrete implementation of orchprovider.VolumeProvisionerProfile
 type pvcOrchProviderProfile struct {
-	pvc        *v1.PersistentVolumeClaim
+	pvc        *v1.Volume
 	profileMap map[string]string
 }
 
@@ -132,7 +132,7 @@ func (op *pvcOrchProviderProfile) Name() v1.OrchProviderProfileRegistry {
 // NOTE:
 //    This method provides a convinient way to access pvc. In other words
 // orchestration provider profile acts as a wrapper over pvc.
-func (op *pvcOrchProviderProfile) PVC() (*v1.PersistentVolumeClaim, error) {
+func (op *pvcOrchProviderProfile) PVC() (*v1.Volume, error) {
 	return op.pvc, nil
 }
 

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -13,38 +13,6 @@
 // a volume in OpenEBS can be considered as a StoragePod.
 package v1
 
-// PersistentVolumeClaim is a user's REQUEST for and CLAIM to a persistent volume
-type PersistentVolumeClaim struct {
-	TypeMeta `json:",inline"`
-	// Standard object's metadata.
-	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
-	// +optional
-	ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-
-	// Spec defines the desired characteristics of a volume requested by a pod author.
-	// More info: http://kubernetes.io/docs/user-guide/persistent-volumes#persistentvolumeclaims
-	// +optional
-	Spec PersistentVolumeClaimSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
-
-	// Status represents the current information/status of a persistent volume claim.
-	// Read-only.
-	// More info: http://kubernetes.io/docs/user-guide/persistent-volumes#persistentvolumeclaims
-	// +optional
-	Status PersistentVolumeClaimStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
-}
-
-// PersistentVolumeClaimList is a list of PersistentVolumeClaim items.
-type PersistentVolumeClaimList struct {
-	TypeMeta `json:",inline"`
-	// Standard list metadata.
-	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds
-	// +optional
-	ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-	// A list of persistent volume claims.
-	// More info: http://kubernetes.io/docs/user-guide/persistent-volumes#persistentvolumeclaims
-	Items []PersistentVolumeClaim `json:"items" protobuf:"bytes,2,rep,name=items"`
-}
-
 // PersistentVolumeClaimSpec describes the common attributes of storage devices
 // and allows a Source for provider-specific attributes
 type PersistentVolumeClaimSpec struct {
@@ -95,36 +63,6 @@ const (
 	ClaimLost PersistentVolumeClaimPhase = "Lost"
 )
 
-// PersistentVolume represents a named volume in OpenEBS that may be accessed
-// by any container, VM, etc. This represents a CREATED resource.
-type PersistentVolume struct {
-	TypeMeta `json:",inline"`
-	// +optional
-	ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-
-	//Spec defines a persistent volume owned by OpenEBS cluster
-	// +optional
-	Spec PersistentVolumeSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
-
-	// Status represents the current information about persistent volume.
-	// +optional
-	Status VolumeStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
-}
-
-// PersistentVolumeList is a list of PersistentVolume items.
-type PersistentVolumeList struct {
-	TypeMeta `json:",inline"`
-
-	// Standard list metadata.
-	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds
-	// +optional
-	ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-
-	// List of persistent volumes.
-	// More info: http://kubernetes.io/docs/user-guide/persistent-volumes
-	Items []PersistentVolume `json:"items" protobuf:"bytes,2,rep,name=items"`
-}
-
 // PersistentVolumeSource represents the source type of the persistent volume.
 //
 // NOTE:
@@ -142,7 +80,7 @@ type PersistentVolumeSource struct {
 // NOTE:
 //    Only one of its members may be specified. Currently OpenEBS is the only
 // member. There may be other members in future.
-type PersistentVolumeSpec struct {
+type VolumeSpec struct {
 	// Resources represents the actual resources of the volume
 	Capacity ResourceList
 	// Source represents the location and type of a volume to mount.
@@ -305,8 +243,8 @@ type ObjectReference struct {
 	FieldPath string
 }
 
-// VolumeSpec holds the config for creating a Volume
-type VolumeSpec struct {
+// VolumeAPISpec holds the config for creating a Volume
+type VolumeAPISpec struct {
 	Kind       string `yaml:"kind"`
 	APIVersion string `yaml:"apiVersion"`
 	Metadata   struct {
@@ -320,10 +258,11 @@ type VolumeSpec struct {
 //Volume is a user's Request for a Openebs volume
 type Volume struct {
 	TypeMeta `json:",inline"`
-
 	// Standard object's metadata
 	ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-
+	//Spec defines a persistent volume owned by OpenEBS cluster
+	// +optional
+	Spec VolumeSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 	// Status represents the current information/status of a volume
 	Status VolumeStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
@@ -331,11 +270,9 @@ type Volume struct {
 // VolumeList is a list of PersistentVolume items.
 type VolumeList struct {
 	TypeMeta `json:",inline"`
-
 	// Standard list metadata.
 	// +optional
 	ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-
 	// List of persistent volumes.
 	// More info: http://kubernetes.io/docs/user-guide/persistent-volumes
 	Items []Volume `json:"items" protobuf:"bytes,2,rep,name=items"`

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -13,11 +13,6 @@
 // a volume in OpenEBS can be considered as a StoragePod.
 package v1
 
-import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	core_v1 "k8s.io/client-go/pkg/api/v1"
-)
-
 // PersistentVolumeClaim is a user's REQUEST for and CLAIM to a persistent volume
 type PersistentVolumeClaim struct {
 	TypeMeta `json:",inline"`
@@ -113,7 +108,7 @@ type PersistentVolume struct {
 
 	// Status represents the current information about persistent volume.
 	// +optional
-	Status PersistentVolumeStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
+	Status VolumeStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
 // PersistentVolumeList is a list of PersistentVolume items.
@@ -197,10 +192,10 @@ const (
 	ReadWriteMany PersistentVolumeAccessMode = "ReadWriteMany"
 )
 
-type PersistentVolumeStatus struct {
+type VolumeStatus struct {
 	// Phase indicates if a volume is available, bound to a claim, or released by a claim
 	// +optional
-	Phase PersistentVolumePhase
+	Phase VolumePhase
 	// A human-readable message indicating details about why the volume is in this state.
 	// +optional
 	Message string
@@ -209,22 +204,22 @@ type PersistentVolumeStatus struct {
 	Reason string
 }
 
-type PersistentVolumePhase string
+type VolumePhase string
 
 const (
 	// used for PersistentVolumes that are not available
-	VolumePending PersistentVolumePhase = "Pending"
+	VolumePending VolumePhase = "Pending"
 	// used for PersistentVolumes that are not yet bound
 	// Available volumes are held by the binder and matched to PersistentVolumeClaims
-	VolumeAvailable PersistentVolumePhase = "Available"
+	VolumeAvailable VolumePhase = "Available"
 	// used for PersistentVolumes that are bound
-	VolumeBound PersistentVolumePhase = "Bound"
+	VolumeBound VolumePhase = "Bound"
 	// used for PersistentVolumes where the bound PersistentVol:syntime onumeClaim was deleted
 	// released volumes must be recycled before becoming available again
 	// this phase is used by the persistent volume claim binder to signal to another process to reclaim the resource
-	VolumeReleased PersistentVolumePhase = "Released"
+	VolumeReleased VolumePhase = "Released"
 	// used for PersistentVolumes that failed to be correctly recycled or deleted after being released from a claim
-	VolumeFailed PersistentVolumePhase = "Failed"
+	VolumeFailed VolumePhase = "Failed"
 )
 
 // Represents a Persistent Disk resource in OpenEBS.
@@ -310,8 +305,8 @@ type ObjectReference struct {
 	FieldPath string
 }
 
-//VsmSpec holds the config for creating a VSM
-type VsmSpec struct {
+// VolumeSpec holds the config for creating a Volume
+type VolumeSpec struct {
 	Kind       string `yaml:"kind"`
 	APIVersion string `yaml:"apiVersion"`
 	Metadata   struct {
@@ -322,43 +317,38 @@ type VsmSpec struct {
 	} `yaml:"metadata"`
 }
 
-// Volume is a command implementation struct
+//Volume is a user's Request for a Openebs volume
 type Volume struct {
-	Kind       string `yaml:"kind" json:"kind"`
-	APIVersion string `yaml:"api_version" json:"api_version"`
-	Metadata   struct {
-		Annotations       interface{} `yaml:"annotations" json:"annotations"`
-		CreationTimestamp interface{} `yaml:"creation_timestamp" json:"creation_timestamp"`
-		Name              string      `yaml:"name" json:"name"`
-		Labels            struct {
-			Storage string `yaml:"storage" json:"storage"`
-		} `yaml:"labels" json:"labels"`
-	} `yaml:"metadata" json:"metadata"`
-	Spec struct {
-		AccessModes interface{} `yaml:"access_modes" json:"access_modes"`
-		Capacity    interface{} `yaml:"capacity" json:"capacity"`
-		ClaimRef    interface{} `yaml:"claim_ref" json:"claim_ref"`
-		OpenEBS     struct {
-			VolumeID string `yaml:"volume_id" json:"volume_id"`
-		} `yaml:"open_ebs" json:"open_ebs"`
-		PersistentVolumeReclaimPolicy string `yaml:"persistent_volume_reclaim_policy" json:"persistent_volume_reclaim_policy"`
-		StorageClassName              string `yaml:"storage_class_name" json:"storage_class_name"`
-	} `yaml:"spec" json:"spec"`
-	Status struct {
-		Message string `yaml:"message" json:"message"`
-		Phase   string `yaml:"phase" json:"phase"`
-		Reason  string `yaml:"reason" json:"reason"`
-	} `yaml:"status" json:"status"`
+	TypeMeta `json:",inline"`
+
+	// Standard object's metadata
+	ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// Status represents the current information/status of a volume
+	Status VolumeStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
+}
+
+// VolumeList is a list of PersistentVolume items.
+type VolumeList struct {
+	TypeMeta `json:",inline"`
+
+	// Standard list metadata.
+	// +optional
+	ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// List of persistent volumes.
+	// More info: http://kubernetes.io/docs/user-guide/persistent-volumes
+	Items []Volume `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
 // -------------Snapshot Structs ----------
 
-// The volume snapshot object accessible to the user. Upon succesful creation of the actual
+// VolumeSnapshot is volume snapshot object accessible to the user. Upon successful creation of the actual
 // snapshot by the volume provider it is bound to the corresponding VolumeSnapshotData through
 // the VolumeSnapshotSpec
 type VolumeSnapshot struct {
-	metav1.TypeMeta `json:",inline"`
-	Metadata        metav1.ObjectMeta `json:"metadata"`
+	TypeMeta `json:",inline"`
+	Metadata ObjectMeta `json:"metadata"`
 
 	// Spec represents the desired state of the snapshot
 	// +optional
@@ -373,16 +363,16 @@ type VolumeSnapshot struct {
 }
 
 type VolumeSnapshotList struct {
-	metav1.TypeMeta `json:",inline"`
-	Metadata        metav1.ListMeta  `json:"metadata"`
-	Items           []VolumeSnapshot `json:"items"`
+	TypeMeta `json:",inline"`
+	Metadata ListMeta         `json:"metadata"`
+	Items    []VolumeSnapshot `json:"items"`
 }
 
 // The desired state of the volume snapshot
 type VolumeSnapshotSpec struct {
 	// PersistentVolumeClaimName is the name of the PVC being snapshotted
 	// +optional
-	PersistentVolumeClaimName string `json:"persistentVolumeClaimName" protobuf:"bytes,1,opt,name=persistentVolumeClaimName"`
+	VolumeName string `json:"volumeName" protobuf:"bytes,1,opt,name=persistentVolumeClaimName"`
 
 	// SnapshotDataName binds the VolumeSnapshot object with the VolumeSnapshotData
 	// +optional
@@ -392,7 +382,7 @@ type VolumeSnapshotSpec struct {
 type VolumeSnapshotStatus struct {
 	// The time the snapshot was successfully created
 	// +optional
-	CreationTimestamp metav1.Time `json:"creationTimestamp" protobuf:"bytes,1,opt,name=creationTimestamp"`
+	CreationTimestamp Time `json:"creationTimestamp" protobuf:"bytes,1,opt,name=creationTimestamp"`
 
 	// Representes the lates available observations about the volume snapshot
 	Conditions []VolumeSnapshotCondition `json:"conditions" protobuf:"bytes,2,rep,name=conditions"`
@@ -411,10 +401,10 @@ type VolumeSnapshotCondition struct {
 	// Type of replication controller condition.
 	Type VolumeSnapshotConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=VolumeSnapshotConditionType"`
 	// Status of the condition, one of True, False, Unknown.
-	Status core_v1.ConditionStatus `json:"status" protobuf:"bytes,2,opt,name=status,casttype=ConditionStatus"`
+	//Status core_v1.ConditionStatus `json:"status" protobuf:"bytes,2,opt,name=status,casttype=ConditionStatus"`
 	// The last time the condition transitioned from one status to another.
 	// +optional
-	LastTransitionTime metav1.Time `json:"lastTransitionTime" protobuf:"bytes,3,opt,name=lastTransitionTime"`
+	LastTransitionTime Time `json:"lastTransitionTime" protobuf:"bytes,3,opt,name=lastTransitionTime"`
 	// The reason for the condition's last transition.
 	// +optional
 	Reason string `json:"reason" protobuf:"bytes,4,opt,name=reason"`

--- a/volume/profiles/profiles.go
+++ b/volume/profiles/profiles.go
@@ -21,7 +21,7 @@ type VolumeProvisionerProfile interface {
 	Name() v1.VolumeProvisionerProfileRegistry
 
 	// Get the persistent volume claim associated with this provisioner profile
-	PVC() (*v1.PersistentVolumeClaim, error)
+	PVC() (*v1.Volume, error)
 
 	// Gets the orchestration provider name.
 	// A persistent volume provisioner plugin may be linked with a orchestrator
@@ -82,7 +82,7 @@ type VolumeProvisionerProfile interface {
 // GetVolProProfileByPVC will return a specific persistent volume provisioner
 // profile. It will decide first based on the provided specifications failing
 // which will ensure a default profile is returned.
-func GetVolProProfileByPVC(pvc *v1.PersistentVolumeClaim) (VolumeProvisionerProfile, error) {
+func GetVolProProfileByPVC(pvc *v1.Volume) (VolumeProvisionerProfile, error) {
 	if pvc == nil {
 		return nil, fmt.Errorf("PVC is required to create a volume provisioner profile")
 	}
@@ -102,7 +102,7 @@ func GetVolProProfileByPVC(pvc *v1.PersistentVolumeClaim) (VolumeProvisionerProf
 //
 // NOTE:
 //    PVC based volume provisioner profile is considered as default
-func GetDefaultVolProProfile(pvc *v1.PersistentVolumeClaim) (VolumeProvisionerProfile, error) {
+func GetDefaultVolProProfile(pvc *v1.Volume) (VolumeProvisionerProfile, error) {
 
 	if pvc == nil {
 		return nil, fmt.Errorf("PVC is required to create default volume provisioner profile")
@@ -115,7 +115,7 @@ func GetDefaultVolProProfile(pvc *v1.PersistentVolumeClaim) (VolumeProvisionerPr
 //
 // GetVolProProfileByName will return a volume provisioner profile by
 // looking up from the provided profile name.
-func GetVolProProfileByName(name string, pvc *v1.PersistentVolumeClaim) (VolumeProvisionerProfile, error) {
+func GetVolProProfileByName(name string, pvc *v1.Volume) (VolumeProvisionerProfile, error) {
 	// TODO
 	// Search from the in-memory registry
 
@@ -136,13 +136,13 @@ func GetVolProProfileByName(name string, pvc *v1.PersistentVolumeClaim) (VolumeP
 //    This is a concrete implementation of
 // volumeprovisioner.VolumeProvisionerProfile
 type pvcVolProProfile struct {
-	pvc     *v1.PersistentVolumeClaim
+	pvc     *v1.Volume
 	vsmName string
 }
 
 // newPvcVolProProfile provides a new instance of VolumeProvisionerProfile that is
 // based on pvc (i.e. persistent volume claim).
-func newPvcVolProProfile(pvc *v1.PersistentVolumeClaim) (VolumeProvisionerProfile, error) {
+func newPvcVolProProfile(pvc *v1.Volume) (VolumeProvisionerProfile, error) {
 	return &pvcVolProProfile{
 		pvc: pvc,
 	}, nil
@@ -172,7 +172,7 @@ func (pp *pvcVolProProfile) Name() v1.VolumeProvisionerProfileRegistry {
 // NOTE:
 //    This method provides a convinient way to access pvc. In other words
 // volume provisioner profile acts as a wrapper over pvc.
-func (pp *pvcVolProProfile) PVC() (*v1.PersistentVolumeClaim, error) {
+func (pp *pvcVolProProfile) PVC() (*v1.Volume, error) {
 	return pp.pvc, nil
 }
 
@@ -201,7 +201,7 @@ func (pp *pvcVolProProfile) Copy(vsm string) (VolumeProvisionerProfile, error) {
 
 	t := strings.TrimSpace(vsm)
 	if t == "" {
-		return nil, fmt.Errorf("VSM name can not be empty")
+		return nil, fmt.Errorf("Volume name can not be empty")
 	}
 
 	// copy
@@ -391,5 +391,5 @@ func (pp *pvcVolProProfile) PersistentPath() (string, error) {
 // NOTE:
 //    This is a concrete implementation of volume.VolumeProvisionerProfile
 type etcdVolProProfile struct {
-	pvc *v1.PersistentVolumeClaim
+	pvc *v1.Volume
 }

--- a/volume/provisioners/jiva/jiva.go
+++ b/volume/provisioners/jiva/jiva.go
@@ -87,7 +87,7 @@ func (j *jivaStor) Name() string {
 // NOTE:
 //    This method is expected to be invoked when pvc is available. In other
 // words this is lazily invoked after the creation of jivaStor.
-func (j *jivaStor) Profile(pvc *v1.PersistentVolumeClaim) (bool, error) {
+func (j *jivaStor) Profile(pvc *v1.Volume) (bool, error) {
 	// Get the persistent volume provisioner profile
 	vProfl, err := volProfile.GetVolProProfileByPVC(pvc)
 	if err != nil {
@@ -180,7 +180,7 @@ func (j *jivaStor) Remover() (provisioners.Remover, bool, error) {
 //
 // NOTE:
 //    This is a concrete implementation of volume.Lister interface
-func (j *jivaStor) List() (*v1.PersistentVolumeList, error) {
+func (j *jivaStor) List() (*v1.VolumeList, error) {
 	// Delegate to the storage util
 	storOps, _ := j.jivaProUtil.StorageOps()
 
@@ -198,7 +198,7 @@ func (j *jivaStor) List() (*v1.PersistentVolumeList, error) {
 //
 // NOTE:
 //    This is a concrete implementation of volume.Informer interface
-func (j *jivaStor) Read(pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolume, error) {
+func (j *jivaStor) Read(pvc *v1.Volume) (*v1.Volume, error) {
 	// TODO
 	// Move the validations to j.Reader()
 
@@ -222,7 +222,7 @@ func (j *jivaStor) Read(pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolume, er
 //
 // NOTE:
 //    This is a concrete implementation of volume.Adder interface
-func (j *jivaStor) Add(pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolume, error) {
+func (j *jivaStor) Add(pvc *v1.Volume) (*v1.Volume, error) {
 	// TODO
 	// Move the validations to j.Adder()
 

--- a/volume/provisioners/jiva/util.go
+++ b/volume/provisioners/jiva/util.go
@@ -34,13 +34,13 @@ type JivaInterface interface {
 // volume provisioner.
 type StorageOps interface {
 	// Info / Read operation
-	ReadStorage(*v1.PersistentVolumeClaim) (*v1.PersistentVolume, error)
+	ReadStorage(*v1.Volume) (*v1.Volume, error)
 
 	// Add operation
-	AddStorage(*v1.PersistentVolumeClaim) (*v1.PersistentVolume, error)
+	AddStorage(*v1.Volume) (*v1.Volume, error)
 
 	// ListStorage will list a collection of persistent volumes
-	ListStorage() (*v1.PersistentVolumeList, error)
+	ListStorage() (*v1.VolumeList, error)
 
 	// Delete operation
 	RemoveStorage() (bool, error)
@@ -93,7 +93,7 @@ func (j *jivaUtil) StorageOps() (StorageOps, bool) {
 
 // ListStorage fetches a collection of jiva persistent volumes.
 // It gets the appropriate orchestration provider to delegate further execution.
-func (j *jivaUtil) ListStorage() (*v1.PersistentVolumeList, error) {
+func (j *jivaUtil) ListStorage() (*v1.VolumeList, error) {
 	// TODO
 	// Move the below set of validations to StorageOps()
 	if j.jivaProProfile == nil {
@@ -128,7 +128,7 @@ func (j *jivaUtil) ListStorage() (*v1.PersistentVolumeList, error) {
 //
 // ReadStorage fetches details of a jiva persistent volume.
 // It gets the appropriate orchestration provider to delegate further execution.
-func (j *jivaUtil) ReadStorage(pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolume, error) {
+func (j *jivaUtil) ReadStorage(pvc *v1.Volume) (*v1.Volume, error) {
 
 	// TODO
 	// Move the below set of validations to StorageOps()
@@ -160,7 +160,7 @@ func (j *jivaUtil) ReadStorage(pvc *v1.PersistentVolumeClaim) (*v1.PersistentVol
 }
 
 // AddStorage adds a jiva persistent volume
-func (j *jivaUtil) AddStorage(pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolume, error) {
+func (j *jivaUtil) AddStorage(pvc *v1.Volume) (*v1.Volume, error) {
 
 	// TODO
 	// Move the below set of validations to StorageOps() method

--- a/volume/provisioners/volume.go
+++ b/volume/provisioners/volume.go
@@ -31,7 +31,7 @@ type VolumeInterface interface {
 	// i.e. much after the initialization of persistent volume provisioner instance.
 	// It is assumed that persistent volume claim will be available at the time of
 	// invoking this method.
-	Profile(*v1.PersistentVolumeClaim) (bool, error)
+	Profile(*v1.Volume) (bool, error)
 
 	// Remover gets the instance capable of deleting volumes w.r.t this
 	// persistent volume provisioner.
@@ -71,7 +71,7 @@ type VolumeInterface interface {
 type Lister interface {
 	// List fetches a collection of persistent volumes created by this volume
 	// provisioner
-	List() (*v1.PersistentVolumeList, error)
+	List() (*v1.VolumeList, error)
 }
 
 // Reader interface abstracts fetching of persistent volume related information
@@ -79,14 +79,14 @@ type Lister interface {
 type Reader interface {
 	// Read fetches the volume details from the persistent volume
 	// provisioner.
-	Read(*v1.PersistentVolumeClaim) (*v1.PersistentVolume, error)
+	Read(*v1.Volume) (*v1.Volume, error)
 }
 
 // Adder interface abstracts creation of persistent volume from a persistent
 // volume provisioner.
 type Adder interface {
 	// Add creates a new persistent volume
-	Add(*v1.PersistentVolumeClaim) (*v1.PersistentVolume, error)
+	Add(*v1.Volume) (*v1.Volume, error)
 }
 
 // Remover interface abstracts deletion of volume of a persistent volume


### PR DESCRIPTION
**What this PR does / why we need it**:
1. This PR is going to fix the API types of Volume.
2. Deprecate redundant structs from the API types.
3. Create single `Volume` struct API type for request and response.
4. Create `VolumeList` struct type for listing the volumes
5. Create `VolumeStatus` struct type, to know the current status/info of a Volume
 
**Which issue this PR fixes** 
fixes openebs/openebs#420

**How to verify this change**
Verified changes by using curl and CLI commands