### PR TITLE
Fix the bug with multi-valued response #1275

### DIFF
--- a/orchprovider/k8s/v1/util_test.go
+++ b/orchprovider/k8s/v1/util_test.go
@@ -137,3 +137,15 @@ func TestK8sUtilServices(t *testing.T) {
 		}
 	}
 }
+
+// TestAddMultiples tests the working of AddMultiples() method.
+//
+func TestAddMultiples(t *testing.T) {
+	p := NewVolumeMarkerBuilder()
+	p.AddMultiples("test", "val1", true)
+	p.AddMultiples("test", "val2", true)
+
+	if p.GetVolumeMarkerValues("test") == "val1,val2" {
+		t.Errorf("Error storing multi-valued keys")
+	}
+}


### PR DESCRIPTION
Signed-off-by: kmova <kiran.mova@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->
Fixes #https://github.com/openebs/openebs/issues/1275

**What this PR does / why we need it**:

maya-apiserver - volume info API is returning only one replica, even when there are multiple replica running for a given volume. 

The response for volume info is formed by the maya-apiserver by querying the controller and replica kubernetes objects. Since there are multiple calls involved, the data received is temporarily stored in "VolumeMarker" - which can store keys with single and multiple values. Since Replica is supposed to be a multiple valued key, I added an unit test for the AddMultiples function. 

The unit test failed, indicating that, though VolumeMarker is updated with multiple values, when framing the response, only one value was being returned. 

This bug was in the way, values were getting appended for the multi-valued markers. 



