### PR TITLE
Add flag to specify the storage engine in maya-exporter

### DIFF
--- a/cmd/maya-exporter/app/command/command.go
+++ b/cmd/maya-exporter/app/command/command.go
@@ -53,7 +53,7 @@ func AddMetricsPathFlag(cmd *cobra.Command, value *string) {
 // controllers IP.
 func AddControllerAddressFlag(cmd *cobra.Command, value *string) {
 	cmd.Flags().StringVarP(value, "controller.addr", "c", *value,
-		"Address of the Jiva volume controller.")
+		"IP address from where metrics to be exported")
 }
 
 // AddCASTypeFlag is used to create flag to pass the storage engine name

--- a/cmd/maya-exporter/app/command/command_test.go
+++ b/cmd/maya-exporter/app/command/command_test.go
@@ -1,0 +1,55 @@
+package command
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmd = &cobra.Command{
+		Short: "Collect metrics from OpenEBS volumes",
+		Long: `maya-exporter can be used to monitor openebs volumes and pools.
+It can be deployed alongside the openebs volume or pool containers as sidecars.`,
+		Example: `maya-exporter -a=http://localhost:8001 -c=:9500 -m=/metrics`,
+	}
+)
+
+func TestRegisterJivaStatsExporter(t *testing.T) {
+	cases := map[string]struct {
+		option *VolumeExporterOptions
+		output error
+	}{
+		"ValidURL": {
+			option: &VolumeExporterOptions{
+				ControllerAddress: "http://localhost:9501",
+			},
+			output: nil,
+		},
+		"InvalidURL": {
+			option: &VolumeExporterOptions{
+				ControllerAddress: "localhost",
+			},
+			output: errors.New("Error in parsing the URI"),
+		},
+        	"EmptyURL": {
+			option: &VolumeExporterOptions{
+				ControllerAddress: "",
+			},
+			output: errors.New("Error in parsing the URI"),
+		},
+
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := tt.option.RegisterJivaStatsExporter()
+			if !reflect.DeepEqual(got, tt.output) {
+				t.Fatalf("RegisterJivaStatsExporter() => [%v], want [%v]", got, tt.output)
+			}
+		})
+	}
+
+}

--- a/cmd/maya-exporter/app/command/exporter_test.go
+++ b/cmd/maya-exporter/app/command/exporter_test.go
@@ -1,0 +1,79 @@
+package command
+
+import (
+	"errors"
+	"net"
+	"reflect"
+	"testing"
+)
+
+func TestInitialize(t *testing.T) {
+	cases := map[string]struct {
+		cmdOptions *VolumeExporterOptions
+		output     string
+	}{
+		"Storage engine is cstor": {
+			cmdOptions: &VolumeExporterOptions{
+				CASType: "cstor",
+			},
+			output: "cstor",
+		},
+		"storage engine is jiva": {
+			cmdOptions: &VolumeExporterOptions{
+				CASType: "jiva",
+			},
+			output: "jiva",
+		},
+		"storage engine is other": {
+			cmdOptions: &VolumeExporterOptions{
+				CASType: "other",
+			},
+			output: "",
+		},
+	}
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := Initialize(tt.cmdOptions)
+			if got != tt.output {
+				t.Fatalf("Initialize() => %v, want %v", got, tt.output)
+			}
+		})
+	}
+}
+func TestStartMayaExporter(t *testing.T) {
+	ErrorMessage := make(chan error)
+	cases := map[string]struct {
+		cmdOptions *VolumeExporterOptions
+		err        error
+	}{
+		"If port is busy and path is `/metrics`": {
+			cmdOptions: &VolumeExporterOptions{
+				ControllerAddress: "localhost:9501",
+				MetricsPath:       "/metrics",
+				ListenAddress:     ":9500",
+			},
+			err: errors.New("bind address already in use, please use another address"),
+		},
+	}
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			startTestServer(t, tt.cmdOptions, ErrorMessage)
+			msg := <-ErrorMessage
+			if !reflect.DeepEqual(msg, tt.err) {
+				t.Fatalf("StartMayaExporter() : expected %v, got %v", tt.err, msg)
+			}
+		})
+	}
+}
+
+func startTestServer(t *testing.T, options *VolumeExporterOptions, errMsg chan error) {
+	go func() {
+		//Block port 9500 and attempt to start http server at 9500.
+		listener, err := net.Listen("tcp", "localhost:9500")
+		defer listener.Close()
+		if err != nil {
+			t.Log(err)
+		}
+		errMsg <- options.StartMayaExporter()
+	}()
+}

--- a/cmd/maya-exporter/main.go
+++ b/cmd/maya-exporter/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"os"
 
 	"github.com/openebs/maya/cmd/maya-exporter/app/command"
@@ -14,7 +15,7 @@ func main() {
 	os.Exit(0)
 }
 
-// Run maya-agent
+// Run maya-exporter
 func run() error {
 	// Init logging
 	mayalogger.InitLogs()
@@ -23,6 +24,7 @@ func run() error {
 	// Create & execute new command
 	cmd, err := command.NewCmdVolumeExporter()
 	if err != nil {
+		log.Println("Can't execute the command, found err :", err)
 		return err
 	}
 


### PR DESCRIPTION
This commit adds the flag `storage.engine` or `-e` which can be
used to specify the storage engine while running the binary.

On branch feature-#1466
Changes to be committed:
	modified:   app/command/command.go
	new file:   app/command/command_test.go
	modified:   app/command/exporter.go
	new file:   app/command/exporter_test.go
	modified:   main.go

1. Why is this change necessary ?
- Refer to issue openebs/openebs#1466

2. How does this change address the issue ?
- This commit adds the option for specifying the storage engine
  via a flag which can be passed while running the binary.

3. How to verify this change ?
- Build and Run the binary with flag "-e" followed by storage engine
  and you should be able to get the result something like given below.
```
$ ./maya-exporter -e="cstor"
I0516 13:26:16.104162   26957 command.go:90] Starting maya-exporter ...
I0516 13:26:16.104235   26957 logs.go:43] maya-exporter does not support cstor yet
```
4. What side effects does this change have ?
- For deployment purpose following changes are needed if storage engine
  is cstor else no change is required because jiva is the default storage
  engine.
```
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: maya-exporter
spec:
  replicas: 1
  template:
    metadata:
      labels:
        name: maya-exporter
    spec:
      # serviceAccountName: prometheus
      containers:
        - name: maya-exporter
          image: openebs/m-exporter:ci
          command: ["maya-exporter"]
          args:
            - "-e=cstor"
          ports:
          - containerPort: 9500
```

5. Other details
- Unit tests added which covers 42% of the statements.
- More effort needed to improve the code coverage which will be
  done in other PRs.

Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>
