### PR TITLE
Move older volume stats cli to cobra cli

### DIFF
--- a/cmd/mayactl/app/command/stats_helper.go
+++ b/cmd/mayactl/app/command/stats_helper.go
@@ -1,0 +1,159 @@
+package command
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+// Volume is a command implementation struct
+type Volume struct {
+	Spec struct {
+		AccessModes interface{} `json:"AccessModes"`
+		Capacity    interface{} `json:"Capacity"`
+		ClaimRef    interface{} `json:"ClaimRef"`
+		OpenEBS     struct {
+			VolumeID string `json:"volumeID"`
+		} `json:"OpenEBS"`
+		PersistentVolumeReclaimPolicy string `json:"PersistentVolumeReclaimPolicy"`
+		StorageClassName              string `json:"StorageClassName"`
+	} `json:"Spec"`
+
+	Status struct {
+		Message string `json:"Message"`
+		Phase   string `json:"Phase"`
+		Reason  string `json:"Reason"`
+	} `json:"Status"`
+	Metadata struct {
+		Annotations       interface{} `json:"annotations"`
+		CreationTimestamp interface{} `json:"creationTimestamp"`
+		Name              string      `json:"name"`
+	} `json:"metadata"`
+}
+
+// Annotations describes volume struct
+type Annotations struct {
+	TargetPortal     string `json:"vsm.openebs.io/targetportals"`
+	ClusterIP        string `json:"vsm.openebs.io/cluster-ips"`
+	Iqn              string `json:"vsm.openebs.io/iqn"`
+	ReplicaCount     string `json:"vsm.openebs.io/replica-count"`
+	ControllerStatus string `json:"vsm.openebs.io/controller-status"`
+	ReplicaStatus    string `json:"vsm.openebs.io/replica-status"`
+	VolSize          string `json:"vsm.openebs.io/volume-size"`
+	ControllerIP     string `json:"vsm.openebs.io/controller-ips"`
+	//	VolAddr          string `json:"vsm.openebs.io/replica-ips"`
+	Replicas string `json:"vsm.openebs.io/replica-ips"`
+}
+
+const (
+	timeout = 5 * time.Second
+)
+
+// getVolDetails gets response in json format of a volume from m-apiserver
+func GetVolDetails(volName string, obj interface{}) error {
+	addr := os.Getenv("MAPI_ADDR")
+	if addr == "" {
+		err := errors.New("MAPI_ADDR environment variable not set")
+		fmt.Println(err)
+		return err
+	}
+
+	url := addr + "/latest/volumes/info/" + volName
+	client := &http.Client{
+		Timeout: timeout,
+	}
+	resp, err := client.Get(url)
+	if resp != nil {
+		if resp.StatusCode == 500 {
+			fmt.Printf("Volume: %s not found at M_API server\n", volName)
+			return errors.New("Internal Server Error")
+		} else if resp.StatusCode == 503 {
+			fmt.Println("M_API server not reachable")
+			return errors.New("Service Unavailable")
+		} else if resp.StatusCode == 404 {
+			fmt.Printf("Volume: %s not found at M_API server\n", volName)
+			return errors.New("Page Not Found")
+		}
+
+	} else {
+		fmt.Println("M_API server not reachable")
+		return err
+	}
+
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	defer resp.Body.Close()
+	return json.NewDecoder(resp.Body).Decode(obj)
+}
+
+// GetVolAnnotations gets annotations of volume
+func GetVolAnnotations(volName string) (*Annotations, error) {
+	var volume Volume
+	var annotations Annotations
+	err := GetVolDetails(volName, &volume)
+	if err != nil || volume.Metadata.Annotations == nil {
+		if volume.Status.Reason == "pending" {
+			fmt.Println("VOLUME status Unknown to M_API server")
+		}
+		return nil, err
+	}
+	for key, value := range volume.Metadata.Annotations.(map[string]interface{}) {
+		switch key {
+		case "vsm.openebs.io/volume-size":
+			annotations.VolSize = value.(string)
+			//	case "fe.jiva.volume.openebs.io/ip":
+			//		annotations.VolAddr = value.(string)
+		case "vsm.openebs.io/iqn":
+			annotations.Iqn = value.(string)
+		case "vsm.openebs.io/replica-count":
+			annotations.ReplicaCount = value.(string)
+		case "vsm.openebs.io/cluster-ips":
+			annotations.ClusterIP = value.(string)
+		case "vsm.openebs.io/replica-ips":
+			annotations.Replicas = value.(string)
+		case "vsm.openebs.io/targetportals":
+			annotations.TargetPortal = value.(string)
+		case "vsm.openebs.io/controller-status":
+			annotations.ControllerStatus = value.(string)
+		case "vsm.openebs.io/replica-status":
+			annotations.ReplicaStatus = value.(string)
+		case "vsm.openebs.io/controller-ips":
+			annotations.ControllerIP = value.(string)
+		}
+	}
+	return &annotations, nil
+}
+
+func GetVolumeSpec(volName string) (*Annotations, error) {
+	var volume Volume
+	var annotations Annotations
+
+	for key, value := range volume.Metadata.Annotations.(map[string]interface{}) {
+		switch key {
+		case "vsm.openebs.io/volume-size":
+			annotations.VolSize = value.(string)
+			//  case "fe.jiva.volume.openebs.io/ip":
+			//      annotations.VolAddr = value.(string)
+		case "vsm.openebs.io/iqn":
+			annotations.Iqn = value.(string)
+		case "vsm.openebs.io/replica-count":
+			annotations.ReplicaCount = value.(string)
+		case "vsm.openebs.io/cluster-ips":
+			annotations.ClusterIP = value.(string)
+		case "vsm.openebs.io/replica-ips":
+			annotations.Replicas = value.(string)
+		case "vsm.openebs.io/targetportals":
+			annotations.TargetPortal = value.(string)
+		case "vsm.openebs.io/controller-status":
+			annotations.ControllerStatus = value.(string)
+		case "vsm.openebs.io/controller-ips":
+			annotations.ControllerIP = value.(string)
+		}
+	}
+	return &annotations, nil
+}

