### PR TITLE
Add flag to specify the storage engine in maya-exporter

### DIFF
--- a/cmd/maya-exporter/app/collector/collector.go
+++ b/cmd/maya-exporter/app/collector/collector.go
@@ -313,9 +313,9 @@ func (e *VolumeExporter) collect() error {
 	aUsed = aUsed * sSize
 	aSize, _ := v1.DivideFloat64(aUsed, v1.BytesToGB)
 	actualUsed.Set(aSize)
-	size, _ := strconv.ParseInt(metrics1.Size, 10, 64)
-	size, _ = v1.DivideInt64(size, v1.BytesToGB)
-	sizeOfVolume.Set(float64(size))
+	size, _ := strconv.ParseFloat(metrics1.Size, 64)
+	size, _ = v1.DivideFloat64(size, v1.BytesToGB)
+	sizeOfVolume.Set(size)
 	url := e.VolumeControllerURL
 	url = strings.TrimSuffix(url, ":9501/v1/stats")
 	url = strings.TrimPrefix(url, "http://")

--- a/cmd/maya-exporter/app/command/command_test.go
+++ b/cmd/maya-exporter/app/command/command_test.go
@@ -1,0 +1,118 @@
+package command
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmd = &cobra.Command{
+		Short: "Collect metrics from OpenEBS volumes",
+		Long: `maya-exporter can be used to monitor openebs volumes and pools.
+It can be deployed alongside the openebs volume or pool containers as sidecars.`,
+		Example: `maya-exporter -a=http://localhost:8001 -c=:9500 -m=/metrics`,
+	}
+)
+
+func TestAddListenAddressFlag(t *testing.T) {
+	cases := map[string]struct {
+		input *cobra.Command
+		value string
+	}{
+		"Valid Command": {
+			input: cmd,
+			value: ":9500",
+		},
+	}
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			AddListenAddressFlag(tt.input, &tt.value)
+		})
+	}
+}
+
+func TestAddMetricsPathFlag(t *testing.T) {
+	cases := map[string]struct {
+		input *cobra.Command
+		value string
+	}{
+		"Valid Command": {
+			input: cmd,
+			value: ":9500",
+		},
+	}
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			AddMetricsPathFlag(tt.input, &tt.value)
+		})
+	}
+}
+
+func TestAddControllerAddressFlag(t *testing.T) {
+	cases := map[string]struct {
+		input *cobra.Command
+		value string
+	}{
+		"Valid Command": {
+			input: cmd,
+			value: ":9500",
+		},
+	}
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			AddControllerAddressFlag(tt.input, &tt.value)
+		})
+	}
+}
+
+func TestAddStorageEngineFlag(t *testing.T) {
+	cases := map[string]struct {
+		input *cobra.Command
+		value string
+	}{
+		"Valid Command": {
+			input: cmd,
+			value: ":9500",
+		},
+	}
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			AddStorageEngineFlag(tt.input, &tt.value)
+		})
+	}
+}
+
+func TestRegisterJivaStatsExporter(t *testing.T) {
+
+	cases := map[string]struct {
+		input  *VolumeExporterOptions
+		output error
+	}{
+		"ValidURL": {
+			input: &VolumeExporterOptions{
+				ControllerAddress: "http://localhost:9501",
+			},
+			output: nil,
+		},
+		"InvalidURL": {
+			input: &VolumeExporterOptions{
+				ControllerAddress: "localhost",
+			},
+			output: nil,
+		},
+	}
+
+	for name, tt := range cases {
+		prometheus.Unregister(tt.input.Exporter)
+		t.Run(name, func(t *testing.T) {
+			got := tt.input.RegisterJivaStatsExporter()
+			if !reflect.DeepEqual(got, tt.output) {
+				t.Fatalf("RegisterJivaStatsExporter() => [%v], want [%v]", got, tt.output)
+			}
+		})
+	}
+
+}

