### PR TITLE
add K8s based StorageClass operations

### DIFF
--- a/cmd/maya-apiserver/app/server/volume_endpoint.go
+++ b/cmd/maya-apiserver/app/server/volume_endpoint.go
@@ -58,17 +58,17 @@ func (s *HTTPServer) vsmList(resp http.ResponseWriter, req *http.Request) (inter
 
 	fmt.Println("[DEBUG] Processing Volume list request")
 
-	// Create a PVC
-	pvc := &v1.Volume{}
+	// Create a Volume
+	vol := &v1.Volume{}
 
 	// Get the persistent volume provisioner instance
-	pvp, err := provisioners.GetVolumeProvisioner(pvc.Labels)
+	pvp, err := provisioners.GetVolumeProvisioner(vol.Labels)
 	if err != nil {
 		return nil, err
 	}
 
 	// Set the volume provisioner profile to provisioner
-	_, err = pvp.Profile(pvc)
+	_, err = pvp.Profile(vol)
 	if err != nil {
 		return nil, err
 	}
@@ -101,18 +101,18 @@ func (s *HTTPServer) vsmRead(resp http.ResponseWriter, req *http.Request, vsmNam
 		return nil, CodedError(400, fmt.Sprintf("Volume name is missing"))
 	}
 
-	// Create a PVC
-	pvc := &v1.Volume{}
-	pvc.Name = vsmName
+	// Create a Volume
+	vol := &v1.Volume{}
+	vol.Name = vsmName
 
 	// Get persistent volume provisioner instance
-	pvp, err := provisioners.GetVolumeProvisioner(pvc.Labels)
+	pvp, err := provisioners.GetVolumeProvisioner(vol.Labels)
 	if err != nil {
 		return nil, err
 	}
 
 	// Set the volume provisioner profile to provisioner
-	_, err = pvp.Profile(pvc)
+	_, err = pvp.Profile(vol)
 	if err != nil {
 		return nil, err
 	}
@@ -123,8 +123,8 @@ func (s *HTTPServer) vsmRead(resp http.ResponseWriter, req *http.Request, vsmNam
 	}
 
 	// TODO
-	// pvc should not be passed again !!
-	details, err := reader.Read(pvc)
+	// vol should not be passed again !!
+	details, err := reader.Read(vol)
 	if err != nil {
 		return nil, err
 	}
@@ -147,18 +147,18 @@ func (s *HTTPServer) vsmDelete(resp http.ResponseWriter, req *http.Request, vsmN
 		return nil, CodedError(400, fmt.Sprintf("Volume name is missing"))
 	}
 
-	// Create a PVC
-	pvc := &v1.Volume{}
-	pvc.Name = vsmName
+	// Create a Volume
+	vol := &v1.Volume{}
+	vol.Name = vsmName
 
 	// Get the persistent volume provisioner instance
-	pvp, err := provisioners.GetVolumeProvisioner(pvc.Labels)
+	pvp, err := provisioners.GetVolumeProvisioner(vol.Labels)
 	if err != nil {
 		return nil, err
 	}
 
-	// Set the volume provisioner profile to provisioner
-	_, err = pvp.Profile(pvc)
+	// Set the volume provisioner profile
+	_, err = pvp.Profile(vol)
 	if err != nil {
 		return nil, err
 	}
@@ -192,26 +192,26 @@ func (s *HTTPServer) vsmAdd(resp http.ResponseWriter, req *http.Request) (interf
 
 	fmt.Println("[DEBUG] Processing Volume add request")
 
-	pvc := v1.Volume{}
+	vol := v1.Volume{}
 
-	// The yaml/json spec is decoded to pvc struct
-	if err := decodeBody(req, &pvc); err != nil {
+	// The yaml/json spec is decoded to vol struct
+	if err := decodeBody(req, &vol); err != nil {
 		return nil, CodedError(400, err.Error())
 	}
 
 	// Name is expected to be available even in the minimalist specs
-	if pvc.Name == "" {
-		return nil, CodedError(400, fmt.Sprintf("Volume name missing in '%v'", pvc))
+	if vol.Name == "" {
+		return nil, CodedError(400, fmt.Sprintf("Volume name missing in '%v'", vol))
 	}
 
 	// Get persistent volume provisioner instance
-	pvp, err := provisioners.GetVolumeProvisioner(pvc.Labels)
+	pvp, err := provisioners.GetVolumeProvisioner(vol.Labels)
 	if err != nil {
 		return nil, err
 	}
 
 	// Set the volume provisioner profile to provisioner
-	_, err = pvp.Profile(&pvc)
+	_, err = pvp.Profile(&vol)
 	if err != nil {
 		return nil, err
 	}
@@ -222,13 +222,13 @@ func (s *HTTPServer) vsmAdd(resp http.ResponseWriter, req *http.Request) (interf
 	}
 
 	// TODO
-	// pvc should not be passed again !!
-	details, err := adder.Add(&pvc)
+	// vol should not be passed again !!
+	details, err := adder.Add(&vol)
 	if err != nil {
 		return nil, err
 	}
 
-	fmt.Println("[DEBUG] Processed Volume add request successfully for '" + pvc.Name + "'")
+	fmt.Println("[DEBUG] Processed Volume add request successfully for '" + vol.Name + "'")
 
 	return details, nil
 }

--- a/orchprovider/k8s/v1/k8s.go
+++ b/orchprovider/k8s/v1/k8s.go
@@ -11,10 +11,9 @@ import (
 	"github.com/openebs/maya/orchprovider"
 	"github.com/openebs/maya/types/v1"
 	volProfile "github.com/openebs/maya/volume/profiles"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sCoreV1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	k8sExtnsV1Beta1 "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
-	//k8sUnversioned "k8s.io/client-go/pkg/api/unversioned"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sApiV1 "k8s.io/client-go/pkg/api/v1"
 	k8sApisExtnsBeta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
@@ -36,42 +35,6 @@ type k8sOrchestrator struct {
 	// NOTE:
 	//    This will be set at runtime.
 	k8sUtlGtr K8sUtilGetter
-
-	// rCount is the number of replica counts
-	//rCount int
-
-	// vsm is the name of the openebs volume
-	//vsm string
-
-	// rImg is the replica image
-	//rImg string
-
-	// persistPath is the persistent path i.e. storage backend of the openebs volume
-	//persistPath string
-
-	// pvc is an instance of persistent volume claim which is provided during
-	// openebs volume operations
-	//pvc *v1.PersistentVolumeClaim
-
-	// k8sClient is an instance of K8sClient that exposes Kubernetes based
-	// operations
-	//k8sClient K8sClient
-
-	// dOps is an instance capable of performing Kubernetes related Deployment
-	// operations
-	//dOps k8sExtnsV1Beta1.DeploymentInterface
-
-	// nodeSelKeysByName contains a mapping of replica identifier & respective
-	// node selector key
-	//nodeSelKeysByName map[string]string
-
-	// nodeSelOpsByName contains a mapping of replica identifier & respective
-	// node selector operator
-	//nodeSelOpsByName map[string]string
-
-	// nodeSelValuesByName contains a mapping of replica identifier & respective
-	// node selector value
-	//nodeSelValuesByName map[string]string
 }
 
 // NewK8sOrchestrator provides a new instance of K8sOrchestrator.
@@ -118,175 +81,6 @@ func (k *k8sOrchestrator) Name() string {
 func (k *k8sOrchestrator) Region() string {
 	return ""
 }
-
-//
-//func (k *k8sOrchestrator) getReplicaCount(volProfile volProfile.VolumeProvisionerProfile) (int, error) {
-// is already set ?
-//	if k.rCount != 0 {
-//		return k.rCount, nil
-//	}
-// else extract it
-//	rCount, err := volProfile.ReplicaCount()
-//	if err != nil {
-//		return 0, err
-//	}
-// set it so that it can be used later as well
-//k.rCount = rCount
-//return k.rCount, nil
-//}
-
-//
-//func (k *k8sOrchestrator) getVSM(volProfile volProfile.VolumeProvisionerProfile) (string, error) {
-// is already set ?
-//if k.vsm != "" {
-//	return k.vsm, nil
-//}
-// else extract it
-//vsm, err := volProfile.VSMName()
-//if err != nil {
-//	return "", err
-//}
-// set it so that it can be used later as well
-//k.vsm = vsm
-//return k.vsm, nil
-//}
-
-//
-//func (k *k8sOrchestrator) getReplicaImg(volProfile volProfile.VolumeProvisionerProfile) (string, error) {
-// is already set ?
-//if k.rImg != "" {
-//	return k.rImg, nil
-//}
-// else extract it
-//rImg, err := volProfile.ReplicaImage()
-//if err != nil {
-//	return "", err
-//}
-// set it so that it can be used later as well
-//k.rImg = rImg
-//return k.rImg, nil
-//}
-
-//
-//func (k *k8sOrchestrator) getPersistPath(volProfile volProfile.VolumeProvisionerProfile) (string, error) {
-// is already set ?
-//if k.persistPath != "" {
-//	return k.persistPath, nil
-//}
-// else extract it
-//persistPath, err := volProfile.PersistentPath()
-//if err != nil {
-//	return "", err
-//}
-// set it so that it can be used later as well
-//k.persistPath = persistPath
-//return k.persistPath, nil
-//}
-
-//
-//func (k *k8sOrchestrator) getPVC(volProfile volProfile.VolumeProvisionerProfile) (*v1.PersistentVolumeClaim, error) {
-// is already set ?
-//if k.pvc != nil {
-//	return k.pvc, nil
-//}
-// else extract it
-//pvc, err := volProfile.PVC()
-//if err != nil {
-//	return nil, err
-//}
-// set it so that it can be used later as well
-//k.pvc = pvc
-//return k.pvc, nil
-//}
-
-//
-//func (k *k8sOrchestrator) getK8sClient(volProfile volProfile.VolumeProvisionerProfile) (K8sClient, error) {
-// is already set ?
-//if k.k8sClient != nil {
-//	return k.k8sClient, nil
-//}
-// else extract it
-//k8sUtl := k8sOrchUtil(k, volProfile)
-//k8sClient, supported := k8sUtl.K8sClient()
-//if !supported {
-//	return nil, fmt.Errorf("K8s client not supported by '%s'", k8sUtl.Name())
-//}
-// set it so that it can be used later as well
-//k.k8sClient = k8sClient
-//return k.k8sClient, nil
-//}
-
-//
-//func (k *k8sOrchestrator) getDeploymentOps(volProfile volProfile.VolumeProvisionerProfile) (k8sExtnsV1Beta1.DeploymentInterface, error) {
-// is already set ?
-//if k.dOps != nil {
-//	return k.dOps, nil
-//}
-// else extract it
-//kc, err := k.getK8sClient(volProfile)
-//if err != nil {
-//	return nil, err
-//}
-// fetch k8s deployment operations
-//dOps, err := kc.DeploymentOps()
-//if err != nil {
-//	return nil, err
-//}
-// set it so that it can be used later as well
-//k.dOps = dOps
-//return k.dOps, nil
-//}
-
-// getNodeSelectorKey gets the key to select a node for replica placement.
-// repIdentifier can be the replica pod name or a user provided replica pod
-// identifier to associate the node selector key with its corresponding node
-// selector value.
-//func (k *k8sOrchestrator) getNodeSelectorKey(repIdentifier string, volProfile volProfile.VolumeProvisionerProfile) (string, error) {
-// is already set ?
-//if k.nodeSelKeysByName != nil && k.nodeSelKeysByName[repIdentifier] != "" {
-//	return k.nodeSelKeysByName[repIdentifier], nil
-//}
-// else extract it
-//nodeSelKey := volProfile.NodeSelectorKey(repIdentifier)
-
-// set it (blank value is valid as well) so that it can be used later as well
-//k.nodeSelKeysByName[repIdentifier] = nodeSelKey
-//return k.nodeSelKeysByName[repIdentifier], nil
-//}
-
-// getNodeSelectorOp gets the operator to select a node for replica placement.
-// repIdentifier can be the replica pod name or a user provided replica pod
-// identifier to associate the node selector operator with its corresponding node
-// selector key & node selector value.
-//func (k *k8sOrchestrator) getNodeSelectorOp(repIdentifier string, volProfile volProfile.VolumeProvisionerProfile) (string, error) {
-// is already set ?
-//if k.nodeSelOpsByName != nil && k.nodeSelOpsByName[repIdentifier] != "" {
-//	return k.nodeSelOpsByName[repIdentifier], nil
-//}
-// else extract it
-//nodeSelOp := volProfile.NodeSelectorOp(repIdentifier)
-
-// set it (blank value is valid as well) so that it can be used later as well
-//k.nodeSelOpsByName[repIdentifier] = nodeSelOp
-//return k.nodeSelOpsByName[repIdentifier], nil
-//}
-
-// getNodeSelectorValues gets the value(s) to select a node for replica placement.
-// repIdentifier can be the replica pod name or a user provided replica pod
-// identifier to associate the node selector value with its corresponding node
-// selector key.
-//func (k *k8sOrchestrator) getNodeSelectorValues(repName string, volProfile volProfile.VolumeProvisionerProfile) (string, error) {
-// is already set ?
-//if k.nodeSelValuesByName != nil && k.nodeSelValuesByName[repName] != "" {
-//	return k.nodeSelValuesByName[repName], nil
-//}
-// else extract it
-//nodeSelVal := volProfile.NodeSelectorValue(repName)
-
-// set it (blank value is valid as well) so that it can be used later as well
-//k.nodeSelValuesByName[repName] = nodeSelVal
-//return k.nodeSelValuesByName[repName], nil
-//}
 
 // TODO
 // Check if StorageOps() can do these stuff in a better way. This method &
@@ -921,16 +715,7 @@ func (k *k8sOrchestrator) createReplicaDeployment(volProProfile volProfile.Volum
 		return nil, err
 	}
 
-	//pCount, err := volProProfile.PersistentPathCount()
-	//if err != nil {
-	//	return nil, err
-	//}
-
-	//if pCount != rCount {
-	//	return nil, fmt.Errorf("VSM '%s' replica count '%d' does not match persistent path count '%d'", vsm, rCount, pCount)
-	//}
-
-	pvc, err := volProProfile.PVC()
+	vol, err := volProProfile.Volume()
 	if err != nil {
 		return nil, err
 	}
@@ -1036,7 +821,7 @@ func (k *k8sOrchestrator) createReplicaDeployment(volProProfile volProfile.Volum
 									// Considering above scenarios, it might make more sense to have
 									// separate K8s Deployment for each replica. However,
 									// there are dis-advantages in diverging from K8s replica set.
-									TopologyKey: v1.GetPVPReplicaTopologyKey(pvc.Labels),
+									TopologyKey: v1.GetPVPReplicaTopologyKey(vol.Labels),
 								},
 							},
 						},
@@ -1048,7 +833,7 @@ func (k *k8sOrchestrator) createReplicaDeployment(volProProfile volProfile.Volum
 							Name:    vsm + string(v1.ReplicaSuffix) + string(v1.ContainerSuffix),
 							Image:   rImg,
 							Command: v1.JivaReplicaCmd,
-							Args:    v1.MakeOrDefJivaReplicaArgs(pvc.Labels, clusterIP),
+							Args:    v1.MakeOrDefJivaReplicaArgs(vol.Labels, clusterIP),
 							Ports: []k8sApiV1.ContainerPort{
 								k8sApiV1.ContainerPort{
 									ContainerPort: v1.DefaultJivaReplicaPort1(),

--- a/orchprovider/k8s/v1/util.go
+++ b/orchprovider/k8s/v1/util.go
@@ -277,14 +277,14 @@ func (k *k8sUtil) getClientSet() (*kubernetes.Clientset, error) {
 	// Get if already available in current instance
 	// NOTE: A new instance of k8sUtil is created per http request
 	if k.inCS != nil {
-		return cs, nil
+		return k.inCS, nil
 	}
 
-	if cs == nil && k.outCS != nil {
-		return cs, nil
+	if k.outCS != nil {
+		return k.outCS, nil
 	}
 
-	// Get it fresh for this instance/http request
+	// Else get it fresh for this instance/http request
 	inC, err := k.IsInCluster()
 	if err != nil {
 		return nil, err
@@ -293,9 +293,11 @@ func (k *k8sUtil) getClientSet() (*kubernetes.Clientset, error) {
 	// set based on in-cluster or out-of-cluster
 	if inC {
 		cs, err = k.getInClusterCS()
+		// set it for future retrievals in same http request
 		k.inCS = cs
 	} else {
 		cs, err = k.getOutClusterCS()
+		// set it for future retrievals in same http request
 		k.outCS = cs
 	}
 

--- a/orchprovider/k8s/v1/util_test.go
+++ b/orchprovider/k8s/v1/util_test.go
@@ -43,7 +43,7 @@ func TestK8sUtil(t *testing.T) {
 
 	for i, c := range cases {
 
-		incActual, err := k8sUtl.InCluster()
+		incActual, err := k8sUtl.IsInCluster()
 		if err != nil {
 			t.Errorf("TestCase: '%d' ExpectedInClusterErr: 'nil' ActualInClusterErr: '%s'", i, err.Error())
 		}

--- a/orchprovider/nomad/v1/nomad_plug.go
+++ b/orchprovider/nomad/v1/nomad_plug.go
@@ -104,17 +104,17 @@ func (n *NomadOrchestrator) StorageOps() (orchprovider.StorageOps, bool) {
 
 // ReadStorage will fetch information about the persistent volume
 func (n *NomadOrchestrator) ReadStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.Volume, error) {
-	pvc, err := volProProfile.PVC()
+	vol, err := volProProfile.Volume()
 	if err != nil {
 		return nil, err
 	}
 
-	jobName, err := PvcToJobName(pvc)
+	jobName, err := VolToJobName(vol)
 	if err != nil {
 		return nil, err
 	}
 
-	job, err := n.nStorApis.StorageInfo(jobName, pvc.Labels)
+	job, err := n.nStorApis.StorageInfo(jobName, vol.Labels)
 	if err != nil {
 		return nil, err
 	}
@@ -130,17 +130,17 @@ func (n *NomadOrchestrator) AddStorage(volProProfile volProfile.VolumeProvisione
 	// Move this entire logic to a separate package that will couple jiva
 	// provisioner with nomad orchestrator
 
-	pvc, err := volProProfile.PVC()
+	vol, err := volProProfile.Volume()
 	if err != nil {
 		return nil, err
 	}
 
-	job, err := PvcToJob(pvc)
+	job, err := VolToJob(vol)
 	if err != nil {
 		return nil, err
 	}
 
-	eval, err := n.nStorApis.CreateStorage(job, pvc.Labels)
+	eval, err := n.nStorApis.CreateStorage(job, vol.Labels)
 	if err != nil {
 		return nil, err
 	}
@@ -152,23 +152,23 @@ func (n *NomadOrchestrator) AddStorage(volProProfile volProfile.VolumeProvisione
 
 // DeleteStorage will remove the VSM.
 func (n *NomadOrchestrator) DeleteStorage(volProProfile volProfile.VolumeProvisionerProfile) (bool, error) {
-	pvc, err := volProProfile.PVC()
+	vol, err := volProProfile.Volume()
 	if err != nil {
 		return false, err
 	}
 
-	job, err := MakeJob(pvc.Name)
+	job, err := MakeJob(vol.Name)
 	if err != nil {
 		return false, err
 	}
 
-	eval, err := n.nStorApis.DeleteStorage(job, pvc.Labels)
+	eval, err := n.nStorApis.DeleteStorage(job, vol.Labels)
 
 	if err != nil {
 		return false, err
 	}
 
-	glog.Infof("Volume '%s' was placed for removal with eval '%v'", pvc.Name, eval)
+	glog.Infof("Volume '%s' was placed for removal with eval '%v'", vol.Name, eval)
 
 	_, err = JobEvalToPv(*job.Name, eval)
 

--- a/types/v1/labels.go
+++ b/types/v1/labels.go
@@ -317,6 +317,15 @@ const (
 	// NOTE:
 	//  PVPNodeAffinityExpressionsLbl is used here as value is a part of the expressions
 	//PVPNodeSelectorValueLbl VolumeProvisionerProfileLabel = PVPNodeAffinityExpressionsLbl
+
+	// PVPSCNameLbl is the key used to specify the name of storage class. This
+	// applies when OpenEBS volume is orchestrated by Maya using Kubernetes.
+	PVPSCNameLbl VolumeProvisionerProfileLabel = "sc/name"
+
+	// PVPSCNamespaceLbl is the key used to specify the namespace of storage
+	// class. This applies when OpenEBS volume is orchestrated by Maya using
+	// Kubernetes.
+	//PVPSCNamespaceLbl VolumeProvisionerProfileLabel = "sc/namespace"
 )
 
 // Deprecate
@@ -436,9 +445,8 @@ const (
 type VolumeProvisionerProfileRegistry string
 
 const (
-	// This is the name of PVC as persistent volume provisioner profile
-	// This is used for labelling PVC as a persistent volume provisioner profile
-	PVCProvisionerProfile VolumeProvisionerProfileRegistry = "pvc"
+	// This is the name of volume provisioner profile
+	VolumeProvisionerProfile VolumeProvisionerProfileRegistry = "vol"
 )
 
 type GenericAnnotations string

--- a/volume/provisioners/jiva/jiva.go
+++ b/volume/provisioners/jiva/jiva.go
@@ -85,11 +85,11 @@ func (j *jivaStor) Name() string {
 // volume provisioner.
 //
 // NOTE:
-//    This method is expected to be invoked when pvc is available. In other
+//    This method is expected to be invoked when vol is available. In other
 // words this is lazily invoked after the creation of jivaStor.
-func (j *jivaStor) Profile(pvc *v1.Volume) (bool, error) {
+func (j *jivaStor) Profile(vol *v1.Volume) (bool, error) {
 	// Get the persistent volume provisioner profile
-	vProfl, err := volProfile.GetVolProProfileByPVC(pvc)
+	vProfl, err := volProfile.GetVolProProfile(vol)
 	if err != nil {
 		return true, err
 	}
@@ -188,7 +188,7 @@ func (j *jivaStor) List() (*v1.VolumeList, error) {
 }
 
 // TODO
-// pvc need not be passed at all as it should have been set via Profile()
+// vol need not be passed at all as it should have been set via Profile()
 //
 // Read provides information about a jiva persistent volume
 //
@@ -198,7 +198,7 @@ func (j *jivaStor) List() (*v1.VolumeList, error) {
 //
 // NOTE:
 //    This is a concrete implementation of volume.Informer interface
-func (j *jivaStor) Read(pvc *v1.Volume) (*v1.Volume, error) {
+func (j *jivaStor) Read(vol *v1.Volume) (*v1.Volume, error) {
 	// TODO
 	// Move the validations to j.Reader()
 
@@ -208,11 +208,11 @@ func (j *jivaStor) Read(pvc *v1.Volume) (*v1.Volume, error) {
 		return nil, fmt.Errorf("Storage operations not supported in '%s:%s' '%s'", j.Label(), j.Name(), j.jivaProUtil.Name())
 	}
 
-	return storOps.ReadStorage(pvc)
+	return storOps.ReadStorage(vol)
 }
 
 // TODO
-// pvc need not be passed at all as it should have been set via Profile()
+// vol need not be passed at all as it should have been set via Profile()
 //
 // Add creates a new jiva persistent volume
 //
@@ -222,7 +222,7 @@ func (j *jivaStor) Read(pvc *v1.Volume) (*v1.Volume, error) {
 //
 // NOTE:
 //    This is a concrete implementation of volume.Adder interface
-func (j *jivaStor) Add(pvc *v1.Volume) (*v1.Volume, error) {
+func (j *jivaStor) Add(vol *v1.Volume) (*v1.Volume, error) {
 	// TODO
 	// Move the validations to j.Adder()
 
@@ -232,7 +232,7 @@ func (j *jivaStor) Add(pvc *v1.Volume) (*v1.Volume, error) {
 		return nil, fmt.Errorf("Storage operations not supported in '%s:%s' '%s'", j.Label(), j.Name(), j.jivaProUtil.Name())
 	}
 
-	return storOps.AddStorage(pvc)
+	return storOps.AddStorage(vol)
 }
 
 // Remove removes a jiva volume


### PR DESCRIPTION
1. Why is this change necessary ?

This is a part of bigger scheme of things namely
openebs/openebs#693, openebs/openebs#694 and
openebs/openebs#409

This particular implementation does a partial
fix of openebs/openebs#694

2. How does this change address the issue ?

- Updates k8s/v1/util.go to include StorageClass
related operations

- Renames pvc to volume

- Cleans up k8s/v1/k8s.go

3. How to verify this change ?

- make should work fine

- The actual verfication will be part of
bigger changes mentioned in above issues.

4. What side effects does this change have ?

- None

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
