### PR TITLE
will pin volume controller to run alongside the application pod

### DIFF
--- a/pkg/apis/openebs.io/v1alpha1/policy.go
+++ b/pkg/apis/openebs.io/v1alpha1/policy.go
@@ -89,6 +89,11 @@ const (
 	//  The corresponding value will be accessed as
 	// {{ .Volume.capacity }}
 	CapacityVTP VolumeTLPProperty = "capacity"
+	// PersistentVolumeClaimVTP is the PVC of the volume
+	// NOTE:
+	//  The corresponding value will be accessed as
+	// {{ .Volume.pvc }}
+	PersistentVolumeClaimVTP VolumeTLPProperty = "pvc"
 )
 
 // PolicyTLPProperty is the name of the property that is found

--- a/pkg/task/result_executor.go
+++ b/pkg/task/result_executor.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2018 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package task
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openebs/maya/pkg/template"
+	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+)
+
+// TaskResultQuery helps in extracting specific data from the task's result
+//
+// NOTE:
+//  A TaskResult is the result obtained after this task's execution.
+type TaskResultQuery struct {
+	// Alias is the name/key used to hold the extracted data from the task's
+	// result
+	Alias string `json:"alias"`
+	// Path contains the path to the property of the taskresult, whose value(s)
+	// need to be extracted.
+	//
+	// NOTE:
+	//  Path will be a string type. It will vary depending on the query language
+	// used. e.g. It can represent a jsonpath or a go template function.
+	//
+	// NOTE:
+	//  Path can be optional i.e. commonly used Paths can be set as constants &
+	// be retrieved from the query's Alias property. Refer KeyToGoPathMap.
+	Path string `json:"path"`
+}
+
+// KeyToJsonPathMap holds often used jsonpath(s) against some predefined keys
+//
+// NOTE: The keys needs to be in smallcase
+var keyToJsonPathMap = map[string]string{
+	// All the K8s objects have name at this path
+	string(v1alpha1.ObjectNameTRTP): "{.metadata.name}",
+	// StoragePool CR's path
+	"poolpath": "{.spec.path}",
+	// K8s Service's cluster ip path
+	"clusterip": "{.spec.clusterIP}",
+}
+
+func jsonPathFromKey(key string) (jsonpath string) {
+	return keyToJsonPathMap[strings.ToLower(key)]
+}
+
+// taskResultStorage is a post task run executor. In other words, this executor
+// may be used after a task is executed resulting with some output
+// (i.e. taskresult). This stores the extracted data from a task
+// result. The storage is done into the task workflow.
+type taskResultStorage struct {
+	// taskID is the identity of the task
+	taskID string
+	// result is the task's result after executing this task
+	result []byte
+	// queries holds the info about the data that needs to be
+	// extracted from the task's result. This extracted data is stored in the
+	// task's workflow.
+	queries []TaskResultQuery
+}
+
+func NewTaskResultStorage(taskID string, queries []TaskResultQuery, result []byte) *taskResultStorage {
+	return &taskResultStorage{
+		taskID:  taskID,
+		queries: queries,
+		result:  result,
+	}
+}
+
+// query will run jsonpath query against the task result. Each of the query
+// will be run in an iteractive manner. All the query outputs will be aggregated
+// & returned.
+func (t *taskResultStorage) query() (map[string]string, error) {
+	var outputs = map[string]string{}
+
+	for _, q := range t.queries {
+		// get the jsonpath
+		path := q.Path
+		if len(path) == 0 {
+			path = jsonPathFromKey(q.Alias)
+		}
+
+		// check again
+		if len(path) == 0 {
+			err := fmt.Errorf("jsonpath not found for key '%s': can not query against task result", q.Alias)
+			return nil, err
+		}
+
+		// t.taskID is provided as a context that can act as an identifier
+		// result is the json doc against which the jsonpath is run
+		jq := template.NewJsonQuery(t.taskID, t.result, path)
+		op, err := jq.Query()
+		if err != nil {
+			return nil, err
+		}
+
+		outputs[q.Alias] = op
+	}
+
+	return outputs, nil
+}
+
+// store will save the data extracted from specific properties of the task
+// result
+//
+// NOTE:
+//  This is currently coupled to JsonPath Query!!!
+func (t *taskResultStorage) store() (storage map[string]interface{}, err error) {
+	outputs, err := t.query()
+	if err != nil {
+		return
+	}
+
+	// attach task ID with the extracted data
+	storage = map[string]interface{}{
+		t.taskID: outputs,
+	}
+
+	return
+}

