### PR TITLE
Add code w.r.t openebs storage policy - drop 1

### DIFF
--- a/pkg/client/k8s/k8s.go
+++ b/pkg/client/k8s/k8s.go
@@ -27,6 +27,27 @@ import (
 	typed_ext_v1beta "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
 )
 
+// K8sKind represents the Kinds understood by Kubernetes
+type K8sKind string
+
+const (
+	// DeploymentKK is a K8s Deployment Kind
+	DeploymentKK K8sKind = "Deployment"
+	// ConfigMapKK is a K8s ConfigMap Kind
+	ConfigMapKK K8sKind = "ConfigMap"
+	// ServiceKK is a K8s Service Kind
+	ServiceKK K8sKind = "Service"
+)
+
+//
+type K8sAPIVersion string
+
+const (
+	ExtensionsV1Beta1KA K8sAPIVersion = "extensions/v1beta1"
+
+	CoreV1KA K8sAPIVersion = "v1"
+)
+
 // K8sClient provides the necessary utility to operate over
 // various K8s Kind objects
 type K8sClient struct {
@@ -143,9 +164,27 @@ func (k *K8sClient) GetService(name string, opts mach_apis_meta_v1.GetOptions) (
 	return sops.Get(name, opts)
 }
 
+// coreV1ServiceOps is a utility function that provides a instance capable of
+// executing various k8s service related operations.
+func (k *K8sClient) coreV1ServiceOps() typed_core_v1.ServiceInterface {
+	return k.cs.CoreV1().Services(k.ns)
+}
+
+// CreateCoreV1Service creates a K8s Service
+func (k *K8sClient) CreateCoreV1Service(svc *api_core_v1.Service) (*api_core_v1.Service, error) {
+	sops := k.coreV1ServiceOps()
+	return sops.Create(svc)
+}
+
 // deploymentOps is a utility function that provides a instance capable of
 // executing various k8s Deployment related operations.
 func (k *K8sClient) deploymentOps() typed_ext_v1beta.DeploymentInterface {
+	return k.cs.ExtensionsV1beta1().Deployments(k.ns)
+}
+
+// extnV1B1DeploymentOps is a utility function that provides a instance capable of
+// executing various k8s Deployment related operations.
+func (k *K8sClient) extnV1B1DeploymentOps() typed_ext_v1beta.DeploymentInterface {
 	return k.cs.ExtensionsV1beta1().Deployments(k.ns)
 }
 
@@ -157,6 +196,12 @@ func (k *K8sClient) GetDeployment(name string, opts mach_apis_meta_v1.GetOptions
 
 	dops := k.deploymentOps()
 	return dops.Get(name, opts)
+}
+
+// GetDeployment fetches the K8s Deployment with the provided name
+func (k *K8sClient) CreateExtnV1B1Deployment(d *api_extn_v1beta1.Deployment) (*api_extn_v1beta1.Deployment, error) {
+	dops := k.extnV1B1DeploymentOps()
+	return dops.Create(d)
 }
 
 // getInClusterCS is used to initialize and return a new http client capable

--- a/pkg/maya/maya.go
+++ b/pkg/maya/maya.go
@@ -29,6 +29,74 @@ import (
 	mach_apis_meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// MayaDeploymentV2 provides utility methods over K8s
+// Deployment object
+type MayaDeploymentV2 struct {
+	// MayaYamlV2 represents a K8s Deployment in
+	// yaml format
+	MayaYamlV2
+}
+
+func NewMayaDeploymentV2ByByte(b []byte) *MayaDeploymentV2 {
+	return &MayaDeploymentV2{
+		MayaYamlV2: MayaYamlV2{
+			YmlInBytes: b,
+		},
+	}
+}
+
+// AsExtnV1B1Deployment returns a extensions/v1beta1 Deployment instance
+func (m *MayaDeploymentV2) AsExtnV1B1Deployment() (*api_extn_v1beta1.Deployment, error) {
+	if m.YmlInBytes == nil {
+		return nil, fmt.Errorf("Missing yaml")
+	}
+
+	// unmarshall the byte into k8s Deployment object
+	deploy := &api_extn_v1beta1.Deployment{}
+	err := yaml.Unmarshal(m.YmlInBytes, deploy)
+	if err != nil {
+		return nil, err
+	}
+
+	return deploy, nil
+}
+
+// MayaServiceV2 provides utility methods over K8s Service
+type MayaServiceV2 struct {
+	// MayaYamlV2 represents a K8s Service in
+	// yaml format
+	MayaYamlV2
+}
+
+func NewMayaServiceV2ByByte(b []byte) *MayaServiceV2 {
+	return &MayaServiceV2{
+		MayaYamlV2: MayaYamlV2{
+			YmlInBytes: b,
+		},
+	}
+}
+
+// AsCoreV1Service returns a v1 Service instance
+func (m *MayaServiceV2) AsCoreV1Service() (*api_core_v1.Service, error) {
+	if m.YmlInBytes == nil {
+		return nil, fmt.Errorf("Missing yaml")
+	}
+
+	// unmarshall the byte into k8s Service object
+	svc := &api_core_v1.Service{}
+	err := yaml.Unmarshal(m.YmlInBytes, svc)
+	if err != nil {
+		return nil, err
+	}
+
+	return svc, nil
+}
+
+// TODO
+// The structures & code written below will undergo changes.
+// Some of these may be deprecated & removed in favour of the
+// structures implemented above.
+
 // MayaPlaceholders is a structure that is composed
 // of various properties. These properties are set as
 // placeholders in a template file.
@@ -444,12 +512,12 @@ func (m *MayaContainer) Load() error {
 }
 
 type MayaDeployment struct {
-	// Deployment represents a K8s Deployment object
-	Deployment *api_extn_v1beta1.Deployment
-
-	// MayaYaml represents the above K8s Deployment in
+	// MayaYaml represents the K8s Deployment in
 	// yaml format
 	MayaYaml
+
+	// Deployment represents a K8s Deployment object
+	Deployment *api_extn_v1beta1.Deployment
 }
 
 func NewMayaDeployment(yaml string) *MayaDeployment {
@@ -468,7 +536,7 @@ func NewMayaDeploymentByByte(b []byte) *MayaDeployment {
 	}
 }
 
-// Load initializes Deployment property of this instance
+// Load returns a extensions/v1beta1 Deployment instance
 func (m *MayaDeployment) Load() error {
 	if m.YmlBytes == nil {
 		// unmarshall the yaml
@@ -479,7 +547,7 @@ func (m *MayaDeployment) Load() error {
 		m.YmlBytes = b
 	}
 
-	// unmarshall the buffer into k8s Deployment object
+	// unmarshall the byte into k8s Deployment object
 	deploy := &api_extn_v1beta1.Deployment{}
 	err := yaml.Unmarshal(m.YmlBytes, deploy)
 	if err != nil {

--- a/pkg/maya/maya_test.go
+++ b/pkg/maya/maya_test.go
@@ -20,8 +20,294 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/openebs/maya/pkg/util"
 	mach_apis_meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// newCustomFuncsHolder is a utility function that returns a new instance of
+// CustomFuncsHolder
+func newCustomFuncsHolder(key, value, ctx string) *CustomFuncsHolder {
+	if len(key) == 0 && len(value) == 0 {
+		return &CustomFuncsHolder{}
+	}
+
+	pairs := map[string]string{
+		key: value,
+	}
+
+	if ctx == "inputs" {
+		return &CustomFuncsHolder{
+			Inputs: pairs,
+		}
+	} else {
+		return &CustomFuncsHolder{
+			Stores: pairs,
+		}
+	}
+}
+
+func TestCustomFuncsHolderInputVal(t *testing.T) {
+	tests := map[string]struct {
+		key   string
+		val   string
+		isErr bool
+	}{
+		"valid input":                {key: "abc", val: "xyz", isErr: false},
+		"empty key as input":         {key: "", val: "xyz", isErr: true},
+		"empty value as input":       {key: "abc", val: "", isErr: true},
+		"empty key & value as input": {key: "", val: "", isErr: true},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			h := newCustomFuncsHolder(test.key, test.val, "inputs")
+			_, err := h.inputVal(test.key)
+
+			if !test.isErr && err != nil {
+				t.Fatalf("Expected: 'no error' Actual: '%s'", err)
+			}
+		})
+	}
+}
+
+func TestCustomFuncsHolderMergeStores(t *testing.T) {
+	tests := map[string]struct {
+		key1   string
+		key2   string
+		val1   string
+		val2   string
+		optype string
+	}{
+		"new":                   {key1: "", val1: "", key2: "k", val2: "v", optype: "new"},
+		"append":                {key1: "k1", val1: "v1", key2: "k2", val2: "v2", optype: "append"},
+		"merge if empty":        {key1: "k1", val1: "", key2: "k1", val2: "v2", optype: "mergeifempty"},
+		"no merge if not empty": {key1: "k1", val1: "v1", key2: "k1", val2: "v2", optype: "nomergeifnotempty"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			h := newCustomFuncsHolder(test.key1, test.val1, "stores")
+			h.mergeStoresIfEmpty(map[string]string{
+				test.key2: test.val2,
+			})
+
+			if test.optype == "new" && h.Stores[test.key2] != test.val2 {
+				t.Fatalf("Expected: 'addition to stores' Actual: '%v'", h.Stores)
+			}
+
+			if test.optype == "append" && h.Stores[test.key1] != test.val1 {
+				t.Fatalf("Expected: 'appending to stores' Actual: '%v'", h.Stores)
+			}
+
+			if test.optype == "append" && h.Stores[test.key2] != test.val2 {
+				t.Fatalf("Expected: 'appending to stores' Actual: '%v'", h.Stores)
+			}
+
+			if test.optype == "mergeifempty" && h.Stores[test.key1] != test.val2 {
+				t.Fatalf("Expected: 'merging of stores' Actual: '%v'", h.Stores)
+			}
+
+			if test.optype == "nomergeifnotempty" && h.Stores[test.key1] != test.val1 {
+				t.Fatalf("Expected: 'no merging of stores' Actual: '%v'", h.Stores)
+			}
+		})
+	}
+}
+
+func TestCustomFuncsHolderMergeInputsIfEmpty(t *testing.T) {
+	tests := map[string]struct {
+		key1   string
+		key2   string
+		val1   string
+		val2   string
+		optype string
+	}{
+		"new":            {key1: "", val1: "", key2: "k", val2: "v", optype: "new"},
+		"append":         {key1: "k1", val1: "v1", key2: "k2", val2: "v2", optype: "append"},
+		"merge if empty": {key1: "k1", val1: "", key2: "k1", val2: "v2", optype: "mergeifempty"},
+		"nomerge":        {key1: "k1", val1: "v1", key2: "k1", val2: "v2", optype: "nomerge"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			h := newCustomFuncsHolder(test.key1, test.val1, "inputs")
+			h.mergeInputsIfEmpty(map[string]string{
+				test.key2: test.val2,
+			})
+
+			if test.optype == "new" && h.Inputs[test.key2] != test.val2 {
+				t.Fatalf("Expected: 'new inputs' Actual: '%v'", h.Inputs)
+			}
+
+			if test.optype == "append" && h.Inputs[test.key1] != test.val1 {
+				t.Fatalf("Expected: 'addition to inputs' Actual: '%v'", h.Inputs)
+			}
+
+			if test.optype == "append" && h.Inputs[test.key2] != test.val2 {
+				t.Fatalf("Expected: 'addition to inputs' Actual: '%v'", h.Inputs)
+			}
+
+			if test.optype == "mergeifempty" && h.Inputs[test.key1] != test.val2 {
+				t.Fatalf("Expected: 'merging of inputs' Actual: '%v'", h.Inputs)
+			}
+
+			if test.optype == "nomerge" && h.Inputs[test.key1] != test.val1 {
+				t.Fatalf("Expected: 'no merging of inputs' Actual: '%v'", h.Inputs)
+			}
+		})
+	}
+}
+
+func TestMayaYamlV2AsMapOfObjects(t *testing.T) {
+	tests := map[string]struct {
+		yaml    string
+		inputk1 string
+		inputv1 string
+		inputk2 string
+		inputv2 string
+		inputk3 string
+		inputv3 string
+		isErr   bool
+	}{
+		"pass inputs & verify as well": {
+			inputk1: "type",
+			inputv1: "testing",
+			inputk2: "operator",
+			inputv2: "testops",
+			inputk3: "operator-version",
+			inputv3: "v2",
+			isErr:   false,
+			yaml: `
+apiVersion: v1
+kind: Service
+metadata:
+  name: ABC
+  labels:
+    openebs.io/type: {{inputs "type"}}
+    openebs.io/operator: {{inputs "operator"}}
+    operator.openebs.io/version: {{inputs "operator-version"}}
+`},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			y := &MayaYamlV2{
+				Yaml: test.yaml,
+				CustomFuncsHolder: CustomFuncsHolder{
+					Inputs: map[string]string{
+						test.inputk1: test.inputv1,
+						test.inputk2: test.inputv2,
+						test.inputk3: test.inputv3,
+					},
+				},
+			}
+
+			obj, err := y.asMapOfObjects()
+
+			if !test.isErr && err != nil {
+				t.Fatalf("Expected: 'no error' Actual: '%s'", err)
+			}
+
+			val1 := util.GetNestedString(obj, []string{"metadata", "labels", "openebs.io/type"}...)
+			val2 := util.GetNestedString(obj, []string{"metadata", "labels", "openebs.io/operator"}...)
+			val3 := util.GetNestedString(obj, []string{"metadata", "labels", "operator.openebs.io/version"}...)
+
+			if !test.isErr && test.inputv1 != val1 {
+				t.Fatalf("Expected: '%s' Actual: '%s'", test.inputv1, val1)
+			}
+
+			if !test.isErr && test.inputv2 != val2 {
+				t.Fatalf("Expected: '%s' Actual: '%s'", test.inputv2, val2)
+			}
+
+			if !test.isErr && test.inputv3 != val3 {
+				t.Fatalf("Expected: '%s' Actual: '%s'", test.inputv3, val3)
+			}
+		})
+	}
+}
+
+func TestTemplateMetaAsTemplateMeta(t *testing.T) {
+
+	yml := `
+apiVersion: {{inputs "version"}}
+kind: {{inputs "kind"}}
+namespace: {{inputs "namespace"}}
+action: {{inputs "action"}}
+`
+
+	tests := map[string]struct {
+		yaml      string
+		kindKey   string
+		kindVal   string
+		verKey    string
+		verVal    string
+		nsKey     string
+		nsVal     string
+		actionKey string
+		actionVal string
+		version   string
+		isErr     bool
+	}{
+		"meta for deployment": {
+			verKey:    "version",
+			verVal:    "extensions/v1beta1",
+			kindKey:   "kind",
+			kindVal:   "Deployment",
+			nsKey:     "namespace",
+			nsVal:     "default",
+			actionKey: "action",
+			actionVal: "get",
+			isErr:     false,
+			yaml:      yml,
+		},
+		"meta for service": {
+			verKey:    "version",
+			verVal:    "v1",
+			kindKey:   "kind",
+			kindVal:   "Service",
+			nsKey:     "namespace",
+			nsVal:     "system",
+			actionKey: "action",
+			actionVal: "put",
+			isErr:     false,
+			yaml:      yml,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			m := NewTemplateMeta(test.yaml, map[string]string{
+				test.verKey:    test.verVal,
+				test.kindKey:   test.kindVal,
+				test.nsKey:     test.nsVal,
+				test.actionKey: test.actionVal,
+			})
+
+			m, err := m.asTemplateMeta()
+
+			if !test.isErr && err != nil {
+				t.Fatalf("Expected: 'no error' Actual: '%s'", err)
+			}
+
+			if !test.isErr && test.verVal != m.APIVersion {
+				t.Fatalf("Expected: '%s' Actual: '%s'", test.verVal, m.APIVersion)
+			}
+
+			if !test.isErr && test.kindVal != m.Kind {
+				t.Fatalf("Expected: '%s' Actual: '%s'", test.kindVal, m.Kind)
+			}
+
+			if !test.isErr && test.nsVal != m.Namespace {
+				t.Fatalf("Expected: '%s' Actual: '%s'", test.nsVal, m.Namespace)
+			}
+
+			if !test.isErr && MayaRunAction(test.actionVal) != m.Action {
+				t.Fatalf("Expected: '%s' Actual: '%s'", test.actionVal, m.Action)
+			}
+		})
+	}
+}
 
 // TestMayaBytes tests if a yaml marshalls to bytes.
 // The tests are written in a table format to provide various

