### PR TITLE
enables rbac on minikube

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
   - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
   # Download minikube.
   - curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-  - sudo minikube start --vm-driver=none --kubernetes-version=v1.7.0
+  - sudo minikube start --vm-driver=none --kubernetes-version=v1.7.0 --extra-config=apiserver.Authorization.Mode=RBAC
   # Fix the kubectl context, as it's often stale.
   - minikube update-context
   # Wait for Kubernetes to be up and ready.

--- a/ci/helm_install_openebs.sh
+++ b/ci/helm_install_openebs.sh
@@ -11,7 +11,7 @@ kubectl get sa
 
 helm repo add openebs-charts https://openebs.github.io/charts/
 helm repo update
-helm install openebs-charts/openebs --set apiserver.tag="ci",jiva.replicas="1",rbacEnable="false"
+helm install openebs-charts/openebs --name ci --set apiserver.tag="ci",jiva.replicas="1"
 
 #Replace this with logic to wait till the pods are running
 sleep 30

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-MAPI_SVC_ADDR=`kubectl get service maya-apiserver-service -o json | grep clusterIP | awk -F\" '{print $4}'`
+MAPI_SVC_ADDR=`kubectl get service -n openebs ci-openebs-maya-apiservice -o json | grep clusterIP | awk -F\" '{print $4}'`
 export MAPI_ADDR="http://${MAPI_SVC_ADDR}:5656"
 export KUBERNETES_SERVICE_HOST="127.0.0.1"
 export MAYACTL="$GOPATH/src/github.com/openebs/maya/bin/maya/mayactl"


### PR DESCRIPTION
Signed-off-by: kmova <kiran.mova@openebs.io>

**What this PR does / why we need it**:
The latest openebs helm chart prefixes the maya-apiservice with release and namespace information as is the convention of helm charts for service names.  This PR, modifies the code used by the mayactl to fetch the IP address of the maya-apiservice using the new naming convention. 

Also, this PR runs the helm chart with RBAC enabled. 

Related PR: https://github.com/openebs/maya/pull/267
