### PR TITLE
Adds unit tests for get and post function in util.go file and adds constant for endpoint paths

### DIFF
--- a/pkg/client/mapiserver/snapshot.go
+++ b/pkg/client/mapiserver/snapshot.go
@@ -16,7 +16,6 @@ limitations under the License.
 package mapiserver
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -29,11 +28,20 @@ import (
 
 	client "github.com/openebs/maya/pkg/client/jiva"
 	"github.com/openebs/maya/types/v1"
-	yaml "gopkg.in/yaml.v2"
 )
 
 const (
-	http_timeout = 5 * time.Second
+	httpTimeout        = 5 * time.Second
+	snapshotCreatePath = "/latest/snapshots/create/"
+	snapshotRevertPath = "/latest/snapshots/revert/"
+	snapshotListPath   = "/latest/snapshots/list/"
+	snapshotTemplate   = `
+Snapshot Details: 
+------------------
+{{ printf "NAME\t CREATED AT\t SIZE(in MB)\t PARENT\t CHILDREN" }}
+{{ printf "-----\t -----------\t ------------\t -------\t ---------" }} {{ range $key, $value := . }}
+{{ printf "%s\t" $value.Name }} {{ printf "%s\t" $value.Created }} {{ printf "%s\t" $value.Size }} {{ printf "%s\t" $value.Parent }} {{ range $value.Children -}} {{printf "%s\n\t \t \t \t" . }} {{ end }} {{ end }}
+`
 )
 
 // SnapshotInfo stores the details of snapshot
