### PR TITLE
adds ability to set tolerations & others in volume policy

### DIFF
--- a/pkg/template/txt_tpl_examples_test.go
+++ b/pkg/template/txt_tpl_examples_test.go
@@ -66,6 +66,63 @@ var AllValues = map[string]interface{}{
 			"nfs": "cstor again",
 		},
 	},
+	"Yml": map[string]interface{}{
+		"msg":   "Hello-OpenEBS",
+		"block": "cstor",
+		"nfs":   "cstor again",
+		"cool":  true,
+	},
+  // The entire value is expressed as a multi-line string
+	"YmlStr": `
+msg: Hello-OpenEBS
+block: cstor
+nfs: "cstor again"
+cool: true
+`,
+  // The entire value is expressed as a multi-line string
+  "YmlStr2": "msg: Hello-OpenEBS\n  block: cstor\n  nfs: \"cstor again\"\n  cool: true",
+	"Ymls": map[string]interface{}{
+		"Yml1": map[string]interface{}{
+			"msg":   "Hello-OpenEBS",
+			"block": "cstor",
+			"nfs":   "cstor again",
+			"cool":  true,
+		},
+		"Yml2": map[string]interface{}{
+			"msg":   "Hello-OpenEBS2",
+			"block": "jiva",
+			"nfs":   "no way",
+			"cool":  true,
+		},
+	},
+  "YmlsArrStr": map[string]interface{}{
+    // The entire array of values is expressed as a multi-line string
+	  "YmlStr": `
+- msg: Hello-OpenEBS
+  block: cstor
+  nfs: "cstor again"
+  cool: true
+- msg: Hello-OpenEBS2
+  block: jiva
+  nfs: "no way"
+  cool: true
+`,
+  },
+  "FromYaml": map[string]interface{}{
+    // The entire array of values is expressed as a multi-line string
+	  "YmlStr": `
+      k1: 
+        msg: Hello-OpenEBS
+        block: cstor
+        nfs: "cstor again"
+        cool: true
+      k2:
+        msg: Hello-OpenEBS2
+        block: jiva
+        nfs: "no way"
+        cool: true
+`,
+  },
 }
 
 // YmlExpected is the expected template
@@ -82,8 +139,114 @@ data:
   cool: true
 `
 
-// IfEqYmlTpl is a yaml template with
-// placeholders
+// YmlExpected2 is the expected template
+// after the values are placed in the template's placeholders
+var YmlExpected2 = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: OpenEBS-configmap
+data:
+  - msg: Hello-OpenEBS
+    block: cstor
+    nfs: "cstor again"
+    cool: true
+  - msg: Hello-OpenEBS2
+    block: jiva
+    nfs: "no way"
+    cool: true
+`
+
+// RangeTpl shows the usage of `range` template func w.r.t to a map
+var RangeTpl = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .My.Name }}-configmap
+data:
+  {{- range $k, $v := .Yml }}
+  {{ $k }}: {{ $v }}
+  {{- end }}
+`
+
+// RangeTpl2 shows the usage of `range` template func w.r.t to a map of maps
+var RangeTpl2 = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .My.Name }}-configmap
+data:
+  {{- range $k, $v := .Ymls }}
+  -
+  {{- range $kk, $vv := $v }}
+    {{ $kk }}: {{ $vv }}
+  {{- end }}
+  {{- end }}
+`
+
+// ToYamlTpl shows the usage of `toYaml` template func
+var ToYamlTpl = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .My.Name }}-configmap
+data:
+{{ toYaml .Yml | indent 2 }}
+`
+
+// FromYamlTpl shows the usage of `fromYaml` template func
+var FromYamlTpl = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .My.Name }}-configmap
+data:
+  {{- $isYaml := .FromYaml.YmlStr | default "false" -}}
+  {{- $yamlVal := fromYaml .FromYaml.YmlStr -}}
+  {{- if ne $isYaml "false" }}
+  {{- range $k, $v := $yamlVal }}
+  - 
+  {{- range $kk, $vv := $v }}
+    {{ $kk }}: {{ $vv }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+`
+
+// YmlStrTpl shows the usage of Yaml in String
+var YmlStrTpl = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .My.Name }}-configmap
+data:
+  {{- .YmlStr | indent 2 -}}
+`
+
+// YmlStrTpl shows the usage of Yaml in String
+var YmlStrTpl2 = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .My.Name }}-configmap
+data:
+  {{ .YmlStr2 }}
+`
+
+// YmlArrStrTpl shows the usage of Yaml array in String
+var YmlArrStrTpl = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .My.Name }}-configmap
+data:
+  {{- $isArrPresent := .YmlsArrStr.YmlStr | default "false" | quote -}}
+  {{- if ne $isArrPresent "false" -}}
+  {{ .YmlsArrStr.YmlStr | indent 2 }}
+  {{- end -}}
+`
+
+// IfEqYmlTpl shows the usage of `if` template func
 var IfEqYmlTpl = `
 apiVersion: v1
 kind: ConfigMap
@@ -96,8 +259,7 @@ data:
   {{ if eq .Storage.favorite.block "cstor" }}cool: true{{ end }}
 `
 
-// TrimLeftWhitespaceYmlTpl is a yaml template with
-// placeholders
+// TrimLeftWhitespaceYmlTpl shows the usage of `if` template func along with trim
 var TrimLeftWhitespaceYmlTpl = `
 apiVersion: v1
 kind: ConfigMap
