### PR TITLE
mayactl volume cmd refactor #505

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,17 @@ before_script:
   - minikube update-context
   # Wait for Kubernetes to be up and ready.
   - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
+  # Download and initialize helm.
+  - ./ci/ubuntu-compile-nsenter.sh && sudo cp .tmp/util-linux-2.30.2/nsenter /usr/bin
+  - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
+  - chmod 700 get_helm.sh
+  - ./get_helm.sh
+  - helm init
 script:
   - kubectl cluster-info
   - kubectl get deployment
   - ./buildscripts/travis-build.sh
+  - ./ci/travis-ci.sh
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 notifications:

--- a/ci/helm_install_openebs.sh
+++ b/ci/helm_install_openebs.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+kubectl -n kube-system create sa tiller 
+kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller 
+kubectl -n kube-system patch deploy/tiller-deploy -p '{"spec": {"template": {"spec": {"serviceAccountName": "tiller"}}}}' 
+
+#Replace this with logic to wait till the pods are running
+sleep 30
+kubectl get pods --all-namespaces 
+kubectl get sa
+
+helm repo add openebs-charts https://openebs.github.io/charts/
+helm repo update
+helm install openebs-charts/openebs --set apiserver.tag="ci",jiva.replicas="1",rbacEnable="false"
+
+#Replace this with logic to wait till the pods are running
+sleep 30
+kubectl get pods --all-namespaces

--- a/ci/mayactl/run_vol_create.sh
+++ b/ci/mayactl/run_vol_create.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+${MAYACTL} volume create -volname $1
+rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi

--- a/ci/mayactl/run_vol_delete.sh
+++ b/ci/mayactl/run_vol_delete.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+${MAYACTL} volume delete -volname $1
+rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi

--- a/ci/mayactl/run_vol_list.sh
+++ b/ci/mayactl/run_vol_list.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+${MAYACTL} volume list
+rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+MAPI_SVC_ADDR=`kubectl get service maya-apiserver-service -o json | grep clusterIP | awk -F\" '{print $4}'`
+export MAPI_ADDR="http://${MAPI_SVC_ADDR}:5656"
+export KUBERNETES_SERVICE_HOST="127.0.0.1"
+export MAYACTL="$GOPATH/src/github.com/openebs/maya/bin/maya/maya"

--- a/ci/test_mayactl.sh
+++ b/ci/test_mayactl.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+source ./ci/setup_env.sh
+
+./ci/mayactl/run_vol_create.sh testvol
+rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+
+./ci/mayactl/run_vol_list.sh 
+rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+
+./ci/mayactl/run_vol_delete.sh testvol
+rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi

--- a/ci/travis-ci.sh
+++ b/ci/travis-ci.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Copyright 2017 The OpenEBS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+./ci/helm_install_openebs.sh
+rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+
+./ci/test_mayactl.sh
+rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi

--- a/ci/ubuntu-compile-nsenter.sh
+++ b/ci/ubuntu-compile-nsenter.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+#
+# Copyright 2017 The Jaeger Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+set -e
+
+sudo apt-get update
+sudo apt-get install libncurses5-dev libslang2-dev gettext zlib1g-dev libselinux1-dev debhelper lsb-release pkg-config po-debconf autoconf automake autopoint libtool
+mkdir .tmp || true
+wget https://www.kernel.org/pub/linux/utils/util-linux/v2.30/util-linux-2.30.2.tar.gz -qO - | tar -xz -C .tmp/
+cd .tmp/util-linux-2.30.2 && ./autogen.sh && ./configure && make nsenter
+

--- a/pkg/client/mapiserver/volume_delete.go
+++ b/pkg/client/mapiserver/volume_delete.go
@@ -1,0 +1,41 @@
+package mapiserver
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	timeoutVolumeDelete = 5 * time.Second
+)
+
+// DeleteVolume will request maya-apiserver to delete volume (vname)
+func DeleteVolume(vname string) error {
+
+	_, err := GetStatus()
+	if err != nil {
+		return fmt.Errorf("Unable to contact maya-apiserver: %s", GetURL())
+	}
+
+	url := GetURL() + "/latest/volumes/delete/" + vname
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+	c := &http.Client{
+		Timeout: timeoutVolumeDelete,
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	code := resp.StatusCode
+	if code != http.StatusOK {
+		return fmt.Errorf("Status error: %v", http.StatusText(code))
+	}
+	return nil
+}

--- a/pkg/client/mapiserver/volumes_list.go
+++ b/pkg/client/mapiserver/volumes_list.go
@@ -1,0 +1,49 @@
+package mapiserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+const (
+	timeoutVolumesList = 5 * time.Second
+)
+
+// ListVolumes and return them as obj
+func ListVolumes(obj interface{}) error {
+
+	_, err := GetStatus()
+	if err != nil {
+		return fmt.Errorf("Unable to contact maya-apiserver: %s", GetURL())
+	}
+
+	url := GetURL() + "/latest/volumes/"
+	client := &http.Client{
+		Timeout: timeoutVolumesList,
+	}
+	resp, err := client.Get(url)
+	if err != nil {
+		return err
+	}
+
+	code := resp.StatusCode
+	if code != http.StatusOK {
+		return fmt.Errorf("Status error: %v", http.StatusText(code))
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(body, &obj)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR contains some fixes for openebs/openebs#505, which will help in moving the maya volume related commands to COBRA. 

The changes included in this commit:
- Refactor the existing commands to delegate the mapaiserver client/server code to pkg/client/mapiserver
- Include basic sanity tests for create/list/delete volume (Currently this is based on shell script, but will be moving toward ginkgo or go based testing in future)
- Includes installation of ci images in minikube via helm
