### PR TITLE
fixes maya api server issue of multiple namespaces

### DIFF
--- a/cmd/maya-apiserver/app/server/volume_endpoint.go
+++ b/cmd/maya-apiserver/app/server/volume_endpoint.go
@@ -11,6 +11,12 @@ import (
 	"github.com/openebs/maya/volume/provisioners"
 )
 
+const (
+	// NamespaceKey is used in request headers to get the
+	// namespace
+	NamespaceKey string = "namespace"
+)
+
 // VolumeSpecificRequest is a http handler implementation. It deals with HTTP
 // requests w.r.t a single Volume.
 //
@@ -60,8 +66,23 @@ func (s *HTTPServer) volumeList(resp http.ResponseWriter, req *http.Request) (in
 
 	glog.Infof("Processing Volume list request")
 
+	// Get the namespace if provided
+	ns := ""
+	if req != nil {
+		ns = req.Header.Get(NamespaceKey)
+	}
+
+	if ns == "" {
+		// We shall override if empty. This seems to be simple enough
+		// that works for most of the usecases.
+		// Otherwise we need to introduce logic to decide for default
+		// namespace depending on operation type.
+		ns = v1.DefaultNamespaceForListOps
+	}
+
 	// Create a Volume
 	vol := &v1.Volume{}
+	vol.Namespace = ns
 
 	// Pass through the policy enforcement logic
 	policy, err := policies_v1.VolumeGenericPolicy()
@@ -114,9 +135,16 @@ func (s *HTTPServer) volumeRead(resp http.ResponseWriter, req *http.Request, vol
 		return nil, CodedError(400, fmt.Sprintf("Volume name is missing"))
 	}
 
+	// Get the namespace if provided
+	ns := ""
+	if req != nil {
+		ns = req.Header.Get(NamespaceKey)
+	}
+
 	// Create a Volume
 	vol := &v1.Volume{}
 	vol.Name = volName
+	vol.Namespace = ns
 
 	// Pass through the policy enforcement logic
 	policy, err := policies_v1.VolumeGenericPolicy()
@@ -171,9 +199,16 @@ func (s *HTTPServer) volumeDelete(resp http.ResponseWriter, req *http.Request, v
 		return nil, CodedError(400, fmt.Sprintf("Volume name is missing"))
 	}
 
+	// Get the namespace if provided
+	ns := ""
+	if req != nil {
+		ns = req.Header.Get(NamespaceKey)
+	}
+
 	// Create a Volume
 	vol := &v1.Volume{}
 	vol.Name = volName
+	vol.Namespace = ns
 
 	// Pass through the policy enforcement logic
 	policy, err := policies_v1.VolumeGenericPolicy()

--- a/orchprovider/k8s/v1/k8s.go
+++ b/orchprovider/k8s/v1/k8s.go
@@ -619,20 +619,65 @@ func (k *k8sOrchestrator) readVSM(vsm string, volProProfile volProfile.VolumePro
 	return pv, nil
 }
 
-// ListStorage will list a collections of VSMs
-func (k *k8sOrchestrator) ListStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.VolumeList, error) {
-	if volProProfile == nil {
-		return nil, fmt.Errorf("Nil volume provisioner profile provided")
+// getAllNamespaces will get all the available namespaces
+// in K8s cluster
+func (k *k8sOrchestrator) getAllNamespaces(vol *v1.Volume) ([]string, error) {
+
+	ku := &k8sUtil{
+		volume: vol,
 	}
 
-	glog.Infof("Listing VSMs at orchestrator '%s: %s'", k.Label(), k.Name())
-
-	dl, err := k.getVSMDeployments(volProProfile)
+	kc, supported, err := ku.K8sClientV2()
 	if err != nil {
 		return nil, err
 	}
 
-	if dl == nil || dl.Items == nil || len(dl.Items) == 0 {
+	if !supported {
+		return nil, fmt.Errorf("K8s client is not supported")
+	}
+
+	nsOps, err := kc.NamespaceOps()
+	if err != nil {
+		return nil, err
+	}
+
+	nsl, err := nsOps.List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var nss []string
+	for _, ns := range nsl.Items {
+		nss = append(nss, ns.Name)
+	}
+
+	return nss, nil
+}
+
+// listStorageByNS will list a collections of volumes for a
+// particular namespace
+func (k *k8sOrchestrator) listStorageByNS(vol *v1.Volume) (*v1.VolumeList, error) {
+	glog.Infof("Listing volumes for namespace '%s'", vol.Namespace)
+
+	vpp, err := volProfile.GetVolProProfile(vol)
+	if err != nil {
+		return nil, err
+	}
+
+	// Need to use a new version of k8sUtil as the volume
+	// it composes determines the namespace to be used
+	// for K8s list operation
+	//
+	// Note: Here volume acts as a placeholder for namespace &
+	// doesnot necessarily represent a volume
+	dl, err := k.getVSMDeployments(&k8sUtil{
+		volume: vol,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if dl == nil || len(dl.Items) == 0 {
 		return nil, nil
 	}
 
@@ -648,19 +693,69 @@ func (k *k8sOrchestrator) ListStorage(volProProfile volProfile.VolumeProvisioner
 
 		vsm := v1.SanitiseVSMName(d.Name)
 		if vsm == "" {
-			return nil, fmt.Errorf("VSM name could not be determined from K8s Deployment 'name: %s'", d.Name)
+			return nil, fmt.Errorf("Volume name could not be determined from K8s Deployment '%s'", d.Name)
 		}
 
-		pv, err := k.readVSM(vsm, volProProfile)
-		if err != nil {
-			// Ignore the error of this particular VSM
-			// Cases where this particular VSM might be in a creating or deleting state
+		pv, _ := k.readVSM(vsm, vpp)
+		if pv == nil {
+			// Ignore the cases where this particular VSM might be in
+			// a creating or deleting state
 			continue
 		}
+
 		pvl.Items = append(pvl.Items, *pv)
 	}
 
-	glog.Infof("Listed VSMs 'count: %d' at orchestrator '%s: %s'", len(pvl.Items), k.Label(), k.Name())
+	glog.Infof("Listed volumes with count '%d' for namespace '%s'", len(pvl.Items), vol.Namespace)
+
+	return pvl, nil
+}
+
+// ListStorage will list a collections of VSMs
+func (k *k8sOrchestrator) ListStorage(volProProfile volProfile.VolumeProvisionerProfile) (*v1.VolumeList, error) {
+	if volProProfile == nil {
+		return nil, fmt.Errorf("Nil volume provisioner profile provided")
+	}
+
+	vol, err := volProProfile.Volume()
+	if err != nil {
+		return nil, err
+	}
+
+	var nss []string
+	if vol.Namespace == v1.DefaultNamespaceForListOps {
+		nss, err = k.getAllNamespaces(vol)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// This will be nil if the list operation is desired
+	// for a specific namespace
+	if nss == nil {
+		return k.listStorageByNS(vol)
+	}
+
+	pvl := &v1.VolumeList{}
+	// We take a copy to avoid mutating the original
+	// volume
+	volCpy := &v1.Volume{}
+	volCpy = vol
+	for _, ns := range nss {
+		// This is most important step
+		// Listing will be done based on namespace
+		volCpy.Namespace = ns
+		l, err := k.listStorageByNS(volCpy)
+		if err != nil {
+			return nil, err
+		}
+
+		if l == nil || len(l.Items) == 0 {
+			continue
+		}
+
+		pvl.Items = append(pvl.Items, l.Items...)
+	}
 
 	return pvl, nil
 }
@@ -1390,16 +1485,18 @@ func (k *k8sOrchestrator) getDeploymentList(vsm string, volProProfile volProfile
 }
 
 // getVSMDeployments fetches all the VSM deployments
-func (k *k8sOrchestrator) getVSMDeployments(volProProfile volProfile.VolumeProvisionerProfile) (*k8sApisExtnsBeta1.DeploymentList, error) {
+func (k *k8sOrchestrator) getVSMDeployments(ku *k8sUtil) (*k8sApisExtnsBeta1.DeploymentList, error) {
 
-	k8sUtl := k8sOrchUtil(k, volProProfile)
-
-	kc, supported := k8sUtl.K8sClient()
-	if !supported {
-		return nil, fmt.Errorf("K8s client not supported by '%s'", k8sUtl.Name())
+	kc, supported, err := ku.K8sClientV2()
+	if err != nil {
+		return nil, err
 	}
 
-	dOps, err := kc.DeploymentOps()
+	if !supported {
+		return nil, fmt.Errorf("K8s client is not supported")
+	}
+
+	dOps, err := kc.DeploymentOps2()
 	if err != nil {
 		return nil, err
 	}
@@ -1424,13 +1521,10 @@ func (k *k8sOrchestrator) getVSMDeployments(volProProfile volProfile.VolumeProvi
 }
 
 // getVSMServices fetches all the VSM services
-func (k *k8sOrchestrator) getVSMServices(volProProfile volProfile.VolumeProvisionerProfile) (*k8sApiV1.ServiceList, error) {
-
-	k8sUtl := k8sOrchUtil(k, volProProfile)
-
-	kc, supported := k8sUtl.K8sClient()
+func (k *k8sOrchestrator) getVSMServices(k8sUtil *k8sUtil) (*k8sApiV1.ServiceList, error) {
+	kc, supported := k8sUtil.K8sClient()
 	if !supported {
-		return nil, fmt.Errorf("K8s client not supported by '%s'", k8sUtl.Name())
+		return nil, fmt.Errorf("K8s client not supported by '%s'", k8sUtil.Name())
 	}
 
 	sOps, err := kc.Services()

--- a/orchprovider/k8s/v1/util.go
+++ b/orchprovider/k8s/v1/util.go
@@ -539,6 +539,14 @@ type K8sClientV2 interface {
 	// NOTE:
 	//  StoragePool is a K8s CRD resource
 	StoragePoolOps() (oe_client_v1alpha1.StoragePoolInterface, error)
+
+	// NamespaceOps provides a NamespaceInterface that exposes
+	// various CRUD operations w.r.t Namespace
+	NamespaceOps() (k8sCoreV1.NamespaceInterface, error)
+
+	// DeploymentOps2 provides all the CRUD operations associated
+	// w.r.t a Deployment
+	DeploymentOps2() (k8sExtnsV1Beta1.DeploymentInterface, error)
 }
 
 // k8sUtil provides the concrete implementation for below interfaces:
@@ -703,7 +711,7 @@ func (k *k8sUtil) Services() (k8sCoreV1.ServiceInterface, error) {
 	return cs.CoreV1().Services(ns), nil
 }
 
-// Services is a utility function that provides a instance capable of
+// DeploymentOps is a utility function that provides a instance capable of
 // executing various k8s Deployment related operations.
 func (k *k8sUtil) DeploymentOps() (k8sExtnsV1Beta1.DeploymentInterface, error) {
 	var cs *kubernetes.Clientset
@@ -820,6 +828,33 @@ func (k *k8sUtil) PVCOps2() (k8sCoreV1.PersistentVolumeClaimInterface, error) {
 	}
 
 	return cs.CoreV1().PersistentVolumeClaims(k.volume.Namespace), nil
+}
+
+// DeploymentOps2 is a utility function that provides a instance capable of
+// executing various k8s Deployment related operations.
+func (k *k8sUtil) DeploymentOps2() (k8sExtnsV1Beta1.DeploymentInterface, error) {
+	cs, err := k.getClientSet()
+	if err != nil {
+		return nil, err
+	}
+
+	// error out if still empty
+	if len(k.volume.Namespace) == 0 {
+		return nil, fmt.Errorf("Nil namespace")
+	}
+
+	return cs.ExtensionsV1beta1().Deployments(k.volume.Namespace), nil
+}
+
+//  NamespaceOps provides the NamespaceInterface object that exposes
+// various CRUD operations
+func (k *k8sUtil) NamespaceOps() (k8sCoreV1.NamespaceInterface, error) {
+	cs, err := k.getClientSet()
+	if err != nil {
+		return nil, err
+	}
+
+	return cs.CoreV1().Namespaces(), nil
 }
 
 func (k *k8sUtil) StoragePoolOps() (oe_client_v1alpha1.StoragePoolInterface, error) {

--- a/types/v1/defaults.go
+++ b/types/v1/defaults.go
@@ -64,6 +64,9 @@ const (
 	// DefaultMonitoringImage contains the default image for
 	// volume monitoring
 	DefaultMonitoringImage string = "openebs/m-exporter:latest"
+
+	// DefaultNamespaceForListOps contains the default
+	DefaultNamespaceForListOps string = "all-namespaces"
 )
 
 var (

--- a/volume/policies/v1/policy_k8s.go
+++ b/volume/policies/v1/policy_k8s.go
@@ -119,6 +119,7 @@ func (p *K8sPolicies) initNS() {
 
 	// possible values for namespace
 	nsVals := []string{
+		p.volume.ObjectMeta.Namespace,
 		p.volume.Labels.K8sNamespace,
 		v1.NamespaceENV(),
 		v1.DefaultNamespace,


### PR DESCRIPTION
https://github.com/openebs/openebs/issues/1055

### 1. Why is this change necessary ?
maya needs to accept namespace inorder to delete & read a volume

### 2. How does this change address the issue ?
maya makes use of request header to extract the namespace during read and delete operation

### 3. How to verify this change ?
- make should work fine
- curl to read & delete a volume should send the namespace in request header with key as namespace
- openebs provisioner should set the request header with key as namespace

### 4. What side effects does this change have ?
- none

### 5. Tests Conducted
```bash
$ kubectl get deploy --all-namespaces -l=vsm
NAMESPACE   NAME               DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
default     my-jiva-vsm-ctrl   1         1         1            1           52s
default     my-jiva-vsm-rep    2         2         2            1           52s
minio       my-jiva-vsm-ctrl   1         1         1            1           3m
minio       my-jiva-vsm-rep    2         2         2            1           3m
```

```bash
$ kubectl get svc --all-namespaces -l=vsm
NAMESPACE   NAME                   TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
default     my-jiva-vsm-ctrl-svc   ClusterIP   10.101.76.244    <none>        3260/TCP,9501/TCP   59s
minio       my-jiva-vsm-ctrl-svc   ClusterIP   10.109.160.242   <none>        3260/TCP,9501/TCP   3m
```
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
