### PR TITLE
Add replica count as a typed property to Volume struct

### DIFF
--- a/orchprovider/k8s/v1/k8s.go
+++ b/orchprovider/k8s/v1/k8s.go
@@ -982,7 +982,7 @@ func (k *k8sOrchestrator) createReplicaDeployment(volProProfile volProfile.Volum
 		},
 		Spec: k8sApisExtnsBeta1.DeploymentSpec{
 			// -- automated K8s way of replica count management
-			Replicas: v1.Replicas(rCount),
+			Replicas: rCount,
 			Template: k8sApiV1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{

--- a/orchprovider/k8s/v1/k8s_test.go
+++ b/orchprovider/k8s/v1/k8s_test.go
@@ -527,8 +527,8 @@ func (e *errRepCountVolumeProfile) ReplicaImage() (string, error) {
 }
 
 // ReplicaCount returns an error
-func (e *errRepCountVolumeProfile) ReplicaCount() (int, error) {
-	return 0, fmt.Errorf("err-rep-count")
+func (e *errRepCountVolumeProfile) ReplicaCount() (*int32, error) {
+	return nil, fmt.Errorf("err-rep-count")
 }
 
 // errPersistentPathCountVolumeProfile returns an error during invocation of
@@ -596,8 +596,10 @@ func (e *okCreateReplicaPodVolumeProfile) ReplicaImage() (string, error) {
 }
 
 // ReplicaCount does not return any error
-func (e *okCreateReplicaPodVolumeProfile) ReplicaCount() (int, error) {
-	return 2, nil
+func (e *okCreateReplicaPodVolumeProfile) ReplicaCount() (*int32, error) {
+	count := 2
+	count32 := int32(count)
+	return &count32, nil
 }
 
 // PersistentPathCount does not return any error

--- a/types/v1/labels.go
+++ b/types/v1/labels.go
@@ -340,7 +340,7 @@ const (
 
 	VolumeSizeAPILbl MayaAPIServiceOutputLabel = "vsm.openebs.io/volume-size"
 
-  // Deprecate
+	// Deprecate
 	ReplicaCountAPILbl MayaAPIServiceOutputLabel = "vsm.openebs.io/replica-count"
 )
 

--- a/types/v1/labels.go
+++ b/types/v1/labels.go
@@ -228,6 +228,8 @@ const (
 	PVPReqReplicaLbl VolumeProvisionerProfileLabel = "volumeprovisioner.mapi.openebs.io/req-replica"
 	// Label / Tag for a persistent volume provisioner's networking support
 	PVPReqNetworkingLbl VolumeProvisionerProfileLabel = "volumeprovisioner.mapi.openebs.io/req-networking"
+
+	// Deprecate
 	// Label / Tag for a persistent volume provisioner's replica count
 	PVPReplicaCountLbl VolumeProvisionerProfileLabel = "volumeprovisioner.mapi.openebs.io/replica-count"
 	// Label / Tag for a persistent volume provisioner's persistent path count
@@ -317,8 +319,10 @@ const (
 	//PVPNodeSelectorValueLbl VolumeProvisionerProfileLabel = PVPNodeAffinityExpressionsLbl
 )
 
+// Deprecate
 type MayaAPIServiceOutputLabel string
 
+// Deprecate all these constants
 const (
 	ReplicaStatusAPILbl MayaAPIServiceOutputLabel = "vsm.openebs.io/replica-status"
 
@@ -336,6 +340,7 @@ const (
 
 	VolumeSizeAPILbl MayaAPIServiceOutputLabel = "vsm.openebs.io/volume-size"
 
+  // Deprecate
 	ReplicaCountAPILbl MayaAPIServiceOutputLabel = "vsm.openebs.io/replica-count"
 )
 

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -81,6 +81,17 @@ type PersistentVolumeSource struct {
 //    Only one of its members may be specified. Currently OpenEBS is the only
 // member. There may be other members in future.
 type VolumeSpec struct {
+  // The context of this volume specification. 
+  // Examples: "controller", "replica". Implicitly inferred to be "replica" 
+  // if unspecified.
+  // +optional
+  Context VolumeContext `json:"context,omitempty" protobuf:"bytes,1,opt,name=context,casttype=VolumeContext"`
+
+  // Number of desired replicas. This is a pointer to distinguish between explicit
+  // zero and not specified. Defaults to 1.
+  // +optional
+  Replicas *int32 `json:"replicas,omitempty" protobuf:"varint,1,opt,name=replicas"`
+
 	// Resources represents the actual resources of the volume
 	Capacity ResourceList
 	// Source represents the location and type of a volume to mount.
@@ -103,6 +114,18 @@ type VolumeSpec struct {
 	// +optional
 	StorageClassName string
 }
+
+type VolumeContext string
+
+const (
+  // ReplicaVolumeContext represents a volume w.r.t 
+  // replica context
+  ReplicaVolumeContext VolumeContext = "Replica"
+  
+  // ControllerVolumeContext represents a volume w.r.t 
+  // controller context
+  ControllerVolumeContext VolumeContext = "Controller"
+)
 
 // PersistentVolumeReclaimPolicy describes a policy for end-of-life maintenance of persistent volumes
 type PersistentVolumeReclaimPolicy string
@@ -258,11 +281,14 @@ type VolumeAPISpec struct {
 //Volume is a user's Request for a Openebs volume
 type Volume struct {
 	TypeMeta `json:",inline"`
+
 	// Standard object's metadata
 	ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-	//Spec defines a persistent volume owned by OpenEBS cluster
-	// +optional
-	Spec VolumeSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
+
+	// Specs contains the desired specifications the volume should have.
+  // +optional
+	Specs []VolumeSpec `json:"specs,omitempty" protobuf:"bytes,2,rep,name=specs"`
+
 	// Status represents the current information/status of a volume
 	Status VolumeStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -81,16 +81,16 @@ type PersistentVolumeSource struct {
 //    Only one of its members may be specified. Currently OpenEBS is the only
 // member. There may be other members in future.
 type VolumeSpec struct {
-  // The context of this volume specification. 
-  // Examples: "controller", "replica". Implicitly inferred to be "replica" 
-  // if unspecified.
-  // +optional
-  Context VolumeContext `json:"context,omitempty" protobuf:"bytes,1,opt,name=context,casttype=VolumeContext"`
+	// The context of this volume specification.
+	// Examples: "controller", "replica". Implicitly inferred to be "replica"
+	// if unspecified.
+	// +optional
+	Context VolumeContext `json:"context,omitempty" protobuf:"bytes,1,opt,name=context,casttype=VolumeContext"`
 
-  // Number of desired replicas. This is a pointer to distinguish between explicit
-  // zero and not specified. Defaults to 1.
-  // +optional
-  Replicas *int32 `json:"replicas,omitempty" protobuf:"varint,1,opt,name=replicas"`
+	// Number of desired replicas. This is a pointer to distinguish between explicit
+	// zero and not specified. Defaults to 1.
+	// +optional
+	Replicas *int32 `json:"replicas,omitempty" protobuf:"varint,1,opt,name=replicas"`
 
 	// Resources represents the actual resources of the volume
 	Capacity ResourceList
@@ -118,13 +118,13 @@ type VolumeSpec struct {
 type VolumeContext string
 
 const (
-  // ReplicaVolumeContext represents a volume w.r.t 
-  // replica context
-  ReplicaVolumeContext VolumeContext = "Replica"
-  
-  // ControllerVolumeContext represents a volume w.r.t 
-  // controller context
-  ControllerVolumeContext VolumeContext = "Controller"
+	// ReplicaVolumeContext represents a volume w.r.t
+	// replica context
+	ReplicaVolumeContext VolumeContext = "Replica"
+
+	// ControllerVolumeContext represents a volume w.r.t
+	// controller context
+	ControllerVolumeContext VolumeContext = "Controller"
 )
 
 // PersistentVolumeReclaimPolicy describes a policy for end-of-life maintenance of persistent volumes
@@ -286,7 +286,7 @@ type Volume struct {
 	ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Specs contains the desired specifications the volume should have.
-  // +optional
+	// +optional
 	Specs []VolumeSpec `json:"specs,omitempty" protobuf:"bytes,2,rep,name=specs"`
 
 	// Status represents the current information/status of a volume

--- a/types/v1/util.go
+++ b/types/v1/util.go
@@ -874,7 +874,6 @@ func DefaultPVPReplicaCount() string {
 	return string(PVPReplicaCountDef)
 }
 
-
 // GetReplicaCount gets the not nil volume replica count
 func GetReplicaCount(spec VolumeSpec) *int32 {
 	val := ReplicaCount(spec)
@@ -902,8 +901,8 @@ func ReplicaCount(spec VolumeSpec) *int32 {
 // DefaultReplicaCount will fetch the coded default value of volume
 // replica count
 func DefaultReplicaCount() *int32 {
-  count, _ := strconv.ParseInt(string(PVPReplicaCountDef), 10, 32)
-  count32 := int32(count)
+	count, _ := strconv.ParseInt(string(PVPReplicaCountDef), 10, 32)
+	count32 := int32(count)
 	return &count32
 }
 

--- a/types/v1/util.go
+++ b/types/v1/util.go
@@ -874,6 +874,39 @@ func DefaultPVPReplicaCount() string {
 	return string(PVPReplicaCountDef)
 }
 
+
+// GetReplicaCount gets the not nil volume replica count
+func GetReplicaCount(spec VolumeSpec) *int32 {
+	val := ReplicaCount(spec)
+	if val == nil {
+		val = DefaultReplicaCount()
+	}
+
+	return val
+}
+
+// ReplicaCount will fetch the value specified against volume replica
+// count if available otherwise will return blank.
+func ReplicaCount(spec VolumeSpec) *int32 {
+	if spec.Replicas != nil {
+		return spec.Replicas
+	}
+
+	// else get from environment variable
+	countStr := OSGetEnv(string(PVPReplicaCountEnvVarKey), nil)
+	count, _ := strconv.ParseInt(countStr, 10, 32)
+	count32 := int32(count)
+	return &count32
+}
+
+// DefaultReplicaCount will fetch the coded default value of volume
+// replica count
+func DefaultReplicaCount() *int32 {
+  count, _ := strconv.ParseInt(string(PVPReplicaCountDef), 10, 32)
+  count32 := int32(count)
+	return &count32
+}
+
 // MakeOrDefJivaReplicaArgs will set the placeholders in jiva replica args with
 // their appropriate runtime values.
 //

--- a/volume/profiles/profiles.go
+++ b/volume/profiles/profiles.go
@@ -311,16 +311,16 @@ func (pp *pvcVolProProfile) StorageSize() (string, error) {
 
 // ReplicaCount get the number of replicas required
 func (pp *pvcVolProProfile) ReplicaCount() (*int32, error) {
-  specs := pp.pvc.Specs
-  
-  for _, spec := range specs {
-    if spec.Context == v1.ReplicaVolumeContext {
-      return v1.GetReplicaCount(spec), nil
-    }
-  }
-  
+	specs := pp.pvc.Specs
+
+	for _, spec := range specs {
+		if spec.Context == v1.ReplicaVolumeContext {
+			return v1.GetReplicaCount(spec), nil
+		}
+	}
+
 	// If you are here, then get from defaults
-  return v1.GetReplicaCount(v1.VolumeSpec{}), nil
+	return v1.GetReplicaCount(v1.VolumeSpec{}), nil
 }
 
 // ControllerIPs gets the IP addresses that needs to be assigned against the

--- a/volume/profiles/profiles.go
+++ b/volume/profiles/profiles.go
@@ -64,7 +64,7 @@ type VolumeProvisionerProfile interface {
 	StorageSize() (string, error)
 
 	// Get the number of replicas
-	ReplicaCount() (int, error)
+	ReplicaCount() (*int32, error)
 
 	// Get the IP addresses that needs to be assigned against the replica(s)
 	ReplicaIPs() ([]string, error)
@@ -310,9 +310,17 @@ func (pp *pvcVolProProfile) StorageSize() (string, error) {
 }
 
 // ReplicaCount get the number of replicas required
-func (pp *pvcVolProProfile) ReplicaCount() (int, error) {
-	// Extract the replica count from pvc
-	return v1.GetPVPReplicaCountInt(pp.pvc.Labels)
+func (pp *pvcVolProProfile) ReplicaCount() (*int32, error) {
+  specs := pp.pvc.Specs
+  
+  for _, spec := range specs {
+    if spec.Context == v1.ReplicaVolumeContext {
+      return v1.GetReplicaCount(spec), nil
+    }
+  }
+  
+	// If you are here, then get from defaults
+  return v1.GetReplicaCount(v1.VolumeSpec{}), nil
 }
 
 // ControllerIPs gets the IP addresses that needs to be assigned against the


### PR DESCRIPTION
1. Why is this change necessary ?

The current volume type makes use of key:value pairs
to determine all its properties. This feature implementation
should move away from using replica count from a generic
k:v pair to a typed property in VolumeSpec. This helps in
ensuring data validation due to typed schema and also paves
the way for representing complex properties in their
corresponding struct (this struct would then be nested inside
VolumeSpec).

Fixes #https://github.com/openebs/openebs/issues/693

2. How does this change address the issue ?

- Implements Replicas as a typed property in VolumeSpec

3. How to verify this change ?

- Details - https://github.com/openebs/openebs/issues/693

4. What side effects does this change have ?

- Earlier way of providing replica count will not work
i.e. below will not work

volumeprovisioner.mapi.openebs.io/replica-count: 1

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
