### PR TITLE
Fix maya-apiserver entrypint for container image

### DIFF
--- a/buildscripts/apiserver/entrypoint.sh
+++ b/buildscripts/apiserver/entrypoint.sh
@@ -7,4 +7,4 @@ MAYA_API_SERVER_NETWORK=$1
 CONTAINER_IP_ADDR=$(ip -4 addr show scope global dev "${MAYA_API_SERVER_NETWORK}" | grep inet | awk '{print $2}' | cut -d / -f 1)
 
 # Start apiserver service
-exec /usr/local/bin/maya-apiserver start -bind="${CONTAINER_IP_ADDR}" 1>&2
+exec /usr/local/bin/maya-apiserver start --bind="${CONTAINER_IP_ADDR}" 1>&2


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit will fix mapiserver start flag which is changes to  --bind
from -bind with latest changes in maya-apiserver.

**Which issue this PR fixes** fixes openebs/openebs#748