--- a/cmd/mayactl/app/command/volume.go
+++ b/cmd/mayactl/app/command/volume.go
@@ -53,6 +53,7 @@ func NewCmdVolume() *cobra.Command {
 		NewCmdVolumeCreate(),
 		NewCmdVolumesList(),
 		NewCmdVolumeDelete(),
+		NewCmdVolumeStats(),
 	)
 	return cmd
 }

--- a/cmd/mayactl/app/command/volume_stats.go
+++ b/cmd/mayactl/app/command/volume_stats.go
@@ -162,7 +162,8 @@ func (c *CmdVolumeStatsOptions) RunVolumeStats(cmd *cobra.Command) error {
 		} else {
 			err := displayStats(annotations, c, statusArray, stats1, stats2)
 			if err != nil {
-
+				fmt.Println("Can't display stats\n", err)
+				return nil
 			}
 		}
 	}

--- a/cmd/mayactl/app/command/volume_stats.go
+++ b/cmd/mayactl/app/command/volume_stats.go
@@ -1,0 +1,315 @@
+/*
+Copyright 2017 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"os"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	client "github.com/openebs/maya/pkg/client/jiva"
+	"github.com/openebs/maya/pkg/util"
+	"github.com/openebs/maya/types/v1"
+	"github.com/spf13/cobra"
+)
+
+var (
+	volumeStatsCommandHelpText = `
+	Usage: maya volume stats <vol> [-size <size>]
+
+	This command queries the stats of the volume.
+
+	Volume stats options:
+	-json
+	Displays the stats in json format.
+
+	`
+)
+
+// CmdVolumeStatsOptions is used to store the value of flags used in the cli
+type CmdVolumeStatsOptions struct {
+	json    string
+	volName string
+}
+
+// NewCmdVolumeCreate creates a new OpenEBS Volume
+func NewCmdVolumeStats() *cobra.Command {
+	options := CmdVolumeStatsOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "stats",
+		Short:   "Displays the runtime statisics of Volume",
+		Long:    volumeStatsCommandHelpText,
+		Example: ` maya volume stats --volname=vol -j=json`,
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(options.Validate(cmd), util.Fatal)
+			util.CheckErr(options.RunVolumeStats(cmd), util.Fatal)
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.volName, "volname", "n", options.volName,
+		"unique volume name.")
+	cmd.Flags().StringVarP(&options.json, "json", "j", options.json, "display output in JSON.")
+	return cmd
+}
+
+// Validate varifies whether a volume name has been provided or not followed by
+// stats command, it returns nil and proceeds to execute the command if there is
+// no error and returns the error if it is missing.
+func (c *CmdVolumeStatsOptions) Validate(cmd *cobra.Command) error {
+	if c.volName == "" {
+		return errors.New("--volname is missing. Please specify a volume name created")
+	}
+	return nil
+}
+
+// RunVolumeStats runs stats command and display the outputs in standard
+// I/O or in json format.
+func (c *CmdVolumeStatsOptions) RunVolumeStats(cmd *cobra.Command) error {
+	fmt.Println("Executing volume stats...")
+
+	var (
+		err, err1, err3 error
+		err2, err4      int
+		status          v1.VolStatus
+		stats1, stats2  v1.VolumeMetrics
+		repStatus       string
+		repCount        int
+	)
+	statusArray := make([]string, 6)
+
+	annotations, err := GetVolAnnotations(c.volName)
+
+	if err != nil || annotations == nil {
+		fmt.Println(err)
+		return nil
+	}
+
+	if annotations.ControllerStatus != "Running" {
+		fmt.Println("Volume not reachable")
+		return nil
+	}
+
+	replicaCount := 0
+	replicaStatus := strings.Split(annotations.ReplicaStatus, ",")
+	for _, repStatus = range replicaStatus {
+		if repStatus == "Pending" {
+			statusArray[replicaCount] = "Unknown"
+			statusArray[replicaCount+1] = "Unknown"
+			statusArray[replicaCount+2] = "Unknown"
+			replicaCount += 3
+		}
+	}
+
+	replicas := strings.Split(annotations.Replicas, ",")
+	for _, replica := range replicas {
+		errCode1, err := client.GetStatus(replica+":9502", &status)
+		if err != nil {
+			if errCode1 == 500 || strings.Contains(err.Error(), "EOF") {
+				statusArray[repCount] = replica
+				statusArray[repCount+1] = "Waiting"
+				statusArray[repCount+2] = "Unknown"
+
+			} else {
+				statusArray[repCount] = replica
+				statusArray[repCount+1] = "Offline"
+				statusArray[repCount+2] = "Unknown"
+			}
+			repCount += 3
+		} else {
+			statusArray[repCount] = replica
+			statusArray[repCount+1] = "Online"
+			statusArray[repCount+2] = status.RevisionCounter
+			repCount += 3
+		}
+
+	}
+	//GetVolumeStats gets volume stats
+	err2, err1 = client.GetVolumeStats(annotations.ClusterIP+":9501", &stats1)
+	if err1 != nil {
+		if (err2 == 500) || (err2 == 503) || err1 != nil {
+			fmt.Println("Volume not Reachable\n", err1)
+			return nil
+		}
+	} else {
+		time.Sleep(1 * time.Second)
+		err4, err3 = client.GetVolumeStats(annotations.ClusterIP+":9501", &stats2)
+		if err3 != nil {
+			if err4 == 500 || err4 == 503 || err3 != nil {
+				fmt.Println("Volume not Reachable\n", err3)
+				return nil
+			}
+		} else {
+			err := displayStats(annotations, c, statusArray, stats1, stats2)
+			if err != nil {
+
+			}
+		}
+	}
+	return nil
+}
+
+// displayStats displays the volume stats as standard output and in json format.
+// By defaault it displays in standard output but if  flag json is passed it
+// displays stats in json format.
+func displayStats(annotations *Annotations, c *CmdVolumeStatsOptions, statusArray []string, stats1 v1.VolumeMetrics, stats2 v1.VolumeMetrics) error {
+
+	var (
+		err          error
+		ReadLatency  int64
+		WriteLatency int64
+
+		AvgReadBlockCountPS  int64
+		AvgWriteBlockCountPS int64
+	)
+
+	// 10 and 64 represents decimal and bits respectively
+	iReadIOPS, _ := strconv.ParseInt(stats1.ReadIOPS, 10, 64) // Initial
+	fReadIOPS, _ := strconv.ParseInt(stats2.ReadIOPS, 10, 64) // Final
+	readIOPS, _ := v1.SubstractInt64(fReadIOPS, iReadIOPS)
+
+	iReadTimePS, _ := strconv.ParseInt(stats1.TotalReadTime, 10, 64)
+	fReadTimePS, _ := strconv.ParseInt(stats2.TotalReadTime, 10, 64)
+	readTimePS, _ := v1.SubstractInt64(fReadTimePS, iReadTimePS)
+
+	iReadBlockCountPS, _ := strconv.ParseInt(stats1.TotalReadBlockCount, 10, 64)
+	fReadBlockCountPS, _ := strconv.ParseInt(stats2.TotalReadBlockCount, 10, 64)
+	readBlockCountPS, _ := v1.SubstractInt64(fReadBlockCountPS, iReadBlockCountPS)
+
+	rThroughput := readBlockCountPS
+	if readIOPS != 0 {
+		ReadLatency, _ = v1.DivideInt64(readTimePS, readIOPS)
+		AvgReadBlockCountPS, _ = v1.DivideInt64(readBlockCountPS, readIOPS)
+	} else {
+		ReadLatency = 0
+		AvgReadBlockCountPS = 0
+	}
+
+	iWriteIOPS, _ := strconv.ParseInt(stats1.WriteIOPS, 10, 64)
+	fWriteIOPS, _ := strconv.ParseInt(stats2.WriteIOPS, 10, 64)
+	writeIOPS, _ := v1.SubstractInt64(fWriteIOPS, iWriteIOPS)
+
+	iWriteTimePS, _ := strconv.ParseInt(stats1.TotalWriteTime, 10, 64)
+	fWriteTimePS, _ := strconv.ParseInt(stats2.TotalWriteTime, 10, 64)
+	writeTimePS, _ := v1.SubstractInt64(fWriteTimePS, iWriteTimePS)
+
+	iWriteBlockCountPS, _ := strconv.ParseInt(stats1.TotalWriteBlockCount, 10, 64)
+	fWriteBlockCountPS, _ := strconv.ParseInt(stats2.TotalWriteBlockCount, 10, 64)
+	writeBlockCountPS, _ := v1.SubstractInt64(fWriteBlockCountPS, iWriteBlockCountPS)
+
+	wThroughput := writeBlockCountPS
+	if writeIOPS != 0 {
+		WriteLatency, _ = v1.DivideInt64(writeTimePS, writeIOPS)
+		AvgWriteBlockCountPS, _ = v1.DivideInt64(writeBlockCountPS, writeIOPS)
+	} else {
+		WriteLatency = 0
+		AvgWriteBlockCountPS = 0
+	}
+
+	sectorSize, _ := strconv.ParseFloat(stats2.SectorSize, 64) // Sector Size
+
+	logicalSize, _ := strconv.ParseFloat(stats2.UsedBlocks, 64) // Logical Size
+	logicalSize = logicalSize * sectorSize
+
+	actualUsed, _ := strconv.ParseFloat(stats2.UsedLogicalBlocks, 64) // Actual Used
+	actualUsed = actualUsed * sectorSize
+
+	annotation := v1.Annotation{
+		IQN:    annotations.Iqn,
+		Volume: c.volName,
+		Portal: annotations.TargetPortal,
+		Size:   annotations.VolSize,
+	}
+
+	if c.json == "json" {
+
+		stat1 := v1.StatsJSON{
+
+			IQN:    annotations.Iqn,
+			Volume: c.volName,
+			Portal: annotations.TargetPortal,
+			Size:   annotations.VolSize,
+
+			ReadIOPS:  readIOPS,
+			WriteIOPS: writeIOPS,
+
+			ReadThroughput:  float64(rThroughput) / v1.BytesToMB, // bytes to MB
+			WriteThroughput: float64(wThroughput) / v1.BytesToMB,
+
+			ReadLatency:  float64(ReadLatency) / v1.MicSec, // Microsecond
+			WriteLatency: float64(WriteLatency) / v1.MicSec,
+
+			AvgReadBlockSize:  AvgReadBlockCountPS / v1.BytesToKB, // Bytes to KB
+			AvgWriteBlockSize: AvgWriteBlockCountPS / v1.BytesToKB,
+
+			SectorSize:  sectorSize,
+			ActualUsed:  actualUsed / v1.BytesToGB,
+			LogicalSize: logicalSize / v1.BytesToGB,
+		}
+
+		data, err := json.MarshalIndent(stat1, "", "\t")
+
+		if err != nil {
+			fmt.Println("Can't Marshal the data ", err)
+		}
+
+		os.Stdout.Write(data)
+
+	} else {
+
+		// Printing using template
+		tmpl, err1 := template.New("test").Parse("IQN     : {{.IQN}}\nVolume  : {{.Volume}}\nPortal  : {{.Portal}}\nSize    : {{.Size}}")
+		err = err1
+		if err != nil {
+			fmt.Println("Can't Parse the template ", err)
+		}
+		err = tmpl.Execute(os.Stdout, annotation)
+		if err != nil {
+			fmt.Println("Can't execute the template ", err)
+		}
+
+		// Printing in tabular form
+		q := tabwriter.NewWriter(os.Stdout, v1.MinWidth, v1.MaxWidth, v1.Padding, ' ', tabwriter.AlignRight|tabwriter.Debug)
+		fmt.Fprintf(q, "\n\nReplica\tStatus\tDataUpdateIndex\t\n")
+		fmt.Fprintf(q, "\t\t\t\n")
+		for i := 0; i < 4; i += 3 {
+
+			fmt.Fprintf(q, "%s\t%s\t%s\t\n", statusArray[i], statusArray[i+1], statusArray[i+2])
+		}
+
+		q.Flush()
+
+		w := tabwriter.NewWriter(os.Stdout, v1.MinWidth, v1.MaxWidth, v1.Padding, ' ', tabwriter.AlignRight|tabwriter.Debug)
+		fmt.Println("\n----------- Performance Stats -----------\n")
+		fmt.Fprintf(w, "r/s\tw/s\tr(MB/s)\tw(MB/s)\trLat(ms)\twLat(ms)\t\n")
+		fmt.Fprintf(w, "%d\t%d\t%.3f\t%.3f\t%.3f\t%.3f\t\n", readIOPS, writeIOPS, float64(rThroughput)/v1.BytesToMB, float64(wThroughput)/v1.BytesToMB, float64(ReadLatency)/v1.MicSec, float64(WriteLatency)/v1.MicSec)
+		w.Flush()
+
+		x := tabwriter.NewWriter(os.Stdout, v1.MinWidth, v1.MaxWidth, v1.Padding, ' ', tabwriter.AlignRight|tabwriter.Debug)
+		fmt.Println("\n------------ Capacity Stats -------------\n")
+		fmt.Fprintf(x, "Logical(GB)\tUsed(GB)\t\n")
+		fmt.Fprintf(x, "%.3f\t%.3f\t\n", logicalSize/v1.BytesToGB, actualUsed/v1.BytesToGB)
+		x.Flush()
+	}
+	return err
+}

--- a/pkg/client/jiva/helper.go
+++ b/pkg/client/jiva/helper.go
@@ -1,0 +1,59 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// GetStatus is the helper function for mayactl.It is used to get the response of
+// the replica created in json format and then the response is then decoded to
+// the desired structure.
+func GetStatus(address string, obj interface{}) (int, error) {
+	replica, err := NewReplicaClient(address)
+	if err != nil {
+		return -1, err
+	}
+	url := replica.Address + "/stats"
+	resp, err := replica.httpClient.Get(url)
+	if resp != nil {
+		if resp.StatusCode == 500 {
+			return 500, errors.New("Internal Server Error")
+		} else if resp.StatusCode == 503 {
+			return 503, errors.New("Service Unavailable")
+		}
+	} else {
+		return -1, errors.New("Server Not Reachable")
+	}
+	if err != nil {
+		return -1, err
+	}
+	defer resp.Body.Close()
+	return 0, json.NewDecoder(resp.Body).Decode(obj)
+}
+
+// GetVolumeStats is used to get the status of volume controller.It is used to
+// get the response in json format and then the response is then decoded to the
+// desired structure.
+func GetVolumeStats(address string, obj interface{}) (int, error) {
+	controller, err := NewControllerClient(address)
+	if err != nil {
+		return -1, err
+	}
+	url := controller.Address + "/stats"
+	resp, err := controller.httpClient.Get(url)
+	if resp != nil {
+		if resp.StatusCode == 500 {
+			return 500, errors.New("Internal Server Error")
+		} else if resp.StatusCode == 503 {
+			return 503, errors.New("Service Unavailable")
+		}
+	} else {
+		return -1, errors.New("Server Not Reachable")
+	}
+	if err != nil {
+		return -1, err
+	}
+	defer resp.Body.Close()
+	rc := json.NewDecoder(resp.Body).Decode(obj)
+	return 0, rc
+}

--- a/types/v1/metrics.go
+++ b/types/v1/metrics.go
@@ -24,9 +24,45 @@ type VolumeMetrics struct {
 	Name              string  `json:"Name"`
 }
 
+type VolStatus struct {
+	Resource        Resource
+	ReplicaCounter  int64  `json:"replicacounter"`
+	RevisionCounter string `json:"revisioncounter"`
+}
+
 type Resource struct {
 	Id      string            `json:"id,omitempty"`
 	Type    string            `json:"type,omitempty"`
 	Links   map[string]string `json:"links"`
 	Actions map[string]string `json:"actions"`
+}
+
+type Annotation struct {
+	IQN    string `json:"Iqn"`
+	Volume string `json:"Volume"`
+	Portal string `json:"Portal"`
+	Size   string `json:"Size"`
+}
+
+type StatsJSON struct {
+	IQN    string `json:"Iqn"`
+	Volume string `json:"Volume"`
+	Portal string `json:"Portal"`
+	Size   string `json:"Size"`
+
+	ReadIOPS  int64 `json:"ReadIOPS"`
+	WriteIOPS int64 `json:"WriteIOPS"`
+
+	ReadThroughput  float64 `json:"ReadThroughput"`
+	WriteThroughput float64 `json:"WriteThroughput"`
+
+	ReadLatency  float64 `json:"ReadLatency"`
+	WriteLatency float64 `json:"WriteLatency"`
+
+	AvgReadBlockSize  int64 `json:"AvgReadBlockSize"`
+	AvgWriteBlockSize int64 `json:"AvgWriteBlockSize"`
+
+	SectorSize  float64 `json:"SectorSize"`
+	ActualUsed  float64 `json:"ActualUsed"`
+	LogicalSize float64 `json:"LogicalSize"`
 }


### PR DESCRIPTION
1. Why is this change necessary ?
- Refers to issue openebs/openebs#505

2. How does this change address the issue ?
- All the commands and flags now moved to maya/cmd/mayactl/command and are using
  the cobra library for the cli.

3. How to verify this change ?
- Run mayactl inside maya-apiserver container to verify this change.
- Alternatively you can copy the binary inside the maya-apiserver and
  run the following commands
  * `mayactl volume stats -n=vol` to get in std I/O
  * `mayactl volume stats -n=vol -j=json` to get in json.

4. What side effects does this change have ?
- none

5. Other details
improvement: part of #179 
 
  