### PR TITLE
Fix controller replica status error

### DIFF
--- a/cmd/mayactl/app/command/snapshot/create.go
+++ b/cmd/mayactl/app/command/snapshot/create.go
@@ -94,7 +94,7 @@ func (c *CmdSnaphotCreateOptions) RunSnapshotCreate(cmd *cobra.Command) error {
 
 	resp := mapiserver.CreateSnapshot(c.volName, c.snapName)
 	if resp != nil {
-		return fmt.Errorf("Error: %v", resp)
+		return fmt.Errorf("Snapshot create failed: %v", resp)
 	}
 
 	fmt.Printf("Volume snapshot Successfully Created:%v\n", c.volName)

--- a/cmd/mayactl/app/command/snapshot/list.go
+++ b/cmd/mayactl/app/command/snapshot/list.go
@@ -45,7 +45,7 @@ func NewCmdSnapshotList() *cobra.Command {
 	return cmd
 }
 
-// Validate validates the flag values
+// ValidateList validates the flag values
 func (c *CmdSnaphotCreateOptions) ValidateList(cmd *cobra.Command) error {
 	if c.volName == "" {
 		return errors.New("--volname is missing. Please specify an unique name")
@@ -53,16 +53,12 @@ func (c *CmdSnaphotCreateOptions) ValidateList(cmd *cobra.Command) error {
 	return nil
 }
 
-// RunSnapshotCreate does tasks related to mayaserver.
+// RunSnapshotList does tasks related to mayaserver.
 func (c *CmdSnaphotCreateOptions) RunSnapshotList(cmd *cobra.Command) error {
-	fmt.Println("Executing volume snapshot list...")
 
 	resp := mapiserver.ListSnapshot(c.volName)
 	if resp != nil {
-		return fmt.Errorf("Error: %v", resp)
+		return fmt.Errorf("Error list available snapshot: %v", resp)
 	}
-
-	fmt.Printf("Volume snapshots are:%v\n", resp)
-
 	return nil
 }

--- a/cmd/mayactl/app/command/snapshot/revert.go
+++ b/cmd/mayactl/app/command/snapshot/revert.go
@@ -43,12 +43,12 @@ func NewCmdSnapshotRevert() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.volName, "volname", "", options.volName,
+	cmd.Flags().StringVarP(&options.volName, "volname", "n", options.volName,
 		"unique volume name.")
 	cmd.MarkPersistentFlagRequired("volname")
 	cmd.MarkPersistentFlagRequired("snapname")
 
-	cmd.Flags().StringVarP(&options.snapName, "snapname", "", options.snapName,
+	cmd.Flags().StringVarP(&options.snapName, "snapname", "s", options.snapName,
 		"unique snapshot name")
 
 	return cmd

--- a/pkg/client/jiva/controller_client.go
+++ b/pkg/client/jiva/controller_client.go
@@ -112,6 +112,9 @@ func (c *ControllerClient) Get(path string, obj interface{}) error {
 	return json.NewDecoder(resp.Body).Decode(obj)
 }
 
+// ListReplicas to get the details of all the existing replicas
+// which contains address and mode of those replicas (RW/R/W) as well as
+// resource information.
 func (c *ControllerClient) ListReplicas(path string) ([]Replica, error) {
 	var resp ReplicaCollection
 

--- a/pkg/client/mapiserver/snapshot.go
+++ b/pkg/client/mapiserver/snapshot.go
@@ -53,12 +53,9 @@ func CreateSnapshot(volName string, snapName string) error {
 	//Marshal serializes the value provided into a YAML document
 	yamlValue, _ := yaml.Marshal(snap)
 
-	fmt.Printf("Volume snapshot spec created:\n%v\n", string(yamlValue))
-
 	url := GetURL() + "/latest/snapshots/create/"
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(yamlValue))
 	if err != nil {
-		fmt.Println("NewRequest error:", err)
 		return err
 	}
 
@@ -69,24 +66,22 @@ func CreateSnapshot(volName string, snapName string) error {
 	}
 	resp, err := c.Do(req)
 	if err != nil {
-		return fmt.Errorf("Do error:%v", err)
-		//return err
+		return err
 	}
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("ReadALL error:%v", err)
-		//return err
+		return err
 	}
 
-	fmt.Println("Body is :", string(body))
 	code := resp.StatusCode
+	if err == nil && code != http.StatusOK {
+		return fmt.Errorf(string(body))
+	}
 
-	fmt.Println("Status Code:", code)
-
-	if err != nil && code != http.StatusOK {
-		return fmt.Errorf("inside error is %v:%v", err, http.StatusText(code))
+	if code != http.StatusOK {
+		return fmt.Errorf("Server status error: %v", http.StatusText(code))
 	}
 	return nil
 }
@@ -134,7 +129,7 @@ func RevertSnapshot(volName string, snapName string) error {
 	code := resp.StatusCode
 
 	if code != http.StatusOK {
-		return fmt.Errorf("Status error: %v", http.StatusText(code))
+		return fmt.Errorf("Server status error: %v", http.StatusText(code))
 	}
 	return nil
 }
@@ -168,7 +163,7 @@ func ListSnapshot(volName string) error {
 	}
 	code := resp.StatusCode
 	if code != http.StatusOK {
-		return fmt.Errorf("Status error: %v", http.StatusText(code))
+		return fmt.Errorf("Server status error: %v", http.StatusText(code))
 	}
 	snapdisk, err := getInfo([]byte(body))
 	if err != nil {

--- a/volume/provisioners/jiva/snapshot_create.go
+++ b/volume/provisioners/jiva/snapshot_create.go
@@ -42,6 +42,11 @@ func Snapshot(snapname string, controllerIP string, labels map[string]string) (c
 		Labels: labels,
 	}
 
+	err = IsExist(snapname, controllerIP)
+	if err != nil {
+		return output, err
+
+	}
 	err = c.post(url, input, &output)
 	return output, err
 }

--- a/volume/provisioners/jiva/snapshot_create.go
+++ b/volume/provisioners/jiva/snapshot_create.go
@@ -42,7 +42,7 @@ func Snapshot(snapname string, controllerIP string, labels map[string]string) (c
 		Labels: labels,
 	}
 
-	err = IsExist(snapname, controllerIP)
+	err = CheckSnapshotExist(snapname, controllerIP)
 	if err != nil {
 		return output, err
 

--- a/volume/provisioners/jiva/snapshot_list.go
+++ b/volume/provisioners/jiva/snapshot_list.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"github.com/golang/glog"
 	client "github.com/openebs/maya/pkg/client/jiva"
 )
 
@@ -76,17 +77,6 @@ func SnapshotList(name string, controllerIP string) (map[string]client.DiskInfo,
 		}
 	}
 	return nil, nil
-}
-
-// ListReplicas to get the details of all the existing replicas
-// which contains address and mode of those replicas (RW/R/W) as well as
-// resource information.
-func (c *ControllerClient) ListReplicas(path string) ([]Replica, error) {
-	var resp ReplicaCollection
-
-	err := c.get(path+"/replicas", &resp)
-
-	return resp.Data, err
 }
 
 // getChain contains the linked info related to replicas
@@ -173,4 +163,65 @@ func (c *ReplicaClient) post(path string, req, resp interface{}) error {
 	}
 
 	return json.NewDecoder(httpResp.Body).Decode(resp)
+}
+
+// IsExist check the existence of snapshot in chain of created snapshots
+func IsExist(snapshot string, controllerIP string) error {
+	controller, err := client.NewControllerClient(controllerIP + ":9501")
+
+	glog.Infof("Validates existence of snapshot [%s] before create %s", snapshot)
+
+	if err != nil {
+		return err
+	}
+
+	replicas, err := controller.ListReplicas(controller.Address)
+	if err != nil {
+		return err
+	}
+
+	first := true
+	for _, r := range replicas {
+		if r.Mode != "RW" {
+			continue
+		}
+
+		if first {
+			first = false
+			chain, _ := getChain(r.Address)
+			_, index := getNameAndIndex(chain, snapshot)
+			if index > 0 {
+				return fmt.Errorf("snapshot [%s] already exists", snapshot)
+			}
+		}
+		return err
+	}
+	return err
+}
+
+// getNameAndIndex get the name and index value based on the existence of
+// snapshot. If snapshot is already exists the index value will be -1
+// if not then any possitive number
+func getNameAndIndex(chain []string, snapshot string) (string, int) {
+	index := find(chain, snapshot)
+
+	if index < 0 {
+		snapshot = fmt.Sprintf("volume-snap-%s.img", snapshot)
+		glog.Infof("Requested snapshot is: %v", snapshot)
+		index = find(chain, snapshot)
+	}
+
+	if index < 0 {
+		return "", index
+	}
+	return snapshot, index
+}
+
+func find(list []string, item string) int {
+	for i, val := range list {
+		if val == item {
+			return i
+		}
+	}
+	return -1
 }

--- a/volume/provisioners/jiva/snapshot_list.go
+++ b/volume/provisioners/jiva/snapshot_list.go
@@ -165,8 +165,8 @@ func (c *ReplicaClient) post(path string, req, resp interface{}) error {
 	return json.NewDecoder(httpResp.Body).Decode(resp)
 }
 
-// IsExist check the existence of snapshot in chain of created snapshots
-func IsExist(snapshot string, controllerIP string) error {
+// CheckSnapshotExist check the existence of snapshot in chain of created snapshots
+func CheckSnapshotExist(snapshot string, controllerIP string) error {
 	controller, err := client.NewControllerClient(controllerIP + ":9501")
 
 	glog.Infof("Validates existence of snapshot [%s] before create %s", snapshot)


### PR DESCRIPTION
**What this PR does / why we need it**:
1.  Fix the snapshot list command to print created
    snapshot of particular volume in table format.
2. Add short flag-name for the --volname(-n) and --snapname(-s)
3. fix jiva controller and replica status error issue
4. fix issue related to replica, it goes into unresponsive/status error(500), due to duplicate snapshot created and replica goes into shutdown state.
5.  Check snapshot existence before creating snapshot ,logged them properly and return that.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes : 
openebs/openebs#961, openebs/openebs#937

**How to verify this change ?**
Tested the changes in k8s cluster environment. 

```sh
I1215 13:29:24.967866       6 k8s.go:512] Fetching info on Volume 'default: pvc-bcf9441c-e199-11e7-9e8e-021c6f7dbe9d'
I1215 13:29:25.001016       6 k8s.go:622] Info fetched successfully for volume 'default: pvc-bcf9441c-e199-11e7-9e8e-021c6f7dbe9d'
I1215 13:29:25.001166       6 volume_endpoint.go:160] Processed Volume read request successfully for 'pvc-bcf9441c-e199-11e7-9e8e-021c6f7dbe9d'
I1215 13:29:25.003337       6 snapshot_list.go:183] Validates existence of snapshot [snap123] before create
I1215 13:29:25.007081       6 snapshot_list.go:221] Requested snapshot is: volume-snap-snap123.img
E1215 13:29:25.007154       6 snapshot_endpoint.go:76] Failed to create snapshot of volume pvc-bcf9441c-e199-11e7-9e8e-021c6f7dbe9d : snapshot [snap123] already exists
2017/12/15 13:29:25.007174 [ERR] http: Request POST /latest/snapshots/create/, error: snapshot [snap123] already exists
```
```sh
$ mayactl snapshot create -n pvc-bcf9441c-e199-11e7-9e8e-021c6f7dbe9d -s snap123
Executing volume snapshot create...
Snapshot create failed: snapshot [snap123] already exists
```