### PR TITLE
docker and build scripts for agent - #690

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -20,6 +20,7 @@ GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 # Specify the name for the binaries
 MAYACTL=maya
 APISERVER=maya-apiserver
+AGENT=maya-agent
 
 # Specify the date o build
 BUILD_DATE = $(shell date +'%Y%m%d%H%M%S')
@@ -109,7 +110,20 @@ install: bin/maya/${MAYACTL}
 
 # Use this to build only the maya-agent.
 maya-agent:
-	GOOS=linux go build ./cmd/maya-agent
+	@echo "----------------------------"
+	@echo "--> maya-agent              "
+	@echo "----------------------------"
+	@CTLNAME=${AGENT} sh -c "'$(PWD)/buildscripts/agent/build.sh'"
+
+# m-agent image. This is going to be decoupled soon.
+agent-image: maya-agent
+	@echo "----------------------------"
+	@echo "--> m-agent image         "
+	@echo "----------------------------"
+	@cp bin/agent/${AGENT} buildscripts/agent/
+	@cd buildscripts/agent && sudo docker build -t openebs/m-agent:ci --build-arg BUILD_DATE=${BUILD_DATE} .
+	@rm buildscripts/agent/${AGENT}
+	@sh buildscripts/agent/push
 
 # Use this to build only the maya apiserver.
 apiserver:

--- a/buildscripts/agent/Dockerfile
+++ b/buildscripts/agent/Dockerfile
@@ -1,0 +1,33 @@
+#
+# This Dockerfile builds a recent maya agent using the latest binary from
+# maya-agent  releases.
+#
+
+FROM alpine:3.6
+
+# TODO: The following env variables should be auto detected.
+ENV MAYA_AGENT_NETWORK="eth0"
+
+RUN apk add --no-cache \
+    iproute2 \
+    curl \
+    net-tools \
+    mii-tool \
+    procps \
+    libc6-compat
+
+COPY maya-agent /usr/local/bin/
+COPY entrypoint.sh /usr/local/bin/
+
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ARG BUILD_DATE
+LABEL org.label-schema.name="m-agent"
+LABEL org.label-schema.description="OpenEBS Agent"
+LABEL org.label-schema.url="http://www.openebs.io/"
+LABEL org.label-schema.vcs-url="https://github.com/openebs/maya"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=$BUILD_DATE
+
+ENTRYPOINT entrypoint.sh "${MAYA_AGENT_NETWORK}"
+EXPOSE 7676

