### PR TITLE
Add replication factor as env to jiva controller

### DIFF
--- a/orchprovider/k8s/v1/k8s.go
+++ b/orchprovider/k8s/v1/k8s.go
@@ -885,7 +885,8 @@ func (k *k8sOrchestrator) createControllerDeployment(volProProfile volProfile.Vo
 	//   - if replication factor is 1, volume will be marked as RW when one replica connects
 	//   - if replication factor is 3, volume will be marked as RW when when atleast 2 replica connect
 	//  Similar logic will be applied to turn the volume into RO, when qorum is lost.
-	//Note: When kubectl scale up/down is done, this ENV needs to be patched. 
+	//Note: When kubectl scale up/down is done for replica deployment, 
+	// this ENV on controller deployment needs to be patched. 
 	rCount, err := volProProfile.ReplicaCount()
 	if err != nil {
 		return nil, err

--- a/types/v1/labels.go
+++ b/types/v1/labels.go
@@ -559,6 +559,9 @@ const (
 	// PortNameAPI is the name given to api ports
 	PortNameAPI JivaAnnotations = "api"
 
+	// ReplicationFactorEnvKey is the name used to pass replica count as env
+	ReplicationFactorEnvKey JivaAnnotations = "REPLICATION_FACTOR"
+
 	// JivaCtrlIPHolder is used as a placeholder for persistent volume controller's
 	// IP address
 	//


### PR DESCRIPTION
Signed-off-by: kmova <kiran.mova@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
The jiva controller needs to determine whether to have the volume as read-only/read-write based on the quorum from the replicas. When the count is not available (in 0.5.x), controller was depending on the registration process to determine the number of replicas that are connected. This auto-registration process leads to several race conditions for determining - whether the volume will be launched with a single replica or multiple replicas. By passing this replication factor, controller will handle the cases for multiple replica's better. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Related to : https://github.com/openebs/jiva/pull/83