### PR TITLE
enables rbac on 1/ minikube local setup & 2/ ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin/
 nohup.out
 .DS_Store
 .testfiles/
+get_helm.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
   - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
   # Download minikube.
   - curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-  - sudo minikube start --vm-driver=none --kubernetes-version=v1.7.0
+  - sudo minikube start --vm-driver=none --kubernetes-version=v1.7.0 --extra-config=apiserver.Authorization.Mode=RBAC
   # Fix the kubectl context, as it's often stale.
   - minikube update-context
   # Wait for Kubernetes to be up and ready.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -96,7 +96,7 @@ sudo chown -R $USER $HOME/.minikube
 sudo chgrp -R $USER $HOME/.minikube
 
 # Start minikube on this host itself
-sudo -E minikube start --vm-driver=none
+sudo -E minikube start --vm-driver=none --extra-config=apiserver.Authorization.Mode=RBAC
 
 # This loop waits until kubectl can access the api server 
 # that Minikube has created
@@ -117,7 +117,7 @@ done
 now=$(date +%Y%m%d-%H%M%S)
 kubectl get po > /tmp/mk-$now 2>&1
 
-grep "The connection to the server 127.0.0.1:8443 was refused - did you specify the right host or port?" /tmp/mk-$now && sudo -E minikube start --vm-driver=none
+grep "The connection to the server 127.0.0.1:8443 was refused - did you specify the right host or port?" /tmp/mk-$now && sudo -E minikube start --vm-driver=none --extra-config=apiserver.Authorization.Mode=RBAC
 
 # loop for the final time
 for i in {1..10}; do # timeout for 10x5=50 seconds/ < 1 minute
@@ -140,7 +140,7 @@ if [ $? -ne 0 ]; then
     echo "================================================="
     echo "Check Status  :: minikube status"
     echo "Start minikube if it's in stopped state"
-    echo "Start Command :: sudo -E minikube start --vm-driver=none"
+    echo "Start Command :: sudo -E minikube start --vm-driver=none --extra-config=apiserver.Authorization.Mode=RBAC"
     echo "================================================="
     echo ""
 fi

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,15 +47,15 @@ SCRIPT
 $minikubescript = <<SCRIPT
 #!/bin/bash
 
-#Install minikube
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
-chmod +x minikube 
-sudo mv minikube /usr/local/bin/
+#Install latest minikube
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 \
+&& chmod +x minikube \
+&& sudo mv minikube /usr/local/bin/
 
-#Install kubectl
-curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
-chmod +x kubectl 
-sudo mv kubectl /usr/local/bin/
+#Install latest kubectl
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
+&& chmod +x kubectl \
+&& sudo mv kubectl /usr/local/bin/
 
 #Setup minikube
 mkdir -p $HOME/.minikube
@@ -98,52 +98,31 @@ sudo chgrp -R $USER $HOME/.minikube
 # Start minikube on this host itself
 sudo -E minikube start --vm-driver=none --extra-config=apiserver.Authorization.Mode=RBAC
 
-# This loop waits until kubectl can access the api server 
-# that Minikube has created
-for i in {1..20}; do # timeout for 20x3=60 seconds/1 minutes
-  kubectl get po &> /dev/null
-  if [ $? -ne 1 ]; then
-      echo ""
-      echo "============================================"
-      echo "Congrats!! minikube's apiserver is running"
-      echo "============================================"
-      echo ""
-      exit 0
-  fi
-  sleep 3
-done
+# Wait for Kubernetes to be up and ready.
+JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
 
-# Re-try minikube start
-now=$(date +%Y%m%d-%H%M%S)
-kubectl get po > /tmp/mk-$now 2>&1
+echo ""
+echo "================================================"
+echo "Congrats!! minikube apiserver is running"
+echo "================================================"
+echo ""
 
-grep "The connection to the server 127.0.0.1:8443 was refused - did you specify the right host or port?" /tmp/mk-$now && sudo -E minikube start --vm-driver=none --extra-config=apiserver.Authorization.Mode=RBAC
+# Download and initialize helm.
+bash ci/ubuntu-compile-nsenter.sh && sudo cp .tmp/util-linux-2.30.2/nsenter /usr/bin
+curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
+chmod 700 get_helm.sh
 
-# loop for the final time
-for i in {1..10}; do # timeout for 10x5=50 seconds/ < 1 minute
-  kubectl get po &> /dev/null
-  if [ $? -ne 1 ]; then
-      echo ""
-      echo "============================================"
-      echo "Congrats!! minikube's apiserver is running"
-      echo "============================================"
-      echo ""
-      exit 0
-  fi
-  sleep 5
-done
+bash ./get_helm.sh
+helm init
 
-# If still not running
-kubectl get po &> /dev/null
-if [ $? -ne 0 ]; then
-    echo ""
-    echo "================================================="
-    echo "Check Status  :: minikube status"
-    echo "Start minikube if it's in stopped state"
-    echo "Start Command :: sudo -E minikube start --vm-driver=none --extra-config=apiserver.Authorization.Mode=RBAC"
-    echo "================================================="
-    echo ""
-fi
+echo ""
+echo "================================================"
+echo "Congrats!! helm is installed"
+echo "================================================"
+echo ""
+
+# run the ci
+bash ci/travis-ci.sh
 
 SCRIPT
 

--- a/ci/helm_install_openebs.sh
+++ b/ci/helm_install_openebs.sh
@@ -11,7 +11,7 @@ kubectl get sa
 
 helm repo add openebs-charts https://openebs.github.io/charts/
 helm repo update
-helm install openebs-charts/openebs --set apiserver.tag="ci",jiva.replicas="1",rbacEnable="false"
+helm install openebs-charts/openebs --set apiserver.tag="ci",jiva.replicas="1",rbacEnable="true"
 
 #Replace this with logic to wait till the pods are running
 sleep 30


### PR DESCRIPTION
1. Why is this change necessary ?

Need to test openebs usecases in rbac enabled setup

2. How does this change address the issue ?

- provides a minikube with rbac enabled

3. How to verify this change ?

- destroy the existing minikube vagrant VM
- recreate the vagrant VM that will now have a minikube with
rbac enabled

4. What side effects does this change have ?

- none

Signed-off-by: amitkumardas <amit.das@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
