### PR TITLE
 Enhance Maya-apiserver to support snapshot API

### DIFF
--- a/cmd/maya-apiserver/app/server/http.go
+++ b/cmd/maya-apiserver/app/server/http.go
@@ -6,11 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	//	"github.com/NYTimes/gziphandler"
-	"github.com/ghodss/yaml"
-	"github.com/openebs/maya/cmd/maya-apiserver/app/config"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/ugorji/go/codec"
 	"io"
 	"io/ioutil"
 	"log"
@@ -19,6 +14,12 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/ghodss/yaml"
+	"github.com/openebs/maya/cmd/maya-apiserver/app/config"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/ugorji/go/codec"
 )
 
 const (
@@ -213,6 +214,9 @@ func (s *HTTPServer) registerHandlers(serviceProvider string, enableDebug bool) 
 	// Request w.r.t to a single VSM entity is handled here
 	s.mux.HandleFunc("/latest/volumes/", s.wrap(latestOpenEBSVolumeRequestCounter,
 		latestOpenEBSVolumeRequestDuration, s.VSMSpecificRequest))
+
+	s.mux.HandleFunc("/latest/snapshot/", s.wrap(latestOpenEBSMetaDataRequestCounter,
+		latestOpenEBSVolumeRequestDuration, s.SnapshotSpecificRequest))
 	// request for metrics is handled here. It displays metrics related to
 	// garbage collection, process, cpu...etc, and the custom metrics created.
 	s.mux.Handle("/metrics", promhttp.Handler())

--- a/cmd/maya-apiserver/app/server/http.go
+++ b/cmd/maya-apiserver/app/server/http.go
@@ -215,7 +215,7 @@ func (s *HTTPServer) registerHandlers(serviceProvider string, enableDebug bool) 
 	s.mux.HandleFunc("/latest/volumes/", s.wrap(latestOpenEBSVolumeRequestCounter,
 		latestOpenEBSVolumeRequestDuration, s.VSMSpecificRequest))
 
-	s.mux.HandleFunc("/latest/snapshot/", s.wrap(latestOpenEBSMetaDataRequestCounter,
+	s.mux.HandleFunc("/latest/snapshots/", s.wrap(latestOpenEBSMetaDataRequestCounter,
 		latestOpenEBSVolumeRequestDuration, s.SnapshotSpecificRequest))
 	// request for metrics is handled here. It displays metrics related to
 	// garbage collection, process, cpu...etc, and the custom metrics created.

--- a/cmd/maya-apiserver/app/server/snapshot_endpoint.go
+++ b/cmd/maya-apiserver/app/server/snapshot_endpoint.go
@@ -1,0 +1,180 @@
+package server
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/openebs/maya/types/v1"
+	"github.com/openebs/maya/volume/provisioners/jiva"
+)
+
+// SnapshotSpecificGetRequest deals with HTTP GET request w.r.t a Volume Snapshot
+func (s *HTTPServer) SnapshotSpecificRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	// Extract info from path after trimming
+	path := strings.TrimPrefix(req.URL.Path, "/latest/snapshot")
+
+	// Is req valid ?
+	if path == req.URL.Path {
+		fmt.Println("Request coming", path)
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+
+	switch {
+	case strings.Contains(path, "/create/"):
+		return s.SnapshotCreate(resp, req)
+	case strings.Contains(path, "/revert/"):
+		return s.SnapshotRevert(resp, req)
+	case strings.Contains(path, "/list"):
+		volName := strings.TrimPrefix(path, "/list/")
+		return s.SnapshotList(resp, req, volName)
+	default:
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+}
+
+// SnapshotCreate is http handler which handles snaphsot-create request
+func (s *HTTPServer) SnapshotCreate(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+
+	if req.Method != "PUT" && req.Method != "POST" {
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+
+	fmt.Println("[DEBUG] Processing Volume Snapshot request")
+
+	snap := v1.VolumeSnapshot{}
+
+	// The yaml/json spec is decoded to pvc struct
+	if err := decodeBody(req, &snap); err != nil {
+
+		return nil, CodedError(400, err.Error())
+	}
+
+	// SnapshotName is expected to be available even in the minimalist specs
+	if snap.Metadata.Name == "" {
+		return nil, CodedError(400, fmt.Sprintf("Snapshot name missing in '%v'", snap.SnapshotName))
+	}
+
+	// Name is expected to be available even in the minimalist specs
+	if snap.Spec.VolumeName == "" {
+
+		return nil, CodedError(400, fmt.Sprintf("PVC Volume name missing in '%v'", snap.Spec.VolumeName))
+	}
+
+	fmt.Println("Volume Name :", snap.Spec.VolumeName)
+	fmt.Println("[DEBUG] Processing snapshot-create request of volume:", snap.Spec.VolumeName)
+
+	voldetails, err := s.vsmRead(resp, req, snap.Spec.VolumeName)
+	if err != nil {
+		return nil, err
+	}
+
+	ControllerIP := voldetails.Annotations["vsm.openebs.io/controller-ips"]
+
+	var labelMap map[string]string
+	snapinfo, err := jiva.Snapshot(snap.Spec.VolumeName, snap.Metadata.Name, ControllerIP, labelMap)
+	if err != nil {
+		log.Printf("Error running create snapshot command: %v", err)
+		return nil, err
+	}
+
+	fmt.Println("[DEBUG] Snapshot created:", snap.Metadata.Name)
+
+	return snapinfo, nil
+}
+
+// SnapshotRevert is http handler for handling snapshot-revert request.
+// Volume and existing snapshot name will be passed as struct fields to
+// revert to that particular snapshot
+func (s *HTTPServer) SnapshotRevert(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	if req.Method != "PUT" && req.Method != "POST" {
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+	fmt.Println("[DEBUG] Processing Volume snapshot-revert request")
+
+	snap := v1.VolumeSnapshot{}
+
+	// The yaml/json spec is decoded to pvc struct
+	if err := decodeBody(req, &snap); err != nil {
+
+		return nil, CodedError(400, err.Error())
+	}
+
+	// SnapshotName is expected to be available even in the minimalist specs
+	if snap.Metadata.Name == "" {
+		return nil, CodedError(400, fmt.Sprintf("[ERROR] Snapshot name missing in '%v'", snap.Metadata.Name))
+	}
+
+	// Name is expected to be available even in the minimalist specs
+	if snap.Spec.VolumeName == "" {
+
+		return nil, CodedError(400, fmt.Sprintf("[ERROR] Volume name missing in '%v'", snap))
+	}
+
+	fmt.Println("Volume Name :", snap.Spec.VolumeName)
+	fmt.Println("[DEBUG] Processing snapshot-revert request of volume:", snap.Spec.VolumeName)
+
+	voldetails, err := s.vsmRead(resp, req, snap.Spec.VolumeName)
+	if err != nil {
+		return nil, err
+	}
+
+	ControllerIP := voldetails.Annotations["vsm.openebs.io/controller-ips"]
+
+	err = jiva.SnapshotRevert(snap.Spec.VolumeName, snap.Metadata.Name, ControllerIP)
+	if err != nil {
+		log.Fatalf("[ERROR] Error running revert snapshot command: %v", err)
+		return nil, err
+	}
+
+	fmt.Println("[DEBUG] Reverting to snapshot:", snap.Metadata.Name)
+	return nil, nil
+
+}
+
+// SnapshotList is http handler for listing all created snapshot specific to particular volume
+func (s *HTTPServer) SnapshotList(resp http.ResponseWriter, req *http.Request, volName string) (interface{}, error) {
+
+	if req.Method != "GET" {
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+	fmt.Println("[DEBUG] Processing Volume snapshot-list request")
+
+	snap := v1.VolumeSnapshot{}
+	snap.Spec.VolumeName = volName
+
+	// Name is expected to be available in specs
+	if snap.Spec.VolumeName == "" {
+
+		return nil, CodedError(400, fmt.Sprintf("[ERROR] Volume name missing in '%v'", snap.Spec.VolumeName))
+	}
+
+	voldetails, err := s.vsmRead(resp, req, volName)
+	if err != nil {
+		return nil, err
+	}
+
+	ControllerIP := voldetails.Annotations["vsm.openebs.io/controller-ips"]
+
+	// list all created snapshot specific to particular volume
+	snapChain, err := jiva.SnapshotList(snap.Spec.VolumeName, ControllerIP)
+	if err != nil {
+		log.Fatalf("[ERROR] Error running list snapshot command: %v", err)
+		return nil, err
+	}
+
+	fmt.Println("[DEBUG] Successfully created snapshot of volume", snap.Spec.VolumeName)
+	return snapChain, nil
+
+}
+
+/*func (s *HTTPServer) getControllerIP(resp http.ResponseWriter, req *http.Request, snap.Spec.Volname string) (string, err) {
+	voldetails, err := s.vsmRead(resp, req, snap.Spec.VolumeName)
+	if err != nil {
+		return "", err
+	}
+
+	controllerIP := voldetails.Annotations["vsm.openebs.io/controller-ips"]
+	return controllerIP, nil
+}*/

--- a/cmd/maya-apiserver/app/server/volume_endpoint.go
+++ b/cmd/maya-apiserver/app/server/volume_endpoint.go
@@ -93,7 +93,7 @@ func (s *HTTPServer) vsmList(resp http.ResponseWriter, req *http.Request) (inter
 }
 
 // vsmRead is the http handler that fetches the details of a VSM
-func (s *HTTPServer) vsmRead(resp http.ResponseWriter, req *http.Request, vsmName string) (interface{}, error) {
+func (s *HTTPServer) vsmRead(resp http.ResponseWriter, req *http.Request, vsmName string) (*v1.Volume, error) {
 
 	fmt.Println("[DEBUG] Processing Volume read request")
 

--- a/command/model.go
+++ b/command/model.go
@@ -21,7 +21,7 @@ const (
 )
 
 type Volumes struct {
-	client.Resource
+	Resource
 	Name         string `json:"name"`
 	ReplicaCount int    `json:"replicaCount"`
 	Endpoint     string `json:"endpoint"`
@@ -33,13 +33,13 @@ type VolumeCollection struct {
 }
 
 type Replica struct {
-	client.Resource
+	Resource
 	Address string `json:"address"`
 	Mode    string `json:"mode"`
 }
 
 type InfoReplica struct {
-	client.Resource
+	Resource
 	Dirty           bool                `json:"dirty"`
 	Rebuilding      bool                `json:"rebuilding"`
 	Head            string              `json:"head"`
@@ -69,17 +69,17 @@ type ReplicaCollection struct {
 }
 
 type MarkDiskAsRemovedInput struct {
-	client.Resource
+	Resource
 	Name string `json:"name"`
 }
 
 type RevertInput struct {
-	client.Resource
+	Resource
 	Name string `json:"name"`
 }
 
 type SnapshotInput struct {
-	client.Resource
+	Resource
 	Name        string            `json:"name"`
 	UserCreated bool              `json:"usercreated"`
 	Created     string            `json:"created"`
@@ -87,7 +87,14 @@ type SnapshotInput struct {
 }
 
 type SnapshotOutput struct {
-	client.Resource
+	Resource
+}
+
+type Resource struct {
+	Id      string            `json:"id,omitempty"`
+	Type    string            `json:"type,omitempty"`
+	Links   map[string]string `json:"links"`
+	Actions map[string]string `json:"actions"`
 }
 
 func Filter(list []string, check func(string) bool) []string {

--- a/example/snap.yaml
+++ b/example/snap.yaml
@@ -1,0 +1,6 @@
+apiVersion: volumesnapshot/v1
+kind: VolumeSnapshot
+metadata:
+  Name: snapdemo1
+spec:
+  VolumeName: ebsvol

--- a/example/snap2.yaml
+++ b/example/snap2.yaml
@@ -1,0 +1,6 @@
+apiVersion: volumesnapshot/v1
+kind: VolumeSnapshot
+metadata:
+  Name: snapdemo2
+spec:
+  VolumeName: ebsvol

--- a/volume/provisioners/jiva/snapshot_create.go
+++ b/volume/provisioners/jiva/snapshot_create.go
@@ -19,7 +19,7 @@ import (
 // Snapshot will create the snapshot of a given volume name 'volname' with name of
 // snapshot 'snapname'. If there is no name provided for snapshot, an auto genrated
 // string will be genrated for this.
-func Snapshot(volname string, snapname string, controllerIP string, labels map[string]string) (command.SnapshotOutput, error) {
+func Snapshot(snapname string, controllerIP string, labels map[string]string) (command.SnapshotOutput, error) {
 	output := command.SnapshotOutput{}
 	var c ControllerClient
 

--- a/volume/provisioners/jiva/snapshot_list.go
+++ b/volume/provisioners/jiva/snapshot_list.go
@@ -24,7 +24,6 @@ func SnapshotList(name string, controllerIP string) (map[string]command.DiskInfo
 	}
 
 	first := true
-	//snapshots := []string{}
 	for _, r := range replicas {
 		if r.Mode != "RW" {
 			continue
@@ -72,23 +71,8 @@ func SnapshotList(name string, controllerIP string) (map[string]command.DiskInfo
 			if err != err {
 				return snapdisk, err
 			}
-			//out := make([]string, len(snapdisk)+1)
-
-			//out[0] = "Name|Created At|Size"
-			//var i int
 			return snapdisk, nil
 
-			/*	for _, disk := range snapdisk {
-					//	if !IsHeadDisk(disk.Name) {
-					out[i+1] = fmt.Sprintf("%s|%s|%s",
-						strings.TrimSuffix(strings.TrimPrefix(disk.Name, "volume-snap-"), ".img"),
-						disk.Created,
-						disk.Size)
-					i = i + 1
-					//	}
-				}
-			*/
-			//fmt.Println(command.FormatList(out))
 		}
 	}
 	return nil, nil

--- a/volume/provisioners/jiva/snapshot_list.go
+++ b/volume/provisioners/jiva/snapshot_list.go
@@ -11,21 +11,16 @@ import (
 )
 
 // SnapshotList to list the created snapshot for given volume
-func SnapshotList(name string) error {
-	annotations, err := command.GetVolumeSpec(name)
-	if err != nil || annotations == nil {
-
-		return err
-	}
-	controller, err := command.NewControllerClient(annotations.ControllerIP + ":9501")
+func SnapshotList(name string, controllerIP string) (map[string]command.DiskInfo, error) {
+	controller, err := command.NewControllerClient(controllerIP + ":9501")
 
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	replicas, err := controller.ListReplicas(controller.Address)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	first := true
@@ -75,26 +70,28 @@ func SnapshotList(name string) error {
 			first = false
 			snapdisk, err := getData(r.Address)
 			if err != err {
-				return err
+				return snapdisk, err
 			}
-			out := make([]string, len(snapdisk)+1)
+			//out := make([]string, len(snapdisk)+1)
 
-			out[0] = "Name|Created At|Size"
-			var i int
+			//out[0] = "Name|Created At|Size"
+			//var i int
+			return snapdisk, nil
 
-			for _, disk := range snapdisk {
-				//	if !IsHeadDisk(disk.Name) {
-				out[i+1] = fmt.Sprintf("%s|%s|%s",
-					strings.TrimSuffix(strings.TrimPrefix(disk.Name, "volume-snap-"), ".img"),
-					disk.Created,
-					disk.Size)
-				i = i + 1
-				//	}
-			}
-			fmt.Println(command.FormatList(out))
+			/*	for _, disk := range snapdisk {
+					//	if !IsHeadDisk(disk.Name) {
+					out[i+1] = fmt.Sprintf("%s|%s|%s",
+						strings.TrimSuffix(strings.TrimPrefix(disk.Name, "volume-snap-"), ".img"),
+						disk.Created,
+						disk.Size)
+					i = i + 1
+					//	}
+				}
+			*/
+			//fmt.Println(command.FormatList(out))
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 // ListReplicas to get the details of all the existing replicas

--- a/volume/provisioners/jiva/snapshot_revert.go
+++ b/volume/provisioners/jiva/snapshot_revert.go
@@ -8,7 +8,7 @@ import (
 // particular snapshot. If there is more then one snapshot has been
 // created for a volume, then user can revert to any specific created
 // snaphot for that particular volume.
-func SnapshotRevert(volname string, snapshot string, controllerIP string) error {
+func SnapshotRevert(snapshot string, controllerIP string) error {
 
 	controller, err := command.NewControllerClient(controllerIP + ":9501")
 

--- a/volume/provisioners/jiva/snapshot_revert.go
+++ b/volume/provisioners/jiva/snapshot_revert.go
@@ -1,8 +1,6 @@
 package jiva
 
 import (
-	"fmt"
-
 	"github.com/openebs/maya/command"
 )
 
@@ -10,19 +8,9 @@ import (
 // particular snapshot. If there is more then one snapshot has been
 // created for a volume, then user can revert to any specific created
 // snaphot for that particular volume.
-func SnapshotRevert(volname string, snapshot string) error {
+func SnapshotRevert(volname string, snapshot string, controllerIP string) error {
 
-	annotations, err := command.GetVolumeSpec(volname)
-	if err != nil || annotations == nil {
-
-		return err
-	}
-
-	if annotations.ControllerStatus != "Running" {
-		fmt.Println("Volume not reachable")
-		return err
-	}
-	controller, err := command.NewControllerClient(annotations.ControllerIP + ":9501")
+	controller, err := command.NewControllerClient(controllerIP + ":9501")
 
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit will enhance maya-apiserver to support snapshot
related API operation. Snapshot can be created/reverted by
simple yaml config file, and can be deleted by simple curl command.

2. How to verify this change ?
Create: Snapshot created by using simple config yaml file

Revert: Snapshot reverted by using simple config yaml file.
        which creates 2 snapshot and then tried reverting to
	each other.

list: Simple curl command will list down the created snapshot,
      specific to particular volume.

**Which issue this PR fixes** 
: fixes #79, #73 , #72 , #12 , openebs/openebs#395 , openebs/openebs#258

```yaml
apiVersion: volumesnapshot/v1
kind: VolumeSnapshot
metadata:
  Name: snapdemo1
spec:
  VolumeName: ebsvol

-------
apiVersion: volumesnapshot/v1
kind: VolumeSnapshot
metadata:
  Name: snapdemo2
spec:
  VolumeName: ebsvol
```
``` sh
Create Snapshot:
$ curl -k -H "Content-Type: application/yaml" -XPOST -d"$(cat snap.yaml)" http://172.17.0.4:5656/latest/snapshots/create/

Revert Snapshot:
$ curl -k -H "Content-Type: application/yaml" -XPOST -d"$(cat snap.yaml)" http://172.17.0.4:5656/latest/snapshots/revert/

List Snapshot:
$ curl http://172.17.0.4:5656/latest/snapshots/list/<volumename>
```