### PR TITLE
Added Unit test for getClientSet() in util_test.go

### DIFF
--- a/orchprovider/k8s/v1/util_test.go
+++ b/orchprovider/k8s/v1/util_test.go
@@ -139,16 +139,16 @@ func TestK8sUtilServices(t *testing.T) {
 	}
 }
 
-func TestK8sUtilgetInClusterCS(t *testing.T) {
+func TestK8sUtilgetClientSet(t *testing.T) {
 	type fields struct {
 		namespace string
 		inCS      *kubernetes.Clientset
 	}
 	tests := []struct {
-		name              string
-		fields            fields
-		expectedClientset *kubernetes.Clientset
-		expectedErr       string
+		name        string
+		fields      fields
+		expectedCS  *kubernetes.Clientset
+		expectedErr string
 	}{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -156,12 +156,12 @@ func TestK8sUtilgetInClusterCS(t *testing.T) {
 				namespace: tt.fields.namespace,
 				inCS:      tt.fields.inCS,
 			}
-			gotClientset, err := k.getInClusterCS()
-			if err != nil && err.Error() != tt.expectedErr {
-				t.Errorf("k8sUtil.getInClusterCS() error = %v, expected Error  %v", err, tt.expectedErr)
+			got, err := k.getClientSet()
+			if (err != nil) && err.Error() != tt.expectedErr {
+				t.Errorf("k8sUtil.getClientSet() error = %v, expected Error %v", err, tt.expectedErr)
 			}
-			if gotClientset != tt.expectedClientset {
-				t.Errorf("k8sUtil.getInClusterCS() = %v, want %v", gotClientset, tt.expectedClientset)
+			if got != tt.expectedCS {
+				t.Errorf("k8sUtil.getClientSet() = %v, want %v", got, tt.expectedCS)
 			}
 		})
 	}

--- a/orchprovider/k8s/v1/util_test.go
+++ b/orchprovider/k8s/v1/util_test.go
@@ -138,7 +138,6 @@ func TestK8sUtilServices(t *testing.T) {
 		}
 	}
 }
-
 func TestK8sUtilgetClientSet(t *testing.T) {
 	type fields struct {
 		namespace string

--- a/orchprovider/k8s/v1/util_test.go
+++ b/orchprovider/k8s/v1/util_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/openebs/maya/types/v1"
 	volProfile "github.com/openebs/maya/volume/profiles"
+	"k8s.io/client-go/kubernetes"
 )
 
 // TestK8sUtilInterfaceCompliance verifies if k8sUtil implements
@@ -135,5 +136,33 @@ func TestK8sUtilServices(t *testing.T) {
 		if err != nil && err.Error() != c.err {
 			t.Errorf("TestCase: '%d' ExpectedServicesErr: '%s' ActualServicesErr: '%s'", i, c.err, err.Error())
 		}
+	}
+}
+
+func TestK8sUtilgetInClusterCS(t *testing.T) {
+	type fields struct {
+		namespace string
+		inCS      *kubernetes.Clientset
+	}
+	tests := []struct {
+		name              string
+		fields            fields
+		expectedClientset *kubernetes.Clientset
+		expectedErr       string
+	}{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := &k8sUtil{
+				namespace: tt.fields.namespace,
+				inCS:      tt.fields.inCS,
+			}
+			gotClientset, err := k.getInClusterCS()
+			if err != nil && err.Error() != tt.expectedErr {
+				t.Errorf("k8sUtil.getInClusterCS() error = %v, expected Error  %v", err, tt.expectedErr)
+			}
+			if gotClientset != tt.expectedClientset {
+				t.Errorf("k8sUtil.getInClusterCS() = %v, want %v", gotClientset, tt.expectedClientset)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Subham Verma <subhamverma2407@gmail.com>



**What this PR does / why we need it**:
- Added Unit Test Case for getClientSet in util_test.go
- To reduce run time logic errors

**Which issue this PR fixes**
This PR fixes issue #797 of 
https://github.com/openebs/openebs/issues/797

