### PR TITLE
Adding Dockerfiles for maya & maya-apisever

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+#
+# This Dockerfile builds the maya components using the Makefile
+# 
+
+FROM golang:latest
+
+ARG BUILD_DATE
+
+LABEL org.label-schema.name="maya"
+LABEL org.label-schema.description="OpenEBS Storage Orchestration Engine"
+LABEL org.label-schema.url="http://www.openebs.io/"
+LABEL org.label-schema.vcs-url="https://github.com/openebs/maya"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=$BUILD_DATE
+
+# Setup environment
+ENV PWD=/usr/local/go/src/github.com/openebs/maya
+
+RUN apt-get update && \
+    apt-get install -y zip
+
+WORKDIR /usr/local/go/src/github.com/openebs/maya
+
+# TODO: Add entrypoint to improve building
+COPY . .
+
+RUN make bootstrap && make bin && make apiserver && make maya-agent && make install

--- a/buildscripts/apiserver/Dockerfile
+++ b/buildscripts/apiserver/Dockerfile
@@ -1,0 +1,39 @@
+#
+# This Dockerfile builds a recent maya api server using the latest binary from
+# maya api server's releases.
+#
+
+FROM alpine:3.6
+
+# TODO: The following env variables should be auto detected.
+ENV MAYA_API_SERVER_NETWORK="eth0"
+
+RUN apk add --no-cache \
+    iproute2 \
+    curl \
+    net-tools \
+    mii-tool \
+    procps \
+    libc6-compat
+RUN mkdir -p /etc/apiserver/orchprovider
+RUN mkdir -p /etc/apiserver/specs
+
+COPY demo-vol1.yaml /etc/apiserver/specs/
+COPY maya-apiserver /usr/local/bin/
+COPY maya /usr/local/bin/
+
+COPY entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ARG BUILD_DATE
+
+LABEL org.label-schema.name="m-apiserver"
+LABEL org.label-schema.description="API server for OpenEBS"
+LABEL org.label-schema.url="http://www.openebs.io/"
+LABEL org.label-schema.vcs-url="https://github.com/openebs/maya"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=$BUILD_DATE
+
+ENTRYPOINT entrypoint.sh "${MAYA_API_SERVER_NETWORK}"
+
+EXPOSE 5656

--- a/buildscripts/mayactl/Dockerfile
+++ b/buildscripts/mayactl/Dockerfile
@@ -1,0 +1,22 @@
+#
+# This Dockerfile builds a recent maya container with latest code
+#
+
+FROM alpine:3.6
+
+RUN apk --no-cache add libc6-compat
+
+COPY maya /usr/local/bin
+
+ARG VERSION
+ARG BUILD_DATE
+
+LABEL org.label-schema.name="maya"
+LABEL org.label-schema.description="CLI for OpenEBS"
+LABEL org.label-schema.url="http://www.openebs.io/"
+LABEL org.label-schema.vcs-url="https://github.com/openebs/maya"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.version=$VERSION
+LABEL org.label-schema.build-date=$BUILD_DATE
+
+ENTRYPOINT ["maya"]


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit will add back the dockerfiles to build the maya inside the docker container as well as 
build the docker-images of maya and maya-apiserver.
