### PR TITLE
Fixes read and write iops output in mayactl stats

### DIFF
--- a/cmd/mayactl/app/command/volume_stats.go
+++ b/cmd/mayactl/app/command/volume_stats.go
@@ -232,32 +232,31 @@ Capacity Stats :
 		Size:   a.VolSize,
 	}
 
-	stat1 := v1.StatsJSON{}
+	stat1 := v1.StatsJSON{
+
+		IQN:    a.Iqn,
+		Volume: c.volName,
+		Portal: a.TargetPortal,
+		Size:   a.VolSize,
+
+		ReadIOPS:  readIOPS,
+		WriteIOPS: writeIOPS,
+
+		ReadThroughput:  float64(rThroughput) / v1.BytesToMB, // bytes to MB
+		WriteThroughput: float64(wThroughput) / v1.BytesToMB,
+
+		ReadLatency:  float64(ReadLatency) / v1.MicSec, // Microsecond
+		WriteLatency: float64(WriteLatency) / v1.MicSec,
+
+		AvgReadBlockSize:  AvgReadBlockCountPS / v1.BytesToKB, // Bytes to KB
+		AvgWriteBlockSize: AvgWriteBlockCountPS / v1.BytesToKB,
+
+		SectorSize:  sectorSize,
+		ActualUsed:  actualUsed / v1.BytesToGB,
+		LogicalSize: logicalSize / v1.BytesToGB,
+	}
+
 	if c.json == "json" {
-
-		stat1 = v1.StatsJSON{
-
-			IQN:    a.Iqn,
-			Volume: c.volName,
-			Portal: a.TargetPortal,
-			Size:   a.VolSize,
-
-			ReadIOPS:  readIOPS,
-			WriteIOPS: writeIOPS,
-
-			ReadThroughput:  float64(rThroughput) / v1.BytesToMB, // bytes to MB
-			WriteThroughput: float64(wThroughput) / v1.BytesToMB,
-
-			ReadLatency:  float64(ReadLatency) / v1.MicSec, // Microsecond
-			WriteLatency: float64(WriteLatency) / v1.MicSec,
-
-			AvgReadBlockSize:  AvgReadBlockCountPS / v1.BytesToKB, // Bytes to KB
-			AvgWriteBlockSize: AvgWriteBlockCountPS / v1.BytesToKB,
-
-			SectorSize:  sectorSize,
-			ActualUsed:  actualUsed / v1.BytesToGB,
-			LogicalSize: logicalSize / v1.BytesToGB,
-		}
 
 		data, err := json.MarshalIndent(stat1, "", "\t")
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
* Fixes read and write iops output in mayactl stats, which was getting updated only if the json flag is set.

**output -**
```sh
$ mayactl volume stats --volname pvc-fa0ca615-7063-11e8-9373-44a842ee39a8
Executing volume stats...

Portal Details :
---------------
IQN     :   iqn.2016-09.com.openebs.jiva:pvc-fa0ca615-7063-11e8-9373-44a842ee39a8
Volume  :   pvc-fa0ca615-7063-11e8-9373-44a842ee39a8
Portal  :   10.0.0.229:3260
Size    :   5G


Replica Stats : 
---------------- 
REPLICA        STATUS      DATAUPDATEINDEX
--------       -------     ---------------- 
172.17.0.5     Running     96935     


Performance Stats :
--------------------
r/s      w/s      r(MB/s)      w(MB/s)      rLat(ms)      wLat(ms)
----     ----     --------     --------     ---------     ---------
0        2        0.000        0.012        0.000         1.007     


Capacity Stats :
---------------
LOGICAL(GB)      USED(GB)
------------     ---------
4.899            4.899    
```
**json output -**
```sh
$ mayactl volume stats --volname pvc-fa0ca615-7063-11e8-9373-44a842ee39a8 -j json
Executing volume stats...
{
	"Iqn": "iqn.2016-09.com.openebs.jiva:pvc-fa0ca615-7063-11e8-9373-44a842ee39a8",
	"Volume": "pvc-fa0ca615-7063-11e8-9373-44a842ee39a8",
	"Portal": "10.0.0.229:3260",
	"Size": "5G",
	"ReadIOPS": 0,
	"WriteIOPS": 23,
	"ReadThroughput": 0,
	"WriteThroughput": 0.15234505758811787,
	"ReadLatency": 0,
	"WriteLatency": 1.088584,
	"AvgReadBlockSize": 0,
	"AvgWriteBlockSize": 6,
	"SectorSize": 4096,
	"ActualUsed": 4.8986358642578125,
	"LogicalSize": 4.898651123046875
}
```

Signed-off-by: Sumit Lalwani <sumit.lalwani97@gmail.com>