### PR TITLE
Support mayactl volume/snapshot operation across namespaces

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,5 @@
 # list only our namespaced directories
-PACKAGES = $(shell go list ./... | grep -v '/vendor/')
+PACKAGES = $(shell go list ./... | grep -v 'vendor\|pkg/apis\|pkg/client/clientset\|pkg/client/listers\|pkg/client/informers')
 
 # Lint our code. Reference: https://golang.org/cmd/vet/
 VETARGS?=-asmdecl -atomic -bool -buildtags -copylocks -methods \

--- a/buildscripts/test-cov.sh
+++ b/buildscripts/test-cov.sh
@@ -3,8 +3,8 @@
 set -e
 echo "" > coverage.txt
 
-for d in $(go list ./... | grep -v vendor); do
-    #TODO - Include -race while creating the coverage profile. 
+for d in $(go list ./... | grep -v 'vendor\|pkg/apis\|pkg/client/clientset\|pkg/client/listers\|pkg/client/informers'); do
+    #TODO - Include -race while creating the coverage profile.
     go test -coverprofile=profile.out -covermode=atomic $d
     if [ -f profile.out ]; then
         cat profile.out >> coverage.txt

--- a/cmd/mayactl/app/command/snapshot/create.go
+++ b/cmd/mayactl/app/command/snapshot/create.go
@@ -83,7 +83,7 @@ func (c *CmdSnaphotOptions) RunSnapshotCreate(cmd *cobra.Command) error {
 
 	resp := mapiserver.CreateSnapshot(c.volName, c.snapName, c.namespace)
 	if resp != nil {
-		return fmt.Errorf("Snapshot create failed: %v", resp)
+		return fmt.Errorf("Snapshot creation failed: %v", resp)
 	}
 
 	fmt.Printf("Volume snapshot Successfully Created:%v\n", c.volName)

--- a/cmd/mayactl/app/command/snapshot/create.go
+++ b/cmd/mayactl/app/command/snapshot/create.go
@@ -44,17 +44,8 @@ import (
 }
 */
 
-// CmdSnaphotCreateOptions holds the options for snapshot
-// create command
-type CmdSnaphotCreateOptions struct {
-	volName  string
-	snapName string
-}
-
 // NewCmdSnapshotCreate creates a snapshot of OpenEBS Volume
 func NewCmdSnapshotCreate() *cobra.Command {
-	options := CmdSnaphotCreateOptions{}
-
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Creates a new Snapshot",
@@ -65,23 +56,21 @@ func NewCmdSnapshotCreate() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.volName, "volname", "n", options.volName,
+	cmd.Flags().StringVarP(&options.volName, "volname", "", options.volName,
 		"unique volume name.")
 	cmd.MarkPersistentFlagRequired("volname")
-	cmd.MarkPersistentFlagRequired("snapname")
-
 	cmd.Flags().StringVarP(&options.snapName, "snapname", "s", options.snapName,
 		"unique snapshot name")
-
+	cmd.MarkPersistentFlagRequired("snapname")
 	return cmd
 }
 
 // Validate validates the flag values
-func (c *CmdSnaphotCreateOptions) Validate(cmd *cobra.Command) error {
-	if c.volName == "" {
+func (c *CmdSnaphotOptions) Validate(cmd *cobra.Command) error {
+	if len(c.volName) == 0 {
 		return errors.New("--volname is missing. Please specify an unique name")
 	}
-	if c.snapName == "" {
+	if len(c.snapName) == 0 {
 		return errors.New("--snapname is missing. Please specify an unique name")
 	}
 
@@ -89,10 +78,10 @@ func (c *CmdSnaphotCreateOptions) Validate(cmd *cobra.Command) error {
 }
 
 // RunSnapshotCreate does tasks related to mayaserver.
-func (c *CmdSnaphotCreateOptions) RunSnapshotCreate(cmd *cobra.Command) error {
+func (c *CmdSnaphotOptions) RunSnapshotCreate(cmd *cobra.Command) error {
 	fmt.Println("Executing volume snapshot create...")
 
-	resp := mapiserver.CreateSnapshot(c.volName, c.snapName)
+	resp := mapiserver.CreateSnapshot(c.volName, c.snapName, c.namespace)
 	if resp != nil {
 		return fmt.Errorf("Snapshot create failed: %v", resp)
 	}

--- a/cmd/mayactl/app/command/snapshot/list.go
+++ b/cmd/mayactl/app/command/snapshot/list.go
@@ -51,7 +51,7 @@ func (c *CmdSnaphotOptions) ValidateList(cmd *cobra.Command) error {
 	return nil
 }
 
-// RunSnapshotList does tasks related to mayaserver.
+// RunSnapshotList makes snapshot-list API request to maya-apiserver
 func (c *CmdSnaphotOptions) RunSnapshotList(cmd *cobra.Command) error {
 
 	resp := mapiserver.ListSnapshot(c.volName, c.namespace)

--- a/cmd/mayactl/app/command/snapshot/list.go
+++ b/cmd/mayactl/app/command/snapshot/list.go
@@ -27,8 +27,6 @@ import (
 
 // NewCmdSnapshotCreate creates a snapshot of OpenEBS Volume
 func NewCmdSnapshotList() *cobra.Command {
-	options := CmdSnaphotCreateOptions{}
-
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Lists all the snapshots of a Volume",
@@ -39,24 +37,24 @@ func NewCmdSnapshotList() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.volName, "volname", "n", options.volName,
+	cmd.Flags().StringVarP(&options.volName, "volname", "", options.volName,
 		"unique volume name.")
 	cmd.MarkPersistentFlagRequired("volname")
 	return cmd
 }
 
 // ValidateList validates the flag values
-func (c *CmdSnaphotCreateOptions) ValidateList(cmd *cobra.Command) error {
-	if c.volName == "" {
+func (c *CmdSnaphotOptions) ValidateList(cmd *cobra.Command) error {
+	if len(c.volName) == 0 {
 		return errors.New("--volname is missing. Please specify an unique name")
 	}
 	return nil
 }
 
 // RunSnapshotList does tasks related to mayaserver.
-func (c *CmdSnaphotCreateOptions) RunSnapshotList(cmd *cobra.Command) error {
+func (c *CmdSnaphotOptions) RunSnapshotList(cmd *cobra.Command) error {
 
-	resp := mapiserver.ListSnapshot(c.volName)
+	resp := mapiserver.ListSnapshot(c.volName, c.namespace)
 	if resp != nil {
 		return fmt.Errorf("Error list available snapshot: %v", resp)
 	}

--- a/cmd/mayactl/app/command/snapshot/revert.go
+++ b/cmd/mayactl/app/command/snapshot/revert.go
@@ -24,15 +24,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-/*type CmdSnaphotCreateOptions struct {
-	volName  string
-	snapName string
-}*/
-
 // NewCmdSnapshotRevert reverts a snapshot of OpenEBS Volume
 func NewCmdSnapshotRevert() *cobra.Command {
-	options := CmdSnaphotCreateOptions{}
-
 	cmd := &cobra.Command{
 		Use:   "revert",
 		Short: "Reverts to specific snapshot of a Volume",
@@ -43,22 +36,21 @@ func NewCmdSnapshotRevert() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.volName, "volname", "n", options.volName,
+	cmd.Flags().StringVarP(&options.volName, "volname", "", options.volName,
 		"unique volume name.")
 	cmd.MarkPersistentFlagRequired("volname")
-	cmd.MarkPersistentFlagRequired("snapname")
-
 	cmd.Flags().StringVarP(&options.snapName, "snapname", "s", options.snapName,
 		"unique snapshot name")
+	cmd.MarkPersistentFlagRequired("snapname")
 
 	return cmd
 }
 
 // RunSnapshotRevert does tasks related to mayaserver.
-func (c *CmdSnaphotCreateOptions) RunSnapshotRevert(cmd *cobra.Command) error {
+func (c *CmdSnaphotOptions) RunSnapshotRevert(cmd *cobra.Command) error {
 	fmt.Println("Executing volume snapshot revert ...")
 
-	resp := mapiserver.RevertSnapshot(c.volName, c.snapName)
+	resp := mapiserver.RevertSnapshot(c.volName, c.snapName, c.namespace)
 	if resp != nil {
 		return fmt.Errorf("Error: %v", resp)
 	}

--- a/cmd/mayactl/app/command/snapshot/snapshot.go
+++ b/cmd/mayactl/app/command/snapshot/snapshot.go
@@ -20,6 +20,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	options = &CmdSnaphotOptions{
+		namespace: "default",
+	}
+)
+
+type CmdSnaphotOptions struct {
+	volName   string
+	snapName  string
+	namespace string
+}
+
 func NewCmdSnapshot() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "snapshot",
@@ -32,6 +44,8 @@ func NewCmdSnapshot() *cobra.Command {
 		NewCmdSnapshotList(),
 		NewCmdSnapshotRevert(),
 	)
+	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace,
+		"namespace name, required if volume is in other then dafault namespace")
 
 	return cmd
 }

--- a/cmd/mayactl/app/command/snapshot/snapshot.go
+++ b/cmd/mayactl/app/command/snapshot/snapshot.go
@@ -45,7 +45,7 @@ func NewCmdSnapshot() *cobra.Command {
 		NewCmdSnapshotRevert(),
 	)
 	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace,
-		"namespace name, required if volume is in other then dafault namespace")
+		"namespace name, required if volume is not in the default namespace")
 
 	return cmd
 }

--- a/cmd/mayactl/app/command/stats_helper.go
+++ b/cmd/mayactl/app/command/stats_helper.go
@@ -55,7 +55,7 @@ func GetVolDetails(volName string, namespace string, obj interface{}) error {
 	}
 	resp, err := c.Do(req)
 	if err != nil {
-		fmt.Printf("Could not get response, found error: %v", err)
+		fmt.Printf("Can't get a response, error found: %v", err)
 		return err
 	}
 

--- a/cmd/mayactl/app/command/stats_helper.go
+++ b/cmd/mayactl/app/command/stats_helper.go
@@ -33,7 +33,7 @@ const (
 )
 
 // getVolDetails gets response in json format of a volume from m-apiserver
-func GetVolDetails(volName string, obj interface{}) error {
+func GetVolDetails(volName string, namespace string, obj interface{}) error {
 	addr := os.Getenv("MAPI_ADDR")
 	if addr == "" {
 		err := util.MAPIADDRNotSet
@@ -42,11 +42,18 @@ func GetVolDetails(volName string, obj interface{}) error {
 	}
 
 	url := addr + "/latest/volumes/info/" + volName
-	client := &http.Client{
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("namespace", namespace)
+
+	c := &http.Client{
 		Timeout: timeout,
 	}
-	resp, err := client.Get(url)
-
+	resp, err := c.Do(req)
 	if err != nil {
 		fmt.Printf("Could not get response, found error: %v", err)
 		return err
@@ -74,9 +81,9 @@ func GetVolDetails(volName string, obj interface{}) error {
 }
 
 // GetVolAnnotations maps annotations of volume to Annotations structure.
-func (annotations *Annotations) GetVolAnnotations(volName string) error {
+func (annotations *Annotations) GetVolAnnotations(volName string, namespace string) error {
 	var volume v1.Volume
-	err := GetVolDetails(volName, &volume)
+	err := GetVolDetails(volName, namespace, &volume)
 	if err != nil || volume.ObjectMeta.Annotations == nil {
 		if volume.Status.Reason == "pending" {
 			fmt.Println("VOLUME status Unknown to M_API server")

--- a/cmd/mayactl/app/command/stats_helper_test.go
+++ b/cmd/mayactl/app/command/stats_helper_test.go
@@ -21,6 +21,7 @@ func TestGetVolDetails(t *testing.T) {
 	)
 	tests := map[string]struct {
 		volumeName string
+		namespace  string
 
 		fakeHandler utiltesting.FakeHandler
 		err         error
@@ -81,12 +82,33 @@ func TestGetVolDetails(t *testing.T) {
 			err:  util.PageNotFound,
 			addr: "MAPI_ADDR",
 		},
+		"OpenebsNamespacedVolume": {
+			volumeName: "vol",
+			namespace:  "",
+			fakeHandler: utiltesting.FakeHandler{
+				StatusCode: 404,
+				T:          t,
+			},
+			err:  util.PageNotFound,
+			addr: "MAPI_ADDR",
+		},
+		"AppNamespacedVolume": {
+			volumeName: "vol",
+			namespace:  "app",
+			fakeHandler: utiltesting.FakeHandler{
+				StatusCode:   200,
+				ResponseBody: string(response),
+				T:            t,
+			},
+			err:  nil,
+			addr: "MAPI_ADDR",
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			server = httptest.NewServer(&tt.fakeHandler)
 			os.Setenv(tt.addr, server.URL)
-			if got := annotation.GetVolAnnotations(tt.volumeName); got != tt.err {
+			if got := annotation.GetVolAnnotations(tt.volumeName, tt.namespace); got != tt.err {
 				t.Fatalf("GetVolDetails(%v) => got %v, want %v ", tt.volumeName, got, tt.err)
 			}
 			defer os.Unsetenv(tt.addr)

--- a/cmd/mayactl/app/command/volume.go
+++ b/cmd/mayactl/app/command/volume.go
@@ -69,7 +69,7 @@ func NewCmdVolume() *cobra.Command {
 		NewCmdVolumeInfo(),
 	)
 	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace,
-		"namespace name, required if volume is in other then dafault namespace")
+		"namespace name, required if volume is not in the default namespace")
 
 	cmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	flag.CommandLine.Parse([]string{})

--- a/cmd/mayactl/app/command/volume.go
+++ b/cmd/mayactl/app/command/volume.go
@@ -17,6 +17,8 @@ limitations under the License.
 package command
 
 import (
+	"flag"
+
 	"github.com/spf13/cobra"
 )
 
@@ -39,7 +41,17 @@ var (
 	$ maya volume stats <vol>
 
 	`
+	options = &CmdVolumeOptions{
+		namespace: "default",
+	}
 )
+
+type CmdVolumeOptions struct {
+	volName   string
+	size      string
+	namespace string
+	json      string
+}
 
 // NewCmdVolume provides options for managing OpenEBS Volume
 func NewCmdVolume() *cobra.Command {
@@ -56,5 +68,10 @@ func NewCmdVolume() *cobra.Command {
 		NewCmdVolumeStats(),
 		NewCmdVolumeInfo(),
 	)
+	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace,
+		"namespace name, required if volume is in other then dafault namespace")
+
+	cmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+	flag.CommandLine.Parse([]string{})
 	return cmd
 }

--- a/cmd/mayactl/app/command/volume_create.go
+++ b/cmd/mayactl/app/command/volume_create.go
@@ -60,12 +60,12 @@ func NewCmdVolumeCreate() *cobra.Command {
 	return cmd
 }
 
-// Validate varifies whether a volume name has been provided or not followed by
-// stats command, it returns nil and proceeds to execute the command if there is
-// no error and returns the error if it is missing.
+// Validate verifies whether a volume name is provided or not followed by
+// stats command. It returns nil and proceeds to execute the command if there is
+// no error and returns an error if it is missing.
 func (c *CmdVolumeOptions) Validate(cmd *cobra.Command) error {
 	if len(c.volName) == 0 {
-		return errors.New("--volname is missing. Please specify an unique name")
+		return errors.New("--volname is missing. Please specify a unique name")
 	}
 	return nil
 }

--- a/cmd/mayactl/app/command/volume_create.go
+++ b/cmd/mayactl/app/command/volume_create.go
@@ -39,15 +39,8 @@ var (
 	`
 )
 
-type CmdVolumeCreateOptions struct {
-	volName string
-	size    string
-}
-
 // NewCmdVolumeCreate creates a new OpenEBS Volume
 func NewCmdVolumeCreate() *cobra.Command {
-	options := CmdVolumeCreateOptions{}
-
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Creates a new Volume",
@@ -64,20 +57,21 @@ func NewCmdVolumeCreate() *cobra.Command {
 
 	cmd.Flags().StringVarP(&options.size, "size", "", options.size,
 		"volume capacity in GB (example: 10G) (default: 5G")
-
 	return cmd
 }
 
-// Run does tasks related to mayaserver.
-func (c *CmdVolumeCreateOptions) Validate(cmd *cobra.Command) error {
-	if c.volName == "" {
+// Validate varifies whether a volume name has been provided or not followed by
+// stats command, it returns nil and proceeds to execute the command if there is
+// no error and returns the error if it is missing.
+func (c *CmdVolumeOptions) Validate(cmd *cobra.Command) error {
+	if len(c.volName) == 0 {
 		return errors.New("--volname is missing. Please specify an unique name")
 	}
 	return nil
 }
 
 // RunVolumeCreate makes create volume request to maya-apiserver after verifying whether the volume already exists or not. In case if the volume already exists it returns the error and come out of execution.
-func (c *CmdVolumeCreateOptions) RunVolumeCreate(cmd *cobra.Command) error {
+func (c *CmdVolumeOptions) RunVolumeCreate(cmd *cobra.Command) error {
 	fmt.Println("Executing volume create...")
 	err := IsVolumeExist(c.volName)
 	if err != nil {

--- a/cmd/mayactl/app/command/volume_delete.go
+++ b/cmd/mayactl/app/command/volume_delete.go
@@ -51,7 +51,7 @@ func NewCmdVolumeDelete() *cobra.Command {
 	return cmd
 }
 
-//RunVolumeDelete will initiate deletion of volume from maya-apiserver
+//RunVolumeDelete will initiate the process of deleting a volume from maya-apiserver
 func (c *CmdVolumeOptions) RunVolumeDelete(cmd *cobra.Command) error {
 	fmt.Println("Executing volume delete...")
 

--- a/cmd/mayactl/app/command/volume_delete.go
+++ b/cmd/mayactl/app/command/volume_delete.go
@@ -17,7 +17,6 @@ limitations under the License.
 package command
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/openebs/maya/pkg/client/mapiserver"
@@ -34,21 +33,14 @@ var (
 	`
 )
 
-// CmdVolumeDeleteOptions stores the input parameters
-type CmdVolumeDeleteOptions struct {
-	volName string
-}
-
 // NewCmdVolumeDelete creates a new OpenEBS Volume
 func NewCmdVolumeDelete() *cobra.Command {
-	options := CmdVolumeDeleteOptions{}
-
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Deletes a Volume",
 		Long:  volumeDeleteCommandHelpText,
 		Run: func(cmd *cobra.Command, args []string) {
-			util.CheckErr(options.ValidateVolumeDelete(cmd), util.Fatal)
+			util.CheckErr(options.Validate(cmd), util.Fatal)
 			util.CheckErr(options.RunVolumeDelete(cmd), util.Fatal)
 		},
 	}
@@ -56,23 +48,14 @@ func NewCmdVolumeDelete() *cobra.Command {
 	cmd.Flags().StringVarP(&options.volName, "volname", "", options.volName,
 		"unique volume name.")
 	cmd.MarkPersistentFlagRequired("volname")
-
 	return cmd
 }
 
-//ValidateVolumeDelete validates the arguments passed
-func (c *CmdVolumeDeleteOptions) ValidateVolumeDelete(cmd *cobra.Command) error {
-	if c.volName == "" {
-		return errors.New("--volname is missing. Please specify an unique name")
-	}
-	return nil
-}
-
 //RunVolumeDelete will initiate deletion of volume from maya-apiserver
-func (c *CmdVolumeDeleteOptions) RunVolumeDelete(cmd *cobra.Command) error {
+func (c *CmdVolumeOptions) RunVolumeDelete(cmd *cobra.Command) error {
 	fmt.Println("Executing volume delete...")
 
-	resp := mapiserver.DeleteVolume(c.volName)
+	resp := mapiserver.DeleteVolume(c.volName, c.namespace)
 	if resp != nil {
 		return fmt.Errorf("Error: %v", resp)
 	}

--- a/cmd/mayactl/app/command/volume_info.go
+++ b/cmd/mayactl/app/command/volume_info.go
@@ -49,11 +49,11 @@ type ReplicaInfo struct {
 	NodeName   string
 }
 
-// NewCmdVolumeInfo shows info of OpenEBS Volume
+// NewCmdVolumeInfo displays OpenEBS Volume information.
 func NewCmdVolumeInfo() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "info",
-		Short:   "Displays the info of Volume",
+		Short:   "Displays Openebs Volume information",
 		Long:    volumeInfoCommandHelpText,
 		Example: `mayactl volume info --volname <vol>`,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -62,7 +62,7 @@ func NewCmdVolumeInfo() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&options.volName, "volname", "", options.volName,
-		"unique volume name.")
+		"a unique volume name.")
 	return cmd
 }
 
@@ -71,7 +71,7 @@ func NewCmdVolumeInfo() *cobra.Command {
 func (c *CmdVolumeOptions) RunVolumeInfo(cmd *cobra.Command) error {
 	annotation := &Annotations{}
 	// GetVolumeAnnotation is called to get the volume controller's info such as
-	// controller's IP, status, iqn, replica IPs etc.\
+	// controller's IP, status, iqn, replica IPs etc.
 	err := annotation.GetVolAnnotations(c.volName, c.namespace)
 	if err != nil {
 		return nil
@@ -119,10 +119,10 @@ func updateReplicasInfo(replicaInfo map[int]*ReplicaInfo) error {
 }
 
 // DisplayVolumeInfo displays the outputs in standard I/O.
-// Currently It displays volume access modes and target portal details only.
+// Currently it displays volume access modes and target portal details only.
 func (c *CmdVolumeOptions) DisplayVolumeInfo(a *Annotations, collection client.ReplicaCollection) error {
 	var (
-		// address, mode are used here as blackbox for the replica info
+		// address and mode are used here as blackbox for the replica info
 		// address keeps the ip and access mode details respectively.
 		address, mode []string
 		replicaCount  int

--- a/cmd/mayactl/app/command/volume_info_test.go
+++ b/cmd/mayactl/app/command/volume_info_test.go
@@ -17,7 +17,7 @@ var (
 )
 
 func TestRunVolumeInfo(t *testing.T) {
-	options := CmdVolumeInfoOptions{}
+	options := CmdVolumeOptions{}
 	cmd := &cobra.Command{
 		Use:   "info",
 		Short: "Displays the info of Volume",
@@ -31,7 +31,7 @@ func TestRunVolumeInfo(t *testing.T) {
 	}
 
 	validCmd := map[string]struct {
-		cmdOptions  *CmdVolumeInfoOptions
+		cmdOptions  *CmdVolumeOptions
 		cmd         *cobra.Command
 		output      error
 		err         error
@@ -39,7 +39,7 @@ func TestRunVolumeInfo(t *testing.T) {
 		fakeHandler utiltesting.FakeHandler
 	}{
 		"WhenErrorGettingAnnotation": {
-			cmdOptions: &CmdVolumeInfoOptions{
+			cmdOptions: &CmdVolumeOptions{
 				volName: "vol1",
 			},
 			cmd: cmd,
@@ -52,7 +52,7 @@ func TestRunVolumeInfo(t *testing.T) {
 			output: nil,
 		},
 		"WhenControllerIsNotRunning": {
-			cmdOptions: &CmdVolumeInfoOptions{
+			cmdOptions: &CmdVolumeOptions{
 				volName: "vol1",
 			},
 			cmd: cmd,
@@ -80,14 +80,14 @@ func TestRunVolumeInfo(t *testing.T) {
 }
 func TestDisplayVolumeInfo(t *testing.T) {
 	validInfo := map[string]struct {
-		cmdOptions *CmdVolumeInfoOptions
+		cmdOptions *CmdVolumeOptions
 		annotation *Annotations
 		replica    client.Replica
 		collection client.ReplicaCollection
 		output     error
 	}{
 		"InfoWhenReplicaIsZero": {
-			cmdOptions: &CmdVolumeInfoOptions{
+			cmdOptions: &CmdVolumeOptions{
 				volName: "vol1",
 			},
 			annotation: &Annotations{
@@ -104,7 +104,7 @@ func TestDisplayVolumeInfo(t *testing.T) {
 			output: nil,
 		},
 		"InfoWhenReplicaIsOne": {
-			cmdOptions: &CmdVolumeInfoOptions{
+			cmdOptions: &CmdVolumeOptions{
 				volName: "vol1",
 			},
 			annotation: &Annotations{
@@ -129,7 +129,7 @@ func TestDisplayVolumeInfo(t *testing.T) {
 			output: nil,
 		},
 		"InfoWhenReplicaIsTwo": {
-			cmdOptions: &CmdVolumeInfoOptions{
+			cmdOptions: &CmdVolumeOptions{
 				volName: "vol1",
 			},
 			annotation: &Annotations{
@@ -158,7 +158,7 @@ func TestDisplayVolumeInfo(t *testing.T) {
 			output: nil,
 		},
 		"InfoWhenReplicaIsThreeAndOnePending": {
-			cmdOptions: &CmdVolumeInfoOptions{
+			cmdOptions: &CmdVolumeOptions{
 				volName: "vol1",
 			},
 			annotation: &Annotations{
@@ -187,7 +187,7 @@ func TestDisplayVolumeInfo(t *testing.T) {
 			output: nil,
 		},
 		"InfoWhenReplicaIsThreeAndTwoPending": {
-			cmdOptions: &CmdVolumeInfoOptions{
+			cmdOptions: &CmdVolumeOptions{
 				volName: "vol1",
 			},
 			annotation: &Annotations{
@@ -212,7 +212,7 @@ func TestDisplayVolumeInfo(t *testing.T) {
 			output: nil,
 		},
 		"InfoWhenReplicaIsThreeAndAllPending": {
-			cmdOptions: &CmdVolumeInfoOptions{
+			cmdOptions: &CmdVolumeOptions{
 				volName: "vol1",
 			},
 			annotation: &Annotations{
@@ -229,7 +229,7 @@ func TestDisplayVolumeInfo(t *testing.T) {
 			output: nil,
 		},
 		"InfoWhenReplicaIsThree": {
-			cmdOptions: &CmdVolumeInfoOptions{
+			cmdOptions: &CmdVolumeOptions{
 				volName: "vol1",
 			},
 			annotation: &Annotations{
@@ -262,7 +262,7 @@ func TestDisplayVolumeInfo(t *testing.T) {
 			output: nil,
 		},
 		"InfoWhenReplicaIsThreeAnd1stNodePendingo": {
-			cmdOptions: &CmdVolumeInfoOptions{
+			cmdOptions: &CmdVolumeOptions{
 				volName: "vol1",
 			},
 			annotation: &Annotations{
@@ -291,7 +291,7 @@ func TestDisplayVolumeInfo(t *testing.T) {
 			output: nil,
 		},
 		"InfoWhenReplicaIsTwoAndOneCrashLoopBackOff": {
-			cmdOptions: &CmdVolumeInfoOptions{
+			cmdOptions: &CmdVolumeOptions{
 				volName: "vol1",
 			},
 			annotation: &Annotations{
@@ -320,7 +320,7 @@ func TestDisplayVolumeInfo(t *testing.T) {
 			output: nil,
 		},
 		"InfoWhenReplicaIsThreeAndOneErrorPullBack": {
-			cmdOptions: &CmdVolumeInfoOptions{
+			cmdOptions: &CmdVolumeOptions{
 				volName: "vol1",
 			},
 			annotation: &Annotations{
@@ -349,7 +349,7 @@ func TestDisplayVolumeInfo(t *testing.T) {
 			output: nil,
 		},
 		"InfoWhenReplicaIsFourAndOneErrPullBackAndOneCrashBack": {
-			cmdOptions: &CmdVolumeInfoOptions{
+			cmdOptions: &CmdVolumeOptions{
 				volName: "vol1",
 			},
 			annotation: &Annotations{
@@ -374,7 +374,7 @@ func TestDisplayVolumeInfo(t *testing.T) {
 			output: nil,
 		},
 		"InfoWhenReplicaIsFourAndOneErrPullBackAndOneCrashBackAndOneNil": {
-			cmdOptions: &CmdVolumeInfoOptions{
+			cmdOptions: &CmdVolumeOptions{
 				volName: "vol1",
 			},
 			annotation: &Annotations{

--- a/cmd/mayactl/app/command/volume_stats.go
+++ b/cmd/mayactl/app/command/volume_stats.go
@@ -68,7 +68,6 @@ func NewCmdVolumeStats() *cobra.Command {
 // I/O or in json format.
 func (c *CmdVolumeOptions) RunVolumeStats(cmd *cobra.Command) error {
 	fmt.Println("Executing volume stats...")
-	fmt.Println("Namespace is :", c.namespace)
 	var (
 		err, err1, err3 error
 		err2, err4      int
@@ -134,7 +133,7 @@ func (c *CmdVolumeOptions) RunVolumeStats(cmd *cobra.Command) error {
 }
 
 // DisplayStats displays the volume stats as standard output and in json format.
-// By defaault it displays in standard output but if  flag json is passed it
+// By default it displays in standard output format, if flag json has passed
 // displays stats in json format.
 func (a *Annotations) DisplayStats(c *CmdVolumeOptions, statusArray []string, stats1 v1.VolumeMetrics, stats2 v1.VolumeMetrics) error {
 

--- a/cmd/mayactl/app/command/volume_stats.go
+++ b/cmd/mayactl/app/command/volume_stats.go
@@ -18,7 +18,6 @@ package command
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"html/template"
 	"os"
@@ -46,16 +45,8 @@ var (
 	`
 )
 
-// CmdVolumeStatsOptions is used to store the value of flags used in the cli
-type CmdVolumeStatsOptions struct {
-	json    string
-	volName string
-}
-
 // NewCmdVolumeCreate creates a new OpenEBS Volume
 func NewCmdVolumeStats() *cobra.Command {
-	options := CmdVolumeStatsOptions{}
-
 	cmd := &cobra.Command{
 		Use:     "stats",
 		Short:   "Displays the runtime statisics of Volume",
@@ -67,27 +58,17 @@ func NewCmdVolumeStats() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.volName, "volname", "n", options.volName,
+	cmd.Flags().StringVarP(&options.volName, "volname", "", options.volName,
 		"unique volume name.")
 	cmd.Flags().StringVarP(&options.json, "json", "j", options.json, "display output in JSON.")
 	return cmd
 }
 
-// Validate varifies whether a volume name has been provided or not followed by
-// stats command, it returns nil and proceeds to execute the command if there is
-// no error and returns the error if it is missing.
-func (c *CmdVolumeStatsOptions) Validate(cmd *cobra.Command) error {
-	if c.volName == "" {
-		return errors.New("--volname is missing. Please try running [mayactl volume list] to see list of volumes")
-	}
-	return nil
-}
-
 // RunVolumeStats runs stats command and display the outputs in standard
 // I/O or in json format.
-func (c *CmdVolumeStatsOptions) RunVolumeStats(cmd *cobra.Command) error {
+func (c *CmdVolumeOptions) RunVolumeStats(cmd *cobra.Command) error {
 	fmt.Println("Executing volume stats...")
-
+	fmt.Println("Namespace is :", c.namespace)
 	var (
 		err, err1, err3 error
 		err2, err4      int
@@ -95,9 +76,8 @@ func (c *CmdVolumeStatsOptions) RunVolumeStats(cmd *cobra.Command) error {
 		stats1, stats2  v1.VolumeMetrics
 		statusArray     []string //keeps track of the replica's status such as IP, Status and Revision counter.
 	)
-
 	annotation := &Annotations{}
-	err = annotation.GetVolAnnotations(c.volName)
+	err = annotation.GetVolAnnotations(c.volName, c.namespace)
 	if err != nil {
 		return nil
 	}
@@ -156,7 +136,7 @@ func (c *CmdVolumeStatsOptions) RunVolumeStats(cmd *cobra.Command) error {
 // DisplayStats displays the volume stats as standard output and in json format.
 // By defaault it displays in standard output but if  flag json is passed it
 // displays stats in json format.
-func (a *Annotations) DisplayStats(c *CmdVolumeStatsOptions, statusArray []string, stats1 v1.VolumeMetrics, stats2 v1.VolumeMetrics) error {
+func (a *Annotations) DisplayStats(c *CmdVolumeOptions, statusArray []string, stats1 v1.VolumeMetrics, stats2 v1.VolumeMetrics) error {
 
 	var (
 		err                  error

--- a/cmd/mayactl/app/command/volume_stats_test.go
+++ b/cmd/mayactl/app/command/volume_stats_test.go
@@ -9,7 +9,7 @@ import (
 func TestDisplayStats(t *testing.T) {
 	validStats := map[string]struct {
 		annotation   *Annotations
-		cmdOptions   *CmdVolumeStatsOptions
+		cmdOptions   *CmdVolumeOptions
 		status       []string
 		initialStats v1.VolumeMetrics
 		finalStats   v1.VolumeMetrics
@@ -17,7 +17,7 @@ func TestDisplayStats(t *testing.T) {
 		replicaCount int
 	}{
 		"StatsStdWhenReplicaIs0": {
-			cmdOptions: &CmdVolumeStatsOptions{
+			cmdOptions: &CmdVolumeOptions{
 				json:    "",
 				volName: "vol1",
 			},
@@ -73,7 +73,7 @@ func TestDisplayStats(t *testing.T) {
 		},
 
 		"StatsStdWhenReplicaIs1": {
-			cmdOptions: &CmdVolumeStatsOptions{
+			cmdOptions: &CmdVolumeOptions{
 				json:    "",
 				volName: "vol1",
 			},
@@ -128,7 +128,7 @@ func TestDisplayStats(t *testing.T) {
 			output: nil,
 		},
 		"StatsStdWhenReplicaIs2": {
-			cmdOptions: &CmdVolumeStatsOptions{
+			cmdOptions: &CmdVolumeOptions{
 				json:    "",
 				volName: "vol1",
 			},
@@ -189,7 +189,7 @@ func TestDisplayStats(t *testing.T) {
 			output: nil,
 		},
 		"StatsJSONWhenReplicaIs3": {
-			cmdOptions: &CmdVolumeStatsOptions{
+			cmdOptions: &CmdVolumeOptions{
 				json:    "json",
 				volName: "vol1",
 			},
@@ -250,7 +250,7 @@ func TestDisplayStats(t *testing.T) {
 			output: nil,
 		},
 		"StatsStdWhenReplicaIs4": {
-			cmdOptions: &CmdVolumeStatsOptions{
+			cmdOptions: &CmdVolumeOptions{
 				json:    "",
 				volName: "vol1",
 			},
@@ -314,7 +314,7 @@ func TestDisplayStats(t *testing.T) {
 			output: nil,
 		},
 		"StatsStdWhenReplicaIs4AndOneErrorPullBack": {
-			cmdOptions: &CmdVolumeStatsOptions{
+			cmdOptions: &CmdVolumeOptions{
 				json:    "",
 				volName: "vol1",
 			},
@@ -378,7 +378,7 @@ func TestDisplayStats(t *testing.T) {
 			output: nil,
 		},
 		"StatsStdWhenReplicaIs4AndOneCrashLoopBackOff": {
-			cmdOptions: &CmdVolumeStatsOptions{
+			cmdOptions: &CmdVolumeOptions{
 				json:    "",
 				volName: "vol1",
 			},
@@ -442,7 +442,7 @@ func TestDisplayStats(t *testing.T) {
 			output: nil,
 		},
 		"StatsStd": {
-			cmdOptions: &CmdVolumeStatsOptions{
+			cmdOptions: &CmdVolumeOptions{
 				json:    "",
 				volName: "vol1",
 			},
@@ -503,7 +503,7 @@ func TestDisplayStats(t *testing.T) {
 			output: nil,
 		},
 		"ReadIOPSIsNotZero": {
-			cmdOptions: &CmdVolumeStatsOptions{
+			cmdOptions: &CmdVolumeOptions{
 				json:    "",
 				volName: "vol1",
 			},
@@ -565,7 +565,7 @@ func TestDisplayStats(t *testing.T) {
 			output: nil,
 		},
 		"WriteIOPSIsZero": {
-			cmdOptions: &CmdVolumeStatsOptions{
+			cmdOptions: &CmdVolumeOptions{
 				json:    "",
 				volName: "vol1",
 			},

--- a/cmd/mayactl/app/command/volumes_list.go
+++ b/cmd/mayactl/app/command/volumes_list.go
@@ -34,15 +34,8 @@ var (
 	`
 )
 
-// CmdVolumesListOptions captures the CLI flags
-type CmdVolumesListOptions struct {
-	volName string
-}
-
 // NewCmdVolumesList display status of OpenEBS Volume(s)
 func NewCmdVolumesList() *cobra.Command {
-	options := CmdVolumesListOptions{}
-
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Display status information about Volume(s)",
@@ -60,7 +53,7 @@ func NewCmdVolumesList() *cobra.Command {
 }
 
 //RunVolumesList will fetch the volumes from maya-apiserver
-func (c *CmdVolumesListOptions) RunVolumesList(cmd *cobra.Command) error {
+func (c *CmdVolumeOptions) RunVolumesList(cmd *cobra.Command) error {
 	//fmt.Println("Executing volume list...")
 
 	var vsms mtypesv1.VolumeList

--- a/cmd/mayactl/app/command/volumes_list.go
+++ b/cmd/mayactl/app/command/volumes_list.go
@@ -34,11 +34,11 @@ var (
 	`
 )
 
-// NewCmdVolumesList display status of OpenEBS Volume(s)
+// NewCmdVolumesList displays status of OpenEBS Volume(s)
 func NewCmdVolumesList() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "Display status information about Volume(s)",
+		Short: "Displays status information about Volume(s)",
 		Long:  volumesListCommandHelpText,
 		Run: func(cmd *cobra.Command, args []string) {
 			util.CheckErr(options.RunVolumesList(cmd), util.Fatal)
@@ -52,7 +52,7 @@ func NewCmdVolumesList() *cobra.Command {
 	return cmd
 }
 
-//RunVolumesList will fetch the volumes from maya-apiserver
+//RunVolumesList fetchs the volumes from maya-apiserver
 func (c *CmdVolumeOptions) RunVolumesList(cmd *cobra.Command) error {
 	//fmt.Println("Executing volume list...")
 

--- a/pkg/client/mapiserver/snapshot.go
+++ b/pkg/client/mapiserver/snapshot.go
@@ -35,7 +35,7 @@ const (
 )
 
 // CreateSnapshot creates a snapshot of volume by invoking the API call to m-apiserver
-func CreateSnapshot(volName string, snapName string) error {
+func CreateSnapshot(volName string, snapName string, namespace string) error {
 
 	_, err := GetStatus()
 	if err != nil {
@@ -59,6 +59,7 @@ func CreateSnapshot(volName string, snapName string) error {
 	}
 
 	req.Header.Add("Content-Type", "application/yaml")
+	req.Header.Set("namespace", namespace)
 
 	c := &http.Client{
 		Timeout: http_timeout,
@@ -85,7 +86,7 @@ func CreateSnapshot(volName string, snapName string) error {
 }
 
 // RevertSnapshot revert a snapshot of volume by invoking the API call to m-apiserver
-func RevertSnapshot(volName string, snapName string) error {
+func RevertSnapshot(volName string, snapName string, namespace string) error {
 
 	_, err := GetStatus()
 	if err != nil {
@@ -109,7 +110,7 @@ func RevertSnapshot(volName string, snapName string) error {
 	}
 
 	req.Header.Add("Content-Type", "application/yaml")
-
+	req.Header.Set("namespace", namespace)
 	c := &http.Client{
 		Timeout: http_timeout,
 	}
@@ -132,7 +133,7 @@ func RevertSnapshot(volName string, snapName string) error {
 }
 
 // ListSnapshot list snapshots of volume by invoking the API call to m-apiserver
-func ListSnapshot(volName string) error {
+func ListSnapshot(volName string, namespace string) error {
 
 	_, err := GetStatus()
 	if err != nil {
@@ -145,6 +146,8 @@ func ListSnapshot(volName string) error {
 	if err != nil {
 		return err
 	}
+	req.Header.Set("namespace", namespace)
+
 	c := &http.Client{
 		Timeout: timeoutVolumeDelete,
 	}

--- a/pkg/client/mapiserver/snapshot.go
+++ b/pkg/client/mapiserver/snapshot.go
@@ -34,7 +34,7 @@ const (
 	http_timeout = 5 * time.Second
 )
 
-// CreateSnapshot creates a snapshot of volume by invoking the API call to m-apiserver
+// CreateSnapshot creates a snapshot of volume by API request to m-apiserver
 func CreateSnapshot(volName string, snapName string, namespace string) error {
 
 	_, err := GetStatus()
@@ -85,7 +85,7 @@ func CreateSnapshot(volName string, snapName string, namespace string) error {
 	return nil
 }
 
-// RevertSnapshot revert a snapshot of volume by invoking the API call to m-apiserver
+// RevertSnapshot reverts a snapshot of volume by API request to m-apiserver
 func RevertSnapshot(volName string, snapName string, namespace string) error {
 
 	_, err := GetStatus()
@@ -132,7 +132,7 @@ func RevertSnapshot(volName string, snapName string, namespace string) error {
 	return nil
 }
 
-// ListSnapshot list snapshots of volume by invoking the API call to m-apiserver
+// ListSnapshot lists snapshots of volume by API request to m-apiserver
 func ListSnapshot(volName string, namespace string) error {
 
 	_, err := GetStatus()

--- a/pkg/client/mapiserver/snapshot_test.go
+++ b/pkg/client/mapiserver/snapshot_test.go
@@ -14,16 +14,18 @@ import (
 )
 
 var (
-	snapshotResponse    = `{"actions":{},"id":"snapdemo1","links":{"self":"http://10.36.0.1:9501/v1/snapshotoutputs/snapdemo1"},"type":"snapshotOutput"}`
-	volumeNameIsMissing = errors.New("Volume name is missing")
-	badReqErr           = errors.New(snapshotResponse)
-	volNotFound         = errors.New("Volume not found")
+	snapshotResponse          = `{"actions":{},"id":"snapdemo1","links":{"self":"http://10.36.0.1:9501/v1/snapshotoutputs/snapdemo1"},"type":"snapshotOutput"}`
+	volumeNameIsMissing       = errors.New("Volume name is missing")
+	badReqErr                 = errors.New(snapshotResponse)
+	volNotFound               = errors.New("Volume not found")
+	NamespaceSnapshotResponse = `{volume-snap-testsnap.img":{"children":["volume-head-001.img"],"created":"2018-06-06T12:45:55Z","name":"volume-snap-testsnap.img","parent":"volume-snap-85437a6a-1945-427b-ba93-58011b34f634.img","removed":false,"size":"377753600","usercreated":true}`
 )
 
 func TestCreateSnapshot(t *testing.T) {
 	tests := map[string]struct {
 		volumeName  string
 		snapName    string
+		namespace   string
 		fakeHandler utiltesting.FakeHandler
 		err         error
 		addr        string
@@ -82,6 +84,30 @@ func TestCreateSnapshot(t *testing.T) {
 			err:  volNotFound,
 			addr: "MAPI_ADDR",
 		},
+		"AppNameSpaceVolume": {
+			volumeName: "testvol",
+			snapName:   "testsnap",
+			namespace:  "app",
+			fakeHandler: utiltesting.FakeHandler{
+				StatusCode:   200,
+				ResponseBody: string(NamespaceSnapshotResponse),
+				T:            t,
+			},
+			err:  nil,
+			addr: "MAPI_ADDR",
+		},
+		"WrongNameSpaceVolume": {
+			volumeName: "testvol",
+			snapName:   "testsnap",
+			namespace:  "",
+			fakeHandler: utiltesting.FakeHandler{
+				StatusCode:   404,
+				ResponseBody: string("Volume 'testvol' not found"),
+				T:            t,
+			},
+			err:  fmt.Errorf("Volume 'testvol' not found"),
+			addr: "MAPI_ADDR",
+		},
 	}
 
 	for name, tt := range tests {
@@ -90,7 +116,7 @@ func TestCreateSnapshot(t *testing.T) {
 			os.Setenv(tt.addr, server.URL)
 			defer os.Unsetenv(tt.addr)
 			defer server.Close()
-			got := CreateSnapshot(tt.volumeName, tt.snapName)
+			got := CreateSnapshot(tt.volumeName, tt.snapName, tt.namespace)
 			if !reflect.DeepEqual(got, tt.err) {
 				t.Fatalf("CreateSnapshot(%v, %v) => got %v, want %v ", tt.volumeName, tt.snapName, got, tt.err)
 			}
@@ -102,6 +128,7 @@ func TestRevertSnapshot(t *testing.T) {
 	tests := map[string]struct {
 		volumeName  string
 		snapName    string
+		namespace   string
 		fakeHandler utiltesting.FakeHandler
 		err         error
 		addr        string
@@ -160,6 +187,28 @@ func TestRevertSnapshot(t *testing.T) {
 			err:  fmt.Errorf("Server status error: %v", http.StatusText(400)),
 			addr: "MAPI_ADDR",
 		},
+		"RevertAppNameSpaceVolume": {
+			volumeName: "testvol",
+			namespace:  "app",
+			fakeHandler: utiltesting.FakeHandler{
+				StatusCode:   200,
+				ResponseBody: string(NamespaceSnapshotResponse),
+				T:            t,
+			},
+			err:  nil,
+			addr: "MAPI_ADDR",
+		},
+		"RevertWrongNameSpaceVolume": {
+			volumeName: "testvol",
+			namespace:  "",
+			fakeHandler: utiltesting.FakeHandler{
+				StatusCode:   404,
+				ResponseBody: string("Volume 'testvol' not found"),
+				T:            t,
+			},
+			err:  fmt.Errorf("Server status error: %v", http.StatusText(404)),
+			addr: "MAPI_ADDR",
+		},
 	}
 
 	for name, tt := range tests {
@@ -168,7 +217,7 @@ func TestRevertSnapshot(t *testing.T) {
 			os.Setenv(tt.addr, server.URL)
 			defer os.Unsetenv(tt.addr)
 			defer server.Close()
-			got := RevertSnapshot(tt.volumeName, tt.snapName)
+			got := RevertSnapshot(tt.volumeName, tt.snapName, tt.namespace)
 			if !reflect.DeepEqual(got, tt.err) {
 				t.Fatalf("RevertSnapshot(%v, %v) => got %v, want %v ", tt.volumeName, tt.snapName, got, tt.err)
 			}
@@ -179,6 +228,7 @@ func TestRevertSnapshot(t *testing.T) {
 func TestListSnapshot(t *testing.T) {
 	tests := map[string]struct {
 		volumeName  string
+		namespace   string
 		fakeHandler utiltesting.FakeHandler
 		err         error
 		addr        string
@@ -232,6 +282,28 @@ func TestListSnapshot(t *testing.T) {
 			err:  fmt.Errorf("Server status error: %v", http.StatusText(400)),
 			addr: "MAPI_ADDR",
 		},
+		"ListAppNameSpaceVolume": {
+			volumeName: "testvol",
+			namespace:  "app",
+			fakeHandler: utiltesting.FakeHandler{
+				StatusCode:   200,
+				ResponseBody: string(NamespaceSnapshotResponse),
+				T:            t,
+			},
+			err:  nil,
+			addr: "MAPI_ADDR",
+		},
+		"ListWrongNameSpaceVolume": {
+			volumeName: "testvol",
+			namespace:  "",
+			fakeHandler: utiltesting.FakeHandler{
+				StatusCode:   404,
+				ResponseBody: string("Volume 'testvol' not found"),
+				T:            t,
+			},
+			err:  fmt.Errorf("Server status error: %v", http.StatusText(404)),
+			addr: "MAPI_ADDR",
+		},
 	}
 
 	for name, tt := range tests {
@@ -240,7 +312,7 @@ func TestListSnapshot(t *testing.T) {
 			os.Setenv(tt.addr, server.URL)
 			defer os.Unsetenv(tt.addr)
 			defer server.Close()
-			got := ListSnapshot(tt.volumeName)
+			got := ListSnapshot(tt.volumeName, tt.namespace)
 			if !reflect.DeepEqual(got, tt.err) {
 				t.Fatalf("ListSnapshot(%v) => got %v, want %v ", tt.volumeName, got, tt.err)
 			}

--- a/pkg/client/mapiserver/volume_delete.go
+++ b/pkg/client/mapiserver/volume_delete.go
@@ -13,7 +13,7 @@ const (
 )
 
 // DeleteVolume will request maya-apiserver to delete volume (vname)
-func DeleteVolume(vname string) error {
+func DeleteVolume(vname string, namespace string) error {
 
 	_, err := GetStatus()
 	if err != nil {
@@ -25,6 +25,8 @@ func DeleteVolume(vname string) error {
 	if err != nil {
 		return err
 	}
+
+	req.Header.Set("namespace", namespace)
 	c := &http.Client{
 		Timeout: timeoutVolumeDelete,
 	}

--- a/pkg/client/mapiserver/volume_delete_test.go
+++ b/pkg/client/mapiserver/volume_delete_test.go
@@ -15,6 +15,7 @@ import (
 func TestDeleteVolume(t *testing.T) {
 	tests := map[string]struct {
 		volumeName  string
+		namespace   string
 		fakeHandler utiltesting.FakeHandler
 		err         error
 		addr        string
@@ -58,6 +59,28 @@ func TestDeleteVolume(t *testing.T) {
 			err:  fmt.Errorf("Status error: %v ", http.StatusText(404)),
 			addr: "MAPI_ADDR",
 		},
+		"DeleteAppNameSpaceVolume": {
+			volumeName: "testvol",
+			namespace:  "app",
+			fakeHandler: utiltesting.FakeHandler{
+				StatusCode:   200,
+				ResponseBody: "Volume 'testvol' deleted Successfully",
+				T:            t,
+			},
+			err:  nil,
+			addr: "MAPI_ADDR",
+		},
+		"DeleteWrongNameSpaceVolume": {
+			volumeName: "testvol",
+			namespace:  "",
+			fakeHandler: utiltesting.FakeHandler{
+				StatusCode:   404,
+				ResponseBody: string("Volume 'testvol' not found"),
+				T:            t,
+			},
+			err:  fmt.Errorf("Status error: %v ", http.StatusText(404)),
+			addr: "MAPI_ADDR",
+		},
 	}
 
 	for name, tt := range tests {
@@ -66,7 +89,7 @@ func TestDeleteVolume(t *testing.T) {
 			os.Setenv(tt.addr, server.URL)
 			defer os.Unsetenv(tt.addr)
 			defer server.Close()
-			got := DeleteVolume(tt.volumeName)
+			got := DeleteVolume(tt.volumeName, tt.namespace)
 			if !reflect.DeepEqual(got, tt.err) {
 				t.Fatalf("DeleteVolume(%v) => got %v, want %v ", tt.volumeName, got, tt.err)
 			}


### PR DESCRIPTION
1. This commit will enhance mayactl to perform volume create/delete/
   list/stats/info cmd for volumes other then default namespace.
2. Mayactl snapshot create/list/revert cmds across volume namespace.
fixes: https://github.com/openebs/openebs/issues/1510
fixes: https://github.com/openebs/openebs/issues/1600
**Volume stats  of percona namespaced volume:**
```sh
$ mayactl volume stats -n percona --volname pvc-186ee6ee-6987-11e8-ac26-02b983f0a4db
Executing volume stats...
IQN     : iqn.2016-09.com.openebs.jiva:pvc-186ee6ee-6987-11e8-ac26-02b983f0a4db
Volume  : pvc-186ee6ee-6987-11e8-ac26-02b983f0a4db
Portal  : 10.111.86.151:3260
Size    : 5G

     Replica|    Status|   DataUpdateIndex|
            |          |                  |
   10.47.0.2|   Running|                 0|
   10.44.0.3|   Running|              2202|
   10.36.0.2|   Running|              2202|

----------- Performance Stats -----------
   r/s|   w/s|   r(MB/s)|   w(MB/s)|   rLat(ms)|   wLat(ms)|
     0|     0|     0.000|     0.000|      0.000|      0.000|

------------ Capacity Stats -------------
   Logical(GB)|   Used(GB)|
         0.352|      0.352|

```
**Volume Info of percona namespaced volume:**
```sh
mayactl volume info --namespace percona --volname pvc-186ee6ee-6987-11e8-ac26-02b983f0a4db
volume namespace is percona

Portal Details :
---------------
IQN     :   iqn.2016-09.com.openebs.jiva:pvc-186ee6ee-6987-11e8-ac26-02b983f0a4db
Volume  :   pvc-186ee6ee-6987-11e8-ac26-02b983f0a4db
Portal  :   10.111.86.151:3260
Size    :   5G
Status  :   Running


Replica Details :
---------------- 
NAME                                                             ACCESSMODE      STATUS      IP            NODE 
-----                                                            -----------     -------     ---           ----- 
pvc-186ee6ee-6987-11e8-ac26-02b983f0a4db-rep-87fc78659-8tzdr     NA              Running     10.47.0.2     kubeminion-02 
pvc-186ee6ee-6987-11e8-ac26-02b983f0a4db-rep-87fc78659-cbfrn     RW              Running     10.44.0.3     kubeminion-01 
pvc-186ee6ee-6987-11e8-ac26-02b983f0a4db-rep-87fc78659-dwxqb     RW              Running     10.36.0.2     kubeminion-03 

```
**Snapshot create of percona namespaced volume:**
```sh
$ mayactl snapshot --namespace percona create --volname pvc-186ee6ee-6987-11e8-ac26-02b983f0a4db --snapname testsnap
Executing volume snapshot create...
Volume snapshot Successfully Created:pvc-186ee6ee-6987-11e8-ac26-02b983f0a4db

```
Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>