### PR TITLE
Fix Apiserver volume status

### DIFF
--- a/orchprovider/k8s/v1/k8s.go
+++ b/orchprovider/k8s/v1/k8s.go
@@ -581,6 +581,7 @@ func (k *k8sOrchestrator) readVSM(vsm string, volProProfile volProfile.VolumePro
 		for _, rp := range rPods.Items {
 			mb.AddReplicaIPs(rp)
 			mb.AddReplicaStatuses(rp)
+			mb.AddReplicaContainerStatuses(rp)
 		}
 	} else {
 		glog.Warningf("Missing Replica Pod(s) for volume '%s: %s'", ns, vsm)
@@ -615,6 +616,11 @@ func (k *k8sOrchestrator) readVSM(vsm string, volProProfile volProfile.VolumePro
 	pv.Name = vsm
 	pv.Annotations = mb.AsAnnotations()
 
+	if mb.IsRunning(pv) {
+		pv.Status.Phase = v1.ContainerRunningVV
+	} else {
+		pv.Status.Phase = v1.ContainerNotRunningVV
+	}
 	glog.Infof("Info fetched successfully for volume '%s: %s'", ns, vsm)
 
 	return pv, nil

--- a/orchprovider/k8s/v1/k8s.go
+++ b/orchprovider/k8s/v1/k8s.go
@@ -613,7 +613,7 @@ func (k *k8sOrchestrator) readVSM(vsm string, volProProfile volProfile.VolumePro
 	pv.Name = vsm
 	pv.Annotations = mb.AsAnnotations()
 
-	if mb.IsRunning(pv) {
+	if mb.IsVolumeRunning(pv) {
 		pv.Status.Phase = v1.VolumePhase(v1.VolumeRunningVV)
 	} else {
 		pv.Status.Phase = v1.VolumePhase(v1.VolumeNotRunningVV)

--- a/orchprovider/k8s/v1/k8s.go
+++ b/orchprovider/k8s/v1/k8s.go
@@ -564,7 +564,7 @@ func (k *k8sOrchestrator) readVSM(vsm string, volProProfile volProfile.VolumePro
 		for _, cp := range cPods.Items {
 			mb.AddControllerIPs(cp)
 			mb.AddControllerStatuses(cp)
-			mb.AddContainerStatuses(cp, v1.ControllerContainerStatusVK)
+			mb.AddControllerContainerStatus(cp)
 		}
 	} else {
 		glog.Warningf("Missing Controller Pod(s) for volume '%s: %s'", ns, vsm)
@@ -581,7 +581,7 @@ func (k *k8sOrchestrator) readVSM(vsm string, volProProfile volProfile.VolumePro
 		for _, rp := range rPods.Items {
 			mb.AddReplicaIPs(rp)
 			mb.AddReplicaStatuses(rp)
-			mb.AddContainerStatuses(rp, v1.ReplicaContainerStatusVK)
+			mb.AddReplicaContainerStatus(rp)
 		}
 	} else {
 		glog.Warningf("Missing Replica Pod(s) for volume '%s: %s'", ns, vsm)

--- a/orchprovider/k8s/v1/k8s.go
+++ b/orchprovider/k8s/v1/k8s.go
@@ -456,14 +456,14 @@ func (k *k8sOrchestrator) DeleteStorage(volProProfile volProfile.VolumeProvision
 // ReadStorage will fetch information about the persistent volume
 //func (k *k8sOrchestrator) ReadStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.PersistentVolumeList, error) {
 func (k *k8sOrchestrator) ReadStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.Volume, error) {
-	// volProProfile is expected to have the VSM name
+	// volProProfile is expected to have the volume name
 	return k.readVSM("", volProProfile)
 }
 
-// readVSM will fetch information about a VSM
+// readVSM will fetch information about a volume
 func (k *k8sOrchestrator) readVSM(vsm string, volProProfile volProfile.VolumeProvisionerProfile) (*v1.Volume, error) {
 
-	// flag that checks if at-least one child object of VSM exists
+	// flag that checks if at-least one child object of Volume exists
 	doesExist := false
 
 	if volProProfile == nil {
@@ -509,7 +509,7 @@ func (k *k8sOrchestrator) readVSM(vsm string, volProProfile volProfile.VolumePro
 		return nil, err
 	}
 
-	glog.Infof("Fetching info on volume '%s: %s'", ns, vsm)
+	glog.Infof("Fetching info on Volume '%s: %s'", ns, vsm)
 
 	//annotations := map[string]string{}
 
@@ -564,6 +564,7 @@ func (k *k8sOrchestrator) readVSM(vsm string, volProProfile volProfile.VolumePro
 		for _, cp := range cPods.Items {
 			mb.AddControllerIPs(cp)
 			mb.AddControllerStatuses(cp)
+			mb.AddControllerContainerStatuses(cp)
 		}
 	} else {
 		glog.Warningf("Missing Controller Pod(s) for volume '%s: %s'", ns, vsm)
@@ -625,7 +626,7 @@ func (k *k8sOrchestrator) ListStorage(volProProfile volProfile.VolumeProvisioner
 		return nil, fmt.Errorf("Nil volume provisioner profile provided")
 	}
 
-	glog.Infof("Listing VSMs at orchestrator '%s: %s'", k.Label(), k.Name())
+	glog.Infof("Listing Volumes at orchestrator '%s: %s'", k.Label(), k.Name())
 
 	dl, err := k.getVSMDeployments(volProProfile)
 	if err != nil {
@@ -648,7 +649,7 @@ func (k *k8sOrchestrator) ListStorage(volProProfile volProfile.VolumeProvisioner
 
 		vsm := v1.SanitiseVSMName(d.Name)
 		if vsm == "" {
-			return nil, fmt.Errorf("VSM name could not be determined from K8s Deployment 'name: %s'", d.Name)
+			return nil, fmt.Errorf("Volume name could not be determined from K8s Deployment 'name: %s'", d.Name)
 		}
 
 		pv, err := k.readVSM(vsm, volProProfile)
@@ -660,7 +661,7 @@ func (k *k8sOrchestrator) ListStorage(volProProfile volProfile.VolumeProvisioner
 		pvl.Items = append(pvl.Items, *pv)
 	}
 
-	glog.Infof("Listed VSMs 'count: %d' at orchestrator '%s: %s'", len(pvl.Items), k.Label(), k.Name())
+	glog.Infof("Listed Volume 'count: %d' at orchestrator '%s: %s'", len(pvl.Items), k.Label(), k.Name())
 
 	return pvl, nil
 }
@@ -728,7 +729,7 @@ func (k *k8sOrchestrator) createControllerDeployment(volProProfile volProfile.Vo
 	}
 
 	if clusterIP == "" {
-		return nil, fmt.Errorf("VSM cluster IP is required to create controller for vsm 'name: %s'", vsm)
+		return nil, fmt.Errorf("Volume cluster IP is required to create controller for volume 'name: %s'", vsm)
 	}
 
 	cImg, imgSupport, err := volProProfile.ControllerImage()
@@ -737,7 +738,7 @@ func (k *k8sOrchestrator) createControllerDeployment(volProProfile volProfile.Vo
 	}
 
 	if !imgSupport {
-		return nil, fmt.Errorf("VSM '%s' requires a controller container image", vsm)
+		return nil, fmt.Errorf("Volume '%s' requires a controller container image", vsm)
 	}
 
 	k8sUtl := k8sOrchUtil(k, volProProfile)
@@ -754,7 +755,7 @@ func (k *k8sOrchestrator) createControllerDeployment(volProProfile volProfile.Vo
 		return nil, err
 	}
 
-	glog.Infof("Adding controller for VSM 'name: %s'", vsm)
+	glog.Infof("Adding controller for volume 'name: %s'", vsm)
 	var tolerationSeconds int64 = 0
 
 	deploy := &k8sApisExtnsBeta1.Deployment{
@@ -878,7 +879,7 @@ func (k *k8sOrchestrator) createReplicaDeployment(volProProfile volProfile.Volum
 	}
 
 	if clusterIP == "" {
-		return nil, fmt.Errorf("VSM cluster IP is required to create replica(s) for vsm 'name: %s'", vsm)
+		return nil, fmt.Errorf("Volume cluster IP is required to create replica(s) for volume 'name: %s'", vsm)
 	}
 
 	rImg, err := volProProfile.ReplicaImage()
@@ -922,7 +923,7 @@ func (k *k8sOrchestrator) createReplicaDeployment(volProProfile volProfile.Volum
 	//for rcIndex := 1; rcIndex <= rCount; rcIndex++ {
 	//glog.Infof("Adding replica #%d for VSM '%s'", rcIndex, vsm)
 
-	glog.Infof("Adding replica(s) for VSM '%s'", vsm)
+	glog.Infof("Adding replica(s) for Volume '%s'", vsm)
 
 	deploy := &k8sApisExtnsBeta1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1070,7 +1071,7 @@ func (k *k8sOrchestrator) createReplicaDeployment(volProProfile volProfile.Volum
 		return nil, err
 	}
 
-	glog.Infof("Successfully added replica(s) 'count: %d' for VSM '%s'", rCount, d.Name)
+	glog.Infof("Successfully added replica(s) 'count: %d' for Volume '%s'", rCount, d.Name)
 
 	//glog.Infof("Successfully added replica #%d for VSM '%s'", rcIndex, d.Name)
 	//} -- end of for loop -- if manual replica addition
@@ -1381,7 +1382,7 @@ func (k *k8sOrchestrator) getDeploymentList(vsm string, volProProfile volProfile
 	}
 
 	if deployList == nil {
-		return nil, fmt.Errorf("VSM(s) '%s:%s' not found at orchestrator '%s:%s'", ns, vsm, k.Label(), k.Name())
+		return nil, fmt.Errorf("Volume(s) '%s:%s' not found at orchestrator '%s:%s'", ns, vsm, k.Label(), k.Name())
 	}
 
 	return deployList, nil

--- a/orchprovider/k8s/v1/k8s.go
+++ b/orchprovider/k8s/v1/k8s.go
@@ -564,7 +564,7 @@ func (k *k8sOrchestrator) readVSM(vsm string, volProProfile volProfile.VolumePro
 		for _, cp := range cPods.Items {
 			mb.AddControllerIPs(cp)
 			mb.AddControllerStatuses(cp)
-			mb.AddControllerContainerStatuses(cp)
+			mb.AddContainerStatuses(cp, v1.ControllerContainerStatusVK)
 		}
 	} else {
 		glog.Warningf("Missing Controller Pod(s) for volume '%s: %s'", ns, vsm)
@@ -581,7 +581,7 @@ func (k *k8sOrchestrator) readVSM(vsm string, volProProfile volProfile.VolumePro
 		for _, rp := range rPods.Items {
 			mb.AddReplicaIPs(rp)
 			mb.AddReplicaStatuses(rp)
-			mb.AddReplicaContainerStatuses(rp)
+			mb.AddContainerStatuses(rp, v1.ReplicaContainerStatusVK)
 		}
 	} else {
 		glog.Warningf("Missing Replica Pod(s) for volume '%s: %s'", ns, vsm)
@@ -609,18 +609,16 @@ func (k *k8sOrchestrator) readVSM(vsm string, volProProfile volProfile.VolumePro
 
 	mb.AddIQN(vsm)
 
-	// TODO
-	// This is a temporary type that is used
-	// Will move to VSM type
 	pv := &v1.Volume{}
 	pv.Name = vsm
 	pv.Annotations = mb.AsAnnotations()
 
 	if mb.IsRunning(pv) {
-		pv.Status.Phase = v1.ContainerRunningVV
+		pv.Status.Phase = v1.VolumePhase(v1.VolumeRunningVV)
 	} else {
-		pv.Status.Phase = v1.ContainerNotRunningVV
+		pv.Status.Phase = v1.VolumePhase(v1.VolumeNotRunningVV)
 	}
+
 	glog.Infof("Info fetched successfully for volume '%s: %s'", ns, vsm)
 
 	return pv, nil

--- a/orchprovider/k8s/v1/k8s_test.go
+++ b/orchprovider/k8s/v1/k8s_test.go
@@ -641,7 +641,7 @@ func TestCreateControllerDeploymentReturnsNoSupportCtrlImg(t *testing.T) {
 	}
 
 	n, _ := volProfile.VSMName()
-	expErr := fmt.Sprintf("VSM '%s' requires a controller container image", n)
+	expErr := fmt.Sprintf("Volume '%s' requires a controller container image", n)
 
 	if err != nil && err.Error() != expErr {
 		t.Errorf("TestCase: Error Message Match \n\tExpectedErr: '%s' \n\tActualErr: '%s'", expErr, err.Error())

--- a/orchprovider/k8s/v1/util.go
+++ b/orchprovider/k8s/v1/util.go
@@ -105,40 +105,6 @@ func (p *VolumeMarkerBuilder) AddMarkers(markers []VolumeMarker) {
 
 // AddMultiples will add a new volume marker or append to an existing
 // volume marker
-/*func (p *VolumeMarkerBuilder) AddMultiples(key, value string, isMul bool) error {
-	if len(key) == 0 {
-		return fmt.Errorf("Marker key is missing")
-	}
-
-	if len(value) == 0 {
-		// nil value(s) are possible
-		value = string(v1.NilVV)
-	}
-
-	for _, a := range p.Items {
-		if a.Key == key && !isMul {
-			return fmt.Errorf("Duplicate marker key '%s'", key)
-		}
-	}
-
-	a := VolumeMarker{
-		Key:        key,
-		IsMultiple: isMul,
-	}
-
-	if isMul {
-		a.Values = append(a.Values, value)
-	} else {
-		a.Value = value
-	}
-
-	items := append(p.Items, a)
-	p.Items = items
-	fmt.Println(p.Items)
-
-	return nil
-}
-*/
 func (p *VolumeMarkerBuilder) AddMultiples(key, value string, isMul bool) error {
 	if len(key) == 0 {
 		return fmt.Errorf("Marker key is missing")
@@ -294,7 +260,7 @@ func (p *VolumeMarkerBuilder) AddContainerStatuses(cp k8sApiV1.Pod, volumekey v1
 }
 
 // IsRunning to compare the state of all containers in a pod
-func (p *VolumeMarkerBuilder) IsRunning(pv *v1.Volume) bool {
+func (p *VolumeMarkerBuilder) IsVolumeRunning(pv *v1.Volume) bool {
 	var cphase, rphase string
 	cstate := pv.Annotations[string(v1.ControllerContainerStatusVK)]
 	cresult := strings.Split(cstate, ",")

--- a/orchprovider/k8s/v1/util.go
+++ b/orchprovider/k8s/v1/util.go
@@ -193,9 +193,9 @@ func (p *VolumeMarkerBuilder) AddControllerStatuses(pod k8sApiV1.Pod) {
 	_ = p.AddMultiples(string(v1.JivaControllerStatusVK), status, true)
 }
 
-// AddControllerContainerStatuses is to fetch the current state of controller containers
+// AddContainerStatuses is to fetch the current state of controller containers
 // inside the pod
-func (p *VolumeMarkerBuilder) AddControllerContainerStatuses(cp k8sApiV1.Pod) {
+func (p *VolumeMarkerBuilder) AddContainerStatuses(cp k8sApiV1.Pod, volumekey v1.VolumeKey) {
 	for _, current := range cp.Status.ContainerStatuses {
 		value := v1.NilVV
 		if current.State.Waiting != nil {
@@ -207,37 +207,13 @@ func (p *VolumeMarkerBuilder) AddControllerContainerStatuses(cp k8sApiV1.Pod) {
 		}
 
 		if current.State.Running != nil {
-			if current.Ready == true {
+			if current.Ready {
 				value = v1.ContainerRunningVV
 			} else {
 				value = v1.ContainerNotRunningVV
 			}
 		}
-		_ = p.AddMultiples(string(v1.ControllerContainerStatusVK), string(value), true)
-	}
-}
-
-// AddReplicaContainerStatuses is to fetch the current state of replica containers
-// inside the pod
-func (p *VolumeMarkerBuilder) AddReplicaContainerStatuses(cp k8sApiV1.Pod) {
-	for _, current := range cp.Status.ContainerStatuses {
-		value := v1.NilVV
-		if current.State.Waiting != nil {
-			value = v1.ContainerWaitingVV
-		}
-
-		if current.State.Terminated != nil {
-			value = v1.ContainerTerminatedVV
-		}
-
-		if current.State.Running != nil {
-			if current.Ready == true {
-				value = v1.ContainerRunningVV
-			} else {
-				value = v1.ContainerNotRunningVV
-			}
-		}
-		_ = p.AddMultiples(string(v1.ReplicaContainerStatusVK), string(value), true)
+		_ = p.AddMultiples(string(volumekey), string(value), true)
 	}
 }
 
@@ -255,7 +231,8 @@ func (p *VolumeMarkerBuilder) AddReplicaContainerStatuses(cp k8sApiV1.Pod) {
 
 // IsRunning to compare the state of all containers in a pod
 func (p *VolumeMarkerBuilder) IsRunning(pv *v1.Volume) bool {
-	if pv.Annotations["openebs.io/controller-container-status"] == v1.ContainerRunningVV && pv.Annotations["openebs.io/replica-container-status"] == v1.ContainerRunningVV {
+	if pv.Annotations[string(v1.ControllerContainerStatusVK)] == string(v1.ContainerRunningVV) &&
+		pv.Annotations[string(v1.ReplicaContainerStatusVK)] == string(v1.ContainerRunningVV) {
 		return true
 	}
 	return false

--- a/orchprovider/k8s/v1/util.go
+++ b/orchprovider/k8s/v1/util.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openebs/maya/types/v1"
 	orchProfile "github.com/openebs/maya/types/v1/profile/orchestrator"
 	volProfile "github.com/openebs/maya/volume/profiles"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	k8sCoreV1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	k8sExtnsV1Beta1 "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
@@ -191,6 +192,21 @@ func (p *VolumeMarkerBuilder) AddControllerStatuses(pod k8sApiV1.Pod) {
 
 	// new key representation
 	_ = p.AddMultiples(string(v1.JivaControllerStatusVK), status, true)
+}
+
+func (p *VolumeMarkerBuilder) AddControllerContainerStatuses(cp k8sApiV1.Pod) {
+	for _, current := range cp.Status.ContainerStatuses {
+		if current.State.Waiting != nil {
+			// Nothing to be done
+			return
+		}
+
+		if current.Ready == true && current.State.Running != nil {
+			_ = p.AddMultiples(string(v1.ControllerContainerStatus), "Running", true)
+		} else {
+			_ = p.AddMultiples(string(v1.ControllerContainerStatus), "NotRunning", true)
+		}
+	}
 }
 
 //
@@ -464,6 +480,10 @@ type K8sClient interface {
 	// PVCOps provides a PVCInterface that exposes various CRUD operations
 	// w.r.t PVC
 	PVCOps() (k8sCoreV1.PersistentVolumeClaimInterface, error)
+
+	// PvStatus provides a PV object to get the status information related to
+	// volume
+	PvStatus(name string) (*k8sApiV1.PersistentVolume, error)
 }
 
 // K8sClientV2 is an abstraction to operate on various k8s entities.
@@ -707,6 +727,32 @@ func (k *k8sUtil) PVCOps() (k8sCoreV1.PersistentVolumeClaimInterface, error) {
 	}
 
 	return cs.CoreV1().PersistentVolumeClaims(ns), nil
+}
+
+// PvStatus will get the status of Persistent Volume from k8s
+func (k *k8sUtil) PvStatus(name string) (*k8sApiV1.PersistentVolume, error) {
+	var cs *kubernetes.Clientset
+
+	inC, err := k.IsInCluster()
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = k.NS()
+	if err != nil {
+		return nil, err
+	}
+
+	if inC {
+		cs, err = k.getInClusterCS()
+	} else {
+		cs, err = k.getOutClusterCS()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return cs.CoreV1().PersistentVolumes().Get(name, metav1.GetOptions{})
 }
 
 // k8sUtil implements K8sClientV2 interface. Hence it returns
@@ -964,6 +1010,25 @@ func SetControllerStatuses(cp k8sApiV1.Pod, annotations map[string]string) {
 		annotations[string(v1.ControllerStatusAPILbl)] = current
 	} else {
 		annotations[string(v1.ControllerStatusAPILbl)] = existing + "," + current
+	}
+}
+
+func SetContainerStatus(cp k8sApiV1.Pod, annotations map[string]string) {
+	for _, current := range cp.Status.ContainerStatuses {
+		if current.State.Waiting != nil {
+			// Nothing to be done
+			return
+		}
+
+		//existing := strings.TrimSpace(annotations[string(v1.ControllerContainerStatus)])
+
+		// Set the value or add to the existing values if not added earlier
+		if current.Ready == true {
+			annotations[string(v1.ControllerContainerStatus)] = "Running"
+		} else {
+			annotations[string(v1.ControllerStatusAPILbl)] = "NotRunning"
+		}
+
 	}
 }
 

--- a/orchprovider/k8s/v1/util.go
+++ b/orchprovider/k8s/v1/util.go
@@ -218,18 +218,6 @@ func (p *VolumeMarkerBuilder) AddContainerStatuses(cp k8sApiV1.Pod, volumekey v1
 }
 
 // IsRunning to compare the state of all containers in a pod
-/*func (p *VolumeMarkerBuilder) IsRunning(keys []string) bool {
-
-	for i := 1; i < len(keys); i++ {
-		if keys[i] != keys[0] {
-			return false
-		}
-	}
-	return true
-}
-*/
-
-// IsRunning to compare the state of all containers in a pod
 func (p *VolumeMarkerBuilder) IsRunning(pv *v1.Volume) bool {
 	if pv.Annotations[string(v1.ControllerContainerStatusVK)] == string(v1.ContainerRunningVV) &&
 		pv.Annotations[string(v1.ReplicaContainerStatusVK)] == string(v1.ContainerRunningVV) {
@@ -1011,25 +999,6 @@ func SetControllerStatuses(cp k8sApiV1.Pod, annotations map[string]string) {
 		annotations[string(v1.ControllerStatusAPILbl)] = existing + "," + current
 	}
 }
-
-/*func SetContainerStatus(cp k8sApiV1.Pod, annotations map[string]string) {
-	for _, current := range cp.Status.ContainerStatuses {
-		if current.State.Waiting != nil {
-			// Nothing to be done
-			return
-		}
-		existing := strings.TrimSpace(annotations[string(v1.ControllerContainerStatus)])
-
-		// Set the value or add to the existing values if not added earlier
-		if current.Ready == true {
-			annotations[string(v1.ControllerContainerStatus)] = existing + "," + "Running"
-		} else {
-			annotations[string(v1.ControllerContainerStatus)] = existing + "," + "NotRunning"
-		}
-
-	}
-}
-*/
 
 //
 func SetReplicaStatuses(rp k8sApiV1.Pod, annotations map[string]string) {

--- a/types/v1/labels.go
+++ b/types/v1/labels.go
@@ -337,7 +337,7 @@ const (
 
 	//ReplicaContainerStatus MayaAPIServiceOutputLabel = "vsm.openebs.io/replica-cont-status"
 
-	ControllerContainerStatus MayaAPIServiceOutputLabel = "vsm.openebs.io/container-status"
+	ControllerContainerStatus MayaAPIServiceOutputLabel = "vsm.openebs.io/controller-container-status"
 
 	ControllerStatusAPILbl MayaAPIServiceOutputLabel = "vsm.openebs.io/controller-status"
 

--- a/types/v1/labels.go
+++ b/types/v1/labels.go
@@ -335,6 +335,10 @@ type MayaAPIServiceOutputLabel string
 const (
 	ReplicaStatusAPILbl MayaAPIServiceOutputLabel = "vsm.openebs.io/replica-status"
 
+	//ReplicaContainerStatus MayaAPIServiceOutputLabel = "vsm.openebs.io/replica-cont-status"
+
+	ControllerContainerStatus MayaAPIServiceOutputLabel = "vsm.openebs.io/container-status"
+
 	ControllerStatusAPILbl MayaAPIServiceOutputLabel = "vsm.openebs.io/controller-status"
 
 	TargetPortalsAPILbl MayaAPIServiceOutputLabel = "vsm.openebs.io/targetportals"

--- a/types/v1/labels.go
+++ b/types/v1/labels.go
@@ -335,10 +335,6 @@ type MayaAPIServiceOutputLabel string
 const (
 	ReplicaStatusAPILbl MayaAPIServiceOutputLabel = "vsm.openebs.io/replica-status"
 
-	//ReplicaContainerStatus MayaAPIServiceOutputLabel = "vsm.openebs.io/replica-cont-status"
-
-	ControllerContainerStatus MayaAPIServiceOutputLabel = "vsm.openebs.io/controller-container-status"
-
 	ControllerStatusAPILbl MayaAPIServiceOutputLabel = "vsm.openebs.io/controller-status"
 
 	TargetPortalsAPILbl MayaAPIServiceOutputLabel = "vsm.openebs.io/targetportals"

--- a/types/v1/policies.go
+++ b/types/v1/policies.go
@@ -135,9 +135,13 @@ const (
 	// VolumeTypeVK is the key to fetch the volume type
 	VolumeTypeVK VolumeKey = "openebs.io/volume-type"
 
-	// ControllerContainerStatus is the key to fetch the status of
-	// containers in a pod
-	ControllerContainerStatus MayaAPIServiceOutputLabel = "openebs.io/controller-container-status"
+	// ControllerContainerStatusVK is the key to fetch the status of
+	// controller containers in a pod
+	ControllerContainerStatusVK VolumeKey = "openebs.io/controller-container-status"
+
+	// ReplicaContainerStatusVK is the key to fetch the status of
+	// replica containers in a pod
+	ReplicaContainerStatusVK VolumeKey = "openebs.io/replica-container-status"
 )
 
 // VolumeValue is a typed string used to represent openebs
@@ -149,4 +153,16 @@ const (
 	// for any storage policy key. This can be a representation of
 	// blank, empty or in-progress status of a storage policy.
 	NilVV VolumeValue = "nil"
+
+	// ContainerWaitingVV represents container waiting state
+	ContainerWaitingVV VolumeValue = "Waiting"
+
+	// ContainerTerminatedVV represents container terminated state
+	ContainerTerminatedVV VolumeValue = "Terminated"
+
+	// ContainerRunningVV represents container running state
+	ContainerRunningVV VolumeValue = "Running"
+
+	// ContainerNotRunningVV represents container not-running state
+	ContainerNotRunningVV VolumeValue = "NotRunning"
 )

--- a/types/v1/policies.go
+++ b/types/v1/policies.go
@@ -134,6 +134,10 @@ const (
 
 	// VolumeTypeVK is the key to fetch the volume type
 	VolumeTypeVK VolumeKey = "openebs.io/volume-type"
+
+	// ControllerContainerStatus is the key to fetch the status of
+	// containers in a pod
+	ControllerContainerStatus MayaAPIServiceOutputLabel = "openebs.io/controller-container-status"
 )
 
 // VolumeValue is a typed string used to represent openebs

--- a/types/v1/policies.go
+++ b/types/v1/policies.go
@@ -165,4 +165,10 @@ const (
 
 	// ContainerNotRunningVV represents container not-running state
 	ContainerNotRunningVV VolumeValue = "NotRunning"
+
+	// VolumeRunningVV represents container running state
+	VolumeRunningVV VolumeValue = "Running"
+
+	// VolumeNotRunningVV represents container not-running state
+	VolumeNotRunningVV VolumeValue = "NotRunning"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit will fix the status which was getting nil before. 
Now there will two status-phase "Running" and "NotRunning"
based on the container status inside the pod.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # openebs/openebs#674

**How to verify changes**:
1. Changes has been tested and below are the response from the M-apiserver, check the `controller-container-status` and `replica-container-status` keys. 
2. Deleted the pods manually and verified the status
 
* 1 replica , 1 controller pod with monitoring enabled

```sh
$ kubectl get po
NAME                                                            READY     STATUS    RESTARTS   AGE
maya-apiserver-625578010-g05j8                                  1/1       Running   0          35m
openebs-provisioner-2970942401-s99fm                            1/1       Running   0          35m
percona                                                         1/1       Running   0          32m
pvc-4e3ab47d-d8e5-11e7-998f-3c970e82da1e-ctrl-538591471-lqq05   2/2       Running   0          32m
pvc-4e3ab47d-d8e5-11e7-998f-3c970e82da1e-rep-4233292174-21xhf   1/1       Running   0          42s
```
```json
{
  "metadata": {
    "annotations": {
      "openebs.io/jiva-controller-ips": "172.17.0.4",
      "vsm.openebs.io/controller-status": "Running",
      "openebs.io/jiva-replica-ips": "172.17.0.5",
      "openebs.io/replica-container-status": "Running",
      "vsm.openebs.io/targetportals": "10.0.0.5:3260",
      "openebs.io/jiva-target-portal": "10.0.0.5:3260",
      "vsm.openebs.io/cluster-ips": "10.0.0.5",
      "openebs.io/jiva-controller-cluster-ip": "10.0.0.5",
      "openebs.io/jiva-replica-status": "Running",
      "openebs.io/jiva-iqn": "iqn.2016-09.com.openebs.jiva:pvc-4e3ab47d-d8e5-11e7-998f-3c970e82da1e",
      "openebs.io/jiva-replica-count": "1",
      "vsm.openebs.io/volume-size": "1G",
      "openebs.io/capacity": "1G",
      "openebs.io/jiva-controller-status": "Running",
      "vsm.openebs.io/replica-ips": "172.17.0.5",
      "vsm.openebs.io/controller-ips": "172.17.0.4",
      "openebs.io/controller-container-status": "Running,Running",
      "vsm.openebs.io/replica-status": "Running",
      "openebs.io/volume-type": "jiva",
      "deployment.kubernetes.io/revision": "1",
      "openebs.io/volume-monitor": "true",
      "openebs.io/storage-pool": "default",
      "vsm.openebs.io/replica-count": "1",
      "vsm.openebs.io/iqn": "iqn.2016-09.com.openebs.jiva:pvc-4e3ab47d-d8e5-11e7-998f-3c970e82da1e"
    },
    "creationTimestamp": null,
    "labels": {},
    "name": "pvc-4e3ab47d-d8e5-11e7-998f-3c970e82da1e"
  },
  "status": {
    "Message": "",
    "Phase": "Running",
    "Reason": ""
  }
}
 ```
* 1 replica , 1 controller pod with monitoring disabled

```sh
 $ kubectl get po
NAME                                                            READY     STATUS    RESTARTS   AGE
maya-apiserver-625578010-g05j8                                  1/1       Running   0          54m
openebs-provisioner-2970942401-s99fm                            1/1       Running   0          54m
percona                                                         1/1       Running   0          17m
pvc-0e319170-d8ea-11e7-998f-3c970e82da1e-ctrl-202484216-0fhw0   1/1       Running   0          17m
pvc-0e319170-d8ea-11e7-998f-3c970e82da1e-rep-2249902491-hcs9p   1/1       Running   0          17m

```
```json
{
  "metadata": {
    "annotations": {
      "openebs.io/storage-pool": "default",
      "openebs.io/volume-type": "jiva",
      "vsm.openebs.io/replica-count": "1",
      "vsm.openebs.io/controller-ips": "172.17.0.4",
      "openebs.io/jiva-controller-status": "Running",
      "vsm.openebs.io/replica-ips": "172.17.0.5",
      "openebs.io/jiva-replica-ips": "172.17.0.5",
      "openebs.io/jiva-target-portal": "10.0.0.118:3260",
      "openebs.io/jiva-controller-cluster-ip": "10.0.0.118",
      "openebs.io/volume-monitor": "false",
      "openebs.io/jiva-replica-count": "1",
      "openebs.io/jiva-controller-ips": "172.17.0.4",
      "vsm.openebs.io/controller-status": "Running",
      "openebs.io/replica-container-status": "Running",
      "vsm.openebs.io/targetportals": "10.0.0.118:3260",
      "vsm.openebs.io/cluster-ips": "10.0.0.118",
      "vsm.openebs.io/iqn": "iqn.2016-09.com.openebs.jiva:pvc-0e319170-d8ea-11e7-998f-3c970e82da1e",
      "deployment.kubernetes.io/revision": "1",
      "vsm.openebs.io/volume-size": "1G",
      "openebs.io/capacity": "1G",
      "openebs.io/controller-container-status": "Running",
      "vsm.openebs.io/replica-status": "Running",
      "openebs.io/jiva-replica-status": "Running",
      "openebs.io/jiva-iqn": "iqn.2016-09.com.openebs.jiva:pvc-0e319170-d8ea-11e7-998f-3c970e82da1e"
    },
    "creationTimestamp": null,
    "labels": {},
    "name": "pvc-0e319170-d8ea-11e7-998f-3c970e82da1e"
  },
  "status": {
    "Message": "",
    "Phase": "Running",
    "Reason": ""
  }
}
```