@@ -112,8 +274,7 @@ data:
   {{- end }}
 `
 
-// WithBlockYmlTpl is a yaml template with
-// scoped placeholders
+// WithBlockYmlTpl shows the usage of `with` template func
 var WithBlockYmlTpl = `
 apiVersion: v1
 kind: ConfigMap
@@ -128,8 +289,7 @@ data:
   cool: true
 `
 
-// SetDefaultsYmlTpl is a yaml template using
-// default template function
+// SetDefaultsYmlTpl shows the usage of `default` template function
 var SetDefaultsYmlTpl = `
 apiVersion: v1
 kind: ConfigMap
@@ -147,6 +307,41 @@ data:
 func TestAll(t *testing.T) {
 
 	tests := map[string]txtTplMock{
+		"Test 'yaml arr in str' condition": {
+			values:      AllValues,
+			ymlTpl:      YmlArrStrTpl,
+			ymlExpected: YmlExpected2,
+		},
+		"Test 'yaml in str' condition": {
+			values:      AllValues,
+			ymlTpl:      YmlStrTpl,
+			ymlExpected: YmlExpected,
+		},
+		"Test 'yaml in str2' condition": {
+			values:      AllValues,
+			ymlTpl:      YmlStrTpl2,
+			ymlExpected: YmlExpected,
+		},
+		"Test 'range2' condition": {
+			values:      AllValues,
+			ymlTpl:      RangeTpl2,
+			ymlExpected: YmlExpected2,
+		},
+		"Test 'range' condition": {
+			values:      AllValues,
+			ymlTpl:      RangeTpl,
+			ymlExpected: YmlExpected,
+		},
+		"Test 'fromYaml' condition": {
+			values:      AllValues,
+			ymlTpl:      FromYamlTpl,
+			ymlExpected: YmlExpected2,
+		},
+		"Test 'toYaml' condition": {
+			values:      AllValues,
+			ymlTpl:      ToYamlTpl,
+			ymlExpected: YmlExpected,
+		},
 		"Test 'if eq' condition": {
 			values:      AllValues,
 			ymlTpl:      IfEqYmlTpl,
@@ -207,7 +402,8 @@ func TestAll(t *testing.T) {
 			// Now Compare
 			ok := reflect.DeepEqual(objExpected, objActual)
 			if !ok {
-				t.Fatalf("\nExpected: '%#v' \nActual: '%#v'", objExpected, objActual)
+				//t.Fatalf("\nExpected: '%#v' \nActual: '%#v'", objExpected, objActual)
+				t.Fatalf("\n\nExpected: '%s' \n\nActual: '%s'", mock.ymlExpected, buf.Bytes())
 			}
 		}) // end of run
 	}


### PR DESCRIPTION
Adds ability to set tolerations & others in volume policy
- This in itself will not enable tolerating the taints
- Appropriate PR(s) needs to be raised to openebs helm charts w.r.t volume policy CRD
- Appropriate PR(s) needs to be raised to volume policies objects

#### Technical: 
VolumePolicy will make use of `fromYaml` template function as well as control loop functions
i.e. `range` to enable tolerations.

e.g. a volume policy snippet will look like:
```yaml
  - name: TaintTolerations
    value: |-
      t1:
        key: node.openebs.io/disktype
        operator: Equal
        value: ssd
        effect: NoSchedule
      t2:
        key: node.openebs.io/disktype
        operator: Equal
        value: ssd
        effect: NoExecute
      t3:
        key: jk
        operator: Equal
        value: jv
        effect: NoSchedule
  - name: EvictionTolerations
    value: |-
      t1:
        effect: NoExecute
        key: node.alpha.kubernetes.io/notReady
        operator: Exists
      t2:
        effect: NoExecute
        key: node.alpha.kubernetes.io/unreachable
        operator: Exists
```
e.g. a replica template snippet looks like:
```yaml
    {{- $isTaintTolerations := .Policy.TaintTolerations.value | default "false" -}}
    {{- $taintTolerationsVal := fromYaml .Policy.TaintTolerations.value -}}
    {{- $isEvictionTolerations := .Policy.EvictionTolerations.value | default "false" -}}
    {{- $evictionTolerationsVal := fromYaml .Policy.EvictionTolerations.value -}}


          tolerations:
          {{- if ne $isTaintTolerations "false" }}
          {{- range $k, $v := $taintTolerationsVal }}
          - 
          {{- range $kk, $vv := $v }}
            {{ $kk }}: {{ $vv }}
          {{- end }}
          {{- end }}
          {{- end }}
          {{- if ne $isEvictionTolerations "false" }}
          {{- range $k, $v := $evictionTolerationsVal }}
          - 
          {{- range $kk, $vv := $v }}
            {{ $kk }}: {{ $vv }}
          {{- end }}
          {{- end }}
          {{- end }}
```

#### UseCase: 
VolumePolicy can set tolerations that can tolerate Kubernetes node taints.

#### Notes: 
There will be further PRs to openebs charts that makes use of tolerations in VolumePolicy

#### Unit Testing:
- ref - https://github.com/openebs/community/tree/master/demos/03MAR2018

#### Issues:
fixes https://github.com/openebs/openebs/issues/1304

#### Changes to be committed:
- modified:   pkg/template/template.go
  - Above adds fromYaml template function that accepts a yaml document & returns a map[string]interface{}
- modified:   pkg/template/txt_tpl_examples_test.go
  - Above shows various unit tests w.r.t template functions

Signed-off-by: AmitKumarDas <amit.das@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
