### PR TITLE
Maya wrapper object for K8s Deployment object

### DIFF
--- a/pkg/maya/maya.go
+++ b/pkg/maya/maya.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2017 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maya
+
+import (
+	"fmt"
+
+	"github.com/ghodss/yaml"
+	api_core_v1 "k8s.io/api/core/v1"
+	api_extn_v1beta1 "k8s.io/api/extensions/v1beta1"
+)
+
+// MayaYaml represents the yaml definition
+// that is typically embedded in various other
+// Maya types
+type MayaYaml struct {
+	// Yaml represents the yaml in string format
+	Yaml string
+}
+
+func (m *MayaYaml) Bytes() ([]byte, error) {
+	if len(m.Yaml) == 0 {
+		return nil, fmt.Errorf("Nil yaml provided")
+	}
+
+	return []byte(m.Yaml), nil
+}
+
+type MayaContainer struct {
+	// Container represents the K8s Container object
+	Container api_core_v1.Container
+
+	// This represents the Container in yaml format
+	MayaYaml
+}
+
+func NewMayaContainer(yaml string) *MayaContainer {
+	return &MayaContainer{
+		MayaYaml: MayaYaml{
+			Yaml: yaml,
+		},
+	}
+}
+
+// Load initializes Container property of this instance
+func (m *MayaContainer) Load() error {
+	// unmarshall the yaml
+	b, err := m.Bytes()
+	if err != nil {
+		return err
+	}
+
+	con := api_core_v1.Container{}
+	err = yaml.Unmarshal(b, &con)
+	if err != nil {
+		return err
+	}
+
+	// load the object
+	m.Container = con
+
+	return nil
+}
+
+// Reload updates the Container property of this instance
+func (m *MayaContainer) Reload(yaml string) error {
+	// update the existing yaml
+	m.Yaml = yaml
+	return m.Load()
+}
+
+type MayaDeployment struct {
+	// Deployment represents the K8s Deployment object
+	Deployment *api_extn_v1beta1.Deployment
+
+	// This represents the Deployment in yaml format
+	MayaYaml
+
+	// MayaContainer provides container related methods
+	// Note: This manner of composing is helpful during unit
+	// testing
+	MayaContainer *MayaContainer
+}
+
+func NewMayaDeployment(yaml string) *MayaDeployment {
+	return &MayaDeployment{
+		MayaYaml: MayaYaml{
+			Yaml: yaml,
+		},
+	}
+}
+
+// SetMayaContainer sets the MayaContainer property
+// of this instance.
+func (m *MayaDeployment) SetMayaContainer() *MayaDeployment {
+	m.MayaContainer = &MayaContainer{}
+	return m
+}
+
+// Load initializes Deployment property of this instance
+func (m *MayaDeployment) Load() error {
+	// unmarshall the yaml
+	b, err := m.Bytes()
+	if err != nil {
+		return err
+	}
+
+	// unmarshall the buffer into k8s Deployment object
+	deploy := &api_extn_v1beta1.Deployment{}
+	err = yaml.Unmarshal(b, deploy)
+	if err != nil {
+		return err
+	}
+
+	// load the object
+	m.Deployment = deploy
+
+	return nil
+}
+
+// AddContainer adds a container object to this
+// instance's Deployment object
+func (m *MayaDeployment) AddContainer(yaml string) error {
+	if m.Deployment == nil {
+		return fmt.Errorf("Deployment is not loaded")
+	}
+
+	if m.MayaContainer == nil {
+		return fmt.Errorf("Nil maya container")
+	}
+
+	err := m.MayaContainer.Reload(yaml)
+	if err != nil {
+		return err
+	}
+
+	cons := append(m.Deployment.Spec.Template.Spec.Containers, m.MayaContainer.Container)
+	m.Deployment.Spec.Template.Spec.Containers = cons
+
+	return nil
+}

