### PR TITLE
Refactor snapshot Cli using cobra pkg

### DIFF
--- a/cmd/mayactl/app/command/commands.go
+++ b/cmd/mayactl/app/command/commands.go
@@ -17,6 +17,7 @@ package command
 import (
 	"flag"
 
+	"github.com/openebs/maya/cmd/mayactl/app/command/snapshot"
 	"github.com/spf13/cobra"
 )
 
@@ -31,6 +32,7 @@ func NewMayaCommand() *cobra.Command {
 	cmd.AddCommand(
 		NewCmdVersion(),
 		NewCmdVolume(),
+		snapshot.NewCmdSnapshot(),
 	)
 
 	// add the glog flags

--- a/cmd/mayactl/app/command/snapshot/create.go
+++ b/cmd/mayactl/app/command/snapshot/create.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package snapshot
 
 import (
@@ -27,6 +43,9 @@ import (
 	//flags.SetFlagsFromEnv(cmd.PersistentFlags(), "MAYA")
 }
 */
+
+// CmdSnaphotCreateOptions holds the options for snapshot
+// create command
 type CmdSnaphotCreateOptions struct {
 	volName  string
 	snapName string

--- a/cmd/mayactl/app/command/snapshot/create.go
+++ b/cmd/mayactl/app/command/snapshot/create.go
@@ -1,0 +1,84 @@
+package snapshot
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/openebs/maya/pkg/client/mapiserver"
+	"github.com/openebs/maya/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+/*func init() {
+	host := os.Getenv("MAPI_ADDR")
+	port := os.Getenv("MAPI_PORT")
+	defaultEndpoint := fmt.Sprintf("%s:%s", host, port)
+	if host == "" || port == "" {
+		fmt.Println("$MAPI_ADDR or $MAPI_ADDR are not set. Check if the maya-apiserver is running.")
+		defaultEndpoint = ""
+	}
+
+	cmd.PersistentFlags().StringVar(&APIServerEndpoint, "api-server-endpoint", defaultEndpoint, "IP endpoint of API server instance (required)")
+	cmd.PersistentFlags().StringVar(&logLevelRaw, "log-level", "WARNING", "logging level for logging/tracing output (valid values: CRITICAL,ERROR,WARNING,NOTICE,INFO,DEBUG,TRACE)")
+
+	cmd.MarkFlagRequired("api-server-endpoint")
+
+	// load the environment variables
+	//flags.SetFlagsFromEnv(cmd.PersistentFlags(), "MAYA")
+}
+*/
+type CmdSnaphotCreateOptions struct {
+	volName  string
+	snapName string
+}
+
+// NewCmdSnapshotCreate creates a snapshot of OpenEBS Volume
+func NewCmdSnapshotCreate() *cobra.Command {
+	options := CmdSnaphotCreateOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Creates a new Snapshot",
+		//Long:  SnapshotCreateCommandHelpText,
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(options.Validate(cmd), util.Fatal)
+			util.CheckErr(options.RunSnapshotCreate(cmd), util.Fatal)
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.volName, "volname", "n", options.volName,
+		"unique volume name.")
+	cmd.MarkPersistentFlagRequired("volname")
+	cmd.MarkPersistentFlagRequired("snapname")
+
+	cmd.Flags().StringVarP(&options.snapName, "snapname", "s", options.snapName,
+		"unique snapshot name")
+
+	return cmd
+}
+
+// Validate validates the flag values
+func (c *CmdSnaphotCreateOptions) Validate(cmd *cobra.Command) error {
+	if c.volName == "" {
+		return errors.New("--volname is missing. Please specify an unique name")
+	}
+	if c.snapName == "" {
+		return errors.New("--snapname is missing. Please specify an unique name")
+	}
+
+	return nil
+}
+
+// RunSnapshotCreate does tasks related to mayaserver.
+func (c *CmdSnaphotCreateOptions) RunSnapshotCreate(cmd *cobra.Command) error {
+	fmt.Println("Executing volume snapshot create...")
+
+	resp := mapiserver.CreateSnapshot(c.volName, c.snapName)
+	if resp != nil {
+		return errors.New(fmt.Sprintf("Error: %v", resp))
+	}
+
+	fmt.Printf("Volume snapshot Successfully Created:%v\n", c.volName)
+
+	return nil
+}

--- a/cmd/mayactl/app/command/snapshot/list.go
+++ b/cmd/mayactl/app/command/snapshot/list.go
@@ -1,0 +1,52 @@
+package snapshot
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/openebs/maya/pkg/client/mapiserver"
+	"github.com/openebs/maya/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdSnapshotCreate creates a snapshot of OpenEBS Volume
+func NewCmdSnapshotList() *cobra.Command {
+	options := CmdSnaphotCreateOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Lists all the snapshots of a Volume",
+		//Long:  SnapshotCreateCommandHelpText,
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(options.ValidateList(cmd), util.Fatal)
+			util.CheckErr(options.RunSnapshotList(cmd), util.Fatal)
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.volName, "volname", "n", options.volName,
+		"unique volume name.")
+	cmd.MarkPersistentFlagRequired("volname")
+	return cmd
+}
+
+// Validate validates the flag values
+func (c *CmdSnaphotCreateOptions) ValidateList(cmd *cobra.Command) error {
+	if c.volName == "" {
+		return errors.New("--volname is missing. Please specify an unique name")
+	}
+	return nil
+}
+
+// RunSnapshotCreate does tasks related to mayaserver.
+func (c *CmdSnaphotCreateOptions) RunSnapshotList(cmd *cobra.Command) error {
+	fmt.Println("Executing volume snapshot list...")
+
+	resp := mapiserver.ListSnapshot(c.volName)
+	if resp != nil {
+		return errors.New(fmt.Sprintf("Error: %v", resp))
+	}
+
+	fmt.Printf("Volume snapshots are:%v\n", resp)
+
+	return nil
+}

