### PR TITLE
wrapper over K8s ConfigMap API call

### DIFF
--- a/pkg/client/k8s/k8s.go
+++ b/pkg/client/k8s/k8s.go
@@ -50,6 +50,10 @@ type K8sClient struct {
 	// NOTE: This property enables unit testing
 	Service *api_core_v1.Service
 
+	// ConfigMap refers to a K8s Service object
+	// NOTE: This property enables unit testing
+	ConfigMap *api_core_v1.ConfigMap
+
 	// Deployment refers to a K8s Deployment object
 	// NOTE: This property enables unit testing
 	Deployment *api_extn_v1beta1.Deployment
@@ -73,6 +77,26 @@ func NewK8sClient(ns string) (*K8sClient, error) {
 		ns: ns,
 		cs: cs,
 	}, nil
+}
+
+// cmOps is a utility function that provides a instance capable of
+// executing various K8s ConfigMap related operations.
+func (k *K8sClient) cmOps() (typed_core_v1.ConfigMapInterface, error) {
+	return k.cs.CoreV1().ConfigMaps(k.ns), nil
+}
+
+// GetConfigMap fetches the K8s ConfigMap with the provided name
+func (k *K8sClient) GetConfigMap(name string, opts mach_apis_meta_v1.GetOptions) (*api_core_v1.ConfigMap, error) {
+	if k.ConfigMap != nil {
+		return k.ConfigMap, nil
+	}
+
+	cops, err := k.cmOps()
+	if err != nil {
+		return nil, err
+	}
+
+	return cops.Get(name, opts)
 }
 
 // pvcOps is a utility function that provides a instance capable of

--- a/pkg/client/k8s/k8s_test.go
+++ b/pkg/client/k8s/k8s_test.go
@@ -24,6 +24,29 @@ import (
 	mach_apis_meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func TestGetConfigMap(t *testing.T) {
+	tests := []struct {
+		name  string
+		opts  mach_apis_meta_v1.GetOptions
+		cm    *api_core_v1.ConfigMap
+		isErr bool
+	}{
+		{"", mach_apis_meta_v1.GetOptions{}, &api_core_v1.ConfigMap{}, false},
+	}
+
+	for _, test := range tests {
+		kc := &K8sClient{
+			ConfigMap: test.cm,
+		}
+
+		_, err := kc.GetConfigMap(test.name, test.opts)
+
+		if !test.isErr && err != nil {
+			t.Fatalf("Expected: 'no error' Actual: '%s'", err)
+		}
+	}
+}
+
 func TestGetPVC(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
1. Why is this change necessary ?

- This helps in simplifying K8s API calls meant for ConfigMap
- This is a part of openebs/openebs#976

2. How does this change address the issue ?

- Adds a wrapper to K8s ConfigMap API call

3. How to verify this change ?

- make test should not result in error

4. What side effects does this change have ?

- none

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
