### PR TITLE
all: simplifications

### DIFF
--- a/cmd/maya-agent/app/command/commands.go
+++ b/cmd/maya-agent/app/command/commands.go
@@ -1,8 +1,6 @@
 package command
 
 import (
-	"fmt"
-
 	goflag "flag"
 
 	"github.com/golang/glog"
@@ -12,7 +10,7 @@ import (
 
 var (
 	cmdName = "maya-agent"
-	usage   = fmt.Sprintf("%s", cmdName)
+	usage   = cmdName
 )
 
 // MayaAgentOptions defines a type for the options of MayaAgent

--- a/cmd/maya-agent/storage/block/device-list.go
+++ b/cmd/maya-agent/storage/block/device-list.go
@@ -19,11 +19,7 @@ func ListBlockExec(resJsonDecoded *v1.BlockDeviceInfo) error {
 	}
 
 	//decode the json output
-	err = json.Unmarshal(res, &resJsonDecoded)
-	if err != nil {
-		return err
-	}
-	return nil
+	return json.Unmarshal(res, &resJsonDecoded)
 }
 
 //FormatOutputForUser is to print disk details to end user only with necessary fields

--- a/cmd/maya-apiserver/app/server/http.go
+++ b/cmd/maya-apiserver/app/server/http.go
@@ -256,7 +256,7 @@ func (s *HTTPServer) wrap(RequestCounter *prometheus.CounterVec, RequestDuration
 		reqURL := req.URL.String()
 		start := time.Now()
 		defer func() {
-			s.logger.Printf("[DEBUG] http: Request %v (%v)", reqURL, time.Now().Sub(start))
+			s.logger.Printf("[DEBUG] http: Request %v (%v)", reqURL, time.Since(start))
 		}()
 
 		// It captures the no of requests and duration of request coming on "/latest/volumes" endpoint.

--- a/cmd/maya-apiserver/app/server/http_test.go
+++ b/cmd/maya-apiserver/app/server/http_test.go
@@ -4,9 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/openebs/maya/cmd/maya-apiserver/app/config"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/ugorji/go/codec"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -15,6 +12,10 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/openebs/maya/cmd/maya-apiserver/app/config"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/ugorji/go/codec"
 )
 
 var (
@@ -227,7 +228,7 @@ func testPrettyPrint(pretty string, prettyFmt bool, t *testing.T) {
 	}
 
 	if !bytes.Equal(expected.Bytes(), actual) {
-		t.Fatalf("bad:\nexpected:\t%q\n\nactual:\t\t%q", string(expected.Bytes()), string(actual))
+		t.Fatalf("bad:\nexpected:\t%q\n\nactual:\t\t%q", expected.String(), string(actual))
 	}
 }
 

--- a/cmd/maya-apiserver/app/server/metadata_endpoint_test.go
+++ b/cmd/maya-apiserver/app/server/metadata_endpoint_test.go
@@ -2,11 +2,12 @@ package server
 
 import (
 	"bytes"
-	"github.com/ugorji/go/codec"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/ugorji/go/codec"
 )
 
 /*var (
@@ -270,7 +271,7 @@ func TestMetaAvailZoneViaWrap(t *testing.T) {
 
 	// compare
 	if !bytes.Equal(expected.Bytes(), actual) {
-		t.Fatalf("bad:\nexpected:\t%q\n\nactual:\t\t%q", string(expected.Bytes()), string(actual))
+		t.Fatalf("bad:\nexpected:\t%q\n\nactual:\t\t%q", expected.String(), string(actual))
 	}
 }
 
@@ -363,7 +364,7 @@ func TestMetaInstanceIDViaWrap(t *testing.T) {
 
 	// compare
 	if !bytes.Equal(expected.Bytes(), actual) {
-		t.Fatalf("bad:\nexpected:\t%q\n\nactual:\t\t%q", string(expected.Bytes()), string(actual))
+		t.Fatalf("bad:\nexpected:\t%q\n\nactual:\t\t%q", expected.String(), string(actual))
 	}
 }
 

--- a/cmd/mayactl/app/command/snapshot/create.go
+++ b/cmd/mayactl/app/command/snapshot/create.go
@@ -94,7 +94,7 @@ func (c *CmdSnaphotCreateOptions) RunSnapshotCreate(cmd *cobra.Command) error {
 
 	resp := mapiserver.CreateSnapshot(c.volName, c.snapName)
 	if resp != nil {
-		return errors.New(fmt.Sprintf("Error: %v", resp))
+		return fmt.Errorf("Error: %v", resp)
 	}
 
 	fmt.Printf("Volume snapshot Successfully Created:%v\n", c.volName)

--- a/cmd/mayactl/app/command/snapshot/list.go
+++ b/cmd/mayactl/app/command/snapshot/list.go
@@ -59,7 +59,7 @@ func (c *CmdSnaphotCreateOptions) RunSnapshotList(cmd *cobra.Command) error {
 
 	resp := mapiserver.ListSnapshot(c.volName)
 	if resp != nil {
-		return errors.New(fmt.Sprintf("Error: %v", resp))
+		return fmt.Errorf("Error: %v", resp)
 	}
 
 	fmt.Printf("Volume snapshots are:%v\n", resp)

--- a/cmd/mayactl/app/command/snapshot/revert.go
+++ b/cmd/mayactl/app/command/snapshot/revert.go
@@ -17,7 +17,6 @@ limitations under the License.
 package snapshot
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/openebs/maya/pkg/client/mapiserver"
@@ -61,9 +60,9 @@ func (c *CmdSnaphotCreateOptions) RunSnapshotRevert(cmd *cobra.Command) error {
 
 	resp := mapiserver.RevertSnapshot(c.volName, c.snapName)
 	if resp != nil {
-		return errors.New(fmt.Sprintf("Error: %v", resp))
+		return fmt.Errorf("Error: %v", resp)
 	}
 
-	fmt.Println("Reverting to snapshot [%s] of volume [%s]", c.snapName, c.volName)
+	fmt.Printf("Reverting to snapshot [%s] of volume [%s]\n", c.snapName, c.volName)
 	return nil
 }

--- a/cmd/mayactl/app/command/volume_create.go
+++ b/cmd/mayactl/app/command/volume_create.go
@@ -81,7 +81,7 @@ func (c *CmdVolumeCreateOptions) RunVolumeCreate(cmd *cobra.Command) error {
 
 	resp := mapiserver.CreateVolume(c.volName, c.size)
 	if resp != nil {
-		return errors.New(fmt.Sprintf("Error: %v", resp))
+		return fmt.Errorf("Error: %v", resp)
 	}
 
 	fmt.Printf("Volume Successfully Created:%v\n", c.volName)

--- a/pkg/client/mapiserver/snapshot.go
+++ b/pkg/client/mapiserver/snapshot.go
@@ -18,7 +18,6 @@ package mapiserver
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -38,7 +37,7 @@ func CreateSnapshot(volName string, snapName string) error {
 
 	_, err := GetStatus()
 	if err != nil {
-		err := errors.New(fmt.Sprintf("Unable to contact maya-apiserver: %s", GetURL()))
+		err := fmt.Errorf("Unable to contact maya-apiserver: %s", GetURL())
 		return err
 	}
 
@@ -79,7 +78,7 @@ func CreateSnapshot(volName string, snapName string) error {
 	code := resp.StatusCode
 
 	if code != http.StatusOK {
-		err := errors.New(fmt.Sprintf("Status error: %v", http.StatusText(code)))
+		err := fmt.Errorf("Status error: %v", http.StatusText(code))
 		return err
 	}
 	return nil
@@ -90,7 +89,7 @@ func RevertSnapshot(volName string, snapName string) error {
 
 	_, err := GetStatus()
 	if err != nil {
-		err := errors.New(fmt.Sprintf("Unable to contact maya-apiserver: %s", GetURL()))
+		err := fmt.Errorf("Unable to contact maya-apiserver: %s", GetURL())
 		return err
 	}
 
@@ -128,8 +127,7 @@ func RevertSnapshot(volName string, snapName string) error {
 	code := resp.StatusCode
 
 	if code != http.StatusOK {
-		err := errors.New(fmt.Sprintf("Status error: %v", http.StatusText(code)))
-		return err
+		return fmt.Errorf("Status error: %v", http.StatusText(code))
 	}
 	return nil
 }
@@ -139,8 +137,7 @@ func ListSnapshot(volName string) error {
 
 	_, err := GetStatus()
 	if err != nil {
-		err := errors.New(fmt.Sprintf("Unable to contact maya-apiserver: %s", GetURL()))
-		return err
+		return fmt.Errorf("Unable to contact maya-apiserver: %s", GetURL())
 	}
 
 	url := GetURL() + "/latest/snapshots/list/" + volName

--- a/pkg/client/mapiserver/volume_create.go
+++ b/pkg/client/mapiserver/volume_create.go
@@ -2,7 +2,6 @@ package mapiserver
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -21,8 +20,7 @@ func CreateVolume(vname string, size string) error {
 
 	_, err := GetStatus()
 	if err != nil {
-		err := errors.New(fmt.Sprintf("Unable to contact maya-apiserver: %s", GetURL()))
-		return err
+		return fmt.Errorf("Unable to contact maya-apiserver: %s", GetURL())
 	}
 
 	var vs v1.VolumeAPISpec
@@ -61,8 +59,7 @@ func CreateVolume(vname string, size string) error {
 	code := resp.StatusCode
 
 	if code != http.StatusOK {
-		err := errors.New(fmt.Sprintf("Status error: %v", http.StatusText(code)))
-		return err
+		return fmt.Errorf("Status error: %v", http.StatusText(code))
 	}
 	return nil
 }

--- a/pkg/client/mapiserver/volumes_list.go
+++ b/pkg/client/mapiserver/volumes_list.go
@@ -40,10 +40,5 @@ func ListVolumes(obj interface{}) error {
 		return err
 	}
 
-	err = json.Unmarshal(body, &obj)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return json.Unmarshal(body, &obj)
 }

--- a/pkg/nethelper/ipcalc.go
+++ b/pkg/nethelper/ipcalc.go
@@ -15,11 +15,7 @@ import (
 func IsCIDR(cidr string) bool {
 	// This handles validation aspects
 	_, _, err := net.ParseCIDR(cidr)
-	if err != nil {
-		return false
-	}
-
-	return true
+	return err == nil
 }
 
 // CIDRSubnet will return the IPMask in decimal format

--- a/volume/provisioners/jiva/snapshot_create.go
+++ b/volume/provisioners/jiva/snapshot_create.go
@@ -43,11 +43,7 @@ func Snapshot(snapname string, controllerIP string, labels map[string]string) (c
 	}
 
 	err = c.post(url, input, &output)
-	if err != nil {
-		return output, err
-	}
-
-	return output, nil
+	return output, err
 }
 
 func (c *ControllerClient) post(path string, req, resp interface{}) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

General simplifications that prevent unnecessary calls.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

There is no directly linked issue.

**Special notes for your reviewer**:

all: simplifications

 * use `fmt.Errorf`, instead of `errors.New(fmt.Printf)` since `fmt.Errorf` already calls `errors.New`
 * don't check error unnecessarily, return it
 * use `bytes.String` directly instead of `string(bytes.Bytes())`
