### PR TITLE
adds rbac & charts to vagrant VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin/
 nohup.out
 .DS_Store
 .testfiles/
+openebs-operator-autogen.yaml


### PR DESCRIPTION
This enables the vagrant VM to include openebs components
via helm after installing minikube.

In near future, the e2e test cases will be run on this
vagrant VM. Meanwhile, one can attempt to run the test cases
that are run in travis, as a manual operation within this VM.

In addition, I shall attempt to minimize the difference
between the travis run and launching this VM.

Signed-off-by: amitkumardas <amit.das@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
