### PR TITLE
 Fix mayactl snapshot command helptext

### DIFF
--- a/cmd/mayactl/app/command/snapshot/create.go
+++ b/cmd/mayactl/app/command/snapshot/create.go
@@ -25,6 +25,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	snapshotCreateCommandHelpText = `
+This command creates a new snapshot.
+
+Usage: mayactl snapshot create [options]
+
+$ mayactl snapshot create --volname <vol> --snapname <snap>
+`
+)
+
 /*func init() {
 	host := os.Getenv("MAPI_ADDR")
 	port := os.Getenv("MAPI_PORT")
@@ -49,7 +59,7 @@ func NewCmdSnapshotCreate() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Creates a new Snapshot",
-		//Long:  SnapshotCreateCommandHelpText,
+		Long:  snapshotCreateCommandHelpText,
 		Run: func(cmd *cobra.Command, args []string) {
 			util.CheckErr(options.Validate(cmd), util.Fatal)
 			util.CheckErr(options.RunSnapshotCreate(cmd), util.Fatal)

--- a/cmd/mayactl/app/command/snapshot/list.go
+++ b/cmd/mayactl/app/command/snapshot/list.go
@@ -25,12 +25,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	snapshotListCommandHelpText = `
+This command displays available snapshots on a volume.
+
+Usage: mayactl snapshot list [options]
+
+$ mayactl snapshot list --volname <vol>
+`
+)
+
 // NewCmdSnapshotCreate creates a snapshot of OpenEBS Volume
 func NewCmdSnapshotList() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Lists all the snapshots of a Volume",
-		//Long:  SnapshotCreateCommandHelpText,
+		Long:  snapshotListCommandHelpText,
 		Run: func(cmd *cobra.Command, args []string) {
 			util.CheckErr(options.ValidateList(cmd), util.Fatal)
 			util.CheckErr(options.RunSnapshotList(cmd), util.Fatal)

--- a/cmd/mayactl/app/command/snapshot/revert.go
+++ b/cmd/mayactl/app/command/snapshot/revert.go
@@ -24,25 +24,37 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	snapshotrevertHelpText = `
+This command rolls back volume data to the specified snapshot. Once the roll back
+to snapshot is successful, all data changes made after the snapshot was taken will
+be posted. This command should be used cautiously and only if there is an issue with
+the current state of data.
+
+Usage: mayactl snapshot revert [options]
+
+$ mayactl snapshot revert --volname <vol> --snapname <snap>
+
+`
+)
+
 // NewCmdSnapshotRevert reverts a snapshot of OpenEBS Volume
 func NewCmdSnapshotRevert() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "revert",
 		Short: "Reverts to specific snapshot of a Volume",
-		Long:  "Reverts to specific snapshot of a Volume",
+		Long:  snapshotrevertHelpText,
 		Run: func(cmd *cobra.Command, args []string) {
 			util.CheckErr(options.Validate(cmd), util.Fatal)
 			util.CheckErr(options.RunSnapshotRevert(cmd), util.Fatal)
 		},
 	}
-
 	cmd.Flags().StringVarP(&options.volName, "volname", "", options.volName,
 		"unique volume name.")
 	cmd.MarkPersistentFlagRequired("volname")
 	cmd.Flags().StringVarP(&options.snapName, "snapname", "s", options.snapName,
 		"unique snapshot name")
 	cmd.MarkPersistentFlagRequired("snapname")
-
 	return cmd
 }
 
@@ -52,9 +64,8 @@ func (c *CmdSnaphotOptions) RunSnapshotRevert(cmd *cobra.Command) error {
 
 	resp := mapiserver.RevertSnapshot(c.volName, c.snapName, c.namespace)
 	if resp != nil {
-		return fmt.Errorf("Error: %v", resp)
+		return fmt.Errorf("Snapshot revert failed: %v", resp)
 	}
-
 	fmt.Printf("Reverting to snapshot [%s] of volume [%s]\n", c.snapName, c.volName)
 	return nil
 }

--- a/cmd/mayactl/app/command/snapshot/snapshot.go
+++ b/cmd/mayactl/app/command/snapshot/snapshot.go
@@ -32,11 +32,42 @@ type CmdSnaphotOptions struct {
 	namespace string
 }
 
+var (
+	snapshotCommandHelpText = `
+Command provides operations related to a volume snapshot.
+
+If you have specified an OpenEBS volume in a namespace other than the 'default',
+you must use --namespace flag with a command. If not, you will see the results only
+in the 'default' namespace.
+
+Usage: mayactl snapshot <subcommand> [options] [args]
+
+Examples:
+  # Create a snapshot:
+    $ mayactl snapshot create --volname <vol> --snapname <snap>
+
+  # Create a snapshot for a volume created in 'test' namespace
+    $ mayactl snapshot create --volname <vol> --snapname <snap> --namespace test
+
+  # Lists snapshot:
+    $ mayactl snapshot list --volname <vol>
+
+  # Lists snapshots for a volume created in 'test' namespace
+    $ mayactl snapshot list --volname <vol> --namespace test
+
+  # Reverts a snapshot:
+    $ mayactl snapshot revert --volname <vol> --snapname <snap>
+
+  # Revert a snapshot for a volume created in 'test' namespace
+    $ mayactl snapshot revert --volname <vol> --snapname <snap> --namespace test
+`
+)
+
 func NewCmdSnapshot() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "snapshot",
-		Short: "Provides operations related to snapshot of a Volume",
-		Long:  "Provides operations related to snapshot of a Volume",
+		Short: "Provides operations related to a Volume snapshot",
+		Long:  snapshotCommandHelpText,
 	}
 
 	cmd.AddCommand(


### PR DESCRIPTION
```sh
$ mayactl snapshot -h

Command provides operations related to a volume snapshot.

If you have specified an OpenEBS volume in a namespace other than the 'default',
you must use --namespace flag with a command. If not, you will see the results only
in the 'default' namespace.

Usage: mayactl snapshot <subcommand> [options] [args]

Examples:
  # Create a snapshot:
    $ mayactl snapshot create --volname <vol> --snapname <snap>

  # Create a snapshot for a volume created in 'test' namespace
    $ mayactl snapshot create --volname <vol> --snapname <snap> --namespace test

  # Lists snapshot:
    $ mayactl snapshot list --volname <vol>

  # Lists snapshots for a volume created in 'test' namespace
    $ mayactl snapshot list --volname <vol> --namespace test

  # Reverts a snapshot:
    $ mayactl snapshot revert --volname <vol> --snapname <snap>

  # Revert a snapshot for a volume created in 'test' namespace
    $ mayactl snapshot revert --volname <vol> --snapname <snap> --namespace test

Usage:
  mayactl snapshot [command]

Available Commands:
  create      Creates a new Snapshot
  list        Lists all the snapshots of a Volume
  revert      Reverts to specific snapshot of a Volume

Flags:
  -h, --help               help for snapshot
  -n, --namespace string   namespace name, required if volume is not in the default namespace (default "default")

```