### PR TITLE
Setup auto-build for maya-volume-exporter image

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -26,7 +26,7 @@ EXPORTER=maya-volume-exporter
 # Specify the date o build
 BUILD_DATE = $(shell date +'%Y%m%d%H%M%S')
 
-all: test mayactl apiserver-image agent-image
+all: test mayactl apiserver-image exporter-image maya-agent
 
 dev: format
 	@MAYACTL=${MAYACTL} MAYA_DEV=1 sh -c "'$(PWD)/buildscripts/mayactl/build.sh'"
@@ -127,14 +127,14 @@ agent-image: maya-agent
 	@sh buildscripts/agent/push
 
 # Use this to build only the maya-volume-exporter.
-maya-volume-exporter:
+exporter:
 	@echo "----------------------------"
 	@echo "--> maya-volume-exporter              "
 	@echo "----------------------------"
 	@CTLNAME=${EXPORTER} sh -c "'$(PWD)/buildscripts/exporter/build.sh'"
 
 # m-exporter image. This is going to be decoupled soon.
-exporter-image: maya-volume-exporter
+exporter-image: exporter
 	@echo "----------------------------"
 	@echo "--> m-exporter image         "
 	@echo "----------------------------"

--- a/buildscripts/exporter/push
+++ b/buildscripts/exporter/push
@@ -19,5 +19,5 @@ then
     sudo docker push openebs/m-exporter:latest;
   fi;
 else
-  echo "No docker credentials provided. Skip uploading openebs/m-agent:ci to docker hub";
+  echo "No docker credentials provided. Skip uploading openebs/m-exporter:ci to docker hub";
 fi;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
volume-exporter can be deployed as side-car to the openebs volumes. This exporter acts as an adaptor for fetching stats from the openebs volumes and exporting them in the prometheus format. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
This PR allows for adding the building and pushing of the volume exporter image via travis. 
Also, will stop building the maya-agent image till it is used.