### PR TITLE
[cstor-integration] Handle IMAGE_TAG in makefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,6 +17,11 @@ EXTERNAL_TOOLS=\
 # list only our .go files i.e. exlcudes any .go files from the vendor directory
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
+ifeq (${IMAGE_TAG}, )
+  IMAGE_TAG = local
+  export IMAGE_TAG
+endif
+
 # Specify the name for the binaries
 MAYACTL=mayactl
 APISERVER=maya-apiserver


### PR DESCRIPTION
1. Why is this change necessary ?
   IMAGE_TAG for docker images needs to be available directly via makefile also.
IMAGE_TAG is handled in buildscripts/travis-build.sh for travis. If user tries to
run make commands directly on local machine, this tag which will not be populated
from travis-build.sh, will be populated from makefile.

2. How does this change address the issue ?
It is handled in such a way, if IMAGE_TAG is not set, then set it as local.

3. How to verify this change ?
Verify if IMAGE_TAG is not set. Run a make command and check if image tag is
local.
Note: IMAGE_TAG selection was handled in travis-build.sh because, it makes use of
travis environment variables and it would be helpful in future, in case of going
through or porting from travis related variables.

Signed-off-by: gkGaneshR <gkganesh126@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->
