### PR TITLE
Add groupcache transitive dependency to Gopkg.toml

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -19,7 +19,7 @@
 #  name = "github.com/x/y"
 #  version = "2.4.0"
 
-required = ["k8s.io/code-generator/cmd/client-gen"]
+required = ["k8s.io/code-generator/cmd/client-gen","github.com/golang/groupcache"]
 
 ignored = ["github.com/aws/aws-sdk-go/aws/credentials/endpointcreds","github.com/emicklei/go-restful/swagger","k8s.io/client-go/pkg/api/v1"]
 


### PR DESCRIPTION
1. Why is this change necessary ?
   Add github.com/golang/groupcache onto Gopkg.toml file until the crd-watcher importing this transitive dependency is merged. Related to https://github.com/openebs/maya/pull/279

2. How does this change address the issue ?
   dep makes sure that this package is not deleted even if it not
imported for every dep ensure.

Signed-off-by: gkGaneshR <gkganesh126@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**Special notes for your reviewer**:
This can be removed from Gopkg.toml file once the crd shared informer is merged.
