### PR TITLE
fixes storagepool in rbac setups

### DIFF
--- a/orchprovider/k8s/v1/k8s.go
+++ b/orchprovider/k8s/v1/k8s.go
@@ -220,12 +220,24 @@ func (k *k8sOrchestrator) SPPolicies() (oe_api_v1alpha1.StoragePoolSpec, error) 
 		return oe_api_v1alpha1.StoragePoolSpec{}, err
 	}
 
-	sp, err := spOps.Get(k.volume.StoragePool, metav1.GetOptions{})
+	// get StoragePool using a list
+	// this is done to separate `not found` from an `actual error`
+	splist, err := spOps.List(metav1.ListOptions{})
 	if err != nil {
 		return oe_api_v1alpha1.StoragePoolSpec{}, err
 	}
 
-	return sp.Spec, nil
+	for _, sp := range splist.Items {
+		if sp.Name == k.volume.StoragePool {
+			// SP policies is the spec associated with the SP
+			return sp.Spec, nil
+		}
+	}
+
+	// the storage pool was not found, return blank specs
+	// NOTE: If a SP is not found then empty spec is returned & not
+	// an error
+	return oe_api_v1alpha1.StoragePoolSpec{}, nil
 }
 
 // PVCPolicies will fetch volume policies based on the PVC

--- a/volume/policies/v1/policy_jiva_k8s.go
+++ b/volume/policies/v1/policy_jiva_k8s.go
@@ -30,7 +30,6 @@ package v1
 import (
 	"fmt"
 
-	"github.com/golang/glog"
 	oe_api_v1alpha1 "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	"github.com/openebs/maya/pkg/util"
 	"github.com/openebs/maya/types/v1"
@@ -241,21 +240,22 @@ func enforceHostPath(p *JivaK8sPolicies) error {
 		return nil
 	}
 
-	// merge from sc policy otherwise
+	// get storagepool
 	err := p.getSPPolicies()
 	if err != nil {
-		// error out if this is not default SP CRD object
-		// we relax the rules if default SP CRD object is
-		// not available
-		if p.volume.StoragePool != v1.DefaultStoragePool {
-			return err
-		}
-		// warn & proceed
-		glog.Warningf(err.Error())
+		return err
 	}
+
+	// path might still be blank if the storagepool
+	// is not found in cluster
 	p.volume.HostPath = p.spSpec.Path
 
-	// merge from env variable & then from default
+	// err for specific storagepool, do not err for default storagepool
+	if len(p.volume.HostPath) == 0 && p.volume.StoragePool != v1.DefaultStoragePool {
+		return fmt.Errorf("StoragePool '%s' is not found", p.volume.StoragePool)
+	}
+
+	// merge if empty from env variable & then from default
 	hps := []string{
 		v1.HostPathENV(),
 		v1.DefaultHostPath,
@@ -268,6 +268,8 @@ func enforceHostPath(p *JivaK8sPolicies) error {
 		}
 	}
 
+	// Need to err at this place as all attempts to
+	// fetch the host path has failed
 	if len(p.volume.HostPath) == 0 {
 		return fmt.Errorf("Nil host path")
 	}

--- a/volume/policies/v1/util.go
+++ b/volume/policies/v1/util.go
@@ -110,7 +110,7 @@ func (p *K8sPolicyOps) SPPolicies(volume *v1.Volume) (oe_api_v1alpha1.StoragePoo
 	}
 
 	if len(volume.StoragePool) == 0 {
-		return oe_api_v1alpha1.StoragePoolSpec{}, fmt.Errorf("Nil storage pool")
+		return oe_api_v1alpha1.StoragePoolSpec{}, fmt.Errorf("Nil storage pool name")
 	}
 
 	// check if orchestrator is available for operations
@@ -133,10 +133,5 @@ func (p *K8sPolicyOps) SPPolicies(volume *v1.Volume) (oe_api_v1alpha1.StoragePoo
 	//
 	// NOTE:
 	//  StoragePool name would have set previously against this volume
-	pol, err := pOrch.SPPolicies()
-	if err != nil {
-		return oe_api_v1alpha1.StoragePoolSpec{}, err
-	}
-
-	return pol, nil
+	return pOrch.SPPolicies()
 }


### PR DESCRIPTION
fixes https://github.com/openebs/openebs/issues/1242
fixes https://github.com/openebs/openebs/issues/1189

Why is this change necessary ?
This ensures use of StoragePool when rbac settings are
applied.

2. How does this change address the issue ?
- Failure to find specific StoragePool will error out
& fail the provisioning

- Failure to find default storage pool will result in
setting /var/openebs as the persistent path

- If StorageClass does not set any StoragePool, then it
results in setting /var/openebs as the persistent path

- Code uses StoragePool object in cluster scope than the earlier
use of namespace scope

3. How to verify this change ?
- One can run through the steps & suggestions made in the
following link to verify the changes
  - https://github.com/openebs/community/tree/master/demos/19FEB2018

4. What side effects does this change have ?
- none

Signed-off-by: amitkumardas <amit.das@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