--- a/cmd/mayactl/app/command/snapshot/list.go
+++ b/cmd/mayactl/app/command/snapshot/list.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package snapshot
 
 import (

--- a/cmd/mayactl/app/command/snapshot/revert.go
+++ b/cmd/mayactl/app/command/snapshot/revert.go
@@ -1,0 +1,53 @@
+package snapshot
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/openebs/maya/pkg/client/mapiserver"
+	"github.com/openebs/maya/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+/*type CmdSnaphotCreateOptions struct {
+	volName  string
+	snapName string
+}*/
+
+// NewCmdSnapshotRevert reverts a snapshot of OpenEBS Volume
+func NewCmdSnapshotRevert() *cobra.Command {
+	options := CmdSnaphotCreateOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "revert",
+		Short: "Reverts to specific snapshot of a Volume",
+		Long:  "Reverts to specific snapshot of a Volume",
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(options.Validate(cmd), util.Fatal)
+			util.CheckErr(options.RunSnapshotRevert(cmd), util.Fatal)
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.volName, "volname", "", options.volName,
+		"unique volume name.")
+	cmd.MarkPersistentFlagRequired("volname")
+	cmd.MarkPersistentFlagRequired("snapname")
+
+	cmd.Flags().StringVarP(&options.snapName, "snapname", "", options.snapName,
+		"unique snapshot name")
+
+	return cmd
+}
+
+// RunSnapshotRevert does tasks related to mayaserver.
+func (c *CmdSnaphotCreateOptions) RunSnapshotRevert(cmd *cobra.Command) error {
+	fmt.Println("Executing volume snapshot revert ...")
+
+	resp := mapiserver.RevertSnapshot(c.volName, c.snapName)
+	if resp != nil {
+		return errors.New(fmt.Sprintf("Error: %v", resp))
+	}
+
+	fmt.Println("Reverting to snapshot [%s] of volume [%s]", c.snapName, c.volName)
+	return nil
+}

--- a/cmd/mayactl/app/command/snapshot/revert.go
+++ b/cmd/mayactl/app/command/snapshot/revert.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package snapshot
 
 import (

--- a/cmd/mayactl/app/command/snapshot/snapshot.go
+++ b/cmd/mayactl/app/command/snapshot/snapshot.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2017 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshot
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewCmdSnapshot() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "snapshot",
+		Short: "Provides operations related to snapshot of a Volume",
+		Long:  "Provides operations related to snapshot of a Volume",
+	}
+
+	cmd.AddCommand(
+		NewCmdSnapshotCreate(),
+		NewCmdSnapshotList(),
+		NewCmdSnapshotRevert(),
+	)
+
+	return cmd
+}

