### PR TITLE
Add maya-agent build command to makefile make all #132

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,7 +25,7 @@ AGENT=maya-agent
 # Specify the date o build
 BUILD_DATE = $(shell date +'%Y%m%d%H%M%S')
 
-all: test mayactl apiserver
+all: test mayactl apiserver maya-agent
 
 dev: format
 	@MAYACTL=${MAYACTL} MAYA_DEV=1 sh -c "'$(PWD)/buildscripts/mayactl/build.sh'"


### PR DESCRIPTION
1. Why is this change necessary ?
 maya-agent binary needs to be build when make all is given.

2. How does this change address the issue ?
 The change adds maya-agent to 'all' tag of GNUmakefile

3. How to verify this change ?
 make all command should be given to see maya-agent binary in bin directory

Signed-off-by: gkGaneshR <gkganesh126@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** 
 fixes #

**Special notes for your reviewer**:
