### PR TITLE
WIP. DO NOT MERGE. Customize feature per Volume.

### DIFF
--- a/types/v1/labels.go
+++ b/types/v1/labels.go
@@ -1,5 +1,24 @@
 package v1
 
+// OpenEBSKind is a typed label that defines any OpenEBS
+// object
+type OpenEBSKind string
+
+const (
+	// VolumeKind is a typed label that represents OpenEBS volume
+	// Kind
+	VolumeKind OpenEBSKind = "volume"
+)
+
+// VolumeType is a typed label that represents the type of
+// OpenEBS volume
+type VolumeType string
+
+const (
+	// JivaVolume is an OpenEBS volume type
+	JivaVolume VolumeType = "jiva"
+)
+
 // NomadEnvironmentVariable is a typed label that defines environment variables
 // that are understood by Nomad
 type NomadEnvironmentVariable string

--- a/volume/profiles/doc.go
+++ b/volume/profiles/doc.go
@@ -1,1 +1,3 @@
+// Package profiles manages transformations of OpenEBS Kind
+// objects to target Kind objects
 package profiles

--- a/volume/profiles/transformer.go
+++ b/volume/profiles/transformer.go
@@ -1,0 +1,19 @@
+package profiles
+
+import (
+	k8sClientV1Beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+)
+
+// Transformer provides common methods for transforming any
+// OpenEBS' Kind to any target's Kind
+type Transformer interface {
+	// Version provides the version of this transformer
+	Version() (string, error)
+}
+
+// K8sDeployTransformer provides method to transform any
+// OpenEBS Kind to corresponding K8s Deployment
+type K8sDeployTransformer interface {
+	// Transform transforms any OpenEBS Kind to K8s Deployment
+	Transform() (*k8sClientV1Beta1.Deployment, error)
+}