--- a/pkg/task/result_executor.go
+++ b/pkg/task/result_executor.go
@@ -18,7 +18,6 @@ package task
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/openebs/maya/pkg/template"
 	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
@@ -41,24 +40,22 @@ type TaskResultQuery struct {
 	//
 	// NOTE:
 	//  Path can be optional i.e. commonly used Paths can be set as constants &
-	// be retrieved from the query's Alias property. Refer KeyToGoPathMap.
+	// be retrieved from the query's Alias property. Refer keyToJsonPathMap.
 	Path string `json:"path"`
 }
 
 // KeyToJsonPathMap holds often used jsonpath(s) against some predefined keys
-//
-// NOTE: The keys needs to be in smallcase
 var keyToJsonPathMap = map[string]string{
 	// All the K8s objects have name at this path
 	string(v1alpha1.ObjectNameTRTP): "{.metadata.name}",
-	// StoragePool CR's path
-	"poolpath": "{.spec.path}",
-	// K8s Service's cluster ip path
-	"clusterip": "{.spec.clusterIP}",
+	// StoragePool (i.e. a Custom Resource) path
+	"poolPath": "{.spec.path}",
+	// K8s Service's cluster IP path
+	"clusterIP": "{.spec.clusterIP}",
 }
 
 func jsonPathFromKey(key string) (jsonpath string) {
-	return keyToJsonPathMap[strings.ToLower(key)]
+	return keyToJsonPathMap[key]
 }
 
 // taskResultStorage is a post task run executor. In other words, this executor

