### PR TITLE
push m-apiserver:ci image to quay.io repo

### DIFF
--- a/buildscripts/apiserver/push
+++ b/buildscripts/apiserver/push
@@ -21,3 +21,12 @@ then
 else
   echo "No docker credentials provided. Skip uploading openebs/m-apiserver:ci to docker hub"; 
 fi;
+
+# Push ci image to quay.io for security scanning
+if [ ! -z "${QNAME}" ] && [ ! -z "${QPASS}" ]; 
+then 
+  sudo docker login -u "${QNAME}" -p "${QPASS}" quay.io;
+  sudo docker tag ${IMAGEID} quay.io/openebs/m-apiserver:ci;
+else
+  echo "Missing quay.io credentials. Skip uploading openebs/m-apiserver:ci to quay.io"; 
+fi;


### PR DESCRIPTION
Signed-off-by: kmova <kiran.mova@openebs.io>

This PR adds the capability to push the m-apiserver:ci image to quay.io container repository: https://quay.io/repository/openebs/m-apiserver. 

The intent in pushing to quay.io repository is to explore the feasibility of enabling automated security scans and get additional container usage statistics. The changes can be further extended to push tagged images also to quay in the future. 