### PR TITLE
support monitoring as a storage policy

### DIFF
--- a/orchprovider/k8s/v1/k8s.go
+++ b/orchprovider/k8s/v1/k8s.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/openebs/maya/orchprovider"
+	"github.com/openebs/maya/pkg/util"
 	"github.com/openebs/maya/types/v1"
 	volProfile "github.com/openebs/maya/volume/profiles"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -698,6 +699,11 @@ func (k *k8sOrchestrator) createControllerDeployment(volProProfile volProfile.Vo
 		return nil, err
 	}
 
+	vol, err := volProProfile.Volume()
+	if err != nil {
+		return nil, err
+	}
+
 	if clusterIP == "" {
 		return nil, fmt.Errorf("VSM cluster IP is required to create controller for vsm 'name: %s'", vsm)
 	}
@@ -797,6 +803,21 @@ func (k *k8sOrchestrator) createControllerDeployment(volProProfile volProfile.Vo
 		if err != nil {
 			return nil, err
 		}
+	}
+	// is volume monitoring enabled ?
+	isMonitoring := !util.CheckFalsy(vol.Monitor)
+	if isMonitoring {
+		// get the sidecar instance
+		sc, err := NewMonitoringSideCar(vol.Monitor, clusterIP)
+		if err != nil {
+			return nil, err
+		}
+		// get the sc container
+		scc, err := sc.generate()
+		if err != nil {
+			return nil, err
+		}
+		deploy.Spec.Template.Spec.Containers = append(deploy.Spec.Template.Spec.Containers, scc)
 	}
 
 	// add persistent volume controller deployment

--- a/orchprovider/k8s/v1/k8s_test.go
+++ b/orchprovider/k8s/v1/k8s_test.go
@@ -421,6 +421,11 @@ func (e *okVsmNameVolumeProfile) VSMName() (string, error) {
 	return "ok-vsm-name", nil
 }
 