--- a/pkg/maya/maya_test.go
+++ b/pkg/maya/maya_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2017 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maya
+
+import (
+	"testing"
+)
+
+func TestMayaBytes(t *testing.T) {
+	tests := []struct {
+		yaml  string
+		isErr bool
+	}{
+		{"", true},
+		{"Hello!!", false},
+	}
+
+	for _, test := range tests {
+		my := &MayaYaml{
+			Yaml: test.yaml,
+		}
+
+		_, err := my.Bytes()
+
+		if !test.isErr && err != nil {
+			t.Fatalf("Expected: 'no error' Actual: '%s'", err)
+		}
+	}
+}
+
+func TestMayaContainerLoad(t *testing.T) {
+	tests := []struct {
+		yaml  string
+		isErr bool
+	}{
+		{"", true},
+		{"Hello!!", true},
+		{`
+name: maya-apiserver
+image: openebs/m-apiserver:test
+ports:
+- containerPort: 5656
+`, false},
+	}
+
+	for _, test := range tests {
+		mc := NewMayaContainer(test.yaml)
+
+		err := mc.Load()
+
+		if !test.isErr && err != nil {
+			t.Fatalf("Expected: 'no error' Actual: '%s'", err)
+		}
+
+		if test.isErr && len(mc.Container.Name) != 0 {
+			t.Fatalf("Expected: 'nil maya container' Actual: '%v'", mc.Container)
+		}
+	}
+}
+
+func TestMayaContainerReload(t *testing.T) {
+	tests := []struct {
+		yaml  string
+		isErr bool
+	}{
+		{"", true},
+		{"Hello!!", true},
+		{`
+name: maya-apiserver
+imagePullPolicy: Always
+image: openebs/m-apiserver:test
+ports:
+- containerPort: 5656
+`, false},
+	}
+
+	for _, test := range tests {
+		mc := NewMayaContainer("")
+
+		err := mc.Reload(test.yaml)
+
+		if !test.isErr && err != nil {
+			t.Fatalf("Expected: 'no error' Actual: '%s'", err)
+		}
+
+		if test.isErr && len(mc.Container.Name) != 0 {
+			t.Fatalf("Expected: 'nil maya container' Actual: '%v'", mc.Container)
+		}
+	}
+}
+
+func TestMayaDeploymentLoad(t *testing.T) {
+	tests := []struct {
+		yaml  string
+		isErr bool
+	}{
+		{"", true},
+		{"Hello!!", true},
+		{`
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: maya-apiserver
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: maya-apiserver
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+      - name: maya-apiserver
+        imagePullPolicy: Always
+        image: openebs/m-apiserver:test
+        ports:
+        - containerPort: 5656
+`, false},
+	}
+
+	for _, test := range tests {
+		md := NewMayaDeployment(test.yaml)
+
+		err := md.Load()
+
+		if !test.isErr && err != nil {
+			t.Fatalf("Expected: 'no error' Actual: '%s'", err)
+		}
+
+		if test.isErr && md.Deployment != nil {
+			t.Fatalf("Expected: 'nil maya deployment' Actual: '%v'", md)
+		}
+	}
+}
+
+func TestMayaDeploymentAddContainer(t *testing.T) {
+
+	deploy := `
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: maya-apiserver
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: maya-apiserver
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+      - name: maya-apiserver
+        imagePullPolicy: Always
+        image: openebs/m-apiserver:test
+        ports:
+        - containerPort: 5656
+`
+
+	tests := []struct {
+		containerYaml string
+		isErr         bool
+	}{
+		{"", true},
+		{"Hello!!", true},
+		{`
+name: maya-apiserver-2
+image: openebs/m-apiserver:test
+`, false},
+	}
+
+	for _, test := range tests {
+		md := NewMayaDeployment(deploy).SetMayaContainer()
+		md.Load()
+		err := md.AddContainer(test.containerYaml)
+
+		if !test.isErr && err != nil {
+			t.Fatalf("Expected: 'no error' Actual: '%s'", err)
+		}
+
+		if test.isErr && len(md.MayaContainer.Container.Name) != 0 {
+			t.Fatalf("Expected: 'nil maya deployment container' Actual: '%v'", md.MayaContainer.Container)
+		}
+
+		if !test.isErr && len(md.Deployment.Spec.Template.Spec.Containers) != 2 {
+			t.Fatalf("Expected: '2 containers in maya deployment' Actual: '%d'", len(md.Deployment.Spec.Template.Spec.Containers))
+		}
+	}
+}


### PR DESCRIPTION
1. Why is this change necessary ?

- This will help maya in building a K8s Deployment object
from various options that are DevOps friendly

- This is part of openebs/openebs#976

2. How does this change address the issue ?

- It create a wrapper object on K8s Deployment
- It provides some utility functions on this wrapper
- More utility functions will appear in future
- Some unit tests have been added for this change

3. How to verify this change ?

- make test should not return any error

4. What side effects does this change have ?

- none

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
