### PR TITLE
Use 127.0.0.1 as target ip for monitoring sidecar

### DIFF
--- a/orchprovider/k8s/v1/k8s.go
+++ b/orchprovider/k8s/v1/k8s.go
@@ -808,7 +808,7 @@ func (k *k8sOrchestrator) createControllerDeployment(volProProfile volProfile.Vo
 	isMonitoring := !util.CheckFalsy(vol.Monitor)
 	if isMonitoring {
 		// get the sidecar instance
-		sc, err := NewMonitoringSideCar(vol.Monitor, clusterIP)
+		sc, err := NewMonitoringSideCar(vol.Monitor)
 		if err != nil {
 			return nil, err
 		}

--- a/orchprovider/k8s/v1/util.go
+++ b/orchprovider/k8s/v1/util.go
@@ -89,7 +89,7 @@ var monSideCarTpl = k8sApiV1.Container{
 //  val can have following values:
 //  1/ `true` or `1` or `yes` or `ok` or
 //  2/ `image: some_repo/some_image:some_tag`
-func NewMonitoringSideCar(val string, targetIPAdd string) (*MonitoringSideCar, error) {
+func NewMonitoringSideCar(val string) (*MonitoringSideCar, error) {
 	// create a new instance
 	m := &MonitoringSideCar{}
 
@@ -103,12 +103,9 @@ func NewMonitoringSideCar(val string, targetIPAdd string) (*MonitoringSideCar, e
 		}
 	}
 
-	m.TargetIP = targetIPAdd
+	// When deploying as sidecar, the targetIP should be 127.0.0.1
+	m.TargetIP = "127.0.0.1"
 	m.SideCar = monSideCarTpl
-
-	if len(m.TargetIP) == 0 {
-		return nil, fmt.Errorf("Monitoring target IP is missing")
-	}
 
 	return m, nil
 }


### PR DESCRIPTION
Related to : https://github.com/openebs/maya/pull/200

The containers running within pod have no idea of the cluster IPs. To communicate with each other, they need to use localhost. 

The spec generated after making the changes from this commit are as follows:
```
 maya-volume-exporter:
    Container ID:  docker://2f122479098a720753967c203a7b2f37a6b98cff174c8c6e6822ee4c3b49ae27
    Image:         openebs/m-exporter:ci
    Image ID:      docker://sha256:28cfd6b38043ae3d0ae43404d11d4b653362ca8cb83d95ee20889c641f133f52
    Port:          9500/TCP
    Command:
      maya-volume-exporter
    Args:
      -c=http://127.0.0.1:9501
    State:          Running
      Started:      Fri, 24 Nov 2017 09:24:17 +0530
    Ready:          True
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from default-token-pc5br (ro)
```