### PR TITLE
Fix mayactl volume stats command

### DIFF
--- a/cmd/mayactl/app/command/volume_stats.go
+++ b/cmd/mayactl/app/command/volume_stats.go
@@ -93,7 +93,6 @@ func (c *CmdVolumeStatsOptions) RunVolumeStats(cmd *cobra.Command) error {
 		err2, err4      int
 		status          v1.VolStatus
 		stats1, stats2  v1.VolumeMetrics
-		repStatus       string
 		statusArray     []string //keeps track of the replica's status such as IP, Status and Revision counter.
 	)
 
@@ -111,16 +110,6 @@ func (c *CmdVolumeStatsOptions) RunVolumeStats(cmd *cobra.Command) error {
 	if annotation.ControllerStatus != "Running" {
 		fmt.Println("Volume not reachable")
 		return nil
-	}
-
-	//replicaCount := 0
-	replicaStatus := strings.Split(annotation.ReplicaStatus, ",")
-	for _, repStatus = range replicaStatus {
-		if repStatus == "Pending" {
-			statusArray = append(statusArray, "Unknown")
-			statusArray = append(statusArray, "Unknown")
-			statusArray = append(statusArray, "Unknown")
-		}
 	}
 
 	replicas := strings.Split(annotation.Replicas, ",")
@@ -302,13 +291,13 @@ func (a *Annotations) DisplayStats(c *CmdVolumeStatsOptions, statusArray []strin
 		q.Flush()
 
 		w := tabwriter.NewWriter(os.Stdout, v1.MinWidth, v1.MaxWidth, v1.Padding, ' ', tabwriter.AlignRight|tabwriter.Debug)
-		fmt.Println("\n----------- Performance Stats -----------\n")
+		fmt.Println("\n----------- Performance Stats -----------")
 		fmt.Fprintf(w, "r/s\tw/s\tr(MB/s)\tw(MB/s)\trLat(ms)\twLat(ms)\t\n")
 		fmt.Fprintf(w, "%d\t%d\t%.3f\t%.3f\t%.3f\t%.3f\t\n", readIOPS, writeIOPS, float64(rThroughput)/v1.BytesToMB, float64(wThroughput)/v1.BytesToMB, float64(ReadLatency)/v1.MicSec, float64(WriteLatency)/v1.MicSec)
 		w.Flush()
 
 		x := tabwriter.NewWriter(os.Stdout, v1.MinWidth, v1.MaxWidth, v1.Padding, ' ', tabwriter.AlignRight|tabwriter.Debug)
-		fmt.Println("\n------------ Capacity Stats -------------\n")
+		fmt.Println("\n------------ Capacity Stats -------------")
 		fmt.Fprintf(x, "Logical(GB)\tUsed(GB)\t\n")
 		fmt.Fprintf(x, "%.3f\t%.3f\t\n", logicalSize/v1.BytesToGB, actualUsed/v1.BytesToGB)
 		x.Flush()

--- a/cmd/mayactl/app/command/volume_stats_test.go
+++ b/cmd/mayactl/app/command/volume_stats_test.go
@@ -11,12 +11,12 @@ func TestDisplayStats(t *testing.T) {
 		TargetPortal:     "10.99.73.74:3260",
 		ClusterIP:        "10.99.73.74",
 		Iqn:              "iqn.2016-09.com.openebs.jiva:vol1",
-		ReplicaCount:     "2",
+		ReplicaCount:     "3",
 		ControllerStatus: "Running",
-		ReplicaStatus:    "Running,Running",
+		ReplicaStatus:    "Running,Running,Offline",
 		VolSize:          "1G",
 		ControllerIP:     "",
-		Replicas:         "10.10.10.10,10.10.10.11",
+		Replicas:         "10.10.10.10,10.10.10.11,nil",
 	}
 
 	validStats := map[string]struct {
@@ -39,6 +39,9 @@ func TestDisplayStats(t *testing.T) {
 				"10.10.10.11",
 				"Online",
 				"1",
+				"nil",
+				"Offline",
+				"Unknown",
 			},
 			initialStats: v1.VolumeMetrics{
 				Name:                 "vol1",
@@ -86,6 +89,9 @@ func TestDisplayStats(t *testing.T) {
 				"10.10.10.11",
 				"Online",
 				"1",
+				"nil",
+				"Offline",
+				"Unknown",
 			},
 			initialStats: v1.VolumeMetrics{
 				Name:                 "vol1",
@@ -133,6 +139,9 @@ func TestDisplayStats(t *testing.T) {
 				"10.10.10.11",
 				"Online",
 				"1",
+				"nil",
+				"Offline",
+				"Unknown",
 			},
 			initialStats: v1.VolumeMetrics{
 				Name:                 "vol1",
@@ -180,6 +189,9 @@ func TestDisplayStats(t *testing.T) {
 				"10.10.10.11",
 				"Online",
 				"1",
+				"nil",
+				"Offline",
+				"Unknown",
 			},
 			initialStats: v1.VolumeMetrics{
 				Name:                 "vol1",


### PR DESCRIPTION
`mayactl volume stats --volname <vol>` shows incorrect information

1. Why is this change necessary ?
- To fix the issue openebs/openebs#1397
- Improve Unit test

2. How does this change address the issue ?
- This commit fixes the issue by removing the unneccessary code.

3. How to verify this change ?
- Create the volume with minimum three replicas
- Run `mayactl volume stats --volname <vol>` and it should show the
  desired output.

4. What side effects does this change have ?
- none

5. Other details
- none

Signed-off-by: utkarshmani1997 <utkarshmani1997@gmail.com>

- fix: openebs/openebs#1397

<!--  Thanks for sending a pull request!  Here are some tips for you -->
<!--
**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