--- a/pkg/task/result_executor_test.go
+++ b/pkg/task/result_executor_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2018 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package task
+
+import (
+	"reflect"
+	"testing"
+	
+	"github.com/openebs/maya/pkg/template"
+)
+
+// resultExecuteMock is the mock structure to test task result
+// templating
+type resultExecuteMock struct {
+	// taskID is the task ID
+	taskID string
+	// bytes hold the data that will be fed while executing the go template
+	bytes []byte
+	// alias is the key against which the value is set,
+	// value is the one that is derived after running jsonpath
+	alias string
+	// path represents the go template function
+	path string
+	// expected is the resulting value i.e. after
+	// executing path against the bytes
+	expected string
+}
+
+func TestResultExecute(t *testing.T) {
+  // this yml should not interfere with the json query to be done later
+  var jsonPathFeederYml = `
+data:
+  meta: |
+    runNamespace: {{ .Volume.runNamespace }}
+    apiVersion: openebs.io/v1alpha1
+    kind: PersistentVolumeClaim
+    objectName: {{ .Volume.pvc }}
+    action: get
+    queries:
+    - alias: affinity
+      path: "{.metadata.annotations.controller\.openebs\.io/affinity}"
+    - alias: affinityTopology
+      path: "{.metadata.annotations.controller\.openebs\.io/affinity-topology}"
+`
+
+	var myPodJson = []byte(`{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "kubectl-tester",
+    "annotations": {
+      "simple": "value",
+      "controller.openebs.io/affinity": "mypin",
+      "controller.openebs.io/affinity-topology": "kubernetes.io/hostname"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "bb",
+        "image": "k8s.gcr.io/busybox",
+        "command": [
+          "sh", "-c", "sleep 5; wget -O - ${KUBERNETES_RO_SERVICE_HOST}:${KUBERNETES_RO_SERVICE_PORT}/api/v1/pods/; sleep 10000"
+        ],
+        "ports": [
+          {
+            "containerPort": 8080
+          }
+        ],
+        "env": [
+          {
+            "name": "KUBERNETES_RO_SERVICE_HOST",
+            "value": "127.0.0.1"
+          },
+          {
+            "name": "KUBERNETES_RO_SERVICE_PORT",
+            "value": "8001"
+          }
+        ],
+        "volumeMounts": [
+          {
+            "name": "test-volume",
+            "mountPath": "/mount/test-volume"
+          }
+        ]
+      },
+      {
+        "name": "kubectl",
+        "image": "k8s.gcr.io/kubectl:v0.18.0-120-gaeb4ac55ad12b1-dirty",
+        "imagePullPolicy": "Always",
+        "args": [
+          "proxy", "-p", "8001"
+        ]
+      }
+    ],
+    "volumes": [
+      {
+        "name": "test-volume",
+        "emptyDir": {}
+      }
+    ]
+  }
+}`)
+
+	tests := map[string]resultExecuteMock{
+		"Test 'name' in yaml": {
+			taskID:   "mypod",
+			alias:    "name",
+			bytes:    myPodJson,
+			path:     "{.metadata.name}",
+			expected: "kubectl-tester",
+		},
+		"Test 'objectName without jsonpath' in yaml": {
+			taskID:   "mypod",
+			alias:    "objectName",
+			bytes:    myPodJson,
+			path:     "",
+			expected: "kubectl-tester",
+		},
+		"Test 'image with condition' in yaml": {
+			taskID:   "mypod",
+			alias:    "containerImage",
+			bytes:    myPodJson,
+			path:     "{.spec.containers[?(@.name=='bb')].image}",
+			expected: "k8s.gcr.io/busybox",
+		},
+		"Test 'mountpath with condition' in yaml": {
+			taskID:   "mypod",
+			alias:    "mountPath",
+			bytes:    myPodJson,
+			path:     "{.spec.containers[?(@.name=='bb')].volumeMounts[?(@.name=='test-volume')].mountPath}",
+			expected: "/mount/test-volume",
+		},
+		"Test 'annotation' in yaml": {
+			taskID:   "mypod",
+			alias:    "simple",
+			bytes:    myPodJson,
+			path:     "{.metadata.annotations.simple}",
+			expected: "value",
+		},
+		"Test 'complex annotation' in yaml": {
+			taskID:   "mypod",
+			alias:    "affinity",
+			bytes:    myPodJson,
+			path:     `{.metadata.annotations.controller\.openebs\.io/affinity}`,
+			expected: "mypin",
+		},
+		"Test 'complex annotation 2' in yaml": {
+			taskID:   "mypod",
+			alias:    "affinityTopology",
+			bytes:    myPodJson,
+			path:     `{.metadata.annotations.controller\.openebs\.io/affinity-topology}`,
+			expected: "kubernetes.io/hostname",
+		},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+		
+		  // go template is run to check if it interferes with jsonpath querying 
+		  // later. go template should not try to execute the jsonquery strings and 
+		  // pass them as-is
+		  _, err := template.AsMapOfObjects(jsonPathFeederYml, map[string]interface{}{
+		    "test": "check",
+		  })
+			if err != nil {
+				t.Fatalf("Expected: 'no interference error' Actual: '%s'", err)
+			}
+      
+      // Now test the jsonpath querying which is done internally in 
+      // TaskResultStorage.store() method
+			q := TaskResultQuery{
+				Alias: mock.alias,
+				Path:  mock.path,
+			}
+
+			s := NewTaskResultStorage(mock.taskID, []TaskResultQuery{q}, mock.bytes)
+			mActual, err := s.store()
+			if err != nil {
+				t.Fatalf("Expected: 'no error' Actual: '%#v'", err)
+			}
+
+			// Get back to expected yaml & unmarshall the yaml into
+			// this object
+			mExpected := map[string]interface{}{
+				mock.taskID: map[string]string{
+					mock.alias: mock.expected,
+				},
+			}
+
+			// Now Compare
+			ok := reflect.DeepEqual(mExpected, mActual)
+			if !ok {
+				t.Fatalf("\nExpected: '%#v' \nActual: '%#v'", mExpected, mActual)
+			}
+		}) // end of run
+	}
+}

--- a/pkg/task/runner.go
+++ b/pkg/task/runner.go
@@ -113,6 +113,8 @@ func (m *TaskRunner) runTasks(values map[string]interface{}, postTaskRunFn PostT
 		// actual task execution
 		result, err := t.execute()
 		if err != nil {
+			// log with verbose details
+			glog.Errorf("Failed to execute task: Task: '%#v'", t)
 			return err
 		}
 

--- a/pkg/template/query.go
+++ b/pkg/template/query.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2018 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"k8s.io/client-go/util/jsonpath"
+)
+
+// QueryType is a typed string to indicate the type of query to use to extract
+// data from a taskresult
+type QueryType string
+
+const (
+	// JsonQT represents the json query to extract data, mostly from a json doc
+	JsonQT QueryType = "jsonpath"
+	// GoQT represents the go template function used to extract data, mostly
+	// from a yaml doc
+	GoQT QueryType = "go-template"
+)
+
+// Query represents a templating interface which provides Execute
+// method that is implemented by specific templating implementations
+type Query interface {
+	Execute() (string, error)
+}
+
+type JsonQuery struct {
+	// name given to this json query operation
+	name string
+	// values is data against which json path will be run
+	values []byte
+	// path represents the json path used to query the json doc
+	path string
+}
+
+func NewJsonQuery(name string, values []byte, path string) *JsonQuery {
+	return &JsonQuery{
+		name:   name,
+		values: values,
+		path:   path,
+	}
+}
+
+// Query will run jsonpath against the json document and return the value at the
+// specified path
+func (m *JsonQuery) Query() (output string, err error) {
+	// get a new jsonpath instance
+	j := jsonpath.New(m.name)
+	j.AllowMissingKeys(true)
+
+	// set the parse path i.e. jsonpath
+	err = j.Parse(m.path)
+	if err != nil {
+		return
+	}
+
+	var values interface{}
+	err = json.Unmarshal(m.values, &values)
+	if err != nil {
+		return
+	}
+
+	buf := new(bytes.Buffer)
+	err = j.Execute(buf, values)
+	if err != nil {
+		return
+	}
+
+	output = buf.String()
+	return
+}

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -64,7 +64,7 @@ func funcMap() template.FuncMap {
 
 	// Add some extra templating functions
 	extra := template.FuncMap{
-		"toYaml": toYaml,
+		"toYaml":   toYaml,
 		"fromYaml": fromYaml,
 	}
 
@@ -102,8 +102,7 @@ func AsTemplatedBytes(context string, yml string, values map[string]interface{})
 	return buf.Bytes(), nil
 }
 
