### PR TITLE
Fix mayactl volume command helptext

### DIFF
--- a/cmd/mayactl/app/command/commands.go
+++ b/cmd/mayactl/app/command/commands.go
@@ -25,7 +25,7 @@ import (
 func NewMayaCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mayactl",
-		Short: "Maya means 'Magic'a tool for storage orchestration",
+		Short: "Maya means 'Magic' a tool for storage orchestration",
 		Long:  `Maya means 'Magic' a tool for storage orchestration`,
 	}
 

--- a/cmd/mayactl/app/command/volume.go
+++ b/cmd/mayactl/app/command/volume.go
@@ -24,23 +24,36 @@ import (
 
 var (
 	volumeCommandHelpText = `
-	Usage: maya volume <subcommand> [options] [args]
+The following commands helps in operating a Volume such as create, list, and so on.
 
-	This command provides operations related to a Volume.
+Usage: mayactl volume <subcommand> [options] [args]
 
-	Create a Volume:
-	$ maya volume create -volname <vol> -size <size>
+Examples:
 
-	List Volumes:
-	$ maya volume list
+ # Create a Volume:
+   $ mayactl volume create --volname <vol> --size <size>
 
-	Delete a Volume:
-	$ maya volume delete -volname <vol>
+ # List Volumes:
+   $ mayactl volume list
 
-	Statistics of a Volume:
-	$ maya volume stats <vol>
+ # Delete a Volume:
+   $ mayactl volume delete --volname <vol>
 
-	`
+ # Delete a Volume created in 'test' namespace:
+   $ mayactl volume delete --volname <vol> --namespace test
+
+ # Statistics of a Volume:
+   $ mayactl volume stats --volname <vol>
+
+ # Statistics of a Volume created in 'test' namespace:
+   $ mayactl volume stats --volname <vol> --namespace test
+
+ # Info of a Volume:
+   $ mayactl volume info --volname <vol>
+
+ # Info of a Volume created in 'test' namespace:
+   $ mayactl volume info --volname <vol> --namespace test
+`
 	options = &CmdVolumeOptions{
 		namespace: "default",
 	}

--- a/cmd/mayactl/app/command/volume_create.go
+++ b/cmd/mayactl/app/command/volume_create.go
@@ -28,15 +28,10 @@ import (
 
 var (
 	volumeCreateCommandHelpText = `
-	Usage: maya volume create -volname <vol> [-size <size>]
+This command creates a new Volume.
 
-	This command creates a new Volume.
-
-	Volume create options:
-	-size
-	Provisioning size of the volume(default is 5G)
-
-	`
+Usage: mayactl volume create --volname <vol> [-size <size>]
+`
 )
 
 // NewCmdVolumeCreate creates a new OpenEBS Volume
@@ -79,11 +74,9 @@ func (c *CmdVolumeOptions) RunVolumeCreate(cmd *cobra.Command) error {
 	}
 	resp := mapiserver.CreateVolume(c.volName, c.size)
 	if resp != nil {
-		return fmt.Errorf("Error: %v", resp)
+		return fmt.Errorf("Volume creation failed: %v", resp)
 	}
-
 	fmt.Printf("Volume Successfully Created:%v\n", c.volName)
-
 	return nil
 }
 