--- a/volume/profiles/transformers/voltok8sdeploy/taint_toleration.go
+++ b/volume/profiles/transformers/voltok8sdeploy/taint_toleration.go
@@ -1,0 +1,185 @@
+package voltok8sdeploy
+
+import (
+	"github.com/openebs/maya/types/v1"
+	k8sClientApiV1 "k8s.io/client-go/pkg/api/v1"
+	k8sClientV1Beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+)
+
+// TaintTolerationTransformer is an implementation of
+// 1. Transformer interface
+// 2. K8sDeployTransformer interface
+type TaintTolerationTransformer struct {
+  // name is the name of this transformer
+  name string
+
+	// volume is the structure that represents an
+	// OpenEBS volume
+	volSpec v1.VolumeSpec
+
+	// deploy is the structure that is created/updated after
+	// transformation of node taint property
+	deploy *k8sClientV1Beta1.Deployment
+}
+
+// NewTaintTolerationTransformer instantiates a new instance of
+// NodeTaintTransformer
+func NewTaintTolerationTransformer(volSpec v1.VolumeSpec, deploy *k8sClientV1Beta1.Deployment) *TaintTolerationTransformer {
+  
+	return &TaintTolerationTransformer{
+	  name: "voltok8sdeploy/TaintToleration",
+		volSpec: volSpec,
+		deploy: deploy,
+	}
+}
+
+// Version provides the version of this transformer
+func (k *TaintTolerationTransformer) Version() (string, error) {
+	return "1.0", nil
+}
+
+// Transform transforms the OpenEBS Volume into K8s Deployment
+func (k *TaintTolerationTransformer) Transform() (*k8sClientV1Beta1.Deployment, error) {
+
+  ver, err := k.Version()
+  if err != nil {
+    return nil, err
+  }
+  
+  if strings.TrimSpace(k.volSpec.TaintToleration.Version) == "" {
+    k.volSpec.TaintToleration.Version = profiles.TaintTolerationVolToK8sDeployVer
+  }
+  
+  if ver != k.volSpec.TaintToleration.Version {
+    // Skip the transformation minus errors, as this transformer is not
+    // supposed to handle transformation
+    return k.deploy, nil
+  }
+
+  if k.volSpec == nil {
+    return nil, fmt.Errorf("Nil VolumeSpec provided to '%s: %s'", k.name, ver)
+  }
+
+  if k.deploy == nil {
+    k.deploy = &k8sClientV1Beta1.Deployment{}
+  }
+  
+ 	// check if taint toleration needs to be set ?
+	nTTs, reqd, err := k.isTaintTolerations()
+	if err != nil {
+		return nil, err
+	}
+
+	if reqd {		  
+		err = addTaintTolerations(nTTs, k.deploy)
+		if err != nil {
+			return nil, err
+		}
+	}
+  
+  return k.deploy, nil
+}
+
+// isTaintTolerations indicates if taint toleration(s) is required
+func (k *TaintTolerationTransformer) isTaintTolerations() ([]string, bool, error) {
+	// Extract the taint toleration for controller
+	nTTs, err := k.getTaintTolerations()
+	if err != nil {
+		return nil, false, err
+	}
+
+	if strings.TrimSpace(nTTs) == "" {
+		return nil, false, nil
+	}
+
+	// nTTs is expected of below form
+	// key=value:effect, key1=value1:effect1
+	// __or__
+	// key=value:effect
+	return strings.Split(nTTs, ","), true, nil
+}
+
+// addTaintTolerations updates the Taint Toleration property
+// against the provided K8s Deployment
+func addTaintTolerations(taintTolerations []string, deploy *k8sClientV1Beta1.Deployment) error {
+
+	// nTT is expected to be in key=value:effect format
+	for _, tt := range taintTolerations {
+		kveArr := strings.Split(tt, ":")
+		if len(kveArr) != 2 {
+			return fmt.Errorf("Invalid args '%s' provided for taint toleration", tt)
+		}
+
+		kv := kveArr[0]
+		effect := strings.TrimSpace(kveArr[1])
+
+		kvArr := strings.Split(kv, "=")
+		if len(kvArr) != 2 {
+			return fmt.Errorf("Invalid kv '%s' provided for taint toleration", kv)
+		}
+		k := strings.TrimSpace(kvArr[0])
+		v := strings.TrimSpace(kvArr[1])
+
+		// Setting to blank to validate later
+		e := k8sApiV1.TaintEffect("")
+
+		// Supports only these two effects
+		if string(k8sClientApiV1.TaintEffectNoExecute) == effect {
+			e = k8sClientApiV1.TaintEffectNoExecute
+		} else if string(k8sClientApiV1.TaintEffectNoSchedule) == effect {
+			e = k8sClientApiV1.TaintEffectNoSchedule
+		}
+
+		if string(e) == "" {
+			return fmt.Errorf("Invalid effect '%s' provided for taint toleration", effect)
+		}
+
+		toleration := k8sApiV1.Toleration{
+			Key:      k,
+			Operator: k8sApiV1.TolerationOpEqual,
+			Value:    v,
+			Effect:   e,
+		}
+
+		tls := append(deploy.Spec.Template.Spec.Tolerations, toleration)
+		deploy.Spec.Template.Spec.Tolerations = tls
+	}
+
+	return nil
+}
+
+// getTaintTolerations gets the taint tolerations if available
+func (k *TaintTolerationTransformer) getTaintTolerations() (string, error) {
+	val, err := taintTolerations(volSpec)
+	if err != nil {
+		return "", err
+	}
+
+	if val == "" {
+		val, err = k.defaultTaintTolerations()
+	}
+
+	return val, err
+}
+
+// taintTolerations extracts the node taint tolerations
+func (k *TaintTolerationTransformer) taintTolerations() (string, error) {
+	val := k.volSpec.TaintToleration.KVEPairs
+
+	if val != "" {
+		return val, nil
+	}
+
+  val = strings.Split(v1.OSGetEnv(string(TaintTolerationEnv)), volSpec.Context),",")
+
+	// else get from environment variable
+	return , nil
+}
+
+// defaultTaintTolerations will fetch the default value for node
+// taint tolerations
+func (k *TaintTolerationTransformer) defaultTaintTolerations() (string, error) {
+	// Controller node taint toleration property is optional. Hence returns blank
+	// (i.e. not required) as default.
+	return "", nil
+}

