### PR TITLE
Add apiserver flag in mayactl command

### DIFF
--- a/cmd/mayactl/app/command/commands.go
+++ b/cmd/mayactl/app/command/commands.go
@@ -18,8 +18,12 @@ import (
 	"flag"
 
 	"github.com/openebs/maya/cmd/mayactl/app/command/snapshot"
+	"github.com/openebs/maya/pkg/client/mapiserver"
 	"github.com/spf13/cobra"
 )
+
+// Variable to capture value from --apiserver flag
+var apiserver *string
 
 // NewCommand creates the `maya` command and its nested children.
 func NewMayaCommand() *cobra.Command {
@@ -27,19 +31,27 @@ func NewMayaCommand() *cobra.Command {
 		Use:   "mayactl",
 		Short: "Maya means 'Magic'a tool for storage orchestration",
 		Long:  `Maya means 'Magic' a tool for storage orchestration`,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+		},
+		// PersistentPreRun is used so that it is inherited in all child commands
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			flagValue := cmd.Flag("apiserver").Value.String()
+			if !(flagValue == "") {
+				mapiserver.SetFlag(flagValue)
+			}
+		},
 	}
-
 	cmd.AddCommand(
 		NewCmdVersion(),
 		NewCmdVolume(),
 		snapshot.NewCmdSnapshot(),
 	)
-
+	// Register --apiserver flag to mayactl command with persistence to all child commands
+	apiserver = cmd.PersistentFlags().StringP("apiserver", "a", "", "IP to connect to maya server[format:scheme://apiserverIP:port]")
 	// add the glog flags
 	cmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 
 	// TODO: switch to a different logging library.
-	flag.CommandLine.Parse([]string{})
-
 	return cmd
 }

--- a/cmd/mayactl/app/command/volumes_list.go
+++ b/cmd/mayactl/app/command/volumes_list.go
@@ -42,7 +42,6 @@ type CmdVolumesListOptions struct {
 // NewCmdVolumesList display status of OpenEBS Volume(s)
 func NewCmdVolumesList() *cobra.Command {
 	options := CmdVolumesListOptions{}
-
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Display status information about Volume(s)",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will enable mayactl to be used from any context by setting apiserver flag to the address where maya api server is exposed.
Example command :  mayactl --apiserver=http://35.225.202.194:32160 volume list 

**Which issue this PR fixes** *
fixes #https://github.com/openebs/openebs/issues/1463
Signed-off-by: sonasingh46 <ashutosh.kumar@openebs.io>

**Special notes for your reviewer**:
