### PR TITLE
Add node name details in mayactl volume info command

### DIFF
--- a/cmd/mayactl/app/command/volume_info.go
+++ b/cmd/mayactl/app/command/volume_info.go
@@ -146,17 +146,10 @@ func (c *CmdVolumeInfoOptions) DisplayVolumeInfo(a *Annotations, collection clie
 	)
 	const (
 		replicaTemplate = `
-<<<<<<< 47d72fc44065a7693c2b53a6ddd45a234114afdf
 		
 Replica Details : 
 ---------------- {{range $key, $value := .}}
 {{ printf "%s\t" $value.Name }} {{ printf "%s\t" $value.AccessMode }} {{ printf "%s\t" $value.Status }} {{ printf "%s\t" $value.IP }} {{ $value.NodeName }} {{end}}
-=======
-============================================== Replica Details ==============================================
-{{range $key, $value := .}}
-{{ printf "%s\t" $value.Name }} {{ printf "%s\t" $value.AccessMode }} {{ printf "%s\t" $value.Status }} {{ printf "%s\t" $value.IP }} {{ $value.NodeName }} {{end}}
-=============================================================================================================
->>>>>>> Proper alignment with the use of tabwriter
 `
 		portalTemplate = `
 Portal Details : 
@@ -217,7 +210,6 @@ Status  :   {{.Status}}
 		address = append(address, strings.TrimSuffix(strings.TrimPrefix(collection.Data[key].Address, "tcp://"), v1.ReplicaPort))
 		mode = append(mode, collection.Data[key].Mode)
 		replicaIPStatus[address[key]].mode = mode[key]
-
 	}
 
 	for k, v := range replicaIPStatus {
@@ -234,22 +226,10 @@ Status  :   {{.Status}}
 		fmt.Println("Error in getting information from K8s. Please try again")
 	}
 
-<<<<<<< 47d72fc44065a7693c2b53a6ddd45a234114afdf
 	tmpl = template.New("ReplicaInfo")
 	tmpl = template.Must(tmpl.Parse(replicaTemplate))
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
-=======
-	if length < replicaCount {
-		for i := length; i < (replicaCount); i++ {
-			replicaInfo[i+1] = &ReplicaInfo{"NA", "NA", replicaStatus[i], "NA", "NA"}
-		}
-	}
-	tmpl = template.New("ReplicaInfo")
-	tmpl = template.Must(tmpl.Parse(replicaTemplate))
-
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 8, ' ', 0)
->>>>>>> Proper alignment with the use of tabwriter
 	err = tmpl.Execute(w, replicaInfo)
 	if err != nil {
 		fmt.Println("Unable to display volume info, found error : ", err)

--- a/cmd/mayactl/app/command/volume_info.go
+++ b/cmd/mayactl/app/command/volume_info.go
@@ -146,10 +146,17 @@ func (c *CmdVolumeInfoOptions) DisplayVolumeInfo(a *Annotations, collection clie
 	)
 	const (
 		replicaTemplate = `
+<<<<<<< 47d72fc44065a7693c2b53a6ddd45a234114afdf
 		
 Replica Details : 
 ---------------- {{range $key, $value := .}}
 {{ printf "%s\t" $value.Name }} {{ printf "%s\t" $value.AccessMode }} {{ printf "%s\t" $value.Status }} {{ printf "%s\t" $value.IP }} {{ $value.NodeName }} {{end}}
+=======
+============================================== Replica Details ==============================================
+{{range $key, $value := .}}
+{{ printf "%s\t" $value.Name }} {{ printf "%s\t" $value.AccessMode }} {{ printf "%s\t" $value.Status }} {{ printf "%s\t" $value.IP }} {{ $value.NodeName }} {{end}}
+=============================================================================================================
+>>>>>>> Proper alignment with the use of tabwriter
 `
 		portalTemplate = `
 Portal Details : 
@@ -227,10 +234,22 @@ Status  :   {{.Status}}
 		fmt.Println("Error in getting information from K8s. Please try again")
 	}
 
+<<<<<<< 47d72fc44065a7693c2b53a6ddd45a234114afdf
 	tmpl = template.New("ReplicaInfo")
 	tmpl = template.Must(tmpl.Parse(replicaTemplate))
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
+=======
+	if length < replicaCount {
+		for i := length; i < (replicaCount); i++ {
+			replicaInfo[i+1] = &ReplicaInfo{"NA", "NA", replicaStatus[i], "NA", "NA"}
+		}
+	}
+	tmpl = template.New("ReplicaInfo")
+	tmpl = template.Must(tmpl.Parse(replicaTemplate))
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 8, ' ', 0)
+>>>>>>> Proper alignment with the use of tabwriter
 	err = tmpl.Execute(w, replicaInfo)
 	if err != nil {
 		fmt.Println("Unable to display volume info, found error : ", err)

--- a/cmd/mayactl/app/command/volume_info.go
+++ b/cmd/mayactl/app/command/volume_info.go
@@ -111,7 +111,7 @@ func (c *CmdVolumeInfoOptions) RunVolumeInfo(cmd *cobra.Command) error {
 	return nil
 }
 
-func updateReplicasInfoWithNodeName(replicaInfo map[int]*ReplicaInfo) error {
+func updateReplicasInfo(replicaInfo map[int]*ReplicaInfo) error {
 	K8sClient, err := k8sclient.NewK8sClient("")
 	if err != nil {
 		return err
@@ -222,7 +222,7 @@ Status  :   {{.Status}}
 		}
 	}
 
-	err = updateReplicasInfoWithNodeName(replicaInfo)
+	err = updateReplicasInfo(replicaInfo)
 	if err != nil {
 		fmt.Println("Error in getting information from K8s. Please try again")
 	}

--- a/pkg/client/k8s/k8s.go
+++ b/pkg/client/k8s/k8s.go
@@ -317,7 +317,17 @@ func (k *K8sClient) GetPod(name string, opts mach_apis_meta_v1.GetOptions) (*api
 	return pops.Get(name, opts)
 }
 
-// ListCoreV1PodAsRaw fetches a list of K8s Pods as per the provided options
+// GetPods fetches the K8s Pods
+func (k *K8sClient) GetPods() ([]api_core_v1.Pod, error) {
+	podLists, err := k.cs.Core().Pods(k.ns).List(mach_apis_meta_v1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return podLists.Items, nil
+}
+
+// ListCoreV1PodAsRaw fetches a list of K8s Pods with the provided options
 func (k *K8sClient) ListCoreV1PodAsRaw(opts mach_apis_meta_v1.ListOptions) (result []byte, err error) {
 	result, err = k.cs.CoreV1().RESTClient().Get().
 		Namespace(k.ns).


### PR DESCRIPTION
Signed-off-by: Sumit Lalwani <sumit.lalwani97@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
* Shows the volume replicas detail with the node name in which that volume is running.
* Shows volume name in mayactl volume info command.
* Adds extra column for Node in info details.

**Which issue this PR fixes**: fixes #350 

**Special notes for your reviewer**:
![screenshot from 2018-06-04 12-25-39](https://user-images.githubusercontent.com/29499601/40975305-1a75e66c-68e8-11e8-9763-f873be1d9879.png)