--- a/cmd/mayactl/app/command/volume_delete.go
+++ b/cmd/mayactl/app/command/volume_delete.go
@@ -26,11 +26,10 @@ import (
 
 var (
 	volumeDeleteCommandHelpText = `
-	Usage: maya volume delete -volname <vol>
+This command initiates a deletion process for an OpenEBS Volume.
 
-	This command initiate a delete for OpenEBS Volume.
-
-	`
+Usage: mayactl volume delete --volname <vol>
+`
 )
 
 // NewCmdVolumeDelete creates a new OpenEBS Volume
@@ -57,7 +56,7 @@ func (c *CmdVolumeOptions) RunVolumeDelete(cmd *cobra.Command) error {
 
 	resp := mapiserver.DeleteVolume(c.volName, c.namespace)
 	if resp != nil {
-		return fmt.Errorf("Error: %v", resp)
+		return fmt.Errorf("Volume deletion failed: %v", resp)
 	}
 
 	fmt.Printf("Volume deletion initiated:%v\n", c.volName)

--- a/cmd/mayactl/app/command/volume_info.go
+++ b/cmd/mayactl/app/command/volume_info.go
@@ -17,11 +17,11 @@ import (
 
 var (
 	volumeInfoCommandHelpText = `
-	    Usage: mayactl volume info --volname <vol>
+This command fetches information and status of the various
+aspects of a Volume such as ISCSI, Controller, and Replica.
 
-        This command fetches the information and status of the various
-	    aspects of the Volume such as ISCSI, Controller and Replica.
-        `
+Usage: mayactl volume info --volname <vol>
+`
 )
 
 //values keeps info of the values of a current address in replicaIPStatus map

--- a/cmd/mayactl/app/command/volume_stats.go
+++ b/cmd/mayactl/app/command/volume_stats.go
@@ -34,15 +34,10 @@ import (
 
 var (
 	volumeStatsCommandHelpText = `
-	Usage: maya volume stats <vol> [-size <size>]
+This command queries the statisics of a volume.
 
-	This command queries the stats of the volume.
-
-	Volume stats options:
-	-json
-	Displays the stats in json format.
-
-	`
+Usage: mayactl volume stats --volname <vol> [-size <size>]
+`
 )
 
 // NewCmdVolumeCreate creates a new OpenEBS Volume
@@ -51,7 +46,7 @@ func NewCmdVolumeStats() *cobra.Command {
 		Use:     "stats",
 		Short:   "Displays the runtime statisics of Volume",
 		Long:    volumeStatsCommandHelpText,
-		Example: ` maya volume stats --volname=vol -j=json`,
+		Example: ` mayactl volume stats --volname=vol -j=json`,
 		Run: func(cmd *cobra.Command, args []string) {
 			util.CheckErr(options.Validate(cmd), util.Fatal)
 			util.CheckErr(options.RunVolumeStats(cmd), util.Fatal)

--- a/cmd/mayactl/app/command/volumes_list.go
+++ b/cmd/mayactl/app/command/volumes_list.go
@@ -27,10 +27,10 @@ import (
 
 var (
 	volumesListCommandHelpText = `
-	Usage: maya volume list [options]
+This command displays status of available Volumes.
+If no volume ID is given, a list of all known volumes will be displayed.
 
-	This command displays status of available Volumes.
-	If no volume ID is given, a list of all known volume will be dumped.
+Usage: mayactl volume list [options]
 	`
 )
 


### PR DESCRIPTION
Signed-off-by: Prateek <prateekpandey14@gmail.com>
fixes: https://github.com/openebs/maya/issues/354
```sh
$ mayactl volume -h
The following command provides operations related to a Volume.

Usage: mayactl volume <subcommand> [options] [args]

Examples:

 # Create a Volume:
   $ mayactl volume create --volname <vol> --size <size>

 # List Volumes:
   $ mayactl volume list

 # Delete a Volume:
   $ mayactl volume delete --volname <vol>

 # Delete a Volume created in 'test' namespace:
   $ mayactl volume delete --volname <vol> --namespace test

 # Statistics of a Volume :
   $ mayactl volume stats --volname <vol>

 # Statistics of a Volume created in 'test' namespace:
   $ mayactl volume stats --volname <vol> --namespace test

 # Info of a Volume:
   $ mayactl volume info --volname <vol>

 # Info of a Volume created in 'test' namespace:
   $ mayactl volume info --volname <vol> --namespace test

Usage:
  mayactl volume [command]

Available Commands:
  create      Creates a new Volume
  delete      Deletes a Volume
  info        Displays Openebs Volume information
  list        Displays status information about Volume(s)
  stats       Displays the runtime statisics of Volume

Flags:
  -h, --help               help for volume
  -n, --namespace string   namespace name, required if volume is not in the default namespace (default "default")

```