@@ -49,112 +57,50 @@ type SnapshotInfo struct {
 
 // CreateSnapshot creates a snapshot of volume by API request to m-apiserver
 func CreateSnapshot(volName string, snapName string, namespace string) error {
-	_, err := GetStatus()
-	if err != nil {
-		return err
+	snap := v1.VolumeSnapshot{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "VolumeSnapshot",
+			APIVersion: "v1",
+		},
+		Metadata: v1.ObjectMeta{
+			Name: snapName,
+		},
+		Spec: v1.VolumeSnapshotSpec{
+			VolumeName: volName,
+		},
 	}
 
-	var snap v1.SnapshotAPISpec
-
-	snap.Kind = "VolumeSnapshot"
-	snap.APIVersion = "v1"
-	snap.Metadata.Name = snapName
-	snap.Spec.VolumeName = volName
-
-	//Marshal serializes the value provided into a YAML document
-	yamlValue, _ := yaml.Marshal(snap)
-
-	url := GetURL() + "/latest/snapshots/create/"
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(yamlValue))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Add("Content-Type", "application/yaml")
-	req.Header.Set("namespace", namespace)
-
-	c := &http.Client{
-		Timeout: http_timeout,
-	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-
-	if err != nil {
-		return err
-	}
-
-	code := resp.StatusCode
-	if err == nil && code != http.StatusOK {
-		return fmt.Errorf(string(body))
-	}
-	if code != http.StatusOK {
-		return fmt.Errorf("Server status error: %v ", http.StatusText(code))
-	}
-	return nil
+	// Marshal serializes the values
+	jsonValue, _ := json.Marshal(snap)
+	_, err := postRequest(GetURL()+snapshotCreatePath, jsonValue, namespace, true)
+	return err
 }
 
 // RevertSnapshot reverts a snapshot of volume by API request to m-apiserver
 func RevertSnapshot(volName string, snapName string, namespace string) error {
-
-	_, err := GetStatus()
-	if err != nil {
-		return err
+	snap := v1.VolumeSnapshot{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "VolumeSnapshot",
+			APIVersion: "v1",
+		},
+		Metadata: v1.ObjectMeta{
+			Name: snapName,
+		},
+		Spec: v1.VolumeSnapshotSpec{
+			VolumeName: volName,
+		},
 	}
 
-	var snap v1.SnapshotAPISpec
-
-	snap.Kind = "VolumeSnapshot"
-	snap.APIVersion = "v1"
-	snap.Metadata.Name = snapName
-	snap.Spec.VolumeName = volName
-
-	//Marshal serializes the value provided into a YAML document
-	yamlValue, _ := yaml.Marshal(snap)
-
-	url := GetURL() + "/latest/snapshots/revert/"
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(yamlValue))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Add("Content-Type", "application/yaml")
-	req.Header.Set("namespace", namespace)
-	c := &http.Client{
-		Timeout: http_timeout,
-	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	_, err = ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-	code := resp.StatusCode
-
-	if code != http.StatusOK {
-		return fmt.Errorf("Server status error: %v", http.StatusText(code))
-	}
-	return nil
+	// Marshal serializes the values
+	jsonValue, _ := json.Marshal(snap)
+	_, err := postRequest(GetURL()+snapshotRevertPath, jsonValue, namespace, false)
+	return err
 }
 
 // ListSnapshot lists snapshots of volume by API request to m-apiserver
 func ListSnapshot(volName string, namespace string) error {
 
-	_, err := GetStatus()
-	if err != nil {
-		return err
-	}
-
-	url := GetURL() + "/latest/snapshots/list/" + volName
-
-	req, err := http.NewRequest("GET", url, nil)
+	body, err := getRequest(GetURL()+snapshotListPath+volName, namespace, false)
 	if err != nil {
 		return err
 	}
@@ -231,16 +177,8 @@ func getInfo(body []byte) (map[string]client.DiskInfo, error) {
 	return s, err
 }
 
+// displayVolumeSnapshot displays the snapshot information in the snapshot template
 func displayVolumeSnapshot(snapshotList []SnapshotInfo) error {
-	const (
-		snapshotTemplate = `
-Snapshot Details: 
-------------------
-{{ printf "NAME\t CREATED AT\t SIZE(in MB)\t PARENT\t CHILDREN" }}
-{{ printf "-----\t -----------\t ------------\t -------\t ---------" }} {{ range $key, $value := . }}
-{{ printf "%s\t" $value.Name }} {{ printf "%s\t" $value.Created }} {{ printf "%s\t" $value.Size }} {{ printf "%s\t" $value.Parent }} {{ range $value.Children -}} {{printf "%s\n\t \t \t \t" . }} {{ end }} {{ end }}
-`
-	)
 
 	tmpl := template.New("SnapshotList")
 	tmpl = template.Must(tmpl.Parse(snapshotTemplate))

--- a/pkg/client/mapiserver/status.go
+++ b/pkg/client/mapiserver/status.go
@@ -6,20 +6,17 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/openebs/maya/pkg/util"
+const (
+	getStatusPath = "/latest/meta-data/instance-id"
 )
 
-// Get the status of maya-apiserver via http
+const (
+	getStatusPath = "/latest/meta-data/instance-id"
+)
+
+// GetStatus returns the status of maya-apiserver via http
 func GetStatus() (string, error) {
-
-	var url bytes.Buffer
-	addr := GetURL()
-	if addr == "" {
-		return "", util.MAPIADDRNotSet
-	}
-	url.WriteString(addr + "/latest/meta-data/instance-id")
-	resp, err := http.Get(url.String())
-
+	body, err := getRequest(GetURL()+getStatusPath, "", false)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/client/mapiserver/utils.go
+++ b/pkg/client/mapiserver/utils.go
@@ -1,7 +1,12 @@
 package mapiserver
 
 import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
 	"net"
+	"net/http"
 	"os"
 	"sort"
 	"time"
@@ -61,4 +66,97 @@ func ChangeDateFormatToUnixDate(snapshotDisks []SnapshotInfo) error {
 		snapshotDisks[index].Created = created.Format(time.UnixDate)
 	}
 	return nil
+}
+
+// postRequest sends request to a url with payload of values
+func postRequest(url string, values []byte, namespace string, chkbody bool) ([]byte, error) {
+	if len(url) == 0 {
+		return nil, errors.New("Invalid URL")
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(values))
+
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+
+	if len(namespace) > 0 {
+		req.Header.Set("namespace", namespace)
+	}
+
+	c := &http.Client{
+		Timeout: volumeCreateTimeout,
+	}
+
+	resp, err := c.Do(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+
+	if err != nil {
+		return nil, err
+	}
+
+	code := resp.StatusCode
+
+	if chkbody && err == nil && code != http.StatusOK {
+		return nil, fmt.Errorf(string(body))
+	}
+
+	if code != http.StatusOK {
+		return nil, fmt.Errorf("Server status error: %v", http.StatusText(code))
+	}
+
+	return nil, nil
+}
+
+// getRequest GETS a request to a url and returns the response
+func getRequest(url string, namespace string, chkbody bool) ([]byte, error) {
+
+	if len(url) == 0 {
+		return nil, errors.New("Invalid URL")
+	}
+
+	req, err := http.NewRequest("GET", url, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(namespace) > 0 {
+		req.Header.Set("namespace", namespace)
+	}
+
+	c := &http.Client{
+		Timeout: timeoutVolumeDelete,
+	}
+
+	resp, err := c.Do(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	code := resp.StatusCode
+
+	body, err := ioutil.ReadAll(resp.Body)
+
+	if chkbody && err == nil && code != http.StatusOK {
+		return nil, fmt.Errorf(string(body))
+	}
+
+	if code != http.StatusOK {
+		return nil, fmt.Errorf("Server status error: %v", http.StatusText(code))
+	}
+
+	return body, nil
 }

--- a/pkg/client/mapiserver/utils_test.go
+++ b/pkg/client/mapiserver/utils_test.go
@@ -1,8 +1,13 @@
 package mapiserver
 
 import (
+	"errors"
+	"net/http/httptest"
 	"os"
+	"reflect"
 	"testing"
+
+	utiltesting "k8s.io/client-go/util/testing"
 )
 
 func TestInitialize(t *testing.T) {
@@ -18,6 +23,239 @@ func TestInitialize(t *testing.T) {
 			os.Setenv(tt.key, tt.value)
 			defer os.Unsetenv(tt.key)
 			Initialize()
+		})
+	}
+}
+
+func TestGetURL(t *testing.T) {
+	cases := map[string]*struct {
+		addr           string
+		envaddr        string
+		expectedoutput string
+	}{
+		"Environment variable set": {
+			envaddr:        "192.168.0.2",
+			expectedoutput: "192.168.0.2",
+		},
+		"Environment vaiable not set": {
+			addr:           "192.168.0.1",
+			expectedoutput: "http://192.168.0.1:5656",
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			if len(tt.envaddr) > 0 {
+				os.Setenv("MAPI_ADDR", tt.envaddr)
+
+			} else {
+				MAPIAddr = tt.addr
+			}
+
+			got := GetURL()
+			os.Unsetenv("MAPI_ADDR")
+			MAPIAddr = ""
+			if !reflect.DeepEqual(got, tt.expectedoutput) {
+				t.Fatalf("GetURL => got %v, want %v ", got, tt.expectedoutput)
+			}
+
+		})
+	}
+}
+
+func TestGetRequest(t *testing.T) {
+	testcases := map[string]*struct {
+		fakeHandler utiltesting.FakeHandler
+		namespace   string
+		err         error
+		chkbody     bool
+		usefakeurl  bool
+		invalidurl  string
+	}{
+		"Invalid Url with no namespace": {
+			fakeHandler: utiltesting.FakeHandler{
+				StatusCode:   400,
+				ResponseBody: string(""),
+				T:            t,
+			},
+			namespace:  "",
+			err:        errors.New("Invalid URL"),
+			chkbody:    false,
+			usefakeurl: false,
+			invalidurl: "",
+		},
+		"No response with no namespace": {
+			fakeHandler: utiltesting.FakeHandler{
+				StatusCode:   400,
+				ResponseBody: string(response),
+				T:            t,
+			},
+			namespace:  "",
+			err:        errors.New("Server status error: Bad Request"),
+			chkbody:    false,
+			usefakeurl: true,
+		},
+		"Url not reachable": {
+			fakeHandler: utiltesting.FakeHandler{
+				StatusCode:   400,
+				ResponseBody: string(response),
+				T:            t,
+			},
+			namespace:  "",
+			err:        errors.New(`Get invalid: unsupported protocol scheme ""`),
+			chkbody:    false,
+			usefakeurl: false,
+			invalidurl: "invalid",
+		},
+		"not parsable url": {
+			fakeHandler: utiltesting.FakeHandler{
+				StatusCode:   400,
+				ResponseBody: string(response),
+				T:            t,
+			},
+			namespace:  "",
+			err:        errors.New(`parse *:: first path segment in URL cannot contain colon`),
+			chkbody:    false,
+			usefakeurl: false,
+			invalidurl: "*:",
+		},
+		"chk body is enabled": {
+			fakeHandler: utiltesting.FakeHandler{
+				StatusCode:   400,
+				ResponseBody: string(response),
+				T:            t,
+			},
+			namespace:  "",
+			err:        errors.New(response),
+			chkbody:    true,
+			usefakeurl: true,
+		},
+		"chk body is enabled with namespace": {
+			fakeHandler: utiltesting.FakeHandler{
+				StatusCode:   400,
+				ResponseBody: string(response),
+				T:            t,
+			},
+			namespace:  "default",
+			err:        errors.New(response),
+			chkbody:    true,
+			usefakeurl: true,
+		},
+	}
+
+	for name, tt := range testcases {
+		t.Run(name, func(t *testing.T) {
+			server := httptest.NewServer(&tt.fakeHandler)
+			url := ""
+			if tt.usefakeurl {
+				url = server.URL
+			} else {
+				url = tt.invalidurl
+			}
+			defer server.Close()
+			_, got := getRequest(url, tt.namespace, tt.chkbody)
+			if got.Error() != tt.err.Error() {
+				t.Fatalf("\nTest Name :%v \n  got => %v \n  want => %v \n", name, got, tt.err)
+			}
+		})
+	}
+}
+
+func TestPostRequest(t *testing.T) {
+	testcases := map[string]*struct {
+		fakeHandler utiltesting.FakeHandler
+		namespace   string
+		err         error
+		chkbody     bool
+		usefakeurl  bool
+		invalidurl  string
+	}{
+		"Invalid Url with no namespace": {
+			fakeHandler: utiltesting.FakeHandler{
+				StatusCode:   400,
+				ResponseBody: string(""),
+				T:            t,
+			},
+			namespace:  "",
+			err:        errors.New("Invalid URL"),
+			chkbody:    false,
+			usefakeurl: false,
+			invalidurl: "",
+		},
+		"No response with no namespace": {
+			fakeHandler: utiltesting.FakeHandler{
+				StatusCode:   400,
+				ResponseBody: string(response),
+				T:            t,
+			},
+			namespace:  "",
+			err:        errors.New("Server status error: Bad Request"),
+			chkbody:    false,
+			usefakeurl: true,
+		},
+		"Url not reachable": {
+			fakeHandler: utiltesting.FakeHandler{
+				StatusCode:   400,
+				ResponseBody: string(response),
+				T:            t,
+			},
+			namespace:  "",
+			err:        errors.New(`Post invalid: unsupported protocol scheme ""`),
+			chkbody:    false,
+			usefakeurl: false,
+			invalidurl: "invalid",
+		},
+		"not parsable url": {
+			fakeHandler: utiltesting.FakeHandler{
+				StatusCode:   400,
+				ResponseBody: string(response),
+				T:            t,
+			},
+			namespace:  "",
+			err:        errors.New(`parse *:: first path segment in URL cannot contain colon`),
+			chkbody:    false,
+			usefakeurl: false,
+			invalidurl: "*:",
+		},
+		"chk body is enabled": {
+			fakeHandler: utiltesting.FakeHandler{
+				StatusCode:   400,
+				ResponseBody: string(response),
+				T:            t,
+			},
+			namespace:  "",
+			err:        errors.New(response),
+			chkbody:    true,
+			usefakeurl: true,
+		},
+		"chk body is enabled with namespace": {
+			fakeHandler: utiltesting.FakeHandler{
+				StatusCode:   400,
+				ResponseBody: string(response),
+				T:            t,
+			},
+			namespace:  "default",
+			err:        errors.New(response),
+			chkbody:    true,
+			usefakeurl: true,
+		},
+	}
+
+	for name, tt := range testcases {
+		t.Run(name, func(t *testing.T) {
+			server := httptest.NewServer(&tt.fakeHandler)
+			url := ""
+			if tt.usefakeurl {
+				url = server.URL
+			} else {
+				url = tt.invalidurl
+			}
+			defer server.Close()
+			r := []byte{23, 4, 23}
+			_, got := postRequest(url, r, tt.namespace, tt.chkbody)
+			if got.Error() != tt.err.Error() {
+				t.Fatalf("\nTest Name :%v \n  got => %v \n  want => %v \n", name, got, tt.err)
+			}
 		})
 	}
 }

--- a/pkg/client/mapiserver/volume_create.go
+++ b/pkg/client/mapiserver/volume_create.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	volume_create_timeout = 5 * time.Second
+	volumeCreateTimeout = 5 * time.Second
+	volumePath          = "/latest/volumes/"
 )
 
 // Create a volume by invoking the API call to m-apiserver
@@ -23,26 +24,12 @@ func CreateVolume(vname string, size string) error {
 	if err != nil {
 		return util.MAPIADDRNotSet
 	}
+	// Marshal serializes the value of vs structure
+	jsonValue, _ := json.Marshal(vs)
 
-	var vs v1.VolumeAPISpec
-
-	vs.Kind = "Volume"
-	vs.APIVersion = "v1"
-	vs.Metadata.Name = vname
-	vs.Metadata.Labels.Storage = size
-
-	//Marshal serializes the value provided into a YAML document
-	yamlValue, _ := yaml.Marshal(vs)
-
-	//fmt.Printf("Volume Spec Created:\n%v\n", string(yamlValue))
-
-	url := GetURL() + "/latest/volumes/"
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(yamlValue))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Add("Content-Type", "application/yaml")
+	_, err := postRequest(GetURL()+volumePath, jsonValue, "", false)
+	return err
+}
 
 	c := &http.Client{
 		Timeout: volume_create_timeout,
@@ -59,8 +46,6 @@ func CreateVolume(vname string, size string) error {
 	}
 	code := resp.StatusCode
 
-	if code != http.StatusOK {
-		return fmt.Errorf("Status error: %v", http.StatusText(code))
-	}
-	return nil
+	_, err := postRequest(GetURL()+volumePath, jsonValue, "", false)
+	return err
 }

--- a/pkg/client/mapiserver/volume_delete.go
+++ b/pkg/client/mapiserver/volume_delete.go
@@ -1,44 +1,16 @@
 package mapiserver
 
 import (
-	"fmt"
-	"net/http"
 	"time"
-
-	"github.com/openebs/maya/pkg/util"
 )
 
 const (
 	timeoutVolumeDelete = 5 * time.Second
+	deleteVolumePath    = "/latest/volumes/delete/"
 )
 
 // DeleteVolume will request maya-apiserver to delete volume (vname)
 func DeleteVolume(vname string, namespace string) error {
-
-	_, err := GetStatus()
-	if err != nil {
-		return util.MAPIADDRNotSet
-	}
-
-	url := GetURL() + "/latest/volumes/delete/" + vname
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("namespace", namespace)
-	c := &http.Client{
-		Timeout: timeoutVolumeDelete,
-	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return err
-	}
-
-	defer resp.Body.Close()
-	code := resp.StatusCode
-	if code != http.StatusOK {
-		return fmt.Errorf("Status error: %v ", http.StatusText(code))
-	}
-	return nil
+	_, err := getRequest(GetURL()+deleteVolumePath+vname, namespace, false)
+	return err
 }

--- a/pkg/client/mapiserver/volumes_list.go
+++ b/pkg/client/mapiserver/volumes_list.go
@@ -11,32 +11,13 @@ import (
 
 const (
 	timeoutVolumesList = 5 * time.Second
+	listVolumePath     = "/latest/volumes/"
 )
 
 // ListVolumes and return them as obj
 func ListVolumes(obj interface{}) error {
 
-	_, err := GetStatus()
-	if err != nil {
-		return err
-	}
-
-	url := GetURL() + "/latest/volumes/"
-	client := &http.Client{
-		Timeout: timeoutVolumesList,
-	}
-	resp, err := client.Get(url)
-	if err != nil {
-		return err
-	}
-
-	code := resp.StatusCode
-	if code != http.StatusOK {
-		return fmt.Errorf("Status Error: %v", http.StatusText(code))
-	}
-
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := getRequest(GetURL()+listVolumePath, v1.DefaultNamespaceForListOps, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**: This PR does the following :
   -> Adds unit tests for Get and Post function present in util.go file mapiserver package .
   -> Changes hardcoded Get and Post URL paths to constant .

**Special notes for your reviewer**:
  -> A integration test with PR's #370 , #374 and #375 has been done and output is pasted below .

```
ashishranjan738@Ashish-PC:~/go/src/github.com/openebs/maya/bin/maya$ ./mayactl --mapiaddr 172.17.0.3 version
Version: v0.6.0-unreleased
Git commit: ad84c7913dc5e7c2db7854f18122e758cc468fb2
GO Version: go1.10.2
GO ARCH: amd64
GO OS: linux
m-apiserver url:  http://172.17.0.3:5656
m-apiserver status:  running
Provider:  Unknown
ashishranjan738@Ashish-PC:~/go/src/github.com/openebs/maya/bin/maya$ ./mayactl --mapiaddr 172.17.0.3 volume list
Name                                      Status
pvc-234f4ba4-7be4-11e8-98cb-98e7f460557e  Running
ashishranjan738@Ashish-PC:~/go/src/github.com/openebs/maya/bin/maya$ ./mayactl --mapiaddr 172.17.0.3 volume info --volname pvc-234f4ba4-7be4-11e8-98cb-98e7f460557e

Portal Details :
---------------
IQN     :   iqn.2016-09.com.openebs.jiva:pvc-234f4ba4-7be4-11e8-98cb-98e7f460557e
Volume  :   pvc-234f4ba4-7be4-11e8-98cb-98e7f460557e
Portal  :   10.0.0.170:3260
Size    :   5G
Status  :   Running

        
Replica Details : 
---------------- 
NAME                                                              ACCESSMODE      STATUS      IP              NODE
-----                                                             -----------     -------     ---             ----- 
pvc-234f4ba4-7be4-11e8-98cb-98e7f460557e-rep-794b5d5b89-kt8ws     RW              Running     172.17.0.11     127.0.0.1 
ashishranjan738@Ashish-PC:~/go/src/github.com/openebs/maya/bin/maya$ ./mayactl --mapiaddr 172.17.0.3 volume stats --volname pvc-234f4ba4-7be4-11e8-98cb-98e7f460557e
Executing volume stats...

Portal Details :
---------------
IQN     :   iqn.2016-09.com.openebs.jiva:pvc-234f4ba4-7be4-11e8-98cb-98e7f460557e
Volume  :   pvc-234f4ba4-7be4-11e8-98cb-98e7f460557e
Portal  :   10.0.0.170:3260
Size    :   5G


Replica Stats : 
---------------- 
REPLICA         STATUS      DATAUPDATEINDEX
--------        -------     ---------------- 
172.17.0.11     Running     0     


Performance Stats :
--------------------
r/s      w/s      r(MB/s)      w(MB/s)      rLat(ms)      wLat(ms)
----     ----     --------     --------     ---------     ---------
0        0        0.000        0.000        0.000         0.000     


Capacity Stats :
---------------
LOGICAL(GB)      USED(GB)
------------     ---------
0.000            0.000    

ashishranjan738@Ashish-PC:~/go/src/github.com/openebs/maya/bin/maya$ ./mayactl --mapiaddr 172.17.0.3 volume create --volname testvol1
Executing volume create...
Volume Successfully Created:testvol1
ashishranjan738@Ashish-PC:~/go/src/github.com/openebs/maya/bin/maya$ ./mayactl --mapiaddr 172.17.0.3 volume list 
Name                                      Status
pvc-234f4ba4-7be4-11e8-98cb-98e7f460557e  Running
testvol1                                  Running
ashishranjan738@Ashish-PC:~/go/src/github.com/openebs/maya/bin/maya$ ./mayactl --mapiaddr 172.17.0.3 snapshot create --snapname testsnap1 --volname pvc-234f4ba4-7be4-11e8-98cb-98e7f460557e
Executing volume snapshot create...
Volume snapshot Successfully Created:pvc-234f4ba4-7be4-11e8-98cb-98e7f460557e

ashishranjan738@Ashish-PC:~/go/src/github.com/openebs/maya/bin/maya$ ./mayactl --mapiaddr 172.17.0.3 snapshot list --volname pvc-234f4ba4-7be4-11e8-98cb-98e7f460557e

Snapshot Details: 
------------------
NAME          CREATED AT                       SIZE(in MB)      PARENT      CHILDREN
-----         -----------                      ------------     -------     --------- 
testsnap1     Fri Jun 29 21:37:32 UTC 2018     0.0000           NA          head-001
                                                                             
ashishranjan738@Ashish-PC:~/go/src/github.com/openebs/maya/bin/maya$ ./mayactl --mapiaddr 172.17.0.3 volume clone --volname testvol2 --sourcevol pvc-234f4ba4-7be4-11e8-98cb-98e7f460557e --snapname testsnap1
Executing volume clone...
Volume successfully cloned:testvol2
ashishranjan738@Ashish-PC:~/go/src/github.com/openebs/maya/bin/maya$ ./mayactl --mapiaddr 172.17.0.3 volume list
Name                                      Status
pvc-234f4ba4-7be4-11e8-98cb-98e7f460557e  Running
testvol1                                  Running
testvol2                                  Running
ashishranjan738@Ashish-PC:~/go/src/github.com/openebs/maya/bin/maya$ ./mayactl --mapiaddr 172.17.0.3 snapshot revert --volname pvc-234f4ba4-7be4-11e8-98cb-98e7f460557e
--snapname is missing. Please specify an unique name
ashishranjan738@Ashish-PC:~/go/src/github.com/openebs/maya/bin/maya$ ./mayactl --mapiaddr 172.17.0.3 snapshot revert --volname pvc-234f4ba4-7be4-11e8-98cb-98e7f460557e --snapname testsnap
Executing volume snapshot revert ...
Snapshot revert failed: Server status error: Internal Server Error
ashishranjan738@Ashish-PC:~/go/src/github.com/openebs/maya/bin/maya$ ./mayactl --mapiaddr 172.17.0.3 snapshot revert --volname pvc-234f4ba4-7be4-11e8-98cb-98e7f460557e --snapname testsnap1
Executing volume snapshot revert ...
Reverting to snapshot [testsnap1] of volume [pvc-234f4ba4-7be4-11e8-98cb-98e7f460557e]
ashishranjan738@Ashish-PC:~/go/src/github.com/openebs/maya/bin/maya$ 

```
  -> Current code coverage of mapiserver package is 89.9% .
```
Running tool: /usr/local/go/bin/go test -coverprofile=/tmp/go-code-cover -timeout 30s github.com/openebs/maya/pkg/client/mapiserver

ok  	github.com/openebs/maya/pkg/client/mapiserver	0.023s	coverage: 89.9% of statements
Success: Tests passed.
```
  -> Merge this PR after merging #375 .