### PR TITLE
refactor maya-agent monitoring code

### DIFF
--- a/cmd/maya-agent/app/exporter/collector/collector.go
+++ b/cmd/maya-agent/app/exporter/collector/collector.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/openebs/maya/pkg/util"
 	"github.com/openebs/maya/types/v1"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -241,25 +240,25 @@ func (e *VolumeExporter) collect() error {
 	// i and f is used for initial and final
 	iRIOPS, _ := strconv.ParseInt(metrics1.ReadIOPS, 10, 64)
 	fRIOPS, _ := strconv.ParseInt(metrics2.ReadIOPS, 10, 64)
-	rIOPS := v1.SubstractInt64(fRIOPS, iRIOPS)
+	rIOPS, _ := v1.SubstractInt64(fRIOPS, iRIOPS)
 	readIOPS.Set(float64(rIOPS))
 
 	iRTimePS, _ := strconv.ParseInt(metrics1.TotalReadTime, 10, 64)
 	fRTimePS, _ := strconv.ParseInt(metrics2.TotalReadTime, 10, 64)
-	rTimePS := v1.SubstractInt64(fRTimePS, iRTimePS)
+	rTimePS, _ := v1.SubstractInt64(fRTimePS, iRTimePS)
 	readTimePS.Set(float64(rTimePS))
 
 	iRBCountPS, _ := strconv.ParseInt(metrics1.TotalReadBlockCount, 10, 64)
 	fRBCountPS, _ := strconv.ParseInt(metrics2.TotalReadBlockCount, 10, 64)
-	rBCountPS := v1.SubstractInt64(fRBCountPS, iRBCountPS)
+	rBCountPS, _ := v1.SubstractInt64(fRBCountPS, iRBCountPS)
 	readBlockCountPS.Set(float64(rBCountPS))
 
 	if rIOPS != 0 {
-		rLatency := v1.DivideInt64(rTimePS, rIOPS)
-		rLatency = v1.DivideInt64(rLatency, util.MicSec)
+		rLatency, _ := v1.DivideInt64(rTimePS, rIOPS)
+		rLatency, _ = v1.DivideInt64(rLatency, v1.MicSec)
 		readLatency.Set(float64(rLatency))
-		avgRBCountPS := v1.DivideInt64(rBCountPS, rIOPS)
-		avgRBCountPS = v1.DivideInt64(rBCountPS, util.BytesToKB)
+		avgRBCountPS, _ := v1.DivideInt64(rBCountPS, rIOPS)
+		avgRBCountPS, _ = v1.DivideInt64(rBCountPS, v1.BytesToKB)
 		avgReadBlockCountPS.Set(float64(avgRBCountPS))
 	} else {
 		readLatency.Set(0)
@@ -268,25 +267,25 @@ func (e *VolumeExporter) collect() error {
 
 	iWIOPS, _ := strconv.ParseInt(metrics1.WriteIOPS, 10, 64)
 	fWIOPS, _ := strconv.ParseInt(metrics2.WriteIOPS, 10, 64)
-	wIOPS := v1.SubstractInt64(fWIOPS, iWIOPS)
+	wIOPS, _ := v1.SubstractInt64(fWIOPS, iWIOPS)
 	writeIOPS.Set(float64(wIOPS))
 
 	iWTimePS, _ := strconv.ParseInt(metrics1.TotalWriteTime, 10, 64)
 	fWTimePS, _ := strconv.ParseInt(metrics2.TotalWriteTime, 10, 64)
-	wTimePS := v1.SubstractInt64(fWTimePS, iWTimePS)
+	wTimePS, _ := v1.SubstractInt64(fWTimePS, iWTimePS)
 	writeTimePS.Set(float64(wTimePS))
 
 	iWBCountPS, _ := strconv.ParseInt(metrics1.TotalWriteBlockCount, 10, 64)
 	fWBCountPS, _ := strconv.ParseInt(metrics2.TotalWriteBlockCount, 10, 64)
-	wBCountPS := v1.SubstractInt64(fWBCountPS, iWBCountPS)
+	wBCountPS, _ := v1.SubstractInt64(fWBCountPS, iWBCountPS)
 	writeBlockCountPS.Set(float64(wBCountPS))
 
 	if wIOPS != 0 {
-		wLatency := v1.DivideInt64(wTimePS, wIOPS)
-		wLatency = v1.DivideInt64(wLatency, util.MicSec)
+		wLatency, _ := v1.DivideInt64(wTimePS, wIOPS)
+		wLatency, _ = v1.DivideInt64(wLatency, v1.MicSec)
 		writeLatency.Set(float64(wLatency))
-		avgWBCountPS := v1.DivideInt64(wBCountPS, wIOPS)
-		avgWBCountPS = v1.DivideInt64(avgWBCountPS, util.BytesToKB)
+		avgWBCountPS, _ := v1.DivideInt64(wBCountPS, wIOPS)
+		avgWBCountPS, _ = v1.DivideInt64(avgWBCountPS, v1.BytesToKB)
 		avgWriteBlockCountPS.Set(float64(avgWBCountPS))
 	} else {
 		writeLatency.Set(0)
@@ -297,10 +296,13 @@ func (e *VolumeExporter) collect() error {
 	sectorSize.Set(float64(sSize))
 	uBlocks, _ := strconv.ParseFloat(metrics2.UsedBlocks, 64)
 	uBlocks = uBlocks * sSize
-	logicalSize.Set(v1.DivideFloat64(uBlocks, util.BytesToGB))
+	lSize, _ := v1.DivideFloat64(uBlocks, v1.BytesToGB)
+
+	logicalSize.Set(lSize)
 	aUsed, _ := strconv.ParseFloat(metrics2.UsedLogicalBlocks, 64)
 	aUsed = aUsed * sSize
-	actualUsed.Set(v1.DivideFloat64(aUsed, util.BytesToGB))
+	aSize, _ := v1.DivideFloat64(aUsed, v1.BytesToGB)
+	actualUsed.Set(aSize)
 	size, _ := strconv.ParseInt(metrics1.Size, 10, 64)
 	sizeOfVolume.Set(float64(size))
 

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -1,0 +1,18 @@
+package util
+
+const (
+	// BytesToGB used to convert bytes to GB
+	BytesToGB = 1073741824
+	// BytesToMB used to convert bytes to MB
+	BytesToMB = 1048567
+	// BytesToKB used to convert bytes to KB
+	BytesToKB = 1024
+	// MicSec used to convert to microsec to second
+	MicSec = 1000000
+	// MinWidth used in tabwriter
+	MinWidth = 0
+	// MaxWidth used in tabwriter
+	MaxWidth = 0
+	// Padding used in tabwriter
+	Padding = 3
+)

--- a/types/v1/math.go
+++ b/types/v1/math.go
@@ -312,3 +312,25 @@ func removeBigIntFactors(d, factor *big.Int) (result *big.Int, times int32) {
 	}
 	return d, times
 }
+
+// SubstractFloat64 returns a - b , where a > b.
+func SubstractFloat64(a float64, b float64) float64 {
+	return (a - b)
+}
+
+// DivideFloat64 returns the value of value divided by base.
+// divide by zero case handled before calling.
+func DivideFloat64(value float64, base float64) float64 {
+	return (value / base)
+}
+
+// SubstractInt64 returns a - b , where a > b.
+func SubstractInt64(a int64, b int64) int64 {
+	return (a - b)
+}
+
+// DivideInt64 returns the value of value divided by base.
+// divide by zero case handled before calling.
+func DivideInt64(value int64, base int64) int64 {
+	return (value / base)
+}

--- a/types/v1/metrics.go
+++ b/types/v1/metrics.go
@@ -19,6 +19,7 @@ type VolumeMetrics struct {
 	UsedLogicalBlocks string `json:"UsedLogicalBlocks"`
 	UsedBlocks        string `json:"UsedBlocks"`
 	SectorSize        string `json:"SectorSize"`
+	Size              string `json:Size`
 }
 
 type Resource struct {


### PR DESCRIPTION
1. Why is this change necessary ?
- Read / write latency was not coming in the metrics
- unit was not correct for the logical size and actual size

2. How does this change address the issue ?
- added variable to gather read / write latency
- added variable to gather avg read / write block count per second

3. How to verify this change ?
- Run maya-agent binary locally or in maya-apiserver container, pass the
  controllerIP via flag `-c` and then do curl localhost:9500/metrics and
  make sure volume is being consumed otherwise it will show zero in all
  the stats fields.

4. What side effects does this change have ?
- none

5. Other details
fix and improvement: [#266](https://github.com/openebs/openebs/issues/266)

<!--  Thanks for sending a pull request!  Here are some tips for you -->
<!--
**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
