### PR TITLE
[WIP]Add apiserver flag in mayactl command

### DIFF
--- a/cmd/mayactl/app/command/commands.go
+++ b/cmd/mayactl/app/command/commands.go
@@ -18,8 +18,12 @@ import (
 	"flag"
 
 	"github.com/openebs/maya/cmd/mayactl/app/command/snapshot"
+	"github.com/openebs/maya/pkg/client/mapiserver"
 	"github.com/spf13/cobra"
 )
+
+// Variable to capture value from --apiserver flag
+var apiserver *string
 
 // NewCommand creates the `maya` command and its nested children.
 func NewMayaCommand() *cobra.Command {
@@ -27,14 +31,24 @@ func NewMayaCommand() *cobra.Command {
 		Use:   "mayactl",
 		Short: "Maya means 'Magic'a tool for storage orchestration",
 		Long:  `Maya means 'Magic' a tool for storage orchestration`,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+		},
+		// PersistentPreRun is used so that it is inherited in all child commands
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			flagValue := cmd.Flag("apiserver").Value.String()
+			if !(flagValue == "") {
+				mapiserver.SetFlag(flagValue)
+			}
+		},
 	}
-
 	cmd.AddCommand(
 		NewCmdVersion(),
 		NewCmdVolume(),
 		snapshot.NewCmdSnapshot(),
 	)
-
+	// Register --apiserver flag to mayactl command with persistence to all child commands
+	apiserver = cmd.PersistentFlags().StringP("apiserver", "a", "", "IP to connect to maya server[format:scheme://apiserverIP:port]")
 	// add the glog flags
 	cmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 

--- a/pkg/client/mapiserver/utils.go
+++ b/pkg/client/mapiserver/utils.go
@@ -5,6 +5,9 @@ import (
 	"os"
 )
 
+var apiserverFlagPresent bool = false
+var apiserverFlagValue string = ""
+
 func Initialize() {
 	mapiaddr := os.Getenv("MAPI_ADDR")
 	if mapiaddr == "" {
@@ -13,7 +16,18 @@ func Initialize() {
 	}
 }
 
+// Function to set value for variable apiserverFlagValue if apiserver flag is present
+func SetFlag(value string) {
+	apiserverFlagPresent = true
+	apiserverFlagValue = value
+}
+
 func GetURL() string {
+	//If apiserver flag is present get maya server ip from apiserver flag
+	if apiserverFlagPresent {
+		return apiserverFlagValue
+	}
+	// If flag is not presetn get maya server ip from environment variable
 	return os.Getenv("MAPI_ADDR")
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will enable mayactl to be used from any context by setting apiserver flag to the address where maya api server is exposed.
Example command : mayactl --apiserver=http://35.225.202.194:32160 volume list
**Which issue this PR fixes** 
fixes #https://github.com/openebs/openebs/issues/1463
Signed-off-by: sonasingh46 <sonasingh46@gmail.com>
**Special notes for your reviewer**:
I am new to writing unit test cases. I will be writing test cases later on.