### PR TITLE
Add pvc label in controller and replica deployment

### DIFF
--- a/orchprovider/k8s/v1/k8s.go
+++ b/orchprovider/k8s/v1/k8s.go
@@ -800,6 +800,8 @@ func (k *k8sOrchestrator) createControllerDeployment(volProProfile volProfile.Vo
 		return nil, err
 	}
 
+	pvc := vol.Labels.K8sPersistentVolumeClaim
+
 	if clusterIP == "" {
 		return nil, fmt.Errorf("Volume cluster IP is required to create controller for volume 'name: %s'", vsm)
 	}
@@ -835,6 +837,7 @@ func (k *k8sOrchestrator) createControllerDeployment(volProProfile volProfile.Vo
 			Name: vsm + string(v1.ControllerSuffix),
 			Labels: map[string]string{
 				string(v1.VSMSelectorKey):               vsm,
+				string(v1.PVCSelectorKey):               pvc,
 				string(v1.VolumeProvisionerSelectorKey): string(v1.JivaVolumeProvisionerSelectorValue),
 				string(v1.ControllerSelectorKey):        string(v1.JivaControllerSelectorValue),
 			},
@@ -848,6 +851,7 @@ func (k *k8sOrchestrator) createControllerDeployment(volProProfile volProfile.Vo
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						string(v1.VSMSelectorKey):        vsm,
+						string(v1.PVCSelectorKey):        pvc,
 						string(v1.ControllerSelectorKey): string(v1.JivaControllerSelectorValue),
 					},
 				},
@@ -971,6 +975,8 @@ func (k *k8sOrchestrator) createReplicaDeployment(volProProfile volProfile.Volum
 		return nil, err
 	}
 
+	pvc := vol.Labels.K8sPersistentVolumeClaim
+
 	// The position is always send as 1
 	// We might want to get the replica index & send it
 	// However, this does not matter if replicas are placed on different hosts !!
@@ -1006,6 +1012,7 @@ func (k *k8sOrchestrator) createReplicaDeployment(volProProfile volProfile.Volum
 			Name: vsm + string(v1.ReplicaSuffix),
 			Labels: map[string]string{
 				string(v1.VSMSelectorKey):               vsm,
+				string(v1.PVCSelectorKey):               pvc,
 				string(v1.VolumeProvisionerSelectorKey): string(v1.JivaVolumeProvisionerSelectorValue),
 				string(v1.ReplicaSelectorKey):           string(v1.JivaReplicaSelectorValue),
 				// -- if manual replica addition
@@ -1023,6 +1030,7 @@ func (k *k8sOrchestrator) createReplicaDeployment(volProProfile volProfile.Volum
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						string(v1.VSMSelectorKey):     vsm,
+						string(v1.PVCSelectorKey):     pvc,
 						string(v1.ReplicaSelectorKey): string(v1.JivaReplicaSelectorValue),
 					},
 				},

--- a/types/v1/labels.go
+++ b/types/v1/labels.go
@@ -485,6 +485,9 @@ const (
 	// VSMSelectorKey is used to filter vsm
 	VSMSelectorKey GenericAnnotations = "vsm"
 
+	//PVCSelectorKey is used to get pvc label
+	PVCSelectorKey GenericAnnotations = "pvc"
+
 	// VSMSelectorKeyEquals is used to filter vsm when selector logic is used
 	VSMSelectorKeyEquals GenericAnnotations = VSMSelectorKey + "="
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

This PR adds a pvc label in the deployment specification files (controller and replica deployment).
Added pvc label in  createControllerDeployment() function in orchprovider/k8s.go 
https://docs.google.com/document/d/1voevyvyvEDfOW1IWjokKe9GVAGh0tmGCWZJSQH7QrBE/edit?usp=sharing

