### PR TITLE
Add ENV variables to specify default node selectors

### DIFF
--- a/orchprovider/k8s/v1/k8s_test.go
+++ b/orchprovider/k8s/v1/k8s_test.go
@@ -431,6 +431,16 @@ func (e *okVsmNameVolumeProfile) IsReplicaNodeTaintTolerations() ([]string, bool
 	return []string{"k=v:NoSchedule"}, true, nil
 }
 
+// IsControllerNodeSelectors specifies a single key value
+func (e *okVsmNameVolumeProfile) IsControllerNodeSelectors() ([]string, bool, error) {
+	return []string{"k=v"}, true, nil
+}
+
+// IsReplicaNodeSelectors specifies a single key value
+func (e *okVsmNameVolumeProfile) IsReplicaNodeSelectors() ([]string, bool, error) {
+	return []string{"k=v"}, true, nil
+}
+
 // okCtrlImgVolumeProfile focusses on not returning any error during invocation
 // of ControllerImage() method
 type okCtrlImgVolumeProfile struct {
@@ -445,6 +455,16 @@ func (e *okCtrlImgVolumeProfile) ControllerImage() (string, bool, error) {
 // ControllerImage does not return any error
 func (e *okCtrlImgVolumeProfile) IsReplicaNodeTaintTolerations() ([]string, bool, error) {
 	return []string{"k=v:NoSchedule"}, true, nil
+}
+
+// IsControllerNodeSelectors specifies a single key value
+func (e *okCtrlImgVolumeProfile) IsControllerNodeSelectors() ([]string, bool, error) {
+	return []string{"k=v"}, true, nil
+}
+
+// IsReplicaNodeSelectors specifies a single key value
+func (e *okCtrlImgVolumeProfile) IsReplicaNodeSelectors() ([]string, bool, error) {
+	return []string{"k=v"}, true, nil
 }
 
 // errVsmNameVolumeProfile focusses on returning error during invocation of

--- a/types/v1/labels.go
+++ b/types/v1/labels.go
@@ -107,6 +107,20 @@ const (
 	// <CTX>__REPLICA_NODE_TAINT_TOLERATION = <some value>
 	PVPReplicaNodeTaintTolerationEnvVarKey EnvironmentVariableKey = "_REPLICA_NODE_TAINT_TOLERATION"
 
+	// PVPControllerNodeSelectorEnvVarKey is the environment variable key for
+	// persistent volume provisioner's node selector for controllers
+	//
+	// Usage:
+	// <CTX>__CONTROLLER_NODE_SELECTOR = <some value>
+	PVPControllerNodeSelectorEnvVarKey EnvironmentVariableKey = "_CONTROLLER_NODE_SELECTOR"
+
+	// PVPReplicaNodeSelectorEnvVarKey is the environment variable key for
+	// persistent volume provisioner's node selector for replicas
+	//
+	// Usage:
+	// <CTX>__REPLICA_NODE_SELECTOR = <some value>
+	PVPReplicaNodeSelectorEnvVarKey EnvironmentVariableKey = "_REPLICA_NODE_SELECTOR"
+
 	// OrchestratorNameEnvVarKey is the environment variable key for
 	// orchestration provider's name
 	//
@@ -252,6 +266,12 @@ const (
 	PVPControllerNodeTaintTolerationLbl VolumeProvisionerProfileLabel = "volumeprovisioner.mapi.openebs.io/controller-node-taint-toleration"
 	// Label / Tag for a persistent volume provisioner's replica node taint toleration
 	PVPReplicaNodeTaintTolerationLbl VolumeProvisionerProfileLabel = "volumeprovisioner.mapi.openebs.io/replica-node-taint-toleration"
+
+	// Label / Tag for a persistent volume provisioner's controller node selector
+	PVPControllerNodeSelectorLbl VolumeProvisionerProfileLabel = "volumeprovisioner.mapi.openebs.io/controller-node-selector"
+
+	// Label / Tag for a persistent volume provisioner's replica node selector
+	PVPReplicaNodeSelectorLbl VolumeProvisionerProfileLabel = "volumeprovisioner.mapi.openebs.io/replica-node-selector"
 
 	// PVPReplicaTopologyKeyLbl is the label for a persistent volume provisioner's
 	// VSM replica topology key

--- a/types/v1/util.go
+++ b/types/v1/util.go
@@ -594,6 +594,82 @@ func DefaultReplicaNodeTaintTolerations() (string, error) {
 	return "", nil
 }
 
+// GetControllerNodeSelectors gets the node selectors for controller if
+// available
+func GetControllerNodeSelectors(profileMap map[string]string) (string, error) {
+	val, err := ControllerNodeSelectors(profileMap)
+	if err != nil {
+		return "", err
+	}
+
+	if val == "" {
+		val, err = DefaultControllerNodeSelectors()
+	}
+
+	return val, err
+}
+
+// ControllerNodeSelectors extracts the node selectors for controller
+func ControllerNodeSelectors(profileMap map[string]string) (string, error) {
+	val := ""
+	if profileMap != nil {
+		val = strings.TrimSpace(profileMap[string(PVPControllerNodeSelectorLbl)])
+	}
+
+	if val != "" {
+		return val, nil
+	}
+
+	// else get from environment variable
+	return OSGetEnv(string(PVPControllerNodeSelectorEnvVarKey), profileMap), nil
+}
+
+// DefaultControllerNodeSelectors will fetch the default value for node
+// selectors for controller
+func DefaultControllerNodeSelectors() (string, error) {
+	// Controller node selector property is optional. Hence returns blank
+	// (i.e. not required) as default.
+	return "", nil
+}
+
+// GetReplicaNodeSelectors gets the node selectors for replica if
+// available
+func GetReplicaNodeSelectors(profileMap map[string]string) (string, error) {
+	val, err := ReplicaNodeSelectors(profileMap)
+	if err != nil {
+		return "", err
+	}
+
+	if val == "" {
+		val, err = DefaultReplicaNodeSelectors()
+	}
+
+	return val, err
+}
+
+// ReplicaNodeSelectors extracts the node selectors for replica
+func ReplicaNodeSelectors(profileMap map[string]string) (string, error) {
+	val := ""
+	if profileMap != nil {
+		val = strings.TrimSpace(profileMap[string(PVPReplicaNodeSelectorLbl)])
+	}
+
+	if val != "" {
+		return val, nil
+	}
+
+	// else get from environment variable
+	return OSGetEnv(string(PVPReplicaNodeSelectorEnvVarKey), profileMap), nil
+}
+
+// DefaultReplicaNodeSelectors will fetch the default value for node
+// selectors for replicas
+func DefaultReplicaNodeSelectors() (string, error) {
+	// Replica node selector property is optional. Hence returns blank
+	// (i.e. not required) as default.
+	return "", nil
+}
+
 // GetOrchestratorNetworkType gets the not nil orchestration provider's network
 // type
 func GetOrchestratorNetworkType(profileMap map[string]string) string {

--- a/volume/profiles/profiles.go
+++ b/volume/profiles/profiles.go
@@ -77,6 +77,12 @@ type VolumeProvisionerProfile interface {
 
 	// Verify if node level taint tolerations are required for replica?
 	IsReplicaNodeTaintTolerations() ([]string, bool, error)
+
+	// Verify if node selectors are required for controller?
+	IsControllerNodeSelectors() ([]string, bool, error)
+
+	// Verify if node selectors are required for replica?
+	IsReplicaNodeSelectors() ([]string, bool, error)
 }
 
 // GetVolProProfile will return a specific persistent volume provisioner
@@ -310,6 +316,48 @@ func (pp *defVolProProfile) IsReplicaNodeTaintTolerations() ([]string, bool, err
 	// __or__
 	// key=value:effect
 	return strings.Split(nTTs, ","), true, nil
+}
+
+// IsControllerNodeSelectors provides the node selectors for controller
+// Since node selectors for controller is an optional feature, it
+// can return false.
+func (pp *defVolProProfile) IsControllerNodeSelectors() ([]string, bool, error) {
+	// Extract the node selectors for Controller
+	nodeSelectors, err := v1.GetControllerNodeSelectors(nil)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if strings.TrimSpace(nodeSelectors) == "" {
+		return nil, false, nil
+	}
+
+	// nodeSelectors is expected of below form
+	// key1=value1, key2=value2
+	// __or__
+	// key=value
+	return strings.Split(nodeSelectors, ","), true, nil
+}
+
+// IsReplicaNodeSelectors provides the node selectors for replica
+// Since node selectors for replica is an optional feature, it
+// can return false.
+func (pp *defVolProProfile) IsReplicaNodeSelectors() ([]string, bool, error) {
+	// Extract the node selectors for replica
+	nodeSelectors, err := v1.GetReplicaNodeSelectors(nil)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if strings.TrimSpace(nodeSelectors) == "" {
+		return nil, false, nil
+	}
+
+	// nodeSelectors is expected of below form
+	// key1=value1, key2=value2
+	// __or__
+	// key=value
+	return strings.Split(nodeSelectors, ","), true, nil
 }
 
 // StorageSize gets the storage size for each persistent volume replica(s)


### PR DESCRIPTION
Signed-off-by: kmova <kiran.mova@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR allows the administrators to specify the nodes on which the OpenEBS Replica and Controller Pods have to be scheduled using Kubernetes "NodeSelector" option. While Taints/Tolerations also can be used for this purpose, "NodeSelectors" are much simpler to setup using the node labels. And an added advantage is that - this can be done without having to worry about pushing taints to non-storage nodes. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
The implementation follows the traditional approach of specifying an ENV variable similar to how taints and tolerations are specified. This code is required only till the CAS Templates feature is available.
