### PR TITLE
fixes openebs/openebs#934 - set capacity from PVC

### DIFF
--- a/volume/policies/v1/policy_jiva_k8s.go
+++ b/volume/policies/v1/policy_jiva_k8s.go
@@ -148,14 +148,15 @@ type enforcePropertyFn func(*JivaK8sPolicies) error
 // enforceCapacity enforces capacity volume
 // policy
 func enforceCapacity(p *JivaK8sPolicies) error {
+	// merge from old label;
+	// this comes from PVC through openebs provisioner
+	if len(p.volume.Capacity) == 0 {
+		p.volume.Capacity = p.volume.Labels.CapacityOld
+	}
+	
 	// merge from sc policy
 	if len(p.volume.Capacity) == 0 {
 		p.volume.Capacity = p.scPolicies[string(v1.CapacityVK)]
-	}
-
-	// merge from old label
-	if len(p.volume.Capacity) == 0 {
-		p.volume.Capacity = p.volume.Labels.CapacityOld
 	}
 
 	// merge from env variable & then from default


### PR DESCRIPTION
1. Why is this change necessary ?

It is seen that volume capacity is always taken from
StorageClass parameters. However, the capacity property
set in PVC should always prevail over any other value.

2. How does this change address the issue ?

- changes the priority order & sets highest priority to
PVC

3. How to verify this change ?

- create volume by setting volume capacity in PVC & StorageClass

4. What side effects does this change have ?

- None

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
