### PR TITLE
Pass the stdout for logging the messages

### DIFF
--- a/cmd/maya-apiserver/app/command/start.go
+++ b/cmd/maya-apiserver/app/command/start.go
@@ -231,7 +231,7 @@ func (c *CmdStartOptions) setupMayaServer(mconfig *config.MayaConfig) error {
 	glog.Info("Starting maya api server ...")
 
 	// Setup maya service i.e. maya api server
-	maya, err := server.NewMayaApiServer(mconfig, nil)
+	maya, err := server.NewMayaApiServer(mconfig, os.Stdout)
 	if err != nil {
 		glog.Errorf("Error starting maya api server: %s", err)
 		return err
@@ -240,7 +240,7 @@ func (c *CmdStartOptions) setupMayaServer(mconfig *config.MayaConfig) error {
 	c.maya = maya
 
 	// Setup the HTTP server
-	http, err := server.NewHTTPServer(maya, mconfig, nil)
+	http, err := server.NewHTTPServer(maya, mconfig, os.Stdout)
 	if err != nil {
 		maya.Shutdown()
 		glog.Errorf("Error starting http server: %s", err)


### PR DESCRIPTION
Fix https://github.com/openebs/openebs/issues/789

As part of the cleanup to move to glog, the logOutput
was set to nil. This was crashing the maya-apiserver when
logs were being flushed. 