--- a/volume/profiles/volume_to_k8s_profile.go
+++ b/volume/profiles/volume_to_k8s_profile.go
@@ -1,0 +1,33 @@
+package profiles
+
+import (
+	"github.com/openebs/maya/types/v1"
+	k8sClientV1Beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+)
+
+// VolumeToK8sDeployProfile is a structure with necessary
+// properties & methods to convert an OpenEBS Volume kind
+// to a K8s Deploy kind
+type VolumeToK8sDeployProfile struct {
+	// Transformer will transform the OpenEBS Volume Kind
+	// to the desired K8s kind
+	transformer *VolToK8sDeployTransformer
+}
+
+// NewVolumeToK8sDeployProfile provides an instance of VolumeK8sProfile
+func NewVolumeToK8sDeployProfile(volType v1.VolumeType, vol *v1.Volume) *VolumeToK8sDeployProfile {
+	return &VolumeToK8sDeployProfile{
+		transformer: NewVolToK8sDeployTransformer(volType, vol, getVolToK8sDeployTransformers()),
+	}
+}
+
+// Deployment will make use of transformers to convert an
+// OpenEBS Kind to a K8s Deployment
+func (p *VolumeToK8sDeployProfile) Deployment() (*k8sClientV1Beta1.Deployment, error) {
+	return p.transformer.Transform()
+}
+
+func getVolToK8sDeployTransformers() []VolToK8sDeployTransType {
+	// TODO Add the transformers !!
+	return []VolToK8sDeployTransType{NodeTaintVolToK8sDeploy}
+}

--- a/volume/profiles/volume_to_k8s_registry.go
+++ b/volume/profiles/volume_to_k8s_registry.go
@@ -1,0 +1,74 @@
+package profiles
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/golang/glog"
+	"github.com/openebs/maya/types/v1"
+	k8sClientV1Beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+)
+
+type VolToK8sDeployTransType string
+
+const (
+	// NodeTaintVolToK8sDeploy is a transformer type used while
+	// transforming a OpenEBS Volume to K8s Deployment
+	TaintTolerationVolToK8sDeploy VolToK8sDeployTransType = "voltok8sdeploy/node-taint"
+)
+
+type DefaultTransformerVersion string
+
+const (
+  // TaintTolerationVolToK8sDeployVer represents the default version
+  // for TaintTolerationVolToK8sDeploy transformer
+  TaintTolerationVolToK8sDeployVer DefaultTransformerVersion = "1.0"
+)
+
+type VolToK8sDeployFactory func(vol *v1.Volume, deploy *k8sClientV1Beta1.Deployment) (K8sDeployTransformer, error)
+
+// Registration is managed in a safe manner via these variables
+var (
+	volToK8sDeployMutex    sync.Mutex
+	volToK8sDeployRegistry = make(map[VolToK8sDeployTransType]VolToK8sDeployFactory)
+)
+
+// HasVolToK8sDeployFactory returns true if transformer type corresponds to
+// an already registered VolToK8sDeployFactory object
+func HasVolToK8sDeployFactory(tt VolToK8sDeployTransType) bool {
+	volToK8sDeployMutex.Lock()
+	defer volToK8sDeployMutex.Unlock()
+
+	_, found := volToK8sDeployRegistry[tt]
+	return found
+}
+
+// RegisterVolToK8sDeployFactory registers a VolToK8sDeployFactory
+// by the transformer type.
+func RegisterVolToK8sDeployFactory(tt VolToK8sDeployTransType, tFactory VolToK8sDeployFactory) {
+	volToK8sDeployMutex.Lock()
+	defer volToK8sDeployMutex.Unlock()
+
+	_, found := volToK8sDeployRegistry[tt]
+	if found {
+		glog.Fatalf("Duplicate registration attempt for VolToK8sDeployTransformer '%s' ", tt)
+	}
+
+	glog.Infof("Registered '%s' as transformer", tt)
+	volToK8sDeployRegistry[tt] = tFactory
+}
+
+// GetVolToK8sDeployTrans creates a new instance of VolToK8sDeployTransformer
+func GetVolToK8sDeployTrans(vol *v1.Volume, deploy *k8sClientV1Beta1.Deployment, tt VolToK8sDeployTransType) (K8sDeployTransformer, error) {
+	volToK8sDeployMutex.Lock()
+	defer volToK8sDeployMutex.Unlock()
+
+	tFactory, found := volToK8sDeployRegistry[tt]
+	if !found {
+		return nil, fmt.Errorf("'%s' is not a registered VolToK8sDeployTransformer", tt)
+	}
+
+	// This functional invocation should result in creation of a new instance of
+	// VolToK8sDeployTransformer
+	return tFactory(vol, deploy)
+}

