### PR TITLE
Change bootstrapper for minikube-0.26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ install:
   - make bootstrap
 before_script:
   # Download kubectl, which is a requirement for using minikube.
-  - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+  - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
   # Download minikube.
   - curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-  - sudo minikube start --vm-driver=none --kubernetes-version=v1.7.0 --extra-config=apiserver.Authorization.Mode=RBAC
+  - sudo minikube start --vm-driver=none --bootstrapper=localkube --kubernetes-version=v1.8.0 --extra-config=apiserver.Authorization.Mode=RBAC
   # Fix the kubectl context, as it's often stale.
   - minikube update-context
   # Wait for Kubernetes to be up and ready.


### PR DESCRIPTION
1. Why is this change necessary ?
fixes: openebs/openebs#298

2. How does this change address the issue ?
Trying to start kubelet inside travis in minikube-0.26 fails. minikube-0.26
makes use of kubeadm bootstrapper which tries to start systemctl-kubelet. Overriding
with localkube bootstrapper(same as v0.25) solves the issue as of now. Also,
the version of kubectl is changed to 1.8 to match vendor.

3. How to verify this change ?
--bootstrapper=localkube flag is added while starting minikube.

Signed-off-by: gkGaneshR <gkganesh126@gmail.com>

**Special notes for your reviewer**:
Ref: https://github.com/kubernetes/minikube/issues/2704