### PR TITLE
Change version to cstor-integration-v0.6

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,6 +17,9 @@ EXTERNAL_TOOLS=\
 # list only our .go files i.e. exlcudes any .go files from the vendor directory
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
+VERSION=$(shell cat VERSION)
+export VERSION
+
 # Specify the name for the binaries
 MAYACTL=mayactl
 APISERVER=maya-apiserver
@@ -101,7 +104,7 @@ bootstrap:
 
 maya-image:
 	@cp bin/maya/${MAYACTL} buildscripts/mayactl/
-	@cd buildscripts/mayactl && sudo docker build -t openebs/maya:ci --build-arg BUILD_DATE=${BUILD_DATE} .
+	@cd buildscripts/mayactl && sudo docker build -t openebs/maya:${VERSION}-ci --build-arg BUILD_DATE=${BUILD_DATE} .
 	@rm buildscripts/mayactl/${MAYACTL}
 	@sh buildscripts/mayactl/push
 
@@ -122,7 +125,7 @@ agent-image: maya-agent
 	@echo "--> m-agent image         "
 	@echo "----------------------------"
 	@cp bin/agent/${AGENT} buildscripts/agent/
-	@cd buildscripts/agent && sudo docker build -t openebs/m-agent:ci --build-arg BUILD_DATE=${BUILD_DATE} .
+	@cd buildscripts/agent && sudo docker build -t openebs/m-agent:${VERSION}-ci --build-arg BUILD_DATE=${BUILD_DATE} .
 	@rm buildscripts/agent/${AGENT}
 	@sh buildscripts/agent/push
 
@@ -139,7 +142,7 @@ exporter-image: exporter
 	@echo "--> m-exporter image         "
 	@echo "----------------------------"
 	@cp bin/exporter/${EXPORTER} buildscripts/exporter/
-	@cd buildscripts/exporter && sudo docker build -t openebs/m-exporter:ci --build-arg BUILD_DATE=${BUILD_DATE} .
+	@cd buildscripts/exporter && sudo docker build -t openebs/m-exporter:${VERSION}-ci --build-arg BUILD_DATE=${BUILD_DATE} .
 	@rm buildscripts/exporter/${EXPORTER}
 	@sh buildscripts/exporter/push
 
@@ -158,7 +161,7 @@ apiserver-image: mayactl apiserver
 	@echo "----------------------------"
 	@cp bin/apiserver/${APISERVER} buildscripts/apiserver/
 	@cp bin/maya/${MAYACTL} buildscripts/apiserver/
-	@cd buildscripts/apiserver && sudo docker build -t openebs/m-apiserver:ci --build-arg BUILD_DATE=${BUILD_DATE} .
+	@cd buildscripts/apiserver && sudo docker build -t openebs/m-apiserver:${VERSION}-ci --build-arg BUILD_DATE=${BUILD_DATE} .
 	@rm buildscripts/apiserver/${APISERVER}
 	@rm buildscripts/apiserver/${MAYACTL}
 	@sh buildscripts/apiserver/push

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-v0.6.0
+cstor-integration-v0.6

--- a/buildscripts/agent/push
+++ b/buildscripts/agent/push
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -e
 
-IMAGEID=$( sudo docker images -q openebs/m-agent:ci )
+IMAGEID=$( sudo docker images -q openebs/m-agent:${VERSION}-ci )
 
 if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
 then 
   sudo docker login -u "${DNAME}" -p "${DPASS}";
   # Push image to docker hub
-  sudo docker push openebs/m-agent:ci ;
+  sudo docker push openebs/m-agent:${VERSION}-ci ;
   if [ ! -z "${TRAVIS_TAG}" ] ; 
   then
     # Push with different tags if tagged as a release
@@ -19,5 +19,5 @@ then
     sudo docker push openebs/m-agent:latest; 
   fi;
 else
-  echo "No docker credentials provided. Skip uploading openebs/m-agent:ci to docker hub"; 
+  echo "No docker credentials provided. Skip uploading openebs/m-agent:${VERSION}-ci to docker hub"; 
 fi;

--- a/buildscripts/apiserver/push
+++ b/buildscripts/apiserver/push
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -e
 
-IMAGEID=$( sudo docker images -q openebs/m-apiserver:ci )
+IMAGEID=$( sudo docker images -q openebs/m-apiserver:${VERSION}-ci )
 
 if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
 then 
   sudo docker login -u "${DNAME}" -p "${DPASS}";
   # Push image to docker hub
-  sudo docker push openebs/m-apiserver:ci ;
+  sudo docker push openebs/m-apiserver:${VERSION}-ci ;
   if [ ! -z "${TRAVIS_TAG}" ] ; 
   then
     # Push with different tags if tagged as a release