--- a/volume/profiles/volume_to_k8s_transformer.go
+++ b/volume/profiles/volume_to_k8s_transformer.go
@@ -1,0 +1,70 @@
+package profiles
+
+import (
+	"github.com/openebs/maya/types/v1"
+	k8sClientV1Beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+)
+
+// VolToK8sDeployTransformer is an implementation of
+// 1. Transformer interface
+// 2. K8sDeployTransformer interface
+type VolToK8sDeployTransformer struct {
+	// volType is the type of OpenEBS Volume Kind
+	volType v1.VolumeType
+
+	// volume is the structure that represents an
+	// OpenEBS volume
+	volume *v1.Volume
+
+	// deploy is the structure that is generated after
+	// transformation of OpenEBS volume
+	deploy *k8sClientV1Beta1.Deployment
+
+	// transTypes is a list (i.e. chain) of transformer
+	// types to be executed to transform an OpenEBS Volume
+	// to corresponding K8s Deployment
+	transTypes []VolToK8sDeployTransType
+}
+
+// NewVolToK8sDeployTransformer instantiates a new instance of
+// VolToK8sDeployTransformer
+func NewVolToK8sDeployTransformer(volType v1.VolumeType, volume *v1.Volume, transTypes []VolToK8sDeployTransType) *VolToK8sDeployTransformer {
+	return &VolToK8sDeployTransformer{
+		volType:    volType,
+		volume:     volume,
+		transTypes: transTypes,
+	}
+}
+
+// Version provides the version of this transformer
+func (k *VolToK8sDeployTransformer) Version() (string, error) {
+	return "1.0", nil
+}
+
+// IsVolumeTypeSupported indicates if this transformer can transform
+// the OpenEBS Volume Type.
+func (k *VolToK8sDeployTransformer) IsVolumeTypeSupported() (bool, error) {
+
+	if k.volType == v1.JivaVolume {
+		return true, nil
+	} else {
+		return false, nil
+	}
+}
+
+// Transform transforms the OpenEBS Kind into K8s Deployment kind
+func (k *VolToK8sDeployTransformer) Transform() (*k8sClientV1Beta1.Deployment, error) {
+
+	for _, tt := range k.transTypes {
+		t, err := GetVolToK8sDeployTrans(k.volume, k.deploy, tt)
+		if err != nil {
+			return nil, err
+		}
+		d, err := t.Transform()
+		if err != nil {
+			return nil, err
+		}
+		k.deploy = d
+	}
+	return k.deploy, nil
+}


### PR DESCRIPTION
1. Why is this change necessary ?

This implementation tries to customize storage
 workload on a per Volume basis. This tries to
convert each Volume property to the targetted
K8s Deploy property.

This is a work in progress and this commit expects
many review comments to make this implementation
a better one.

2. How does this change address the issue ?

- Simplified Workflow: An endpoint captures
the Volume yaml and converts it to respective
Volume struct. It passes through the provisioner
as is. The provisioner passes the Volume struct
to the orchprovider. K8s orchprovider will use a
profile object to transform the Volume to a
corresponding K8s Deploy. The transform method
iterates through a number of transformers each dealing
with a specific volume property.

- Have a look at added/updated files, packages
Necessary comments have been provided in the files
itself.

3. How to verify this change ?

- Cannot be verified. The src does not compile.

4. What side effects does this change have ?

- This will not be checked-in.

- No side effects

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
