### PR TITLE
Fixing golint issues on types/v1/quantity.go.

### DIFF
--- a/types/v1/quantity.go
+++ b/types/v1/quantity.go
@@ -120,6 +120,7 @@ type CanonicalValue interface {
 // Format lists the three possible formattings of a quantity.
 type Format string
 
+// The possible quantity formattings.
 const (
 	DecimalExponent = Format("DecimalExponent") // e.g., 12e6
 	BinarySI        = Format("BinarySI")        // e.g., 12Mi (12 * 2^20)
@@ -142,11 +143,11 @@ const (
 	splitREString = "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
 )
 
-var (
-	// splitRE is used to get the various parts of a number.
-	splitRE = regexp.MustCompile(splitREString)
+// splitRE is used to get the various parts of a number.
+var splitRE = regexp.MustCompile(splitREString)
 
-	// Errors that could happen while parsing a string.
+// Errors that could happen while parsing a string.
+var (
 	ErrFormatWrong = errors.New("quantities must match the regular expression '" + splitREString + "'")
 	ErrNumeric     = errors.New("unable to parse numeric part of quantity")
 	ErrSuffix      = errors.New("unable to parse quantity's suffix")
@@ -497,7 +498,7 @@ func (q *Quantity) Sign() int {
 	return q.i.Sign()
 }
 
-// AsScaled returns the current value, rounded up to the provided scale, and returns
+// AsScale returns the current value, rounded up to the provided scale, and returns
 // false if the scale resulted in a loss of precision.
 func (q *Quantity) AsScale(scale Scale) (CanonicalValue, bool) {
 	if q.d.Dec != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Fixes `golint` issues for `types/v1/quantity.go`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes openebs/openebs#757

**Special notes for your reviewer**:
The open issues asks to resolve 

```
Line 16: warning: package comment should be of the form "Package v1 ..." (golint)
```

but I'm not too sure how to proceed. It looks like most of the files in that package have a similar `// This is extracted from ...` type comment. Should we leave this as is? Extract this into a `docs.go`? Change the comment specifically on `quantity.go`?