### PR TITLE
Add code w.r.t openebs storage policy - drop 1 - WIP

### DIFF
--- a/pkg/client/k8s/k8s.go
+++ b/pkg/client/k8s/k8s.go
@@ -27,6 +27,27 @@ import (
 	typed_ext_v1beta "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
 )
 
+// K8sKind represents the Kinds understood by Kubernetes
+type K8sKind string
+
+const (
+	// DeploymentKK is a K8s Deployment Kind
+	DeploymentKK K8sKind = "Deployment"
+	// ConfigMapKK is a K8s ConfigMap Kind
+	ConfigMapKK K8sKind = "ConfigMap"
+	// ServiceKK is a K8s Service Kind
+	ServiceKK K8sKind = "Service"
+)
+
+//
+type K8sAPIVersion string
+
+const (
+	ExtensionsV1Beta1KA K8sAPIVersion = "extensions/v1beta1"
+
+	CoreV1KA K8sAPIVersion = "v1"
+)
+
 // K8sClient provides the necessary utility to operate over
 // various K8s Kind objects
 type K8sClient struct {
@@ -143,9 +164,27 @@ func (k *K8sClient) GetService(name string, opts mach_apis_meta_v1.GetOptions) (
 	return sops.Get(name, opts)
 }
 
+// coreV1ServiceOps is a utility function that provides a instance capable of
+// executing various k8s service related operations.
+func (k *K8sClient) coreV1ServiceOps() typed_core_v1.ServiceInterface {
+	return k.cs.CoreV1().Services(k.ns)
+}
+
+// CreateCoreV1Service creates a K8s Service
+func (k *K8sClient) CreateCoreV1Service(svc *api_core_v1.Service) (*api_core_v1.Service, error) {
+	sops := k.coreV1ServiceOps()
+	return sops.Create(svc)
+}
+
 // deploymentOps is a utility function that provides a instance capable of
 // executing various k8s Deployment related operations.
 func (k *K8sClient) deploymentOps() typed_ext_v1beta.DeploymentInterface {
+	return k.cs.ExtensionsV1beta1().Deployments(k.ns)
+}
+
+// extnV1B1DeploymentOps is a utility function that provides a instance capable of
+// executing various k8s Deployment related operations.
+func (k *K8sClient) extnV1B1DeploymentOps() typed_ext_v1beta.DeploymentInterface {
 	return k.cs.ExtensionsV1beta1().Deployments(k.ns)
 }
 
@@ -157,6 +196,12 @@ func (k *K8sClient) GetDeployment(name string, opts mach_apis_meta_v1.GetOptions
 
 	dops := k.deploymentOps()
 	return dops.Get(name, opts)
+}
+
+// GetDeployment fetches the K8s Deployment with the provided name
+func (k *K8sClient) CreateExtnV1B1Deployment(d *api_extn_v1beta1.Deployment) (*api_extn_v1beta1.Deployment, error) {
+	dops := k.extnV1B1DeploymentOps()
+	return dops.Create(d)
 }
 
 // getInClusterCS is used to initialize and return a new http client capable

--- a/pkg/maya/maya.go
+++ b/pkg/maya/maya.go
@@ -29,6 +29,546 @@ import (
 	mach_apis_meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// CustomFuncsHolder contains properties that are
+// used to build custom text/template functions
+type CustomFuncsHolder struct {
+	// Inputs contains the k:v pairs required to
+	// set the template's placeholders
+	Inputs map[string]string `json:"inputs"`
+	// Stores contains the k:v pairs out of resulting
+	// actions on the template's embedded object
+	Stores map[string]string
+}
+
+func customFuncVal(pairs map[string]string, context, key string) (string, error) {
+	if len(pairs) == 0 {
+		return "", fmt.Errorf("No %s found", context)
+	}
+
+	if len(key) == 0 {
+		return "", fmt.Errorf("Missing %s key", context)
+	}
+
+	val := pairs[key]
+	if len(val) == 0 {
+		return "", fmt.Errorf("Nil value for %s key '%s'", context, key)
+	}
+
+	return val, nil
+}
+
+func (f *CustomFuncsHolder) inputVal(key string) (string, error) {
+	return customFuncVal(f.Inputs, "inputs", key)
+}
+
+func (f *CustomFuncsHolder) storeVal(key string) (string, error) {
+	return customFuncVal(f.Stores, "stores", key)
+}
+
+func (f *CustomFuncsHolder) setInputIfEmpty(key, value string) {
+	if len(f.Inputs[key]) == 0 {
+		f.Inputs[key] = value
+	}
+}
+
+func (f *CustomFuncsHolder) setStore(key, value string) {
+	f.Stores[key] = value
+}
+
+func (f *CustomFuncsHolder) setStoreIfEmpty(key, value string) {
+	if len(f.Stores[key]) == 0 {
+		f.Stores[key] = value
+	}
+}
+
+func (f *CustomFuncsHolder) mergeInputsIfEmpty(inputs map[string]string) {
+	if len(f.Inputs) == 0 {
+		f.Inputs = inputs
+		return
+	}
+
+	for k, v := range inputs {
+		f.setInputIfEmpty(k, v)
+	}
+}
+
+func (f *CustomFuncsHolder) mergeStoresIfEmpty(stores map[string]string) {
+	if len(f.Stores) == 0 {
+		f.Stores = stores
+		return
+	}
+
+	for k, v := range stores {
+		f.setStoreIfEmpty(k, v)
+	}
+}
+
+func (f *CustomFuncsHolder) mergeStores(stores map[string]string) {
+	if len(f.Stores) == 0 {
+		f.Stores = stores
+		return
+	}
+
+	for k, v := range stores {
+		f.setStore(k, v)
+	}
+}
+
+// MayaYamlV2 represents a yaml definition
+//
+// This yaml is expected to be marshalled into
+// corresponding go struct
+type MayaYamlV2 struct {
+	// Yaml represents a templated yaml in string format
+	Yaml string
+
+	// YmlInBytes represents the templated yaml in
+	// byte slice format
+	YmlInBytes []byte
+}
+
+func (m *MayaYamlV2) asByteArr() ([]byte, error) {
+	if m.YmlInBytes != nil {
+		return m.YmlInBytes, nil
+	}
+
+	if len(m.Yaml) == 0 {
+		return nil, fmt.Errorf("Yaml is not set")
+	}
+
+	return []byte(m.Yaml), nil
+}
+
+func (m *MayaYamlV2) getYaml() (string, error) {
+	if len(m.Yaml) == 0 {
+		return "", fmt.Errorf("Yaml is not set")
+	}
+
+	return m.Yaml, nil
+}
+
+// load sets the byte slice corresponding to the yaml
+func (m *MayaYamlV2) load() error {
+	if m.YmlInBytes == nil {
+		// unmarshall the yaml
+		b, err := m.asByteArr()
+		if err != nil {
+			return err
+		}
+		m.YmlInBytes = b
+	}
+
+	return nil
+}
+
+// MayaRunAction signifies the action to be taken
+// against a MayaTemplate
+type MayaRunAction string
+
+const (
+	// GetMRA flags a action as get. Typically used to fetch
+	// an object from its name.
+	GetMRA MayaRunAction = "get"
+
+	// PutMRA flags a action as put. Typically used to put
+	// an  object.
+	PutMRA MayaRunAction = "put"
+)
+
+// TemplateInfo composes various properties that provides
+// information about a MayaTemplate
+type TemplateInfo struct {
+	// Kind of the template contents
+	Kind string `json:"kind"`
+	// APIVersion of the template contents
+	APIVersion string `json:"apiVersion"`
+	// Namespace of the template contents
+	Namespace string `json:"namespace"`
+	// Action to be invoked on the template contents
+	Action MayaRunAction `json:"action"`
+	// CustomFuncsHolder exposes the functions
+	// that are set as custom functions in text/template
+	CustomFuncsHolder
+	// MayaYamlV2 provides the templated yaml representation
+	// of this instance
+	MayaYamlV2
+}
+
+func NewTemplateInfo(yaml string, inputs map[string]string) TemplateInfo {
+	return TemplateInfo{
+		MayaYamlV2: MayaYamlV2{
+			Yaml: yaml,
+		},
+		CustomFuncsHolder: CustomFuncsHolder{
+			Inputs: inputs,
+			Stores: map[string]string{},
+		},
+	}
+}
+
+// templateInfoAsByte returns a byte slice format of
+// its yaml representation
+func (m *TemplateInfo) templateInfoAsByte() ([]byte, error) {
+	yml, err := m.getYaml()
+	if err != nil {
+		return nil, err
+	}
+
+	tpl := template.New("templateinfo")
+	tpl.Funcs(template.FuncMap{
+		"inputs": m.inputVal,
+		"stores": m.storeVal,
+	})
+
+	tpl, err = tpl.Parse(yml)
+	if err != nil {
+		return nil, err
+	}
+
+	// this has implementation of io.Writer
+	// that is required by the template
+	var buf bytes.Buffer
+
+	// execute the parsed yaml against this instance
+	// & write the result into the buffer
+	err = tpl.Execute(&buf, m)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// asTemplateInfo returns a TemplateInfo structure
+// from its corresponding yaml representation
+func (m *TemplateInfo) asTemplateInfo() (TemplateInfo, error) {
+	t := TemplateInfo{}
+
+	// unmarshall the yaml
+	b, err := m.templateInfoAsByte()
+	if err != nil {
+		return t, err
+	}
+
+	err = yaml.Unmarshal(b, t)
+	if err != nil {
+		return t, err
+	}
+
+	return t, nil
+}
+
+func (m *TemplateInfo) isDeployment() bool {
+	return m.Kind == string(k8s.DeploymentKK)
+}
+
+func (m *TemplateInfo) isService() bool {
+	return m.Kind == string(k8s.ServiceKK)
+}
+
+func (m *TemplateInfo) isConfigMap() bool {
+	return m.Kind == string(k8s.ConfigMapKK)
+}
+
+func (m *TemplateInfo) isGet() bool {
+	return m.Action == GetMRA
+}
+
+func (m *TemplateInfo) isPut() bool {
+	return m.Action == PutMRA
+}
+
+func (m *TemplateInfo) isExtnV1B1() bool {
+	return m.APIVersion == string(k8s.ExtensionsV1Beta1KA)
+}
+
+func (m *TemplateInfo) isCoreV1() bool {
+	return m.APIVersion == string(k8s.CoreV1KA)
+}
+
+func (m *TemplateInfo) isExtnV1B1Deploy() bool {
+	return m.isExtnV1B1() && m.isDeployment()
+}
+
+func (m *TemplateInfo) isCoreV1Service() bool {
+	return m.isCoreV1() && m.isService()
+}
+
+func (m *TemplateInfo) isPutExtnV1B1Deploy() bool {
+	return m.isExtnV1B1Deploy() && m.isPut()
+}
+
+func (m *TemplateInfo) isPutCoreV1Service() bool {
+	return m.isCoreV1Service() && m.isPut()
+}
+
+// MayaTemplate represents a MayaTemplate as seen in
+// its YAML format
+type MayaTemplate struct {
+	// TemplateInfo provides the information about this
+	// template
+	TemplateInfo
+	// CustomFuncsHolder exposes the functions
+	// that are set as custom functions in text/template
+	CustomFuncsHolder
+	// MayaYamlV2 represents this template's embedded yaml
+	MayaYamlV2 `json:"yaml"`
+	// k8sClient is the client to invoke Kubernetes APIs
+	k8sClient *k8s.K8sClient
+}
+
+func NewMayaTemplate(mayaTplYml, tplInfoYml string, inputs map[string]string) (*MayaTemplate, error) {
+
+	t := NewTemplateInfo(tplInfoYml, inputs)
+	t, err := t.asTemplateInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	return &MayaTemplate{
+		TemplateInfo: t,
+		MayaYamlV2: MayaYamlV2{
+			Yaml: mayaTplYml,
+		},
+		CustomFuncsHolder: CustomFuncsHolder{
+			Inputs: inputs,
+			Stores: map[string]string{},
+		},
+	}, nil
+}
+
+// mayaTemplateAsByte returns a byte slice format of its yaml
+// representation
+func (m *MayaTemplate) mayaTemplateAsByte() ([]byte, error) {
+	yml, err := m.getYaml()
+	if err != nil {
+		return nil, err
+	}
+
+	tpl := template.New("mayatemplate")
+	tpl.Funcs(template.FuncMap{
+		"inputs": m.inputVal,
+		"stores": m.storeVal,
+	})
+
+	tpl, err = tpl.Parse(yml)
+	if err != nil {
+		return nil, err
+	}
+
+	// this has implementation of io.Writer
+	// that is required by the template
+	var buf bytes.Buffer
+
+	// execute the parsed yaml against this instance
+	// & write the result into the buffer
+	err = tpl.Execute(&buf, m)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// Execute will execute the MayaTemplate depending on informations
+// set in TemplateInfo
+func (m *MayaTemplate) Execute(stores map[string]string) error {
+	if m.k8sClient == nil {
+		// Make use of the namespace that is set in TemplateInfo
+		kc, err := k8s.NewK8sClient(m.Namespace)
+		if err != nil {
+			return err
+		}
+		m.k8sClient = kc
+	}
+
+	if m.isPutExtnV1B1Deploy() {
+		d, err := m.asExtnV1B1Deploy(stores)
+		if err != nil {
+			return err
+		}
+
+		d, err = m.k8sClient.CreateExtnV1B1Deployment(d)
+		if err != nil {
+			return err
+		}
+	}
+
+	if m.isPutCoreV1Service() {
+		s, err := m.asCoreV1Svc(stores)
+		if err != nil {
+			return err
+		}
+
+		s, err = m.k8sClient.CreateCoreV1Service(s)
+		if err != nil {
+			return err
+		}
+		stores["service-ip"] = s.Spec.ClusterIP
+	}
+
+	return nil
+}
+
+// asExtnV1B1Deploy generates a K8s Deployment object
+// out of the embedded yaml
+func (m *MayaTemplate) asExtnV1B1Deploy(stores map[string]string) (*api_extn_v1beta1.Deployment, error) {
+	if !m.isDeployment() {
+		return nil, fmt.Errorf("Invalid kind: Deployment required")
+	}
+
+	if !m.isExtnV1B1() {
+		return nil, fmt.Errorf("Invalid version: extensions/v1beta1 required")
+	}
+
+	m.mergeStores(stores)
+
+	b, err := m.mayaTemplateAsByte()
+	if err != nil {
+		return nil, err
+	}
+
+	d := NewMayaDeploymentV2ByByte(b)
+	return d.AsExtnV1B1Deployment()
+}
+
+// asCoreV1Svc generates a K8s Service object
+// out of the embedded yaml
+func (m *MayaTemplate) asCoreV1Svc(stores map[string]string) (*api_core_v1.Service, error) {
+	if !m.isService() {
+		return nil, fmt.Errorf("Invalid kind: Service required")
+	}
+
+	if !m.isCoreV1() {
+		return nil, fmt.Errorf("Invalid version: v1 required")
+	}
+
+	m.mergeStores(stores)
+
+	b, err := m.mayaTemplateAsByte()
+	if err != nil {
+		return nil, err
+	}
+
+	s := NewMayaServiceV2ByByte(b)
+	return s.AsCoreV1Service()
+}
+
+// MayaDeploymentV2 provides utility methods over K8s
+// Deployment object
+type MayaDeploymentV2 struct {
+	// MayaYamlV2 represents a K8s Deployment in
+	// yaml format
+	MayaYamlV2
+}
+
+func NewMayaDeploymentV2(yaml string) *MayaDeploymentV2 {
+	return &MayaDeploymentV2{
+		MayaYamlV2: MayaYamlV2{
+			Yaml: yaml,
+		},
+	}
+}
+
+func NewMayaDeploymentV2ByByte(b []byte) *MayaDeploymentV2 {
+	return &MayaDeploymentV2{
+		MayaYamlV2: MayaYamlV2{
+			YmlInBytes: b,
+		},
+	}
+}
+
+// AsExtnV1B1Deployment returns a extensions/v1beta1 Deployment instance
+func (m *MayaDeploymentV2) AsExtnV1B1Deployment() (*api_extn_v1beta1.Deployment, error) {
+	err := m.load()
+	if err != nil {
+		return nil, err
+	}
+
+	// unmarshall the byte into k8s Deployment object
+	deploy := &api_extn_v1beta1.Deployment{}
+	err = yaml.Unmarshal(m.YmlInBytes, deploy)
+	if err != nil {
+		return nil, err
+	}
+
+	return deploy, nil
+}
+
+// MayaServiceV2 provides utility methods over K8s Service
+type MayaServiceV2 struct {
+	// MayaYamlV2 represents a K8s Service in
+	// yaml format
+	MayaYamlV2
+}
+
+func NewMayaServiceV2(yaml string) *MayaServiceV2 {
+	return &MayaServiceV2{
+		MayaYamlV2: MayaYamlV2{
+			Yaml: yaml,
+		},
+	}
+}
+
+func NewMayaServiceV2ByByte(b []byte) *MayaServiceV2 {
+	return &MayaServiceV2{
+		MayaYamlV2: MayaYamlV2{
+			YmlInBytes: b,
+		},
+	}
+}
+
+// AsCoreV1Service returns a v1 Service instance
+func (m *MayaServiceV2) AsCoreV1Service() (*api_core_v1.Service, error) {
+	err := m.load()
+	if err != nil {
+		return nil, err
+	}
+
+	// unmarshall the byte into k8s Service object
+	svc := &api_core_v1.Service{}
+	err = yaml.Unmarshal(m.YmlInBytes, svc)
+	if err != nil {
+		return nil, err
+	}
+
+	return svc, nil
+}
+
+// TODO
+// Move these to pkg/maya/policy.go
+//
+// TemplateInfoFilter flags if the provided template
+// suits the invoking function's requirement
+//type TemplateInfoFilter func(TemplateInfo) bool
+
+// OpenEBSKind represents various kinds of openebs objects
+//type OpenEBSKind string
+
+//const (
+// MayaRunOEK represents a MayaRun object
+//MayaRunOEK OpenEBSKind = "MayaRun"
+// MayaTemplateOEK represents a MayaTemplate object
+//MayaTemplateOEK OpenEBSKind = "MayaTemplate"
+//)
+
+// TemplateSelector helps in selecting or identifying
+// required template
+//type TemplateSelector struct {
+// Kind of template that needs to be selected
+//Kind OpenEBSKind
+// Select is the boolean selection function
+//Select TemplateInfoFilter
+// Path is the required path found in the selected
+// template. It represents any nested path location.
+//Path ...string
+//}
+
+// TODO
+// The structures & code written below will undergo changes.
+// Some of these may be deprecated & removed in favour of the
+// structures implemented above.
+
 // MayaPlaceholders is a structure that is composed
 // of various properties. These properties are set as
 // placeholders in a template file.
@@ -444,12 +984,12 @@ func (m *MayaContainer) Load() error {
 }
 
 type MayaDeployment struct {
-	// Deployment represents a K8s Deployment object
-	Deployment *api_extn_v1beta1.Deployment
-
-	// MayaYaml represents the above K8s Deployment in
+	// MayaYaml represents the K8s Deployment in
 	// yaml format
 	MayaYaml
+
+	// Deployment represents a K8s Deployment object
+	Deployment *api_extn_v1beta1.Deployment
 }
 
 func NewMayaDeployment(yaml string) *MayaDeployment {
@@ -468,7 +1008,7 @@ func NewMayaDeploymentByByte(b []byte) *MayaDeployment {
 	}
 }
 
-// Load initializes Deployment property of this instance
+// Load returns a extensions/v1beta1 Deployment instance
 func (m *MayaDeployment) Load() error {
 	if m.YmlBytes == nil {
 		// unmarshall the yaml
@@ -479,7 +1019,7 @@ func (m *MayaDeployment) Load() error {
 		m.YmlBytes = b
 	}
 
-	// unmarshall the buffer into k8s Deployment object
+	// unmarshall the byte into k8s Deployment object
 	deploy := &api_extn_v1beta1.Deployment{}
 	err := yaml.Unmarshal(m.YmlBytes, deploy)
 	if err != nil {

--- a/pkg/maya/runner.go
+++ b/pkg/maya/runner.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2017 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maya
+
+import (
+	"bytes"
+	"text/template"
+
+	"github.com/ghodss/yaml"
+	"github.com/openebs/maya/pkg/client/k8s"
+	api_core_v1 "k8s.io/api/core/v1"
+	mach_apis_meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Task refers to a MayaTemplate
+type Task struct {
+	TemplateName string `json:"template"`
+}
+
+// RunTemplate is a structure that represents a
+// MayaRun template
+type RunTemplate struct {
+	// CustomFuncsHolder holds the inputs provided to this
+	// template
+	CustomFuncsHolder
+	// Tasks are the references to MayaTemplates
+	Tasks []Task `json:"tasks"`
+	// MayaYamlV2 is the yaml representation of RunTemplate
+	MayaYamlV2
+}
+
+// NewRunTemplate returns an instance of MayaConfigMapV2
+// based on the provided yaml
+func NewRunTemplate(yaml string) *RunTemplate {
+	return &RunTemplate{
+		MayaYamlV2: MayaYamlV2{
+			Yaml: yaml,
+		},
+	}
+}
+
+// runTemplateAsByte returns a byte slice format of
+// its yaml representation
+func (m *RunTemplate) runTemplateAsByte() ([]byte, error) {
+	yml, err := m.getYaml()
+	if err != nil {
+		return nil, err
+	}
+
+	tpl, err := template.New("runtemplate").Parse(yml)
+	if err != nil {
+		return nil, err
+	}
+
+	// this has implementation of io.Writer
+	// that is required by the template
+	var buf bytes.Buffer
+
+	// execute the parsed yaml against this instance
+	// & write the result into the buffer
+	err = tpl.Execute(&buf, m)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// AsTemplateInfo returns a TemplateInfo structure
+// from its corresponding yaml representation
+func (m *RunTemplate) AsRunTemplate() (*RunTemplate, error) {
+	// unmarshall the yaml
+	b, err := m.runTemplateAsByte()
+	if err != nil {
+		return nil, err
+	}
+
+	t := &RunTemplate{}
+	err = yaml.Unmarshal(b, t)
+	if err != nil {
+		return nil, err
+	}
+
+	return t, nil
+}
+
+// MayaRunner does the low level operations of running a
+// MayaRun template
+type MayaRunner struct {
+	// runTplName of the RunTemplate that is actually the name of
+	// a K8s ConfigMap
+	runTplName string
+	// searchNamespace where the RunTemplate & MayaTemplate are
+	// available
+	searchNamespace string
+	// CustomFuncsHolder is the placeholder to keep the
+	// inputs as well as the stores
+	CustomFuncsHolder
+	// array of templates that are found in RunTemplate & are
+	// meant to be run
+	templates []*MayaTemplate
+}
+
+func NewMayaRunner(name, searchNamespace string) *MayaRunner {
+	return &MayaRunner{
+		runTplName:      name,
+		searchNamespace: searchNamespace,
+		CustomFuncsHolder: CustomFuncsHolder{
+			Inputs: map[string]string{},
+			Stores: map[string]string{},
+		},
+	}
+}
+
+// getKCToFetchTemplates gets the K8s Client that is pointing to the
+// namespace where maya template(s) are available
+func (m *MayaRunner) getKCToFetchTemplates() (*k8s.K8sClient, error) {
+	return k8s.NewK8sClient(m.searchNamespace)
+}
+
+// fetchTemplate returns the corresponding ConfigMap
+// NOTE:
+//  A Template e.g. MayaTemplate or RunTemplate is actually
+// a K8s ConfigMap
+func (m *MayaRunner) fetchTemplate(tplName string) (*api_core_v1.ConfigMap, error) {
+	kc, err := m.getKCToFetchTemplates()
+	if err != nil {
+		return nil, err
+	}
+
+	return kc.GetConfigMap(tplName, mach_apis_meta_v1.GetOptions{})
+}
+
+// getRunTemplate returns an instance of RunTemplate
+// from ConfigMap
+func (m *MayaRunner) getRunTemplate() (*RunTemplate, error) {
+	cm, err := m.fetchTemplate(m.runTplName)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewRunTemplate(cm.Data["yaml"]), nil
+}
+
+// getMayaTemplate returns an instance of MayaTemplate
+// from ConfigMap
+func (m *MayaRunner) getMayaTemplate(mayaTplName string, inputs map[string]string) (*MayaTemplate, error) {
+	cm, err := m.fetchTemplate(mayaTplName)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewMayaTemplate(cm.Data["yaml"], cm.Data["meta"], inputs)
+}
+
+// loadRunTemplate loads up the RunTemplate instance
+func (m *MayaRunner) loadRunTemplate() (*RunTemplate, error) {
+	// get the instance of RunTemplate
+	rt, err := m.getRunTemplate()
+	if err != nil {
+		return nil, err
+	}
+
+	// load run template's yaml representation into corresponding
+	// go struct
+	return rt.AsRunTemplate()
+}
+
+// Run will run each MayaTemplate in the provided
+// namespace
+func (m *MayaRunner) Run(runNamespace string) error {
+	rt, err := m.loadRunTemplate()
+	if err != nil {
+		return err
+	}
+
+	// merge the RunTemplate's inputs & stores with runner
+	m.mergeInputsIfEmpty(rt.Inputs)
+	m.mergeStoresIfEmpty(rt.Stores)
+	// This is the namespace where RunTemplate will execute its
+	// tasks i.e. MayaTemplates. However, this may not be the case
+	// always if MayaTemplate hardcodes its namespace.
+	m.setInputIfEmpty("namespace", runNamespace)
+
+	// get an instance of MayaTemplate & store them
+	// to be executed later
+	for _, task := range rt.Tasks {
+		mt, err := m.getMayaTemplate(task.TemplateName, m.Inputs)
+		if err != nil {
+			return err
+		}
+		m.templates = append(m.templates, mt)
+	}
+
+	for _, template := range m.templates {
+		err := template.Execute(m.Stores)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
1. Why is this change necessary ?

openebs needs to add storage policies as an intuitive way
for admins & users to use storage yet have granular control.

This is a partial commit w.r.t issue
https://github.com/openebs/openebs/issues/1007
https://github.com/openebs/openebs/issues/1010
https://github.com/openebs/openebs/issues/976

doc at
https://docs.google.com/document/d/1oX_AcDMuhg2HVn3nmYDaZ-ABQv_V0v_DhbbySUImAhg/

2. How does this change address the issue ?

- adds RunTemplate & MayaTemplate related code

3. How to verify this change ?

- make should run fine
- Examples should be provided to enable developer & user
to understand the usage

4. What side effects does this change have ?

- Need to provide UT
- Should be treated as WIP till then

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
