### PR TITLE
Setup cstor-pool unit testing in pod

### DIFF
--- a/buildscripts/cstor-pool-mgmt/Dockerfile.test
+++ b/buildscripts/cstor-pool-mgmt/Dockerfile.test
@@ -1,0 +1,35 @@
+#
+# This Dockerfile runs cstor-pool-mgmt tests using the latest binary from
+# cstor-pool-mgmt  releases.
+#
+
+#openebs/cstor-base is the image that contains cstor related binaries and
+#libraries - zpool, zfs, zrepl
+FROM openebs/cstor-base:ci
+
+ARG DAPPER_HOST_ARCH=amd64
+ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
+ENV PATH /go/bin:$PATH
+
+# Install Go & tools
+ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
+    GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
+RUN wget -O - https://dl.google.com/go/go1.9.4.linux-amd64.tar.gz | tar -xzf - -C /usr/local && \
+	go version
+
+ENV PROJECT=$GOPATH/src/github.com/openebs/maya
+COPY $DST_REPO $PROJECT
+#COPY $DST_REPO/buildscripts/cstor-pool-mgmt/entrypoint-test.sh 
+
+RUN chmod +x $PROJECT/entrypoint-test.sh
+
+ARG BUILD_DATE
+LABEL org.label-schema.name="cstor-pool-mgmt-test"
+LABEL org.label-schema.description="OpenEBS"
+LABEL org.label-schema.url="http://www.openebs.io/"
+LABEL org.label-schema.vcs-url="https://github.com/openebs/maya"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=$BUILD_DATE
+
+ENTRYPOINT $PROJECT/entrypoint-test.sh
+EXPOSE 7677

--- a/buildscripts/cstor-pool-mgmt/entrypoint-test.sh
+++ b/buildscripts/cstor-pool-mgmt/entrypoint-test.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -ex
+
+cd $GOPATH/src/github.com/openebs/maya
+./buildscripts/cstor-pool-mgmt/test-cov-cstor.sh
+rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+
+if [ $SRC_REPO != $DST_REPO ];
+then
+        echo "Copying coverage.txt to $SRC_REPO"
+        cp coverage.txt $SRC_REPO/
+        cd $SRC_REPO
+fi
+

--- a/buildscripts/cstor-pool-mgmt/pod-cstor-pool-test.yaml
+++ b/buildscripts/cstor-pool-mgmt/pod-cstor-pool-test.yaml
@@ -1,0 +1,53 @@
+# The pod runs unit tests for cstor-pool-mgmt.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cstor-pool-test
+  # Note that the Pod does not need to be in the same namespace as the loader.
+  labels:
+    app: cstor-pool-test
+spec:
+#  serviceAccountName: openebs-maya-operator
+  containers:
+  - name: cstor-pool
+    image: openebs/cstor-main:ci
+    ports:
+    - containerPort: 80
+    securityContext: 
+      privileged: true
+
+    volumeMounts:
+    - name: device
+      mountPath: /host/dev     
+      mountPropagation: Bidirectional
+    - name: tmp
+      mountPath: /tmp
+      mountPropagation: Bidirectional
+
+ 
+  - name:    cstor-pool-mgmt-test
+    image: openebs/cstor-test:ci
+    ports:
+    - containerPort: 80
+    securityContext: 
+      privileged: true
+    volumeMounts:
+    - name: device
+      mountPath: /host/dev
+      mountPropagation: Bidirectional
+    - name: tmp
+      mountPath: /tmp
+      mountPropagation: Bidirectional
+
+  volumes:
+  - name: device
+    hostPath:
+      # directory location on host
+      path: /dev
+      # this field is optional
+      type: Directory
+  - name: tmp
+    hostPath:
+      path: /tmp
+      type: Directory

--- a/buildscripts/cstor-pool-mgmt/test-cov-cstor.sh
+++ b/buildscripts/cstor-pool-mgmt/test-cov-cstor.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd cmd/cstor-pool-mgmt
+
+echo "" > coverage.txt
+
+for d in $(go list ./... | grep -v controller); do
+    #TODO - Include -race while creating the coverage profile. 
+    go test -coverprofile=profile.out -covermode=atomic $d
+    if [ -f profile.out ]; then
+        cat profile.out >> coverage.txt
+        rm profile.out
+    fi
+done

--- a/buildscripts/cstor-pool-mgmt/travis-test-cstor.sh
+++ b/buildscripts/cstor-pool-mgmt/travis-test-cstor.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -ex
+
+# Copyright 2017 The OpenEBS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cp ./buildscripts/cstor-pool-mgmt/Dockerfile.test .
+cp ./buildscripts/cstor-pool-mgmt/entrypoint-test.sh .
+cp ./buildscripts/cstor-pool-mgmt/test-cov-cstor.sh .
+
+#make golint-travis
+#rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+
+sudo docker build -f Dockerfile.test -t openebs/cstor-test:ci .
+kubectl apply -f ./buildscripts/cstor-pool-mgmt/pod-cstor-pool-test.yaml


### PR DESCRIPTION
1. Why is this change necessary ?
fixes: openebs/openebs#1388

2. How does this change address the issue ?
Run unit tests inside pod, by copying openebs/maya with the latest commit,
install golang on top of cstor-base image(containing zpool, zfs binaries).

3. How to verify this change ?
The unit tests will be run in business logic - openebs/maya#284.

Signed-off-by: gkGaneshR <gkganesh126@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
