### PR TITLE
Fix travis-failure master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ install:
   - make bootstrap
 before_script:
   # Download kubectl, which is a requirement for using minikube.
-  - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+   - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.4/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
   # Download minikube.
   - curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-  - sudo minikube start --vm-driver=none --bootstrapper=localkube --kubernetes-version=v1.8.0 --extra-config=apiserver.Authorization.Mode=RBAC
+  - sudo minikube start --vm-driver=none --bootstrapper=localkube --kubernetes-version=v1.9.4 --extra-config=apiserver.Authorization.Mode=RBAC
   # Fix the kubectl context, as it's often stale.
   - minikube update-context
   # Wait for Kubernetes to be up and ready.

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - make bootstrap
 before_script:
   # Download kubectl, which is a requirement for using minikube.
-   - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.4/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+  - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.4/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
   # Download minikube.
   - curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
   - sudo minikube start --vm-driver=none --bootstrapper=localkube --kubernetes-version=v1.9.4 --extra-config=apiserver.Authorization.Mode=RBAC

--- a/ci/helm_install_openebs.sh
+++ b/ci/helm_install_openebs.sh
@@ -9,9 +9,9 @@ sleep 30
 kubectl get pods --all-namespaces 
 kubectl get sa
 
-helm repo add openebs-charts https://openebs.github.io/charts/
 helm repo update
-helm install openebs-charts/openebs --name ci --set apiserver.tag="ci",jiva.replicas="1"
+helm version
+helm install stable/openebs --name ci --namespace openebs --set apiserver.imageTag="ci",jiva.replicas="1"
 
 #Replace this with logic to wait till the pods are running
 sleep 30

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-MAPI_SVC_ADDR=`kubectl get service -n openebs ci-openebs-maya-apiservice -o json | grep clusterIP | awk -F\" '{print $4}'`
+MAPI_SVC_ADDR=`kubectl get service -n openebs ci-openebs-apiservice -o json | grep clusterIP | awk -F\" '{print $4}'`
 export MAPI_ADDR="http://${MAPI_SVC_ADDR}:5656"
 export KUBERNETES_SERVICE_HOST="127.0.0.1"
 export MAYACTL="$GOPATH/src/github.com/openebs/maya/bin/maya/mayactl"

--- a/ci/ubuntu-compile-nsenter.sh
+++ b/ci/ubuntu-compile-nsenter.sh
@@ -16,7 +16,7 @@
 set -e
 
 sudo apt-get update
-sudo apt-get install libncurses5-dev libslang2-dev gettext zlib1g-dev libselinux1-dev debhelper lsb-release pkg-config po-debconf autoconf automake autopoint libtool
+sudo apt-get install libncurses5-dev libslang2-dev gettext zlib1g-dev libselinux1-dev debhelper lsb-release pkg-config po-debconf autoconf automake autopoint libtool bison
 mkdir .tmp || true
 wget https://www.kernel.org/pub/linux/utils/util-linux/v2.30/util-linux-2.30.2.tar.gz -qO - | tar -xz -C .tmp/
 cd .tmp/util-linux-2.30.2 && ./autogen.sh && ./configure && make nsenter


### PR DESCRIPTION
     Fix travis build error with minikube 1.7.0

     The following changes were made:
      - Upgrading the minikube to 1.9.4 and also specifying the bootstrapper as localkube
      - Use the kubernetes stable chart and make the change to maya-apiservce env accordingly
      - Fix issue with helm 2.9.0 connecting to tiller

Signed-off-by: gkGaneshR <gkganesh126@gmail.com>