--- a/buildscripts/agent/build.sh
+++ b/buildscripts/agent/build.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# This script builds the application from source for multiple platforms.
+set -e
+
+# Get the parent directory of where this script is.
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
+DIR="$( cd -P "$( dirname "$SOURCE" )/../.." && pwd )"
+
+# Change into that directory
+cd "$DIR"
+
+# Get the git commit
+GIT_COMMIT="$(git rev-parse HEAD)"
+GIT_DIRTY="$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)"
+
+# Determine the arch/os combos we're building for
+XC_ARCH=${XC_ARCH:-"386 amd64"}
+XC_OS=${XC_OS:-"linux"}
+
+XC_ARCHS=(${XC_ARCH// / })
+XC_OSS=(${XC_OS// / })
+
+# Delete the old contents
+echo "==> Removing old bin/agent contents..."
+rm -rf bin/agent/*
+mkdir -p bin/agent/
+
+# Fetch the tags before using git rev-list --tags
+git fetch --tags >/dev/null 2>&1
+GIT_TAG="$(git describe --tags $(git rev-list --tags --max-count=1))"
+
+if [ -z "${GIT_TAG}" ];
+then
+    GIT_TAG="0.0.1"
+fi
+
+if [ -z "${CTLNAME}" ];
+then
+    CTLNAME="agent"
+fi
+
+# If its dev mode, only build for ourself
+if [[ "${M_AGENT_DEV}" ]]; then
+    XC_OS=$(go env GOOS)
+    XC_ARCH=$(go env GOARCH)
+fi
+
+# Build!
+echo "==> Building ${CTLNAME} ..."
+
+for GOOS in "${XC_OSS[@]}"
+do
+    for GOARCH in "${XC_ARCHS[@]}"
+    do
+        output_name="bin/agent/"$GOOS"_"$GOARCH"/"$CTLNAME
+
+        if [ $GOOS = "windows" ]; then
+            output_name+='.exe'
+        fi
+        env GOOS=$GOOS GOARCH=$GOARCH go build -ldflags \
+           "-X main.GitCommit='${GIT_COMMIT}${GIT_DIRTY}' \
+            -X main.CtlName='${CTLNAME}' \
+            -X main.Version='${GIT_TAG}'"\
+            -o $output_name\
+           ./cmd/maya-agent
+
+    done
+done
+
+echo ""
+
+# Move all the compiled things to the $GOPATH/bin
+GOPATH=${GOPATH:-$(go env GOPATH)}
+case $(uname) in
+    CYGWIN*)
+        GOPATH="$(cygpath $GOPATH)"
+        ;;
+esac
+OLDIFS=$IFS
+IFS=: MAIN_GOPATH=($GOPATH)
+IFS=$OLDIFS
+
+# Create the gopath bin if not already available
+mkdir -p ${MAIN_GOPATH}/bin/
+
+# Copy our OS/Arch to ${MAIN_GOPATH}/bin/ directory
+DEV_PLATFORM="./bin/agent/$(go env GOOS)_$(go env GOARCH)"
+for F in $(find ${DEV_PLATFORM} -mindepth 1 -maxdepth 1 -type f); do
+    cp ${F} bin/agent/
+    cp ${F} ${MAIN_GOPATH}/bin/
+done
+
+if [[ "x${M_AGENT_DEV}" == "x" ]]; then
+    # Zip and copy to the dist dir
+    echo "==> Packaging..."
+    for PLATFORM in $(find ./bin/agent -mindepth 1 -maxdepth 1 -type d); do
+        OSARCH=$(basename ${PLATFORM})
+        echo "--> ${OSARCH}"
+
+        pushd $PLATFORM >/dev/null 2>&1
+        zip ../${CTLNAME}-${OSARCH}.zip ./*
+        popd >/dev/null 2>&1
+    done
+fi
+
+# Done!
+echo
+echo "==> Results:"
+ls -hl bin/agent/

--- a/buildscripts/agent/entrypoint.sh
+++ b/buildscripts/agent/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -ex
+
+MAYA_AGENT_NETWORK=$1
+
+CONTAINER_IP_ADDR=$(ip -4 addr show scope global dev "${MAYA_AGENT_NETWORK}" | grep inet | awk '{print $2}' | cut -d / -f 1)
+
+# Start agent service
+exec /usr/local/bin/maya-agent up -bind="${CONTAINER_IP_ADDR}" 1>&2

--- a/buildscripts/agent/push
+++ b/buildscripts/agent/push
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+IMAGEID=$( sudo docker images -q openebs/m-agent:ci )
+
+if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
+then 
+  sudo docker login -u "${DNAME}" -p "${DPASS}";
+  # Push image to docker hub
+  sudo docker push openebs/m-agent:ci ;
+  if [ ! -z "${TRAVIS_TAG}" ] ; 
+  then
+    # Push with different tags if tagged as a release
+    # When github is tagged with a release, then Travis will 
+    # set the release tag in env TRAVIS_TAG
+    sudo docker tag ${IMAGEID} openebs/m-agent:${TRAVIS_TAG}
+    sudo docker push openebs/m-agent:${TRAVIS_TAG}; 
+    sudo docker tag ${IMAGEID} openebs/m-agent:latest
+    sudo docker push openebs/m-agent:latest; 
+  fi;
+else
+  echo "No docker credentials provided. Skip uploading openebs/m-agent:ci to docker hub"; 
+fi;


### PR DESCRIPTION
This PR adds the initial version of the build and docker files for maya-agent.

Fixes https://github.com/openebs/openebs/issues/690

**Special notes for your reviewer**: 
The build scripts are similar to maya-apiserver. Which also makes a case for merging all the build scripts together, which can be taken up in the future as part of : https://github.com/openebs/openebs/issues/499