--- a/pkg/maya/runner.go
+++ b/pkg/maya/runner.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2017 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maya
+
+import (
+	"bytes"
+	"strconv"
+	"text/template"
+
+	"github.com/ghodss/yaml"
+	"github.com/openebs/maya/pkg/client/k8s"
+	api_core_v1 "k8s.io/api/core/v1"
+	mach_apis_meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Task refers to a MayaTemplate
+type Task struct {
+	TemplateName string `json:"template"`
+}
+
+// RunTemplate is a structure that represents a
+// MayaRun template
+type RunTemplate struct {
+	// CustomFuncsHolder holds the inputs provided to this
+	// template
+	CustomFuncsHolder
+	// Tasks are the references to MayaTemplates
+	Tasks []Task `json:"tasks"`
+	// MayaYamlV2 is the yaml representation of RunTemplate
+	MayaYamlV2
+}
+
+// NewRunTemplate returns an instance of MayaConfigMapV2
+// based on the provided yaml
+func NewRunTemplate(yaml string) *RunTemplate {
+	return &RunTemplate{
+		MayaYamlV2: MayaYamlV2{
+			Yaml: yaml,
+		},
+	}
+}
+
+// runTemplateAsByte returns a byte slice format of
+// its yaml representation
+func (m *RunTemplate) runTemplateAsByte() ([]byte, error) {
+	yml, err := m.getYaml()
+	if err != nil {
+		return nil, err
+	}
+
+	tpl, err := template.New("runtemplate").Parse(yml)
+	if err != nil {
+		return nil, err
+	}
+
+	// this has implementation of io.Writer
+	// that is required by the template
+	var buf bytes.Buffer
+
+	// execute the parsed yaml against this instance
+	// & write the result into the buffer
+	err = tpl.Execute(&buf, m)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// AsTemplateInfo returns a TemplateInfo structure
+// from its corresponding yaml representation
+func (m *RunTemplate) AsRunTemplate() (*RunTemplate, error) {
+	// unmarshall the yaml
+	b, err := m.runTemplateAsByte()
+	if err != nil {
+		return nil, err
+	}
+
+	t := &RunTemplate{}
+	err = yaml.Unmarshal(b, t)
+	if err != nil {
+		return nil, err
+	}
+
+	return t, nil
+}
+
+// MayaRunner does the low level operations of running a
+// MayaRun template
+type MayaRunner struct {
+	// runTplName of the RunTemplate that is actually the name of
+	// a K8s ConfigMap
+	runTplName string
+	// searchNamespace where the RunTemplate & MayaTemplate are
+	// available
+	searchNamespace string
+	// CustomFuncsHolder is the placeholder to keep the
+	// inputs as well as the stores
+	CustomFuncsHolder
+	// array of templates that are found in RunTemplate & are
+	// meant to be run
+	templates []*MayaTemplate
+}
+
+func NewMayaRunner(name, searchNamespace string) *MayaRunner {
+	return &MayaRunner{
+		runTplName:      name,
+		searchNamespace: searchNamespace,
+		CustomFuncsHolder: CustomFuncsHolder{
+			Inputs: map[string]string{},
+			Stores: map[string]string{},
+		},
+	}
+}
+
+// getKCToFetchTemplates gets the K8s Client that is pointing to the
+// namespace where maya template(s) are available
+func (m *MayaRunner) getKCToFetchTemplates() (*k8s.K8sClient, error) {
+	return k8s.NewK8sClient(m.searchNamespace)
+}
+
+// fetchTemplate returns the corresponding ConfigMap
+// NOTE:
+//  A Template e.g. MayaTemplate or RunTemplate is actually
+// a K8s ConfigMap
+func (m *MayaRunner) fetchTemplate(tplName string) (*api_core_v1.ConfigMap, error) {
+	kc, err := m.getKCToFetchTemplates()
+	if err != nil {
+		return nil, err
+	}
+
+	return kc.GetConfigMap(tplName, mach_apis_meta_v1.GetOptions{})
+}
+
+// getRunTemplate returns an instance of RunTemplate
+// from ConfigMap
+func (m *MayaRunner) getRunTemplate() (*RunTemplate, error) {
+	cm, err := m.fetchTemplate(m.runTplName)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO
+	// Validations if this CM is actually a RunTemplate
+
+	return NewRunTemplate(cm.Data["yaml"]), nil
+}
+
+// getMayaTemplate returns an instance of MayaTemplate
+// from ConfigMap
+func (m *MayaRunner) getMayaTemplate(mayaTplName string, inputs map[string]string) (*MayaTemplate, error) {
+	cm, err := m.fetchTemplate(mayaTplName)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO
+	// Validations if this CM is actually a MayaTemplate
+
+	return NewMayaTemplate(cm.Data["yaml"], cm.Data["meta"], inputs)
+}
+
+// loadRunTemplate loads up the RunTemplate instance
+func (m *MayaRunner) loadRunTemplate() (*RunTemplate, error) {
+	// get the instance of RunTemplate
+	rt, err := m.getRunTemplate()
+	if err != nil {
+		return nil, err
+	}
+
+	// load run template's yaml representation into corresponding
+	// go struct
+	return rt.AsRunTemplate()
+}
+
+// Run will run each MayaTemplate in the provided
+// namespace
+func (m *MayaRunner) Run(runNamespace string) error {
+	rt, err := m.loadRunTemplate()
+	if err != nil {
+		return err
+	}
+
+	// This is the namespace where RunTemplate will execute the
+	// MayaTemplates. However, this may not be the case
+	// always if MayaTemplate hardcodes its namespace.
+	m.Inputs["namespace"] = runNamespace
+
+	// Try merging the RunTemplate's inputs & stores with runner
+	// NOTE: MayaRunner's inputs & stores takes precedence
+	// over the template's inputs & stores.
+	// NOTE: The idea is to never override the placeholder
+	// values once they are set in the workflow.
+	m.mergeInputsIfEmpty(rt.Inputs)
+	m.mergeStoresIfEmpty(rt.Stores)
+
+	// get an instance of MayaTemplate & store them
+	// to be executed later
+	for _, task := range rt.Tasks {
+		mt, err := m.getMayaTemplate(task.TemplateName, m.Inputs)
+		if err != nil {
+			return err
+		}
+		m.templates = append(m.templates, mt)
+	}
+
+	for i, template := range m.templates {
+		template.mergeStoresIfEmpty(m.Stores)
+
+		err := template.execute(strconv.Itoa(i))
+		if err != nil {
+			return err
+		}
+
+		m.mergeStoresIfEmpty(template.Stores)
+	}
+	return nil
+}

--- a/pkg/maya/template.go
+++ b/pkg/maya/template.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2017 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maya
+
+import (
+	"fmt"
+	"github.com/ghodss/yaml"
+	"github.com/openebs/maya/pkg/client/k8s"
+
+	api_core_v1 "k8s.io/api/core/v1"
+	api_extn_v1beta1 "k8s.io/api/extensions/v1beta1"
+)
+
+// MayaRunAction signifies the action to be taken
+// against a MayaTemplate
+type MayaRunAction string
+
+const (
+	// GetMRA flags a action as get. Typically used to fetch
+	// an object from its name.
+	GetMRA MayaRunAction = "get"
+
+	// PutMRA flags a action as put. Typically used to put
+	// an  object.
+	PutMRA MayaRunAction = "put"
+)
+
+// TemplateMeta composes various properties that provides
+// information about a MayaTemplate
+type TemplateMeta struct {
+	// Kind of the template contents
+	Kind string `json:"kind"`
+	// APIVersion of the template contents
+	APIVersion string `json:"apiVersion"`
+	// Namespace of the template contents
+	Namespace string `json:"namespace"`
+	// Action to be invoked on the template contents
+	Action MayaRunAction `json:"action"`
+	// MayaYamlV2 provides the templated yaml representation
+	// of this instance
+	MayaYamlV2
+}
+
+func NewTemplateMeta(yaml string, inputs map[string]string) *TemplateMeta {
+	return &TemplateMeta{
+		MayaYamlV2: MayaYamlV2{
+			Yaml: yaml,
+			CustomFuncsHolder: CustomFuncsHolder{
+				Inputs: inputs,
+				Stores: map[string]string{},
+			},
+		},
+	}
+}
+
+// asTemplateMeta returns a new instance of TemplateMeta
+// that corresponds to this instance's yaml
+func (m *TemplateMeta) asTemplateMeta() (*TemplateMeta, error) {
+	// unmarshall the yaml
+	b, err := m.asTemplatedBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	t := &TemplateMeta{}
+	err = yaml.Unmarshal(b, t)
+	if err != nil {
+		return nil, err
+	}
+
+	return t, nil
+}
+
+func (m *TemplateMeta) isDeployment() bool {
+	return m.Kind == string(k8s.DeploymentKK)
+}
+
+func (m *TemplateMeta) isService() bool {
+	return m.Kind == string(k8s.ServiceKK)
+}
+
+func (m *TemplateMeta) isConfigMap() bool {
+	return m.Kind == string(k8s.ConfigMapKK)
+}
+
+func (m *TemplateMeta) isGet() bool {
+	return m.Action == GetMRA
+}
+
+func (m *TemplateMeta) isPut() bool {
+	return m.Action == PutMRA
+}
+
+func (m *TemplateMeta) isExtnV1B1() bool {
+	return m.APIVersion == string(k8s.ExtensionsV1Beta1KA)
+}
+
+func (m *TemplateMeta) isCoreV1() bool {
+	return m.APIVersion == string(k8s.CoreV1KA)
+}
+
+func (m *TemplateMeta) isExtnV1B1Deploy() bool {
+	return m.isExtnV1B1() && m.isDeployment()
+}
+
+func (m *TemplateMeta) isCoreV1Service() bool {
+	return m.isCoreV1() && m.isService()
+}
+
+func (m *TemplateMeta) isPutExtnV1B1Deploy() bool {
+	return m.isExtnV1B1Deploy() && m.isPut()
+}
+
+func (m *TemplateMeta) isPutCoreV1Service() bool {
+	return m.isCoreV1Service() && m.isPut()
+}
+
+// MayaTemplate represents a MayaTemplate as seen in
+// its YAML format
+type MayaTemplate struct {
+	// TemplateMeta provides the information about this
+	// template
+	TemplateMeta
+	// MayaYamlV2 represents this template's embedded yaml
+	MayaYamlV2 `json:"yaml"`
+	// k8sClient is the client to invoke Kubernetes APIs
+	k8sClient *k8s.K8sClient
+}
+
+func NewMayaTemplate(mayaTplYml, tplInfoYml string, inputs map[string]string) (*MayaTemplate, error) {
+
+	t := NewTemplateMeta(tplInfoYml, inputs)
+	t, err := t.asTemplateMeta()
+	if err != nil {
+		return nil, err
+	}
+
+	return &MayaTemplate{
+		TemplateMeta: *t,
+		MayaYamlV2: MayaYamlV2{
+			Yaml: mayaTplYml,
+			CustomFuncsHolder: CustomFuncsHolder{
+				Inputs: inputs,
+				Stores: map[string]string{},
+			},
+		},
+	}, nil
+}
+
+// asExtnV1B1Deploy generates a K8s Deployment object
+// out of the embedded yaml
+func (m *MayaTemplate) asExtnV1B1Deploy() (*api_extn_v1beta1.Deployment, error) {
+	if !m.isDeployment() {
+		return nil, fmt.Errorf("Invalid kind: Deployment required")
+	}
+
+	if !m.isExtnV1B1() {
+		return nil, fmt.Errorf("Invalid version: extensions/v1beta1 required")
+	}
+
+	b, err := m.asTemplatedBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	d := NewMayaDeploymentV2ByByte(b)
+	return d.AsExtnV1B1Deployment()
+}
+
+// asCoreV1Svc generates a K8s Service object
+// out of the embedded yaml
+func (m *MayaTemplate) asCoreV1Svc() (*api_core_v1.Service, error) {
+	if !m.isService() {
+		return nil, fmt.Errorf("Invalid kind: Service required")
+	}
+
+	if !m.isCoreV1() {
+		return nil, fmt.Errorf("Invalid version: v1 required")
+	}
+
+	b, err := m.asTemplatedBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	s := NewMayaServiceV2ByByte(b)
+	return s.AsCoreV1Service()
+}
+
+// getK8sClient returns the K8sClient based on the namespace
+// set in this instance
+func (m *MayaTemplate) getK8sClient() (*k8s.K8sClient, error) {
+	// Make use of the namespace that is set in TemplateMeta
+	return k8s.NewK8sClient(m.Namespace)
+}
+
+// putExtnV1B1Deploy will put a Deployment as defined in
+// the MayaTemplate
+func (m *MayaTemplate) putExtnV1B1Deploy() (bool, error) {
+	d, err := m.asExtnV1B1Deploy()
+	if err != nil {
+		return false, err
+	}
+
+	kc, err := m.getK8sClient()
+	if err != nil {
+		return false, err
+	}
+
+	d, err = kc.CreateExtnV1B1Deployment(d)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// putCoreV1Service will put a Service as defined in
+// the MayaTemplate
+func (m *MayaTemplate) putCoreV1Service(storeIdentifier string) (bool, error) {
+	s, err := m.asCoreV1Svc()
+	if err != nil {
+		return false, err
+	}
+
+	kc, err := m.getK8sClient()
+	if err != nil {
+		return false, err
+	}
+
+	s, err = kc.CreateCoreV1Service(s)
+	if err != nil {
+		return false, err
+	}
+
+	// Set the resulting service ip
+	m.mergeStoresIfEmpty(map[string]string{
+		storeIdentifier + "-service-ip": s.Spec.ClusterIP,
+	})
+
+	return true, nil
+}
+
+// Execute will execute the MayaTemplate depending on informations
+// available in TemplateMeta
+func (m *MayaTemplate) execute(storeIdentifier string) error {
+	var isExecuted bool
+	var err error
+	if m.isPutExtnV1B1Deploy() {
+		isExecuted, err = m.putExtnV1B1Deploy()
+	} else if m.isPutCoreV1Service() {
+		isExecuted, err = m.putCoreV1Service(storeIdentifier)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if isExecuted {
+		return nil
+	} else {
+		return fmt.Errorf("Not supported operation '%v'", m.TemplateMeta)
+	}
+}

--- a/pkg/maya/yaml.go
+++ b/pkg/maya/yaml.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2017 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maya
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	"github.com/ghodss/yaml"
+)
+
+// CustomFuncsHolder contains properties that are
+// used to build custom text/template functions
+type CustomFuncsHolder struct {
+	// Inputs contains the k:v pairs required to
+	// set the template's placeholders
+	Inputs map[string]string `json:"inputs"`
+	// Stores contains the k:v pairs out of resulting
+	// actions on the template's embedded object
+	Stores map[string]string
+}
+
+func customFuncVal(pairs map[string]string, context, key string) (string, error) {
+	if len(pairs) == 0 {
+		return "", fmt.Errorf("No %s found", context)
+	}
+
+	if len(key) == 0 {
+		return "", fmt.Errorf("Missing %s key", context)
+	}
+
+	val := pairs[key]
+	if len(val) == 0 {
+		return "", fmt.Errorf("Nil value for %s key '%s'", context, key)
+	}
+
+	return val, nil
+}
+
+func (f *CustomFuncsHolder) inputVal(key string) (string, error) {
+	return customFuncVal(f.Inputs, "inputs", key)
+}
+
+func (f *CustomFuncsHolder) storeVal(key string) (string, error) {
+	return customFuncVal(f.Stores, "stores", key)
+}
+
+func (f *CustomFuncsHolder) setStore(key, value string) {
+	f.Stores[key] = value
+}
+
+func (f *CustomFuncsHolder) setInput(key, value string) {
+	f.Inputs[key] = value
+}
+
+func (f *CustomFuncsHolder) setStoreIfEmpty(key, value string) {
+	if len(f.Stores[key]) == 0 {
+		f.Stores[key] = value
+	} else {
+		// TODO log
+	}
+}
+
+func (f *CustomFuncsHolder) setInputIfEmpty(key, value string) {
+	if len(f.Inputs[key]) == 0 {
+		f.Inputs[key] = value
+	} else {
+		// TODO log
+	}
+}
+
+// mergeInputsIfEmpty is an append minus override
+//
+// NOTE: Immutability is fundamental to having systems
+// that work as per instructions and later to ensure
+// better debuggability
+func (f *CustomFuncsHolder) mergeInputsIfEmpty(inputs map[string]string) {
+	if len(f.Inputs) == 0 {
+		f.Inputs = inputs
+		return
+	}
+
+	for k, v := range inputs {
+		f.setInputIfEmpty(k, v)
+	}
+}
+
+// mergeStoresIfEmpty is an append minus override
+//
+// NOTE: Immutability is fundamental to having systems
+// that work as per instructions and later to ensure
+// better debuggability
+func (f *CustomFuncsHolder) mergeStoresIfEmpty(stores map[string]string) {
+	if len(f.Stores) == 0 {
+		f.Stores = stores
+		return
+	}
+
+	for k, v := range stores {
+		f.setStoreIfEmpty(k, v)
+	}
+}
+
+// MayaYamlV2 represents a yaml definition
+//
+// This yaml is expected to be marshalled into
+// corresponding go struct. YAMLs will be used to specify
+// DevOps intents.
+type MayaYamlV2 struct {
+	// Yaml represents a templated yaml in string format
+	Yaml string
+
+	// CustomFuncsHolder contains the values menat to replace
+	// the placeholders set in the YAML. It also exposes functions
+	// as text/template's custom functions. We need custom functions
+	// to retain the user friendliness of the YAML.
+	CustomFuncsHolder
+
+	// YmlInBytes represents the templated yaml in
+	// byte slice format. This is typically the result of applying
+	// text/template on the YAML that has ocassional placeholders.
+	YmlInBytes []byte
+}
+
+// getYaml provides the yaml in string format
+func (m *MayaYamlV2) getYaml() (string, error) {
+	if len(m.Yaml) == 0 {
+		return "", fmt.Errorf("Yaml is not set")
+	}
+
+	return m.Yaml, nil
+}
+
+// asTemplatedBytes returns a byte slice format of its yaml
+// representation. This []byte is derived after applying the
+// text/template.
+func (m *MayaYamlV2) asTemplatedBytes() ([]byte, error) {
+	yml, err := m.getYaml()
+	if err != nil {
+		return nil, err
+	}
+
+	tpl := template.New("mayayaml")
+	// Any maya yaml exposes below custom functions. These are
+	// used to set placeholders at runtime.
+	tpl.Funcs(template.FuncMap{
+		"inputs": m.inputVal,
+		"stores": m.storeVal,
+	})
+
+	tpl, err = tpl.Parse(yml)
+	if err != nil {
+		return nil, err
+	}
+
+	// this has implementation of io.Writer
+	// that is required by the template
+	var buf bytes.Buffer
+
+	// execute the parsed yaml against this instance
+	// & write the result into the buffer
+	err = tpl.Execute(&buf, m)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// asMapOfObjects returns a map of any objects
+// that corresponds to this instance's yaml
+//
+// NOTE: This is required in the cases where developer does not
+// know the targetted go struct to unmarshall this yaml into.
+// However, this developer will be interested in a particular
+// piece from the entire yaml. Developer will use this
+// method before trying to get the desired piece.
+func (m *MayaYamlV2) asMapOfObjects() (map[string]interface{}, error) {
+	// templated & then unmarshall-ed version of this yaml
+	b, err := m.asTemplatedBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	// Any given YAML can be unmarshalled into a map of any objects
+	var obj map[string]interface{}
+	err = yaml.Unmarshal(b, &obj)
+	if err != nil {
+		return nil, err
+	}
+
+	return obj, nil
+}

--- a/pkg/util/unstructured.go
+++ b/pkg/util/unstructured.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+Copyright 2018 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// These are based on functions from k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.
+// They are copied here to make them exported.
+//
+// TODO
+// Check if it makes sense to have the entire unstructured package of
+// k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
+// It might be required to put the entire thing into maya/pkg/unstructured
+package util
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/json"
+)
+
+func GetNestedField(obj map[string]interface{}, fields ...string) interface{} {
+	var val interface{} = obj
+	for _, field := range fields {
+		if _, ok := val.(map[string]interface{}); !ok {
+			return nil
+		}
+		val = val.(map[string]interface{})[field]
+	}
+	return val
+}
+
+func GetNestedFieldInto(out interface{}, obj map[string]interface{}, fields ...string) error {
+	objMap := GetNestedField(obj, fields...)
+	if objMap == nil {
+		// If field has no value, leave `out` as is.
+		return nil
+	}
+	// Decode into the requested output type.
+	data, err := json.Marshal(objMap)
+	if err != nil {
+		return fmt.Errorf("can't encode nested field %v: %v", strings.Join(fields, "."), err)
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("can't decode nested field %v into type %T: %v", strings.Join(fields, "."), out, err)
+	}
+	return nil
+}
+
+func GetNestedString(obj map[string]interface{}, fields ...string) string {
+	if str, ok := GetNestedField(obj, fields...).(string); ok {
+		return str
+	}
+	return ""
+}
+
+func GetNestedArray(obj map[string]interface{}, fields ...string) []interface{} {
+	if arr, ok := GetNestedField(obj, fields...).([]interface{}); ok {
+		return arr
+	}
+	return nil
+}
+
+func GetNestedInt64(obj map[string]interface{}, fields ...string) int64 {
+	if str, ok := GetNestedField(obj, fields...).(int64); ok {
+		return str
+	}
+	return 0
+}
+
+func GetNestedInt64Pointer(obj map[string]interface{}, fields ...string) *int64 {
+	nested := GetNestedField(obj, fields...)
+	switch n := nested.(type) {
+	case int64:
+		return &n
+	case *int64:
+		return n
+	default:
+		return nil
+	}
+}
+
+func GetNestedSlice(obj map[string]interface{}, fields ...string) []string {
+	if m, ok := GetNestedField(obj, fields...).([]interface{}); ok {
+		strSlice := make([]string, 0, len(m))
+		for _, v := range m {
+			if str, ok := v.(string); ok {
+				strSlice = append(strSlice, str)
+			}
+		}
+		return strSlice
+	}
+	return nil
+}
+
+func GetNestedMap(obj map[string]interface{}, fields ...string) map[string]string {
+	if m, ok := GetNestedField(obj, fields...).(map[string]interface{}); ok {
+		strMap := make(map[string]string, len(m))
+		for k, v := range m {
+			if str, ok := v.(string); ok {
+				strMap[k] = str
+			}
+		}
+		return strMap
+	}
+	return nil
+}
+
+func SetNestedField(obj map[string]interface{}, value interface{}, fields ...string) {
+	m := obj
+	if len(fields) > 1 {
+		for _, field := range fields[0 : len(fields)-1] {
+			if _, ok := m[field].(map[string]interface{}); !ok {
+				m[field] = make(map[string]interface{})
+			}
+			m = m[field].(map[string]interface{})
+		}
+	}
+	m[fields[len(fields)-1]] = value
+}
+
+func DeleteNestedField(obj map[string]interface{}, fields ...string) {
+	m := obj
+	if len(fields) > 1 {
+		for _, field := range fields[0 : len(fields)-1] {
+			if _, ok := m[field].(map[string]interface{}); !ok {
+				m[field] = make(map[string]interface{})
+			}
+			m = m[field].(map[string]interface{})
+		}
+	}
+	delete(m, fields[len(fields)-1])
+}
+
+func SetNestedSlice(obj map[string]interface{}, value []string, fields ...string) {
+	m := make([]interface{}, 0, len(value))
+	for _, v := range value {
+		m = append(m, v)
+	}
+	SetNestedField(obj, m, fields...)
+}
+
+func SetNestedMap(obj map[string]interface{}, value map[string]string, fields ...string) {
+	m := make(map[string]interface{}, len(value))
+	for k, v := range value {
+		m[k] = v
+	}
+	SetNestedField(obj, m, fields...)
+}


### PR DESCRIPTION
openebs needs to add storage policies as an intuitive way
for admins & users to use storage yet have granular control.

This is a partial commit w.r.t issue
https://github.com/openebs/openebs/issues/1007
https://github.com/openebs/openebs/issues/1010
https://github.com/openebs/openebs/issues/976

doc at
https://docs.google.com/document/d/1oX_AcDMuhg2HVn3nmYDaZ-ABQv_V0v_DhbbySUImAhg/

2. How does this change address the issue ?

- adds RunTemplate & MayaTemplate related code

3. How to verify this change ?

- make should run fine
- Examples should be provided to enable developer & user
to understand the usage

4. What side effects does this change have ?

- None

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