--- a/cmd/maya-exporter/app/command/exporter_test.go
+++ b/cmd/maya-exporter/app/command/exporter_test.go
@@ -1,0 +1,64 @@
+package command
+
+import (
+	"net"
+	"reflect"
+	"testing"
+)
+
+func TestInitialize(t *testing.T) {
+	cases := map[string]struct {
+		cmdOptions *VolumeExporterOptions
+		output     string
+	}{
+		"Storage engine is cstor": {
+			cmdOptions: &VolumeExporterOptions{
+				StorageEngine: "cstor",
+			},
+			output: "cstor",
+		},
+		"storage engine is jiva": {
+			cmdOptions: &VolumeExporterOptions{
+				StorageEngine: "jiva",
+			},
+			output: "jiva",
+		},
+		"storage engine is other": {
+			cmdOptions: &VolumeExporterOptions{
+				StorageEngine: "other",
+			},
+			output: "",
+		},
+	}
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := Initialize(tt.cmdOptions)
+			if !reflect.DeepEqual(got, tt.output) {
+				t.Fatalf("Initialize() => %v, want %v", got, tt.output)
+			}
+		})
+	}
+}
+
+func TestStartMayaExporter(t *testing.T) {
+	ErrorMessage := make(chan error)
+	cmdOptions := &VolumeExporterOptions{
+		ControllerAddress: "localhost:9501",
+		MetricsPath:       "/metrics",
+		ListenAddress:     ":9500",
+	}
+	go func() {
+		//Block port 9090 and attempt to start http server at 9090.
+		p1, err := net.Listen("tcp", "localhost:9500")
+		defer p1.Close()
+		if err != nil {
+			t.Log(err)
+		}
+		ErrorMessage <- cmdOptions.StartMayaExporter()
+	}()
+	msg := <-ErrorMessage
+	if msg != nil {
+		t.Log("Try to start http server in a port which is busy.")
+		t.Log(msg)
+	}
+}

--- a/cmd/maya-exporter/main.go
+++ b/cmd/maya-exporter/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"os"
 
 	"github.com/openebs/maya/cmd/maya-exporter/app/command"
@@ -14,7 +15,7 @@ func main() {
 	os.Exit(0)
 }
 
-// Run maya-agent
+// Run maya-exporter
 func run() error {
 	// Init logging
 	mayalogger.InitLogs()
@@ -23,6 +24,7 @@ func run() error {
 	// Create & execute new command
 	cmd, err := command.NewCmdVolumeExporter()
 	if err != nil {
+		log.Println("Can't execute the command, found err :", err)
 		return err
 	}
 


### PR DESCRIPTION
This commit adds the flag `storage.engine` or `-e` which can be
used to specify the storage engine while running the binary.

On branch feature-#1466
Changes to be committed:
	modified:   app/collector/collector.go
	modified:   app/command/command.go
	new file:   app/command/command_test.go
	modified:   app/command/exporter.go
	new file:   app/command/exporter_test.go
	modified:   main.go

1. Why is this change necessary ?
- Refer to issue openebs/openebs#1312 and openebs/openebs#1466

2. How does this change address the issue ?
- This commit adds the option for specifying the storage engine
  via a flag which can be passed while running the binary.
- This commit changes the type of size from int64 to float64.Hence
  now the output will not be zero if volume size is less than 1GB.

3. How to verify this change ?
- Build and Run the binary with flag "-e" followed by storage engine
  and you should be able to get the result something like given below.
```
$ ./maya-exporter -e="cstor"
I0516 13:26:16.104162   26957 command.go:90] Starting maya-exporter ...
I0516 13:26:16.104235   26957 logs.go:43] maya-exporter does not support cstor yet
```
4. What side effects does this change have ?
- For deployment purpose following changes are needed if storage engine
  is cstor else no change is required because jiva is the default storage
  engine.
```
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: maya-exporter
spec:
  replicas: 1
  template:
    metadata:
      labels:
        name: maya-exporter
    spec:
      # serviceAccountName: prometheus
      containers:
        - name: maya-exporter
          image: openebs/m-exporter:ci
          command: ["maya-exporter"]
          args:
            - "-e=cstor"
          ports:
          - containerPort: 9500
```

5. Other details
- Unit tests added which covers 42% of the statements.
- More effort needed to improve the code coverage which will be
  done in other PRs.

Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>
