### PR TITLE
allow topology key without application label for jiva replica deployments

### DIFF
--- a/orchprovider/k8s/v1/k8s.go
+++ b/orchprovider/k8s/v1/k8s.go
@@ -1128,9 +1128,17 @@ func (k *k8sOrchestrator) createReplicaDeployment(volProProfile volProfile.Volum
 	//Depending on the topology key, additional label selectors may be required. 
 	if replicaTopoKeyDomainLV  != "" && replicaTopoKeyTypeLV  != "" {
 		replicaTopoKey =  replicaTopoKeyDomainLV   + "/" + replicaTopoKeyTypeLV  
-		//TODO : We are assuming here that the topology keys depend on
-		// the application label.
-		repAntiAffinityLabelSpec[string(v1.ApplicationSelectorKey)] = appLV
+		//There are two scenarios for specifying custom topology keys:
+		//(a) Deploy the application using a statefulset where application has single replica
+		//    In this case, an application label to use as key is specified. 
+		//(b) Deploy the replicas of a single application need to be spread out.
+		//    In this case, there is no need to specify a seperate the application label.
+		//    Use the auto generated id. 
+		if appLV != "" {
+			repAntiAffinityLabelSpec[string(v1.ApplicationSelectorKey)] = appLV
+		} else {
+			repAntiAffinityLabelSpec[string(v1.VSMSelectorKey)] = vsm
+		}
 	} else {
 		//For host based anti-affinity, use the vsm name additional label
 		repAntiAffinityLabelSpec[string(v1.VSMSelectorKey)] = vsm


### PR DESCRIPTION
Signed-off-by: kmova <kiran.mova@openebs.io>

**What this PR does / why we need it**: 

This PR enhances the functionality provided by https://github.com/openebs/maya/pull/380

A application label will help to spread out the replicas across volumes as is supported by #380. However there may be cases where the different replica's within a given volume need to be spread across different AZs. This PR adds a check to see if the user has specified an application label, if not, it will use the auto-generated pvc label to spread out the replicas. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
This PR also fixes a case, where application developer misses to specify a application label, then a generic string `openebs/replica: jiva-replica` will be used for anti-affinity. The anti-affinity spec will be as follows:
```
      - labelSelector:
          matchLabels:
            openebs/replica: jiva-replica
        topologyKey: failure-domain.beta.kubernetes.io/zone
```
This rule will result in only one volume to be provisioned in a node or zone depending on the topology key. 

If an application label is not specified, the auto-generated pvc name will be used. The anti-affinity spec will be as follows:
```
      - labelSelector:
          matchLabels:
            vsm: pvc-a246b23d-85e3-11e8-9ef7-42010a800016
            openebs/replica: jiva-replica
        topologyKey: failure-domain.beta.kubernetes.io/zone
```