--- a/pkg/client/jiva/model.go
+++ b/pkg/client/jiva/model.go
@@ -49,7 +49,7 @@ type InfoReplica struct {
 	Chain           []string            `json:"chain"`
 	Disks           map[string]DiskInfo `json:"disks"`
 	RemainSnapshots int                 `json:"remainsnapshots"`
-	RevisionCounter string               `json:"revisioncounter"`
+	RevisionCounter string              `json:"revisioncounter"`
 }
 
 type DiskInfo struct {

--- a/pkg/client/mapiserver/snapshot.go
+++ b/pkg/client/mapiserver/snapshot.go
@@ -1,0 +1,187 @@
+package mapiserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/openebs/maya/command"
+	client "github.com/openebs/maya/pkg/client/jiva"
+	"github.com/openebs/maya/types/v1"
+	yaml "gopkg.in/yaml.v2"
+)
+
+const (
+	http_timeout = 5 * time.Second
+)
+
+// CreateSnapshot creates a snapshot of volume by invoking the API call to m-apiserver
+func CreateSnapshot(volName string, snapName string) error {
+
+	_, err := GetStatus()
+	if err != nil {
+		err := errors.New(fmt.Sprintf("Unable to contact maya-apiserver: %s", GetURL()))
+		return err
+	}
+
+	var snap v1.SnapshotAPISpec
+
+	snap.Kind = "VolumeSnapshot"
+	snap.APIVersion = "v1"
+	snap.Metadata.Name = snapName
+	snap.Spec.VolumeName = volName
+
+	//Marshal serializes the value provided into a YAML document
+	yamlValue, _ := yaml.Marshal(snap)
+
+	fmt.Printf("Volume snapshot spec created:\n%v\n", string(yamlValue))
+
+	url := GetURL() + "/latest/snapshots/create/"
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(yamlValue))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("Content-Type", "application/yaml")
+
+	c := &http.Client{
+		Timeout: http_timeout,
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	_, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	fmt.Println(resp)
+	code := resp.StatusCode
+
+	if code != http.StatusOK {
+		err := errors.New(fmt.Sprintf("Status error: %v", http.StatusText(code)))
+		return err
+	}
+	return nil
+}
+
+// RevertSnapshot revert a snapshot of volume by invoking the API call to m-apiserver
+func RevertSnapshot(volName string, snapName string) error {
+
+	_, err := GetStatus()
+	if err != nil {
+		err := errors.New(fmt.Sprintf("Unable to contact maya-apiserver: %s", GetURL()))
+		return err
+	}
+
+	var snap v1.SnapshotAPISpec
+
+	snap.Kind = "VolumeSnapshot"
+	snap.APIVersion = "v1"
+	snap.Metadata.Name = snapName
+	snap.Spec.VolumeName = volName
+
+	//Marshal serializes the value provided into a YAML document
+	yamlValue, _ := yaml.Marshal(snap)
+
+	url := GetURL() + "/latest/snapshots/revert/"
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(yamlValue))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("Content-Type", "application/yaml")
+
+	c := &http.Client{
+		Timeout: http_timeout,
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	_, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	code := resp.StatusCode
+
+	if code != http.StatusOK {
+		err := errors.New(fmt.Sprintf("Status error: %v", http.StatusText(code)))
+		return err
+	}
+	return nil
+}
+
+// ListSnapshot list snapshots of volume by invoking the API call to m-apiserver
+func ListSnapshot(volName string) error {
+
+	_, err := GetStatus()
+	if err != nil {
+		err := errors.New(fmt.Sprintf("Unable to contact maya-apiserver: %s", GetURL()))
+		return err
+	}
+
+	url := GetURL() + "/latest/snapshots/list/" + volName
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+	c := &http.Client{
+		Timeout: timeoutVolumeDelete,
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	code := resp.StatusCode
+	if code != http.StatusOK {
+		return fmt.Errorf("Status error: %v", http.StatusText(code))
+	}
+	snapdisk, err := getInfo([]byte(body))
+	out := make([]string, len(snapdisk)+1)
+
+	out[0] = "Name|Created At|Size"
+	var i int
+
+	for _, disk := range snapdisk {
+		//	if !IsHeadDisk(disk.Name) {
+		out[i+1] = fmt.Sprintf("%s|%s|%s",
+			strings.TrimSuffix(strings.TrimPrefix(disk.Name, "volume-snap-"), ".img"),
+			disk.Created,
+			disk.Size)
+		i = i + 1
+		//	}
+	}
+	fmt.Println(command.FormatList(out))
+
+	return nil
+}
+
+func getInfo(body []byte) (*map[string]client.DiskInfo, error) {
+
+	var s = new(map[string]client.DiskInfo)
+	err := json.Unmarshal(body, &s)
+	if err != nil {
+		fmt.Println("whoops:", err)
+		return nil, err
+	}
+
+	return s, err
+
+}

--- a/pkg/client/mapiserver/snapshot.go
+++ b/pkg/client/mapiserver/snapshot.go
@@ -167,6 +167,9 @@ func ListSnapshot(volName string) error {
 		return fmt.Errorf("Status error: %v", http.StatusText(code))
 	}
 	snapdisk, err := getInfo([]byte(body))
+	if err != nil {
+		fmt.Println("Failed to get the snapshot data", err)
+	}
 	/*out := make([]string, len(snapdisk)+1)
 
 	out[0] = "Name|Created At|Size"
@@ -193,7 +196,7 @@ func getInfo(body []byte) (*map[string]client.DiskInfo, error) {
 	var s = new(map[string]client.DiskInfo)
 	err := json.Unmarshal(body, &s)
 	if err != nil {
-		fmt.Println("whoops:", err)
+		fmt.Println("Unmarshling Error:", err)
 		return nil, err
 	}
 

--- a/pkg/client/mapiserver/snapshot.go
+++ b/pkg/client/mapiserver/snapshot.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2017 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package mapiserver
 
 import (
@@ -7,10 +22,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"strings"
 	"time"
 
-	"github.com/openebs/maya/command"
 	client "github.com/openebs/maya/pkg/client/jiva"
 	"github.com/openebs/maya/types/v1"
 	yaml "gopkg.in/yaml.v2"
@@ -154,7 +167,7 @@ func ListSnapshot(volName string) error {
 		return fmt.Errorf("Status error: %v", http.StatusText(code))
 	}
 	snapdisk, err := getInfo([]byte(body))
-	out := make([]string, len(snapdisk)+1)
+	/*out := make([]string, len(snapdisk)+1)
 
 	out[0] = "Name|Created At|Size"
 	var i int
@@ -167,8 +180,10 @@ func ListSnapshot(volName string) error {
 			disk.Size)
 		i = i + 1
 		//	}
-	}
-	fmt.Println(command.FormatList(out))
+	}*/
+
+	//	fmt.Println(util.FormatList(out))
+	fmt.Println(snapdisk)
 
 	return nil
 }

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -277,7 +277,17 @@ type VolumeAPISpec struct {
 	} `yaml:"metadata"`
 }
 
