### PR TITLE
Set images with :latest tag & expose them as env variables

### DIFF
--- a/orchprovider/k8s/v1/k8s.go
+++ b/orchprovider/k8s/v1/k8s.go
@@ -831,12 +831,14 @@ func (k *k8sOrchestrator) createControllerDeployment(volProProfile volProfile.Vo
 	isMonitoring := !util.CheckFalsy(vol.Monitor)
 	if isMonitoring {
 		// get the sidecar instance
-		sc, err := NewMonitoringSideCar(vol.Monitor)
+		sc := NewMonitoringSideCar()
+		err := sc.Set(vol.Monitor)
 		if err != nil {
 			return nil, err
 		}
+
 		// get the sidecar container
-		scc, err := sc.generate()
+		scc, err := sc.Get()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -27,10 +27,14 @@ var falsyValues = map[string]bool{
 	"0":     true,
 	"NO":    true,
 	"FALSE": true,
+	"BLANK": true,
 }
 
 // CheckFalsy checks for non-truthiness of the passed argument.
 func CheckFalsy(falsy string) bool {
+	if len(falsy) == 0 {
+		falsy = "blank"
+	}
 	return falsyValues[strings.ToUpper(falsy)]
 }
 

--- a/types/v1/defaults.go
+++ b/types/v1/defaults.go
@@ -37,10 +37,10 @@ const (
 
 	// DefaultJivaControllerImage contains the default jiva controller
 	// image
-	DefaultJivaControllerImage string = "openebs/jiva:0.4.0"
+	DefaultJivaControllerImage string = "openebs/jiva:latest"
 
 	// DefaultJivaReplicaImage contains the default jiva replica image
-	DefaultJivaReplicaImage string = "openebs/jiva:0.4.0"
+	DefaultJivaReplicaImage string = "openebs/jiva:latest"
 
 	// DefaultStoragePool contains the name of default storage pool
 	DefaultStoragePool string = "default"
@@ -60,6 +60,10 @@ const (
 	// DefaultMonitorLabelValue contains the default value for Label value
 	// used for volume monitoring polciy
 	DefaultMonitorLabelValue string = "volume_exporter_prometheus"
+
+	// DefaultMonitoringImage contains the default image for
+	// volume monitoring
+	DefaultMonitoringImage string = "openebs/m-exporter:latest"
 )
 
 var (

--- a/types/v1/envs.go
+++ b/types/v1/envs.go
@@ -78,79 +78,89 @@ const (
 
 	// MonitorENVK is the ENV key to fetch the volume monitoring details
 	MonitorENVK ENVKey = "OPENEBS_IO_VOLUME_MONITOR"
+
+	// MonitorImageENVK is the ENV key to fetch the volume monitoring image
+	MonitorImageENVK ENVKey = "OPENEBS_IO_VOLUME_MONITOR_IMAGE"
 )
+
+// ENVKeyToDefaults maps the ENV keys to corresponding default
+// values. This is required when ENV keys are not set & at
+// the same time default values are OK to be considered.
+var ENVKeyToDefaults = map[ENVKey]string{
+	MonitorImageENVK: DefaultMonitoringImage,
+}
 
 // VolumeTypeENV will fetch the value of volume type
 // from ENV variable if present
 func VolumeTypeENV() VolumeType {
-	val := getEnv(VolumeTypeENVK)
+	val := GetEnv(VolumeTypeENVK)
 	return VolumeType(val)
 }
 
 // OrchProviderENV will fetch the value of volume's orchestrator
 // from ENV variable if present
 func OrchProviderENV() OrchProvider {
-	val := getEnv(OrchProviderENVK)
+	val := GetEnv(OrchProviderENVK)
 	return OrchProvider(val)
 }
 
 func K8sStorageClassENV() string {
-	val := getEnv(K8sStorageClassENVK)
+	val := GetEnv(K8sStorageClassENVK)
 	return val
 }
 
 func NamespaceENV() string {
-	val := getEnv(NamespaceENVK)
+	val := GetEnv(NamespaceENVK)
 	return val
 }
 
 func K8sOutClusterENV() string {
-	val := getEnv(K8sOutClusterENVK)
+	val := GetEnv(K8sOutClusterENVK)
 	return val
 }
 
 func CapacityENV() string {
-	val := getEnv(CapacityENVK)
+	val := GetEnv(CapacityENVK)
 	return val
 }
 
 func JivaReplicasENV() *int32 {
-	val := util.StrToInt32(getEnv(JivaReplicasENVK))
+	val := util.StrToInt32(GetEnv(JivaReplicasENVK))
 	return val
 }
 
 func JivaReplicaImageENV() string {
-	val := getEnv(JivaReplicaImageENVK)
+	val := GetEnv(JivaReplicaImageENVK)
 	return val
 }
 
 func JivaControllersENV() *int32 {
-	val := util.StrToInt32(getEnv(JivaControllersENVK))
+	val := util.StrToInt32(GetEnv(JivaControllersENVK))
 	return val
 }
 
 func JivaControllerImageENV() string {
-	val := getEnv(JivaControllerImageENVK)
+	val := GetEnv(JivaControllerImageENVK)
 	return val
 }
 
 func StoragePoolENV() string {
-	val := getEnv(StoragePoolENVK)
+	val := GetEnv(StoragePoolENVK)
 	return val
 }
 
 func HostPathENV() string {
-	val := getEnv(HostPathENVK)
+	val := GetEnv(HostPathENVK)
 	return val
 }
 
 func MonitorENV() string {
-	val := getEnv(MonitorENVK)
+	val := GetEnv(MonitorENVK)
 	return val
 }
 
-// getEnv fetches the environment variable value from the machine's
+// GetEnv fetches the environment variable value from the machine's
 // environment
-func getEnv(envKey ENVKey) string {
+func GetEnv(envKey ENVKey) string {
 	return strings.TrimSpace(os.Getenv(string(envKey)))
 }


### PR DESCRIPTION
1. Why is this change necessary ?

The various images used during volume provisioning should
default to appropriate image name & have :latest as its tag.
In addition, these images should be exposed as ENV variables
in maya api service.

2. How does this change address the issue ?

- All the images point to :latest

- All the images are controlled by ENV variable

3. How to verify this change ?

- deploy maya api server with ENV variables

- create a volume and check for the correctness
of various images

4. What side effects does this change have ?

- none

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