-// AsMapOfObjects returns a map of any objects
-// based on the provided yaml & values
+// AsMapOfObjects returns a map of objects based on the provided yaml & values
 func AsMapOfObjects(yml string, values map[string]interface{}) (map[string]interface{}, error) {
 	// templated & then unmarshall-ed version of this yaml
 	b, err := AsTemplatedBytes("MapOfObjects", yml, values)
@@ -113,6 +112,24 @@ func AsMapOfObjects(yml string, values map[string]interface{}) (map[string]inter
 
 	// Any given YAML can be unmarshalled into a map of arbitrary objects
 	var obj map[string]interface{}
+	err = yaml.Unmarshal(b, &obj)
+	if err != nil {
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+// AsMapOfStrings returns a map of strings based on the provided yaml & values
+func AsMapOfStrings(context string, yml string, values map[string]interface{}) (map[string]string, error) {
+	// templated & then unmarshall-ed version of this yaml
+	b, err := AsTemplatedBytes(context+"MapOfStrings", yml, values)
+	if err != nil {
+		return nil, err
+	}
+
+	// Any given YAML can be unmarshalled into a map of strings
+	var obj map[string]string
 	err = yaml.Unmarshal(b, &obj)
 	if err != nil {
 		return nil, err

--- a/pkg/template/txt_tpl_examples_test.go
+++ b/pkg/template/txt_tpl_examples_test.go
@@ -72,15 +72,15 @@ var AllValues = map[string]interface{}{
 		"nfs":   "cstor again",
 		"cool":  true,
 	},
-  // The entire value is expressed as a multi-line string
+	// The entire value is expressed as a multi-line string
 	"YmlStr": `
 msg: Hello-OpenEBS
 block: cstor
 nfs: "cstor again"
 cool: true
 `,
-  // The entire value is expressed as a multi-line string
-  "YmlStr2": "msg: Hello-OpenEBS\n  block: cstor\n  nfs: \"cstor again\"\n  cool: true",
+	// The entire value is expressed as a multi-line string
+	"YmlStr2": "msg: Hello-OpenEBS\n  block: cstor\n  nfs: \"cstor again\"\n  cool: true",
 	"Ymls": map[string]interface{}{
 		"Yml1": map[string]interface{}{
 			"msg":   "Hello-OpenEBS",
@@ -95,9 +95,9 @@ cool: true
 			"cool":  true,
 		},
 	},
-  "YmlsArrStr": map[string]interface{}{
-    // The entire array of values is expressed as a multi-line string
-	  "YmlStr": `
+	"YmlsArrStr": map[string]interface{}{
+		// The entire array of values is expressed as a multi-line string
+		"YmlStr": `
 - msg: Hello-OpenEBS
   block: cstor
   nfs: "cstor again"
@@ -107,10 +107,10 @@ cool: true
   nfs: "no way"
   cool: true
 `,
-  },
-  "FromYaml": map[string]interface{}{
-    // The entire array of values is expressed as a multi-line string
-	  "YmlStr": `
+	},
+	"FromYaml": map[string]interface{}{
+		// The entire array of values is expressed as a multi-line string
+		"YmlStr": `
       k1: 
         msg: Hello-OpenEBS
         block: cstor
@@ -122,7 +122,7 @@ cool: true
         nfs: "no way"
         cool: true
 `,
-  },
+	},
 }
 
 // YmlExpected is the expected template


### PR DESCRIPTION
1/ Why is this change necessary?

This lets `volume controller` & `application` PODs
to run in the same topology key, e.g. in the same K8s node.

fixes https://github.com/openebs/openebs/issues/1257

2/ How does this change address the issue?

- `modified:   pkg/apis/openebs.io/v1alpha1/policy.go`
  - Above change ensures use of pvc as a top level volume policy property
- `modified:   pkg/client/k8s/k8s.go`
  - Above has changes for invoking K8s APIs w.r.t. PVC
- `new file:   pkg/task/result_executor.go`
- `new file:   pkg/task/result_executor_test.go`
- `new file:   pkg/template/query.go`
  - Above introduces the concept of querying a task's result for specific data.
  - It makes use of jsonpath from kubernetes client-go repository
- `modified:   pkg/task/runner.go`
  - Above has changes to log verbose details in case of task failures
- `modified:   pkg/task/task.go`
  - Above has changes to accomodate queries (i.e. jsonpath querying) as part of MetaTask
  - It has changes to make get calls to PVC API (i.e. as a task) in the task workflow
- `modified:   pkg/template/template.go`
  - Above introduces go templating of a yaml into a map of strings
- `modified:   pkg/volume/volume.go`
  - Above has changes to use of namespace
  - It also has changes to use PVC

3/ How to verify this change?

- openebs volume controller sets the pod affinity policies based on:
  - the labels set in the application workload as well as
  - the annotations in the PVC this application workload refers to

- the application pod specs should have a label that matches this affinity
  - i.e. `controller.openebs.io/affinity: unique-app-label-value`

- The application specs should try to provide a unique label value for the label
key `controller.openebs.io/affinity`

- The application specs can also provide the topologyKey to be considered
for pod affinity.
  - This topology key can be set in the application specifications labels
  - i.e. `controller.openebs.io/affinity-topology: kubernetes.io/hostname`

- If topologyKey is not provided then volume controller pod affinity will default
to `kubernetes.io/hostname`

- Finally above affinity & affinity-topology labels needs to be present as
annotations in the PVC that this application refers to.

- sample application specifications:
```yaml
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
 name: jenkins
spec:
 replicas: 1
 template:
  metadata:
   labels:
    app: jenkins-app
    controller.openebs.io/affinity: mypin
    controller.openebs.io/affinity-topology: kubernetes.io/hostname
  spec:
   securityContext:
     fsGroup: 1000
   containers:
   - name: jenkins
     imagePullPolicy: IfNotPresent
     image: jenkins/jenkins:lts
     ports:
     - containerPort: 8080
     volumeMounts:
     - mountPath: /var/jenkins_home
       name: jenkins-home
   volumes:
   - name: jenkins-home
     persistentVolumeClaim:
      claimName: openebs-podaffinity-0.6.0
```

- sample pvc specifications:
```yaml
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: openebs-podaffinity-0.6.0
  annotations:
    controller.openebs.io/affinity: mypin
    controller.openebs.io/affinity-topology: kubernetes.io/hostname
spec:
  accessModes:
    - ReadWriteOnce
  volumeMode: Filesystem
  resources:
    requests:
      storage: 1Gi
  storageClassName: openebs-podaffinity-0.6.0
```

- sample volumepolicy specifications:
```yaml
apiVersion: openebs.io/v1alpha1
kind: VolumePolicy
metadata:
  name: openebs-policy-podaffinity-0.6.0
spec:
  policies:
  - name: VolumeMonitor
    enabled: "true"
  - name: ControllerImage
    value: openebs/jiva:0.5.0
  - name: ReplicaImage
    value: openebs/jiva:0.5.0
  - name: ReplicaCount
    value: "1"
  - name: StoragePool
    value: ssd
  run:
    searchNamespace: default
    tasks:
    - template: volume-service-0.6.0
      identity: vsvc
    - template: volume-path-0.6.0
      identity: vpath
    - template: volume-pvc-0.6.0
      identity: vpvc
    - template: volume-controller-0.6.0
      identity: vctrl
    - template: volume-replica-0.6.0
      identity: vrep
```

- sample volumepolicy pvc template that fetches pod affinity annotations from pvc:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: volume-pvc-0.6.0
  annotations:
    openebs.io/policy: VolumePolicy
    policy.openebs.io/version: 0.6.0
  namespace: default
data:
  meta: |
    runNamespace: {{ .Volume.runNamespace }}
    apiVersion: v1
    kind: PersistentVolumeClaim
    objectName: {{ .Volume.pvc }}
    action: get
    queries:
    - alias: objectName
      path: |-
        {.metadata.name}
    - alias: affinity
      path: |-
        {.metadata.annotations.controller\.openebs\.io/affinity}
    - alias: affinityTopology
      path: |-
        {.metadata.annotations.controller\.openebs\.io/affinity-topology}
```

- sample volumepolicy controller template snippet:
```yaml
        spec:
          {{- if ne .TaskResult.vpvc.affinity "" }}
          affinity:
            podAffinity:
              requiredDuringSchedulingIgnoredDuringExecution:
              - labelSelector:
                  matchExpressions:
                  - key: controller.openebs.io/affinity
                    operator: In
                    values:
                    - {{ .TaskResult.vpvc.affinity }}
                topologyKey: {{ .TaskResult.vpvc.affinityTopology | default "kubernetes.io/hostname" }}
          {{- end }}
```

4/ What side-effects does this change have?

- Inter-pod affinity and anti-affinity require substantial
amount of processing which can slow down scheduling in
large clusters significantly. We do not recommend using them
in clusters larger than several hundred nodes.

- There are currently two types of pod affinity:
  1/ requiredDuringSchedulingIgnoredDuringExecution and
  2/ preferredDuringSchedulingIgnoredDuringExecution
which denote “hard” vs. “soft” requirements.

volume controller uses hard requirement & hence there are chances
to the volume controller pod being put into a pending state till the
application pod is not created.

Signed-off-by: AmitKumarDas <amit.das@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
