### PR TITLE
Adds sub tests

### DIFF
--- a/pkg/client/k8s/k8s_test.go
+++ b/pkg/client/k8s/k8s_test.go
@@ -25,116 +25,128 @@ import (
 )
 
 func TestGetConfigMap(t *testing.T) {
-	tests := []struct {
+	tests := map[string]struct {
 		name  string
 		opts  mach_apis_meta_v1.GetOptions
 		cm    *api_core_v1.ConfigMap
 		isErr bool
 	}{
-		{"", mach_apis_meta_v1.GetOptions{}, &api_core_v1.ConfigMap{}, false},
+		"": {"", mach_apis_meta_v1.GetOptions{}, &api_core_v1.ConfigMap{}, false},
 	}
 
-	for _, test := range tests {
-		kc := &K8sClient{
-			ConfigMap: test.cm,
-		}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
 
-		_, err := kc.GetConfigMap(test.name, test.opts)
+			kc := &K8sClient{
+				ConfigMap: test.cm,
+			}
 
-		if !test.isErr && err != nil {
-			t.Fatalf("Expected: 'no error' Actual: '%s'", err)
-		}
+			_, err := kc.GetConfigMap(test.name, test.opts)
+
+			if !test.isErr && err != nil {
+				t.Fatalf("Expected: 'no error' Actual: '%s'", err)
+			}
+		})
 	}
 }
 
 func TestGetPVC(t *testing.T) {
-	tests := []struct {
+	tests := map[string]struct {
 		name  string
 		opts  mach_apis_meta_v1.GetOptions
 		pvc   *api_core_v1.PersistentVolumeClaim
 		isErr bool
 	}{
-		{"", mach_apis_meta_v1.GetOptions{}, &api_core_v1.PersistentVolumeClaim{}, false},
+		"": {"", mach_apis_meta_v1.GetOptions{}, &api_core_v1.PersistentVolumeClaim{}, false},
 	}
 
-	for _, test := range tests {
-		kc := &K8sClient{
-			PVC: test.pvc,
-		}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
 
-		_, err := kc.GetPVC(test.name, test.opts)
+			kc := &K8sClient{
+				PVC: test.pvc,
+			}
 
-		if !test.isErr && err != nil {
-			t.Fatalf("Expected: 'no error' Actual: '%s'", err)
-		}
+			_, err := kc.GetPVC(test.name, test.opts)
+
+			if !test.isErr && err != nil {
+				t.Fatalf("Expected: 'no error' Actual: '%s'", err)
+			}
+		})
 	}
 }
 
 func TestGetService(t *testing.T) {
-	tests := []struct {
+	tests := map[string]struct {
 		name    string
 		opts    mach_apis_meta_v1.GetOptions
 		service *api_core_v1.Service
 		isErr   bool
 	}{
-		{"", mach_apis_meta_v1.GetOptions{}, &api_core_v1.Service{}, false},
+		"": {"", mach_apis_meta_v1.GetOptions{}, &api_core_v1.Service{}, false},
 	}
 
-	for _, test := range tests {
-		kc := &K8sClient{
-			Service: test.service,
-		}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			kc := &K8sClient{
+				Service: test.service,
+			}
 
-		_, err := kc.GetService(test.name, test.opts)
+			_, err := kc.GetService(test.name, test.opts)
 
-		if !test.isErr && err != nil {
-			t.Fatalf("Expected: 'no error' Actual: '%s'", err)
-		}
+			if !test.isErr && err != nil {
+				t.Fatalf("Expected: 'no error' Actual: '%s'", err)
+			}
+		})
 	}
 }
 
 func TestGetPod(t *testing.T) {
-	tests := []struct {
+	tests := map[string]struct {
 		name  string
 		opts  mach_apis_meta_v1.GetOptions
 		pod   *api_core_v1.Pod
 		isErr bool
 	}{
-		{"", mach_apis_meta_v1.GetOptions{}, &api_core_v1.Pod{}, false},
+		"": {"", mach_apis_meta_v1.GetOptions{}, &api_core_v1.Pod{}, false},
 	}
 
-	for _, test := range tests {
-		kc := &K8sClient{
-			Pod: test.pod,
-		}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			kc := &K8sClient{
+				Pod: test.pod,
+			}
 
-		_, err := kc.GetPod(test.name, test.opts)
+			_, err := kc.GetPod(test.name, test.opts)
 
-		if !test.isErr && err != nil {
-			t.Fatalf("Expected: 'no error' Actual: '%s'", err)
-		}
+			if !test.isErr && err != nil {
+				t.Fatalf("Expected: 'no error' Actual: '%s'", err)
+			}
+		})
 	}
 }
 
 func TestGetDeployment(t *testing.T) {
-	tests := []struct {
+	tests := map[string]struct {
 		name   string
 		opts   mach_apis_meta_v1.GetOptions
 		deploy *api_extn_v1beta1.Deployment
 		isErr  bool
 	}{
-		{"", mach_apis_meta_v1.GetOptions{}, &api_extn_v1beta1.Deployment{}, false},
+		"": {"", mach_apis_meta_v1.GetOptions{}, &api_extn_v1beta1.Deployment{}, false},
 	}
 
-	for _, test := range tests {
-		kc := &K8sClient{
-			Deployment: test.deploy,
-		}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			kc := &K8sClient{
+				Deployment: test.deploy,
+			}
 
-		_, err := kc.GetDeployment(test.name, test.opts)
+			_, err := kc.GetDeployment(test.name, test.opts)
 
-		if !test.isErr && err != nil {
-			t.Fatalf("Expected: 'no error' Actual: '%s'", err)
-		}
+			if !test.isErr && err != nil {
+				t.Fatalf("Expected: 'no error' Actual: '%s'", err)
+			}
+		})
 	}
 }

