### PR TITLE
Fix travis build error with minikube 1.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ install:
   - make bootstrap
 before_script:
   # Download kubectl, which is a requirement for using minikube.
-  - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+  - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.4/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
   # Download minikube.
   - curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-  - sudo minikube start --vm-driver=none --kubernetes-version=v1.7.0 --extra-config=apiserver.Authorization.Mode=RBAC
+  - sudo minikube start --vm-driver=none --bootstrapper=localkube --kubernetes-version=v1.9.4 --extra-config=apiserver.Authorization.Mode=RBAC
   # Fix the kubectl context, as it's often stale.
   - minikube update-context
   # Wait for Kubernetes to be up and ready.

--- a/ci/helm_install_openebs.sh
+++ b/ci/helm_install_openebs.sh
@@ -3,16 +3,23 @@
 kubectl -n kube-system create sa tiller 
 kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller 
 kubectl -n kube-system patch deploy/tiller-deploy -p '{"spec": {"template": {"spec": {"serviceAccountName": "tiller"}}}}' 
+# With helm 2.9.0 and K8s 1.9.x there is an issue 
+# Use the following workaround to enable access
+# https://github.com/kubernetes/helm/issues/3985#issuecomment-385102874
+kubectl -n kube-system patch deployment tiller-deploy -p '{"spec": {"template": {"spec": {"automountServiceAccountToken": true}}}}'
 
 #Replace this with logic to wait till the pods are running
 sleep 60
 kubectl get pods --all-namespaces 
 kubectl get sa --all-namespaces
 
-helm repo add openebs-charts https://openebs.github.io/charts/
 helm repo update
-helm install openebs-charts/openebs --name ci --set apiserver.imageTag="ci",apiserver.replicas="1",jiva.replicas="1"
+helm version
+helm install stable/openebs --name ci --namespace openebs --set apiserver.imageTag="ci",jiva.replicas="1"
 
 #Replace this with logic to wait till the pods are running
 sleep 30
-kubectl get pods --all-namespaces -o yaml
+kubectl get pods --all-namespaces
+sleep 30
+kubectl apply -f https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-storageclasses.yaml
+

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-MAPI_SVC_ADDR=`kubectl get service -n openebs ci-openebs-maya-apiservice -o json | grep clusterIP | awk -F\" '{print $4}'`
+MAPI_SVC_ADDR=`kubectl get service -n openebs ci-openebs-apiservice -o json | grep clusterIP | awk -F\" '{print $4}'`
 export MAPI_ADDR="http://${MAPI_SVC_ADDR}:5656"
 export KUBERNETES_SERVICE_HOST="127.0.0.1"
 export MAYACTL="$GOPATH/src/github.com/openebs/maya/bin/maya/maya"

--- a/ci/ubuntu-compile-nsenter.sh
+++ b/ci/ubuntu-compile-nsenter.sh
@@ -16,7 +16,7 @@
 set -e
 
 sudo apt-get update
-sudo apt-get install libncurses5-dev libslang2-dev gettext zlib1g-dev libselinux1-dev debhelper lsb-release pkg-config po-debconf autoconf automake autopoint libtool
+sudo apt-get install libncurses5-dev libslang2-dev gettext zlib1g-dev libselinux1-dev debhelper lsb-release pkg-config po-debconf autoconf automake autopoint libtool bison
 mkdir .tmp || true
 wget https://www.kernel.org/pub/linux/utils/util-linux/v2.30/util-linux-2.30.2.tar.gz -qO - | tar -xz -C .tmp/
 cd .tmp/util-linux-2.30.2 && ./autogen.sh && ./configure && make nsenter


### PR DESCRIPTION
Travis builds on PRs are failing, due to setup issues with minikube 1.7.0

Found a couple of issues: 
- minikube has changed the way services are installed. a bootstrapper flag has to be specified. 
- helm had issues connecting to tiller, had to use a workaround of granting additional permissions. 
While fixing the above, also made the change to use the latest kubernetes stable openebs charts. 