+// VSMName does not return any error
+func (e *okVsmNameVolumeProfile) Volume() (*v1.Volume, error) {
+	return &v1.Volume{}, nil
+}
+
 // ControllerImage does not return any error
 func (e *okVsmNameVolumeProfile) IsReplicaNodeTaintTolerations() ([]string, bool, error) {
 	return []string{"k=v:NoSchedule"}, true, nil

--- a/orchprovider/k8s/v1/util.go
+++ b/orchprovider/k8s/v1/util.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/ghodss/yaml"
+	"github.com/openebs/maya/pkg/util"
 	"github.com/openebs/maya/types/v1"
 	orchProfile "github.com/openebs/maya/types/v1/profile/orchestrator"
 	volProfile "github.com/openebs/maya/volume/profiles"
@@ -20,6 +22,79 @@ import (
 
 	"k8s.io/client-go/rest"
 )
+
+type MonitoringSideCar struct {
+	// TargetIP is the IP Address of the
+	// service using which this sidecar will
+	// pull metrics info
+	TargetIP string
+
+	// Image of this sidecar
+	Image string `json:"image,omitempty"`
+
+	// SideCar is the K8s type that represents a sidecar
+	SideCar k8sApiV1.Container
+}
+
+// monSideCarTpl is the K8s type (used as a template) that gets
+// built as a sidecar
+var monSideCarTpl = k8sApiV1.Container{
+	Name:  "maya-volume-exporter",
+	Image: "openebs/m-exporter:ci",
+	Command: []string{
+		"maya-volume-exporter",
+	},
+	Args: []string{
+		"-c=http://__TARGET_IP__:9501",
+	},
+	Ports: []k8sApiV1.ContainerPort{
+		k8sApiV1.ContainerPort{
+			ContainerPort: 9500,
+		},
+	},
+}
+
+// NewMonitoringSideCar returns a new instance of MonitoringSideCar.
+//
+// NOTE:
+//  val can have following values:
+//  1/ `true` or `1` or `yes` or `ok` or
+//  2/ `image: some_repo/some_image:some_tag`
+func NewMonitoringSideCar(val string, targetIPAdd string) (*MonitoringSideCar, error) {
+	// create a new instance
+	m := &MonitoringSideCar{}
+
+	// truthy value indicates use of defaults in the sidecar
+	// Otherwise specific values has been provided to generate the sidecar
+	if !util.CheckTruthy(val) {
+		// set with provided/specific values
+		err := yaml.Unmarshal([]byte(val), m)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	m.TargetIP = targetIPAdd
+	m.SideCar = monSideCarTpl
+
+	if len(m.TargetIP) == 0 {
+		return nil, fmt.Errorf("Monitoring target IP is missing")
+	}
+
+	return m, nil
+}
+
+// generate returns a K8s Container type from the yaml specification
+func (m *MonitoringSideCar) generate() (k8sApiV1.Container, error) {
+
+	m.SideCar.Args[0] = strings.Replace(m.SideCar.Args[0], "__TARGET_IP__", m.TargetIP, 1)
+
+	if len(m.Image) != 0 {
+		m.SideCar.Image = m.Image
+	}
+
+	return m.SideCar, nil
+}
 
 // K8sUtilGetter is an abstraction to fetch instances of K8sUtilInterface
 type K8sUtilGetter interface {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -22,6 +22,18 @@ func CheckTruthy(truth string) bool {
 	return truthyValues[strings.ToUpper(truth)]
 }
 
+// falsyValues maps a set of values which are considered as false
+var falsyValues = map[string]bool{
+	"0":     true,
+	"NO":    true,
+	"FALSE": true,
+}
+
+// CheckFalsy checks for non-truthiness of the passed argument.
+func CheckFalsy(falsy string) bool {
+	return falsyValues[strings.ToUpper(falsy)]
+}
+
 // CheckErr to handle command errors
 func CheckErr(err error, handleErr func(string)) {
 	if err == nil {

--- a/types/v1/defaults.go
+++ b/types/v1/defaults.go
@@ -47,6 +47,11 @@ const (
 
 	// DefaultHostPath contains the default host path value
 	DefaultHostPath string = "/var/openebs"
+
+	// DefaultMonitor contains the default value for volume
+	// monitoring policy. Value of `false` indicates
+	// volume monitoring is disabled by default.
+	DefaultMonitor string = "false"
 )
 
 var (

--- a/types/v1/envs.go
+++ b/types/v1/envs.go
@@ -75,6 +75,9 @@ const (
 
 	// HostPathENVK is the ENV key to fetch host path
 	HostPathENVK ENVKey = "OPENEBS_IO_HOST_PATH"
+
+	// MonitorENVK is the ENV key to fetch the volume monitoring details
+	MonitorENVK ENVKey = "OPENEBS_IO_VOLUME_MONITOR"
 )
 
 // VolumeTypeENV will fetch the value of volume type
@@ -138,6 +141,11 @@ func StoragePoolENV() string {
 
 func HostPathENV() string {
 	val := getEnv(HostPathENVK)
+	return val
+}
+
+func MonitorENV() string {
+	val := getEnv(MonitorENVK)
 	return val
 }
 

--- a/types/v1/policies.go
+++ b/types/v1/policies.go
@@ -109,4 +109,7 @@ const (
 
 	// StoragePoolVK is the key to fetch the name of storage pool
 	StoragePoolVK VolumeKey = "openebs.io/storage-pool"
+
+	// MonitorVK is the key to fetch the monitoring details
+	MonitorVK VolumeKey = "openebs.io/volume-monitor"
 )

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -45,6 +45,14 @@ type Volume struct {
 	// +optional
 	HostPath string `json:"hostpath,omitempty" protobuf:"bytes,1,opt,name=hostpath"`
 
+	// Monitor flags as well provides values for monitoring the volume
+	// e.g. a value of:
+	//  - `false` or empty value indicates monitoring is not required
+	//  - `image: openebs/m-exporter:ci` indicates monitoring is enabled
+	// and should use the provided image
+	//  - `true` indicates monitoring is required & should use the defaults
+	Monitor string `json:"monitor,omitempty" protobuf:"bytes,1,opt,name=monitor"`
+
 	// Specs contains the desired specifications the volume should have.
 	// +optional
 	Specs []VolumeSpec `json:"specs,omitempty" protobuf:"bytes,2,rep,name=specs"`

--- a/volume/policies/v1/policy_jiva_k8s.go
+++ b/volume/policies/v1/policy_jiva_k8s.go
@@ -136,6 +136,7 @@ func (p *JivaK8sPolicies) getPropertyEnforcers() []enforcePropertyFn {
 		enforceReplicaCount,
 		enforceControllerImage,
 		enforceControllerCount,
+		enforceMonitoring,
 	}
 }
 
@@ -200,6 +201,33 @@ func enforceStoragePool(p *JivaK8sPolicies) error {
 
 	if len(p.volume.StoragePool) == 0 {
 		return fmt.Errorf("Nil storage pool")
+	}
+
+	return nil
+}
+
+// enforceMonitoring enforces volume monitoring policy
+func enforceMonitoring(p *JivaK8sPolicies) error {
+	// merge from sc policy
+	if len(p.volume.Monitor) == 0 {
+		p.volume.Monitor = p.scPolicies[string(v1.MonitorVK)]
+	}
+
+	// merge from env variable & then from default
+	mVals := []string{
+		v1.MonitorENV(),
+		v1.DefaultMonitor,
+	}
+
+	// Ensure non-empty value is set
+	for _, mVal := range mVals {
+		if len(p.volume.Monitor) == 0 {
+			p.volume.Monitor = mVal
+		}
+	}
+
+	if len(p.volume.Monitor) == 0 {
+		return fmt.Errorf("Nil volume monitor")
 	}
 
 	return nil


### PR DESCRIPTION
1. Why is this change necessary ?

It has been desired to have a storage policy that
enables, disables or customizes monitoring on a per
volume basis.

2. How does this change address the issue ?

- introduces a storage policy k:v that can be set
in StorageClass

3. How to verify this change ?

- refer openebs/openebs#925

4. What side effects does this change have ?

- None

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
