### PR TITLE
Change version to cstor-integration-v0.6

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-v0.6.0
+cstor-integration-v0.6


### PR DESCRIPTION
For cstor-feature-integration branch, the version file needs to be
changed to cstor-integration-v0.6

Signed-off-by: gkGaneshR <gkganesh126@gmail.com>


