### PR TITLE
Add volname, iqn, portal as label in Uptime gauge

### DIFF
--- a/cmd/maya-agent/app/exporter/collector/collector_test.go
+++ b/cmd/maya-agent/app/exporter/collector/collector_test.go
@@ -108,25 +108,7 @@ func TestCollector(t *testing.T) {
 	} {
 		func() {
 			// response is the response expected from the test server.
-			var response = `{"ReadIOPS":"1",
-			"ReplicaCounter":6,
-			"RevisionCounter":100,
-			"SCSIIOCount":null,
-			"SectorSize":"4096",
-			"Size":"5G",
-		    "TotalReadBlockCount":"10",
-		    "TotalReadTime":"10",
-		    "TotalWriteTime":"15",
-		    "TotatWriteBlockCount":"10",
-		    "UsedBlocks":"1048576",
-		    "UsedLogicalBlocks":"1048576",
-		    "WriteIOPS":"15",
-		    "actions":{},
-		    "links":{
-			  "self":"http://localhost:9501/v1/stats"
-		    },
-		    "type":"stats"
-    }`
+			var response = `{"Name":"vol","ReadIOPS":"1","ReplicaCounter":6,"RevisionCounter":100,"SCSIIOCount":null,"SectorSize":"4096","Size":"5G","TotalReadBlockCount":"10","TotalReadTime":"10","TotalWriteTime":"15","TotatWriteBlockCount":"10","UpTime":10,"UsedBlocks":"1048576","UsedLogicalBlocks":"1048576","WriteIOPS":"15","actions":{},"links":{"self":"http://localhost:9501/v1/stats"},"type":"stats"}`
 			// This is dummy server which gives response in json format and it
 			// is used to map the response with the fields of struct VolumeMetrics.
 			controller := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/types/v1/metrics.go
+++ b/types/v1/metrics.go
@@ -16,10 +16,12 @@ type VolumeMetrics struct {
 	TotalWriteTime       string `json:"TotalWriteTime"`
 	TotalWriteBlockCount string `json:"TotatWriteBlockCount"`
 
-	UsedLogicalBlocks string `json:"UsedLogicalBlocks"`
-	UsedBlocks        string `json:"UsedBlocks"`
-	SectorSize        string `json:"SectorSize"`
-	Size              string `json:Size`
+	UsedLogicalBlocks string  `json:"UsedLogicalBlocks"`
+	UsedBlocks        string  `json:"UsedBlocks"`
+	SectorSize        string  `json:"SectorSize"`
+	Size              string  `json:"Size"`
+	UpTime            float64 `json:"UpTime"`
+	Name              string  `json:"Name"`
 }
 
 type Resource struct {


### PR DESCRIPTION
1. Why is this change necessary ?
- volume uptime, volname, iqn and portal details were missing in exporter code.
- volume size was in bytes.

2. How does this change address the issue ?
- added a gauge uptime and iqn, portal, volname as labels.
- changed the size into GB.

3. How to verify this change ?
- run maya-agent locally or within maya-apiserver by passing controller's
  IP as flag `maya-agent monitor`.
- or run as deployment.

4. What side effects does this change have ?
- A little change on the structure, added two new fields Name and uptime
  this depends on the jiva. PR openebs/jiva#30 raised for these changes.

5. Other details
improvement: openebs/openebs#886
fix: corrected the unit of volume size.

<!--  Thanks for sending a pull request!  Here are some tips for you -->
<!--
**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
