### PR TITLE
Change maya-volume-exporter --> maya-exporter

### DIFF
--- a/orchprovider/k8s/v1/util.go
+++ b/orchprovider/k8s/v1/util.go
@@ -500,7 +500,7 @@ var monSideCarTpl = k8sApiV1.Container{
 	Name:  "maya-volume-exporter",
 	Image: v1.DefaultMonitoringImage,
 	Command: []string{
-		"maya-volume-exporter",
+		"maya-exporter",
 	},
 	Args: []string{
 		"-c=http://__TARGET_IP__:9501",


### PR DESCRIPTION
Changes the `maya-volume-exporter` binary name to `maya-exporter` as part of new changes.
The new changes was added by this PR https://github.com/openebs/maya/commit/82c0de3ff3b496ed64dcf63225021647bb964784

Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com> 