-// -------------Snapshot Structs ----------
+// SnapshotAPISpec hsolds the config for creating asnapshot of volume
+type SnapshotAPISpec struct {
+	Kind       string `yaml:"kind"`
+	APIVersion string `yaml:"apiVersion"`
+	Metadata   struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		VolumeName string `yaml:"volumeName"`
+	} `yaml:"spec"`
+}
 
 // VolumeSnapshot is volume snapshot object accessible to the user. Upon successful creation of the actual
 // snapshot by the volume provider it is bound to the corresponding VolumeSnapshotData through


### PR DESCRIPTION
**What this PR does / why we need it**:
1. This commit will add and refactor snapshot cli using cobra pkg.
2. Adding apiserver client
3. This commit will add `snapshot create` and `snapshot revert` command using cobra pkg.

**Which issue this PR fixes** 
fixes openebs/openebs#506

**Special notes for your reviewer**:
```
$ mayactl
Maya means 'Magic' a tool for storage orchestration

Usage:
  maya [command]

Available Commands:
  help        Help about any command
  snapshot    Provides operations related to snapshot of a Volume
  version     Prints version and other details relevant to maya
  volume      Provides operations related to a Volume

Flags:
      --alsologtostderr                  log to standard error as well as files
  -h, --help                             help for maya
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --logtostderr                      log to standard error instead of files
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
  -v, --v Level                          log level for V logs
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

Use "maya [command] --help" for more information about a command.

```
```
$ mayactl snapshot create -h
Creates a new Snapshot

Usage:
  maya snapshot create [flags]

Flags:
  -h, --help              help for create
  -s, --snapname string   unique snapshot name
  -n, --volname string    unique volume name.

Global Flags:
      --alsologtostderr                  log to standard error as well as files
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --logtostderr                      log to standard error instead of files
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
  -v, --v Level                          log level for V logs
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
```
