### PR TITLE
Expose volume properties and policies through annotations

### DIFF
--- a/types/v1/policies.go
+++ b/types/v1/policies.go
@@ -77,14 +77,15 @@ type VolumeLabels struct {
 
 // VolumeKey is a typed string used to represent openebs
 // volume related policy keys. These keys along with their
-// values will be fetched from various sources like
-// K8s StorageClass, maya.io, bots etc. during volume **provisioning**.
-// The commonality between these different sources are these keys.
+// values will be fetched from various K8s Kinds
 type VolumeKey string
 
 const (
 	// CapacityVK is the key to fetch volume capacity
 	CapacityVK VolumeKey = "openebs.io/capacity"
+
+	// JivaIQNVK is the key to fetch volume iqn
+	JivaIQNVK VolumeKey = "openebs.io/jiva-iqn"
 
 	// IsK8sServiceVK is the key to fetch a boolean indicating
 	// if a K8s service is required during volume provisioning
@@ -101,15 +102,47 @@ const (
 	// JivaControllerImageVK is the key to fetch the jiva controller image
 	JivaControllerImageVK VolumeKey = "openebs.io/jiva-controller-image"
 
-	// JivaReplicasVK is the key to fetch replica count
+	// JivaReplicasVK is the key to fetch jiva replica count
 	JivaReplicasVK VolumeKey = "openebs.io/jiva-replica-count"
 
-	// JivaControllersVK is the key to fetch controller count
+	// JivaControllersVK is the key to fetch jiva controller count
 	JivaControllersVK VolumeKey = "openebs.io/jiva-controller-count"
+
+	// JivaReplicaIPsVK is the key to fetch jiva replica IP Addresses
+	JivaReplicaIPsVK VolumeKey = "openebs.io/jiva-replica-ips"
+
+	// JivaControllerIPsVK is the key to fetch jiva controller IP Addresses
+	JivaControllerIPsVK VolumeKey = "openebs.io/jiva-controller-ips"
+
+	// JivaReplicaStatusVK is the key to fetch jiva replica status(-es)
+	JivaReplicaStatusVK VolumeKey = "openebs.io/jiva-replica-status"
+
+	// JivaControllerStatusVK is the key to fetch jiva controller status(-es)
+	JivaControllerStatusVK VolumeKey = "openebs.io/jiva-controller-status"
+
+	// JivaControllerClusterIPVK is the key to fetch jiva controller cluster ip
+	JivaControllerClusterIPVK VolumeKey = "openebs.io/jiva-controller-cluster-ip"
+
+	// JivaTargetPortalVK is the key to fetch jiva target portal address
+	JivaTargetPortalVK VolumeKey = "openebs.io/jiva-target-portal"
 
 	// StoragePoolVK is the key to fetch the name of storage pool
 	StoragePoolVK VolumeKey = "openebs.io/storage-pool"
 
 	// MonitorVK is the key to fetch the monitoring details
 	MonitorVK VolumeKey = "openebs.io/volume-monitor"
+
+	// VolumeTypeVK is the key to fetch the volume type
+	VolumeTypeVK VolumeKey = "openebs.io/volume-type"
+)
+
+// VolumeValue is a typed string used to represent openebs
+// volume related policy values.
+type VolumeValue string
+
+const (
+	// NilVV is the value that represents is Nil i.e. null value
+	// for any storage policy key. This can be a representation of
+	// blank, empty or in-progress status of a storage policy.
+	NilVV VolumeValue = "nil"
 )

--- a/volume/policies/v1/policy_jiva_k8s.go
+++ b/volume/policies/v1/policy_jiva_k8s.go
@@ -153,7 +153,7 @@ func enforceCapacity(p *JivaK8sPolicies) error {
 	if len(p.volume.Capacity) == 0 {
 		p.volume.Capacity = p.volume.Labels.CapacityOld
 	}
-	
+
 	// merge from sc policy
 	if len(p.volume.Capacity) == 0 {
 		p.volume.Capacity = p.scPolicies[string(v1.CapacityVK)]


### PR DESCRIPTION
1. Why is this change necessary ?

Maya has been setting various policies against a volume
during later's provisioning. However, these set of
applied policies should get reflected when a volume
detail is queried. As of now, there is no proper way to
get the applied policies on any given openebs volume.

2. How does this change address the issue ?

- The volume properties and policies are set in the
annotations property while doing a /info API call

3. How to verify this change ?

- create volume & do a /info check
e.g. curl http://maya-api-service-ip:5656/latest/volumes/info/volume-name

4. What side effects does this change have ?

- none

5. Sample output after an /info call to maya-api-service

```json
{
  "metadata": {
    "annotations": {
      "openebs.io\/jiva-controller-cluster-ip": "10.0.0.110",
      "openebs.io\/jiva-iqn": "iqn.2016-09.com.openebs.jiva:pvc-980f39a9-d36f-11e7-aa89-080027a8df8b",
      "openebs.io\/volume-monitor": "true",
      "openebs.io\/volume-type": "jiva",
      "vsm.openebs.io\/volume-size": "4G",
      "vsm.openebs.io\/controller-ips": "172.17.0.6",
      "vsm.openebs.io\/cluster-ips": "10.0.0.110",
      "openebs.io\/jiva-replica-status": "Running",
      "openebs.io\/jiva-target-portal": "10.0.0.110:3260",
      "openebs.io\/storage-pool": "default",
      "openebs.io\/capacity": "4G",
      "vsm.openebs.io\/controller-status": "Running",
      "vsm.openebs.io\/replica-ips": "172.17.0.7",
      "vsm.openebs.io\/replica-status": "Running",
      "deployment.kubernetes.io\/revision": "1",
      "vsm.openebs.io\/replica-count": "1",
      "openebs.io\/jiva-replica-count": "1",
      "openebs.io\/jiva-replica-ips": "172.17.0.7",
      "vsm.openebs.io\/targetportals": "10.0.0.110:3260",
      "openebs.io\/jiva-controller-ips": "172.17.0.6",
      "openebs.io\/jiva-controller-status": "Running",
      "vsm.openebs.io\/iqn": "iqn.2016-09.com.openebs.jiva:pvc-980f39a9-d36f-11e7-aa89-080027a8df8b"
    },
    "creationTimestamp": null,
    "labels": {
      
    },
    "name": "pvc-980f39a9-d36f-11e7-aa89-080027a8df8b"
  },
  "status": {
    "Message": "",
    "Phase": "",
    "Reason": ""
  }
}
```