--- a/pkg/client/k8s/k8s_test.go
+++ b/pkg/client/k8s/k8s_test.go
@@ -31,7 +31,7 @@ func TestGetConfigMap(t *testing.T) {
 		cm    *api_core_v1.ConfigMap
 		isErr bool
 	}{
-		"": {"", mach_apis_meta_v1.GetOptions{}, &api_core_v1.ConfigMap{}, false},
+		"valid configmap": {"", mach_apis_meta_v1.GetOptions{}, &api_core_v1.ConfigMap{}, false},
 	}
 
 	for name, test := range tests {
@@ -57,7 +57,7 @@ func TestGetPVC(t *testing.T) {
 		pvc   *api_core_v1.PersistentVolumeClaim
 		isErr bool
 	}{
-		"": {"", mach_apis_meta_v1.GetOptions{}, &api_core_v1.PersistentVolumeClaim{}, false},
+		"valid volume claim": {"", mach_apis_meta_v1.GetOptions{}, &api_core_v1.PersistentVolumeClaim{}, false},
 	}
 
 	for name, test := range tests {
@@ -83,7 +83,7 @@ func TestGetService(t *testing.T) {
 		service *api_core_v1.Service
 		isErr   bool
 	}{
-		"": {"", mach_apis_meta_v1.GetOptions{}, &api_core_v1.Service{}, false},
+		"valid service": {"", mach_apis_meta_v1.GetOptions{}, &api_core_v1.Service{}, false},
 	}
 
 	for name, test := range tests {
@@ -108,7 +108,7 @@ func TestGetPod(t *testing.T) {
 		pod   *api_core_v1.Pod
 		isErr bool
 	}{
-		"": {"", mach_apis_meta_v1.GetOptions{}, &api_core_v1.Pod{}, false},
+		"valid pod": {"", mach_apis_meta_v1.GetOptions{}, &api_core_v1.Pod{}, false},
 	}
 
 	for name, test := range tests {
@@ -133,7 +133,7 @@ func TestGetDeployment(t *testing.T) {
 		deploy *api_extn_v1beta1.Deployment
 		isErr  bool
 	}{
-		"": {"", mach_apis_meta_v1.GetOptions{}, &api_extn_v1beta1.Deployment{}, false},
+		"valid deployment": {"", mach_apis_meta_v1.GetOptions{}, &api_extn_v1beta1.Deployment{}, false},
 	}
 
 	for name, test := range tests {

--- a/pkg/maya/maya_test.go
+++ b/pkg/maya/maya_test.go
@@ -21,24 +21,26 @@ import (
 )
 
 func TestMayaBytes(t *testing.T) {
-	tests := []struct {
+	tests := map[string]struct {
 		yaml  string
 		isErr bool
 	}{
-		{"", true},
-		{"Hello!!", false},
+		"blank yaml": {"", true},
+		"hello yaml": {"Hello!!", false},
 	}
 
-	for _, test := range tests {
-		my := &MayaYaml{
-			Yaml: test.yaml,
-		}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			my := &MayaYaml{
+				Yaml: test.yaml,
+			}
 
-		_, err := my.Bytes()
+			_, err := my.Bytes()
 
-		if !test.isErr && err != nil {
-			t.Fatalf("Expected: 'no error' Actual: '%s'", err)
-		}
+			if !test.isErr && err != nil {
+				t.Fatalf("Expected: 'no error' Actual: '%s'", err)
+			}
+		})
 	}
 }
 
@@ -154,13 +156,13 @@ ports:
 }
 
 func TestMayaDeploymentLoad(t *testing.T) {
-	tests := []struct {
+	tests := map[string]struct {
 		yaml  string
 		isErr bool
 	}{
-		{"", true},
-		{"Hello!!", true},
-		{`
+		"blank yaml": {"", true},
+		"hello yaml": {"Hello!!", true},
+		"valid yaml": {`
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
@@ -183,18 +185,20 @@ spec:
 `, false},
 	}
 
-	for _, test := range tests {
-		md := NewMayaDeployment(test.yaml)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			md := NewMayaDeployment(test.yaml)
 
-		err := md.Load()
+			err := md.Load()
 
-		if !test.isErr && err != nil {
-			t.Fatalf("Expected: 'no error' Actual: '%s'", err)
-		}
+			if !test.isErr && err != nil {
+				t.Fatalf("Expected: 'no error' Actual: '%s'", err)
+			}
 
-		if test.isErr && md.Deployment != nil {
-			t.Fatalf("Expected: 'nil maya deployment' Actual: '%v'", md)
-		}
+			if test.isErr && md.Deployment != nil {
+				t.Fatalf("Expected: 'nil maya deployment' Actual: '%v'", md)
+			}
+		})
 	}
 }
 
@@ -228,13 +232,13 @@ spec:
 		t.Fatalf("Error in test logic: '%v'", err)
 	}
 
-	tests := []struct {
+	tests := map[string]struct {
 		containerYaml string
 		isError       bool
 	}{
-		{containerYaml: "", isError: true},
-		{containerYaml: "Hello!!", isError: true},
-		{containerYaml: `
+		"blank yaml": {containerYaml: "", isError: true},
+		"hello yaml": {containerYaml: "Hello!!", isError: true},
+		"valid struct yaml": {containerYaml: `
 name: maya-apiserver-2
 imagePullPolicy: Always
 image: openebs/m-apiserver:test
@@ -243,15 +247,17 @@ ports:
 `, isError: false},
 	}
 
-	for _, test := range tests {
-		err := md.AddContainer(test.containerYaml)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := md.AddContainer(test.containerYaml)
 
-		if !test.isError && err != nil {
-			t.Fatalf("Expected: 'no error' Actual: '%s'", err)
-		}
+			if !test.isError && err != nil {
+				t.Fatalf("Expected: 'no error' Actual: '%s'", err)
+			}
 
-		if !test.isError && len(md.Deployment.Spec.Template.Spec.Containers) != 2 {
-			t.Fatalf("Expected: '2 containers in maya deployment' Actual: '%d'", len(md.Deployment.Spec.Template.Spec.Containers))
-		}
+			if !test.isError && len(md.Deployment.Spec.Template.Spec.Containers) != 2 {
+				t.Fatalf("Expected: '2 containers in maya deployment' Actual: '%d'", len(md.Deployment.Spec.Template.Spec.Containers))
+			}
+		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: dungeonmaster18 <umesh4257@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Adds sub test.

- [x] [openebs/openebs#998](https://github.com/openebs/openebs/issues/998)
- [X] [openebs/openebs#1000](https://github.com/openebs/openebs/issues/1000)

Here is the output:

k8s_test.go
```
$ go test -v
=== RUN   TestGetConfigMap
=== RUN   TestGetConfigMap/TestGetConfigMap
--- PASS: TestGetConfigMap (0.00s)
    --- PASS: TestGetConfigMap/TestGetConfigMap (0.00s)
=== RUN   TestGetPVC
=== RUN   TestGetPVC/TestGetPVC
--- PASS: TestGetPVC (0.00s)
    --- PASS: TestGetPVC/TestGetPVC (0.00s)
=== RUN   TestGetService
=== RUN   TestGetService/TestGetServices
--- PASS: TestGetService (0.00s)
    --- PASS: TestGetService/TestGetServices (0.00s)
=== RUN   TestGetPod
=== RUN   TestGetPod/TestGetPod
--- PASS: TestGetPod (0.00s)
    --- PASS: TestGetPod/TestGetPod (0.00s)
=== RUN   TestGetDeployment
=== RUN   TestGetDeployment/TestGetDeployment
--- PASS: TestGetDeployment (0.00s)
    --- PASS: TestGetDeployment/TestGetDeployment (0.00s)
PASS
ok      github.com/openebs/maya/pkg/client/k8s  0.046s

```

**P.S**
I have now added sub tests. If this looks good to you guys. I can go on and add for maya_test.go

cc / @kmova @AmitKumarDas @prateekpandey14 