### PR TITLE
maya-agent iscsi and makefile images #740

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,7 +25,7 @@ AGENT=maya-agent
 # Specify the date o build
 BUILD_DATE = $(shell date +'%Y%m%d%H%M%S')
 
-all: test mayactl apiserver maya-agent
+all: test mayactl apiserver-image agent-image
 
 dev: format
 	@MAYACTL=${MAYACTL} MAYA_DEV=1 sh -c "'$(PWD)/buildscripts/mayactl/build.sh'"

--- a/buildscripts/agent/Dockerfile
+++ b/buildscripts/agent/Dockerfile
@@ -3,18 +3,17 @@
 # maya-agent  releases.
 #
 
-FROM alpine:3.6
+FROM ubuntu:16.04
 
 # TODO: The following env variables should be auto detected.
 ENV MAYA_AGENT_NETWORK="eth0"
 
-RUN apk add --no-cache \
+RUN apt-get update && apt-get install -y \
     iproute2 \
     curl \
-    net-tools \
-    mii-tool \
+    net-tools \   
     procps \
-    libc6-compat
+    open-iscsi
 
 COPY maya-agent /usr/local/bin/
 COPY entrypoint.sh /usr/local/bin/


### PR DESCRIPTION
1. Why is this change necessary ?
 The change is necessary for maya-agent to be connected with iscsi-targets.The os is changed from alpine to ubuntu to avoid certain file running errors on using iscsi. The make all command of makefile will test, build and push images of apiserver and maya-agent. 

2. How does this change address the issue ?
 The dockerfile's run field is added with open-iscsi. GNUmakefile is modified to test, build and push images of apiserver and maya-agent on 'all' field.

3. How to verify this change ?
 For maya-agent,  docker build -f Dockerfile
 For makefile, make-all

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
