### PR TITLE
Refactor Jiva controller and replica clients

### DIFF
--- a/command/snapshot_delete.go
+++ b/command/snapshot_delete.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/openebs/maya/pkg/client/jiva"
+	//	"github.com/rancher/go-rancher/client"
 )
 
 type SnapshotDeleteCommand struct {
@@ -22,7 +25,7 @@ type SnapshotDeleteCommand struct {
 
 func (s *SnapshotDeleteCommand) Help() string {
 	helpText := `
-	Usage: maya snapshot delete -volname <vol> 
+	Usage: maya snapshot delete -volname <vol>
 
 	This command will delete all snapshots of a Volume.
 
@@ -61,7 +64,7 @@ func (s *SnapshotDeleteCommand) DeleteSnapshot(volume string, snapshot string) e
 
 		return err
 	}
-	controller, err := NewControllerClient(annotations.ControllerIP + ":9501")
+	controller, err := client.NewControllerClient(annotations.ControllerIP + ":9501")
 
 	if err != nil {
 		return err
@@ -89,8 +92,8 @@ func (s *SnapshotDeleteCommand) DeleteSnapshot(volume string, snapshot string) e
 	return nil
 }
 
-func (s *SnapshotDeleteCommand) isRebuilding(replicaInController *Replica) (bool, error) {
-	repClient, err := NewReplicaClient(replicaInController.Address)
+func (s *SnapshotDeleteCommand) isRebuilding(replicaInController *client.Replica) (bool, error) {
+	repClient, err := client.NewReplicaClient(replicaInController.Address)
 	if err != nil {
 		return false, err
 	}
@@ -103,12 +106,12 @@ func (s *SnapshotDeleteCommand) isRebuilding(replicaInController *Replica) (bool
 	return replica.Rebuilding, nil
 }
 
-func (s *SnapshotDeleteCommand) markSnapshotAsRemoved(replicaInController *Replica, snapshot string) error {
+func (s *SnapshotDeleteCommand) markSnapshotAsRemoved(replicaInController *client.Replica, snapshot string) error {
 	if replicaInController.Mode != "RW" {
 		return fmt.Errorf("Can only mark snapshot as removed from replica in mode RW, got %s", replicaInController.Mode)
 	}
 
-	repClient, err := NewReplicaClient(replicaInController.Address)
+	repClient, err := client.NewReplicaClient(replicaInController.Address)
 	if err != nil {
 		return err
 	}
@@ -118,18 +121,4 @@ func (s *SnapshotDeleteCommand) markSnapshotAsRemoved(replicaInController *Repli
 	}
 
 	return nil
-}
-
-func (c *ReplicaClient) MarkDiskAsRemoved(disk string) error {
-
-	_, err := c.GetReplica()
-	if err != nil {
-		return err
-	}
-	//url := "/replicas/1?action=markdiskasremoved"
-	url := "/replicas/1?action=removedisk"
-
-	return c.post(url, &MarkDiskAsRemovedInput{
-		Name: disk,
-	}, nil)
 }

--- a/command/snapshot_revert.go
+++ b/command/snapshot_revert.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/openebs/maya/pkg/client/jiva"
 )
 
 // SnapshotRevertCommand struct for reverting snapshot of a Volume
@@ -63,21 +65,20 @@ func (c *ControllerClient) RevertSnapshot(volname string, snapshot string) error
 		fmt.Println("Volume not reachable")
 		return err
 	}
-	controller, err := NewControllerClient(annotations.ControllerIP + ":9501")
+	controller, err := client.NewControllerClient(annotations.ControllerIP + ":9501")
 
 	if err != nil {
 		return err
 	}
 
-	//var c *ControllerClient
-	volume, err := GetVolume(controller.Address)
+	volume, err := client.GetVolume(controller.Address)
 	if err != nil {
 		return err
 	}
 
 	url := controller.Address + "/volumes/" + volume.Id + "?action=revert"
 
-	return c.post(url, RevertInput{
+	return controller.Post(url, client.RevertInput{
 		Name: snapshot,
 	}, nil)
 }

--- a/pkg/client/jiva/controller_client.go
+++ b/pkg/client/jiva/controller_client.go
@@ -1,0 +1,122 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// NewControllerClient create the new controller client
+func NewControllerClient(address string) (*ControllerClient, error) {
+	address = strings.TrimPrefix(address, "tcp://")
+
+	if !strings.HasPrefix(address, "http") {
+		address = "http://" + address
+	}
+
+	if !strings.HasSuffix(address, "/v1") {
+		address += "/v1"
+	}
+
+	u, err := url.Parse(address)
+	if err != nil {
+		return nil, err
+	}
+
+	parts := strings.Split(u.Host, ":")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("Invalid address %s, must have a port in it", address)
+	}
+
+	timeout := time.Duration(2 * time.Second)
+	client := &http.Client{
+		Timeout: timeout,
+	}
+
+	return &ControllerClient{
+		Host:       parts[0],
+		Address:    address,
+		httpClient: client,
+	}, nil
+}
+
+func (c *ControllerClient) Post(path string, req, resp interface{}) error {
+	return c.Do("POST", path, req, resp)
+}
+
+func (c *ControllerClient) Do(method, path string, req, resp interface{}) error {
+	b, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+
+	bodyType := "application/json"
+	url := path
+	if !strings.HasPrefix(url, "http") {
+		url = c.Address + path
+
+	}
+
+	httpReq, err := http.NewRequest(method, url, bytes.NewBuffer(b))
+	if err != nil {
+		return err
+	}
+	httpReq.Header.Set("Content-Type", bodyType)
+
+	httpResp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return err
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode >= 300 {
+		content, _ := ioutil.ReadAll(httpResp.Body)
+		return fmt.Errorf("Bad response: %d %s: %s", httpResp.StatusCode, httpResp.Status, content)
+	}
+
+	if resp == nil {
+		return nil
+	}
+	return json.NewDecoder(httpResp.Body).Decode(resp)
+}
+
+func GetVolume(path string) (*Volumes, error) {
+	var volume VolumeCollection
+	var c ControllerClient
+
+	err := c.Get(path+"/volumes", &volume)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(volume.Data) == 0 {
+		return nil, errors.New("No volume found")
+	}
+
+	return &volume.Data[0], nil
+}
+func (c *ControllerClient) Get(path string, obj interface{}) error {
+	//	resp, err := http.Get(c.address + path)
+	resp, err := http.Get(path)
+
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return json.NewDecoder(resp.Body).Decode(obj)
+}
+
+func (c *ControllerClient) ListReplicas(path string) ([]Replica, error) {
+	var resp ReplicaCollection
+
+	err := c.Get(path+"/replicas", &resp)
+
+	return resp.Data, err
+}

--- a/pkg/client/jiva/controller_client.go
+++ b/pkg/client/jiva/controller_client.go
@@ -102,7 +102,6 @@ func GetVolume(path string) (*Volumes, error) {
 	return &volume.Data[0], nil
 }
 func (c *ControllerClient) Get(path string, obj interface{}) error {
-	//	resp, err := http.Get(c.address + path)
 	resp, err := http.Get(path)
 
 	if err != nil {

--- a/pkg/client/jiva/model.go
+++ b/pkg/client/jiva/model.go
@@ -1,9 +1,8 @@
-package command
+package client
 
 import (
+	"net/http"
 	"strings"
-
-	"github.com/rancher/go-rancher/client"
 )
 
 const (
@@ -28,7 +27,7 @@ type Volumes struct {
 }
 
 type VolumeCollection struct {
-	client.Collection
+	Collection
 	Data []Volumes `json:"data"`
 }
 
@@ -50,7 +49,7 @@ type InfoReplica struct {
 	Chain           []string            `json:"chain"`
 	Disks           map[string]DiskInfo `json:"disks"`
 	RemainSnapshots int                 `json:"remainsnapshots"`
-	RevisionCounter string              `json:"revisioncounter"`
+	RevisionCounter int64               `json:"revisioncounter"`
 }
 
 type DiskInfo struct {
@@ -64,7 +63,7 @@ type DiskInfo struct {
 }
 
 type ReplicaCollection struct {
-	client.Collection
+	Collection
 	Data []Replica `json:"data"`
 }
 
@@ -73,11 +72,27 @@ type MarkDiskAsRemovedInput struct {
 	Name string `json:"name"`
 }
 
+// ReplicaClient is Client structure
+type ReplicaClient struct {
+	Address    string
+	SyncAgent  string
+	Host       string
+	httpClient *http.Client
+}
+
+type ControllerClient struct {
+	Address    string
+	Host       string
+	httpClient *http.Client
+}
+
 type RevertInput struct {
 	Resource
 	Name string `json:"name"`
 }
 
+// SnapshotInput is Input struct to create
+// snapshot
 type SnapshotInput struct {
 	Resource
 	Name        string            `json:"name"`
@@ -95,6 +110,39 @@ type Resource struct {
 	Type    string            `json:"type,omitempty"`
 	Links   map[string]string `json:"links"`
 	Actions map[string]string `json:"actions"`
+}
+
+type Collection struct {
+	Type         string                 `json:"type,omitempty"`
+	ResourceType string                 `json:"resourceType,omitempty"`
+	Links        map[string]string      `json:"links,omitempty"`
+	CreateTypes  map[string]string      `json:"createTypes,omitempty"`
+	Actions      map[string]string      `json:"actions,omitempty"`
+	SortLinks    map[string]string      `json:"sortLinks,omitempty"`
+	Pagination   *Pagination            `json:"pagination,omitempty"`
+	Sort         *Sort                  `json:"sort,omitempty"`
+	Filters      map[string][]Condition `json:"filters,omitempty"`
+}
+
+type Sort struct {
+	Name    string `json:"name,omitempty"`
+	Order   string `json:"order,omitempty"`
+	Reverse string `json:"reverse,omitempty"`
+}
+
+type Condition struct {
+	Modifier string      `json:"modifier,omitempty"`
+	Value    interface{} `json:"value,omitempty"`
+}
+
+type Pagination struct {
+	Marker   string `json:"marker,omitempty"`
+	First    string `json:"first,omitempty"`
+	Previous string `json:"previous,omitempty"`
+	Next     string `json:"next,omitempty"`
+	Limit    *int64 `json:"limit,omitempty"`
+	Total    *int64 `json:"total,omitempty"`
+	Partial  bool   `json:"partial,omitempty"`
 }
 
 func Filter(list []string, check func(string) bool) []string {
@@ -115,6 +163,7 @@ func Contains(arr []string, val string) bool {
 	}
 	return false
 }
+
 func IsHeadDisk(diskName string) bool {
 	if strings.HasPrefix(diskName, headPrefix) && strings.HasSuffix(diskName, headSuffix) {
 		return true

--- a/pkg/client/jiva/model.go
+++ b/pkg/client/jiva/model.go
@@ -49,7 +49,7 @@ type InfoReplica struct {
 	Chain           []string            `json:"chain"`
 	Disks           map[string]DiskInfo `json:"disks"`
 	RemainSnapshots int                 `json:"remainsnapshots"`
-	RevisionCounter int64               `json:"revisioncounter"`
+	RevisionCounter string               `json:"revisioncounter"`
 }
 
 type DiskInfo struct {

--- a/pkg/client/jiva/replica_client.go
+++ b/pkg/client/jiva/replica_client.go
@@ -1,0 +1,120 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// NewReplicaClient create the new replica client
+func NewReplicaClient(address string) (*ReplicaClient, error) {
+	address = strings.TrimPrefix(address, "tcp://")
+
+	if !strings.HasPrefix(address, "http") {
+		address = "http://" + address
+	}
+
+	if !strings.HasSuffix(address, "/v1") {
+		address += "/v1"
+	}
+
+	u, err := url.Parse(address)
+	if err != nil {
+		return nil, err
+	}
+
+	parts := strings.Split(u.Host, ":")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("Invalid address %s, must have a port in it", address)
+	}
+	port, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return nil, err
+	}
+	syncAgent := strings.Replace(address, fmt.Sprintf(":%d", port), fmt.Sprintf(":%d", port+2), -1)
+
+	timeout := time.Duration(2 * time.Second)
+	client := &http.Client{
+		Timeout: timeout,
+	}
+
+	return &ReplicaClient{
+		Host:       parts[0],
+		Address:    address,
+		SyncAgent:  syncAgent,
+		httpClient: client,
+	}, nil
+}
+
+func (c *ReplicaClient) GetReplica() (InfoReplica, error) {
+	var replica InfoReplica
+
+	err := c.Get(c.Address+"/replicas/1", &replica)
+
+	return replica, err
+}
+
+func (c *ReplicaClient) Get(url string, obj interface{}) error {
+	if !strings.HasPrefix(url, "http") {
+		url = c.Address + url
+	}
+
+	resp, err := c.httpClient.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return json.NewDecoder(resp.Body).Decode(obj)
+}
+
+func (c *ReplicaClient) Post(path string, req, resp interface{}) error {
+	b, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+
+	bodyType := "application/json"
+	url := path
+
+	if !strings.HasPrefix(url, "http") {
+		url = c.Address + path
+	}
+
+	httpResp, err := c.httpClient.Post(url, bodyType, bytes.NewBuffer(b))
+	if err != nil {
+		return err
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode >= 300 {
+		content, _ := ioutil.ReadAll(httpResp.Body)
+		return fmt.Errorf("Bad response: %d %s: %s", httpResp.StatusCode, httpResp.Status, content)
+	}
+
+	if resp == nil {
+		return nil
+	}
+
+	return json.NewDecoder(httpResp.Body).Decode(resp)
+}
+
+func (c *ReplicaClient) MarkDiskAsRemoved(disk string) error {
+
+	_, err := c.GetReplica()
+	if err != nil {
+		return err
+	}
+	//url := "/replicas/1?action=markdiskasremoved"
+	url := "/replicas/1?action=removedisk"
+
+	return c.Post(url, &MarkDiskAsRemovedInput{
+		Name: disk,
+	}, nil)
+}

--- a/volume/provisioners/jiva/snapshot_create.go
+++ b/volume/provisioners/jiva/snapshot_create.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/openebs/maya/command"
+	"github.com/openebs/maya/pkg/client/jiva"
 )
 
 /*var (
@@ -19,8 +20,8 @@ import (
 // Snapshot will create the snapshot of a given volume name 'volname' with name of
 // snapshot 'snapname'. If there is no name provided for snapshot, an auto genrated
 // string will be genrated for this.
-func Snapshot(snapname string, controllerIP string, labels map[string]string) (command.SnapshotOutput, error) {
-	output := command.SnapshotOutput{}
+func Snapshot(snapname string, controllerIP string, labels map[string]string) (client.SnapshotOutput, error) {
+	output := client.SnapshotOutput{}
 	var c ControllerClient
 
 	controller, err := command.NewControllerClient(controllerIP + ":9501")
@@ -29,14 +30,14 @@ func Snapshot(snapname string, controllerIP string, labels map[string]string) (c
 		return output, err
 	}
 
-	volume, err := command.GetVolume(controller.Address)
+	volume, err := client.GetVolume(controller.Address)
 	if err != nil {
 		return output, err
 	}
 
 	url := controller.Address + "/volumes/" + volume.Id + "?action=snapshot"
 
-	input := command.SnapshotInput{
+	input := client.SnapshotInput{
 		Name:   snapname,
 		Labels: labels,
 	}

--- a/volume/provisioners/jiva/snapshot_list.go
+++ b/volume/provisioners/jiva/snapshot_list.go
@@ -7,12 +7,12 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/openebs/maya/command"
+	client "github.com/openebs/maya/pkg/client/jiva"
 )
 
 // SnapshotList to list the created snapshot for given volume
-func SnapshotList(name string, controllerIP string) (map[string]command.DiskInfo, error) {
-	controller, err := command.NewControllerClient(controllerIP + ":9501")
+func SnapshotList(name string, controllerIP string) (map[string]client.DiskInfo, error) {
+	controller, err := client.NewControllerClient(controllerIP + ":9501")
 
 	if err != nil {
 		return nil, err
@@ -91,7 +91,7 @@ func (c *ControllerClient) ListReplicas(path string) ([]Replica, error) {
 
 // getChain contains the linked info related to replicas
 func getChain(address string) ([]string, error) {
-	repClient, err := command.NewReplicaClient(address)
+	repClient, err := client.NewReplicaClient(address)
 	if err != nil {
 		return nil, err
 	}
@@ -105,8 +105,8 @@ func getChain(address string) ([]string, error) {
 }
 
 // getData to get the linked Diskinfo related to replicas
-func getData(address string) (map[string]command.DiskInfo, error) {
-	repClient, err := command.NewReplicaClient(address)
+func getData(address string) (map[string]client.DiskInfo, error) {
+	repClient, err := client.NewReplicaClient(address)
 	if err != nil {
 		return nil, err
 	}

--- a/volume/provisioners/jiva/snapshot_revert.go
+++ b/volume/provisioners/jiva/snapshot_revert.go
@@ -1,8 +1,6 @@
 package jiva
 
-import (
-	"github.com/openebs/maya/command"
-)
+import client "github.com/openebs/maya/pkg/client/jiva"
 
 // SnapshotRevert will be responsible for reverting to a
 // particular snapshot. If there is more then one snapshot has been
@@ -10,14 +8,14 @@ import (
 // snaphot for that particular volume.
 func SnapshotRevert(snapshot string, controllerIP string) error {
 
-	controller, err := command.NewControllerClient(controllerIP + ":9501")
+	controller, err := client.NewControllerClient(controllerIP + ":9501")
 
 	if err != nil {
 		return err
 	}
 
 	//var c *ControllerClient
-	volume, err := command.GetVolume(controller.Address)
+	volume, err := client.GetVolume(controller.Address)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will refactor the jiva controller and replica client codes 
and move inside to `pkg/client/jiva`.
This will help us to write CTL commands related to Volume and snapshots.