@@ -19,14 +19,14 @@ then
     sudo docker push openebs/m-apiserver:latest; 
   fi;
 else
-  echo "No docker credentials provided. Skip uploading openebs/m-apiserver:ci to docker hub"; 
+  echo "No docker credentials provided. Skip uploading openebs/m-apiserver:${VERSION}-ci to docker hub"; 
 fi;
 
 # Push ci image to quay.io for security scanning
 if [ ! -z "${QNAME}" ] && [ ! -z "${QPASS}" ]; 
 then 
   sudo docker login -u "${QNAME}" -p "${QPASS}" quay.io;
-  sudo docker tag ${IMAGEID} quay.io/openebs/m-apiserver:ci;
+  sudo docker tag ${IMAGEID} quay.io/openebs/m-apiserver:${VERSION}-ci;
 else
-  echo "Missing quay.io credentials. Skip uploading openebs/m-apiserver:ci to quay.io"; 
+  echo "Missing quay.io credentials. Skip uploading openebs/m-apiserver:${VERSION}-ci to quay.io"; 
 fi;

--- a/buildscripts/cstor-pool-mgmt/push
+++ b/buildscripts/cstor-pool-mgmt/push
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -e
 
-IMAGEID=$( sudo docker images -q openebs/cstor-pool-mgmt:ci )
+IMAGEID=$( sudo docker images -q openebs/cstor-pool-mgmt:${VERSION}-ci )
 
 if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
 then 
   sudo docker login -u "${DNAME}" -p "${DPASS}";
   # Push image to docker hub
-  sudo docker push openebs/cstor-pool-mgmt:ci ;
+  sudo docker push openebs/cstor-pool-mgmt:${VERSION}-ci ;
   if [ ! -z "${TRAVIS_TAG}" ] ; 
   then
     # Push with different tags if tagged as a release
@@ -19,5 +19,5 @@ then
     sudo docker push openebs/cstor-pool-mgmt:latest; 
   fi;
 else
-  echo "No docker credentials provided. Skip uploading openebs/cstor-pool-mgmt:ci to docker hub"; 
+  echo "No docker credentials provided. Skip uploading openebs/cstor-pool-mgmt:${VERSION}-ci to docker hub"; 
 fi;

--- a/buildscripts/exporter/push
+++ b/buildscripts/exporter/push
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -e
 
-IMAGEID=$( sudo docker images -q openebs/m-exporter:ci )
+IMAGEID=$( sudo docker images -q openebs/m-exporter:${VERSION}-ci )
 
 if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ];
 then
   sudo docker login -u "${DNAME}" -p "${DPASS}";
   # Push image to docker hub
-  sudo docker push openebs/m-exporter:ci ;
+  sudo docker push openebs/m-exporter:${VERSION}-ci ;
   if [ ! -z "${TRAVIS_TAG}" ] ;
   then
     # Push with different tags if tagged as a release
@@ -19,5 +19,5 @@ then
     sudo docker push openebs/m-exporter:latest;
   fi;
 else
-  echo "No docker credentials provided. Skip uploading openebs/m-exporter:ci to docker hub";
+  echo "No docker credentials provided. Skip uploading openebs/m-exporter:${VERSION}-ci to docker hub";
 fi;

--- a/buildscripts/mayactl/push
+++ b/buildscripts/mayactl/push
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -e
 
-IMAGEID=$( sudo docker images -q openebs/maya:ci )
+IMAGEID=$( sudo docker images -q openebs/maya:${VERSION}-ci )
 
 if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
 then 
   sudo docker login -u "${DNAME}" -p "${DPASS}"; 
-  sudo docker push openebs/maya:ci ; 
+  sudo docker push openebs/maya:${VERSION}-ci ; 
   if [ ! -z "${TRAVIS_TAG}" ] ; 
   then
     #Push the release tag image to docker hub repository
@@ -18,5 +18,5 @@ then
     sudo docker push openebs/maya:latest; 
   fi;
 else
-  echo "No docker credentials provided. Skip uploading openebs/maya:ci to docker hub"; 
+  echo "No docker credentials provided. Skip uploading openebs/maya:${VERSION}-ci to docker hub"; 
 fi;


### PR DESCRIPTION
1. Why is this change necessary ?
   For new cstor-feature-integration branch, the version file needs
to be changed to cstor-integration-v0.6 and docker image tags correspondingly
to cstor-integration-v0.6-ci.

2. How does this change address the issue ?
   Version file is read in makefile and being used in docker build and push commands.

Signed-off-by: gkGaneshR <gkganesh126@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**Special notes for your reviewer**:
This is to avoid conflicts while push docker images of different branches.