### PR TITLE
Include application label passed from provisioner on jiva deployments

### DIFF
--- a/orchprovider/k8s/v1/k8s.go
+++ b/orchprovider/k8s/v1/k8s.go
@@ -871,7 +871,7 @@ func (k *k8sOrchestrator) createControllerDeployment(volProProfile volProfile.Vo
 		string(v1.ControllerSelectorKey):           string(v1.JivaControllerSelectorValue),
 	}
 
-	//Add the application label to the replica deployment if it exists.
+	//Add the application label to the controller deployment if it exists.
 	appLV := vol.Labels.ApplicationOld
 	if appLV != "" {
 		ctrlLabelSpec[string(v1.ApplicationSelectorKey)] = appLV

--- a/types/v1/labels.go
+++ b/types/v1/labels.go
@@ -508,6 +508,9 @@ const (
 	//PVCSelectorKey is used to get pvc label
 	PVCSelectorKey GenericAnnotations = "pvc"
 
+	//ApplicationSelectorKey is used to get application label
+	ApplicationSelectorKey GenericAnnotations = "application"
+
 	// VSMSelectorKeyEquals is used to filter vsm when selector logic is used
 	VSMSelectorKeyEquals GenericAnnotations = VSMSelectorKey + "="
 

--- a/types/v1/policies.go
+++ b/types/v1/policies.go
@@ -34,6 +34,16 @@ type OldVolumeLabels struct {
 
 	// ControllersOld contains the controller count
 	ControllersOld *int32 `json:"volumeprovisioner.mapi.openebs.io/controller-count,omitempty" protobuf:"varint,1,opt,name=volumeprovisioner.mapi.openebs.io/controller-count"`
+
+	// ApplicationOld contains the application label associated with volume
+	ApplicationOld string `json:"volumeprovisioner.mapi.openebs.io/application,omitempty" protobuf:"bytes,1,opt,name=volumeprovisioner.mapi.openebs.io/application"`
+
+	// ReplicaTopologyKeyDomainOld contains the domain that needs to be specified for Replica Deployment PodAntiAffinity Topology Key
+	ReplicaTopologyKeyDomainOld string `json:"volumeprovisioner.mapi.openebs.io/replica-topology-key-domain,omitempty" protobuf:"bytes,1,opt,name=volumeprovisioner.mapi.openebs.io/replica-topology-key-domain"`
+
+	// ReplicaTopologyKeyTypeOld contains the type that needs to be specified for Replica Deployment PodAntiAffinity Topology Key
+	ReplicaTopologyKeyTypeOld string `json:"volumeprovisioner.mapi.openebs.io/replica-topology-key-type,omitempty" protobuf:"bytes,1,opt,name=volumeprovisioner.mapi.openebs.io/replica-topology-key-type"`
+
 }
 
 // K8sVolumeLabels is a typed structure that consists of


### PR DESCRIPTION
Signed-off-by: kmova <kiran.mova@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Related to https://github.com/openebs/external-storage/pull/44

The provisioner will send additional information like application and the type of failure domain that needs to be set on the PVs created for a given application. If this information is available the maya-apiserver will have to do the following:
- If application label is received from provisioner (to the volume request), then add it to the controller and replica deployments. This label can further be used for setting affinity/anti-affinity rules or for performing some higher level abstractions like - taking a snapshot on all the volumes belonging to a given application at the same time. etc., 
- If a topology keys are sent, use them instead of the default hostname based toloplogy key. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
- This PR contains the first commit for adding the application labels. Further commits will follow that will set the anti-affinity based on the topology keys. 
- The labels are included in the OldVolumeLabels struct, with the intent that when CAS templates are used, these labels also will need to be refactored. 