### PR TITLE
fix issues associated with CAS Template execution

### DIFF
--- a/pkg/task/meta.go
+++ b/pkg/task/meta.go
@@ -135,6 +135,10 @@ func newMetaTaskExecutor(yml string, values map[string]interface{}) (*metaTaskEx
 	}, nil
 }
 
+func (m *metaTaskExecutor) setObjectName(objName string) {
+	m.metaTask.ObjectName = objName
+}
+
 func (m *metaTaskExecutor) getMetaInfo() MetaTask {
 	return m.metaTask
 }
@@ -295,8 +299,9 @@ func (m *metaTaskExecutor) asRollbackInstance(objectName string) (*metaTaskExecu
 		return nil, true, fmt.Errorf(errMsg)
 	}
 
-	// build the rollback version of this MetaTask
+	// build the rollback version of this meta task
 	rbMT := MetaTask{
+		// Setting the action to "Delete" is the key
 		Action:     DeleteTA,
 		ObjectName: objectName,
 		TaskIdentity: TaskIdentity{
@@ -314,14 +319,14 @@ func (m *metaTaskExecutor) asRollbackInstance(objectName string) (*metaTaskExecu
 		return nil, true, err
 	}
 
-	var repeater repeatWithResourceExecutor
-	if m.repeater.isRepeat() {
-		repeater = newRepeatWithResourceExecByObjectNames(objectName)
-	}
+	//var repeater repeatWithResourceExecutor
+	//if m.repeater.isRepeat() {
+	//	repeater = newRepeatWithResourceExecByObjectNames(objectName)
+	//}
 
 	return &metaTaskExecutor{
 		metaTask:   rbMT,
 		identifier: i,
-		repeater:   repeater,
+		//repeater:   repeater,
 	}, true, nil
 }

--- a/pkg/task/meta.go
+++ b/pkg/task/meta.go
@@ -319,14 +319,8 @@ func (m *metaTaskExecutor) asRollbackInstance(objectName string) (*metaTaskExecu
 		return nil, true, err
 	}
 
-	//var repeater repeatWithResourceExecutor
-	//if m.repeater.isRepeat() {
-	//	repeater = newRepeatWithResourceExecByObjectNames(objectName)
-	//}
-
 	return &metaTaskExecutor{
 		metaTask:   rbMT,
 		identifier: i,
-		//repeater:   repeater,
 	}, true, nil
 }

--- a/pkg/task/repeat_with.go
+++ b/pkg/task/repeat_with.go
@@ -28,6 +28,9 @@ const (
 	// NamespaceRWK indicates that the repeat resource is of kind Kubernetes
 	// namespace
 	NamespaceRWK RepeatWithKind = "namespace"
+	// TaskObjectNameRWK indicates that the repeat resource is of type task object
+	// name
+	TaskObjectNameRWK RepeatWithKind = "name"
 )
 
 // RepeatWithResource enables repetitive execution of a task based on this
@@ -75,6 +78,7 @@ func newRepeatWithResourceExecutor(repeatWith RepeatWithResource) repeatWithReso
 func newRepeatWithResourceExecByObjectNames(objectNames string) repeatWithResourceExecutor {
 	return repeatWithResourceExecutor{
 		repeatWith: RepeatWithResource{
+			Kind:      TaskObjectNameRWK,
 			Resources: strings.Split(strings.TrimSpace(objectNames), ","),
 		},
 	}
@@ -84,6 +88,12 @@ func newRepeatWithResourceExecByObjectNames(objectNames string) repeatWithResour
 // namespace
 func (r repeatWithResourceExecutor) isNamespaceRepeat() bool {
 	return r.repeatWith.Kind == NamespaceRWK
+}
+
+// isTaskObjectNameRepeat flags if the repeat resource is of kind task object
+// name
+func (r repeatWithResourceExecutor) isTaskObjectNameRepeat() bool {
+	return r.repeatWith.Kind == TaskObjectNameRWK
 }
 
 // isRepeat flags if there is any requirement to repeat the task execution

--- a/pkg/task/runner.go
+++ b/pkg/task/runner.go
@@ -113,12 +113,15 @@ func (m *TaskGroupRunner) isTaskIDUnique(identity string) (unique bool) {
 //  This is just the planning for rollback & not actual rollback.
 // In the events of issues this planning will be useful.
 func (m *TaskGroupRunner) planForRollback(te *taskExecutor, objectName string) error {
+	// There are cases where multiple objects may be created due to a single
+	// RunTask. In such cases, object name will have comma separated list of
+	// object names.
 	objNames := strings.Split(objectName, ",")
 
 	// plan the rollback for all the objects that got created
-	for _, oName := range objNames {
+	for _, name := range objNames {
 		// entire rollback plan is encapsulated in the task itself
-		rte, err := te.asRollbackInstance(strings.TrimSpace(oName))
+		rte, err := te.asRollbackInstance(strings.TrimSpace(name))
 		if err != nil {
 			return err
 		}

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -234,6 +234,13 @@ func (m *taskExecutor) repeatWith() (err error) {
 			m.resetK8sClient(resource)
 		}
 
+		if rwExec.isTaskObjectNameRepeat() {
+			// if repetition is based on task object name itself, then the task's
+			// object name needs to be set
+			m.metaTaskExec.setObjectName(resource)
+			m.objectName = resource
+		}
+
 		// set the currently active repeat resource
 		util.SetNestedField(m.templateValues, resource, string(v1alpha1.ListItemsTLP), string(v1alpha1.CurrentRepeatResourceLITP))
 
@@ -517,7 +524,7 @@ func (m *taskExecutor) deleteAppsV1B1Deployment() (err error) {
 	objectNames := strings.Split(strings.TrimSpace(m.objectName), ",")
 
 	for _, name := range objectNames {
-		err = m.k8sClient.DeleteAppsV1B1Deployment(name)
+		err = m.k8sClient.DeleteAppsV1B1Deployment(strings.TrimSpace(name))
 		if err != nil {
 			return
 		}
@@ -532,7 +539,7 @@ func (m *taskExecutor) deleteExtnV1B1Deployment() (err error) {
 	objectNames := strings.Split(strings.TrimSpace(m.objectName), ",")
 
 	for _, name := range objectNames {
-		err = m.k8sClient.DeleteExtnV1B1Deployment(name)
+		err = m.k8sClient.DeleteExtnV1B1Deployment(strings.TrimSpace(name))
 		if err != nil {
 			return
 		}
@@ -563,7 +570,7 @@ func (m *taskExecutor) deleteCoreV1Service() (err error) {
 	objectNames := strings.Split(strings.TrimSpace(m.objectName), ",")
 
 	for _, name := range objectNames {
-		err = m.k8sClient.DeleteCoreV1Service(name)
+		err = m.k8sClient.DeleteCoreV1Service(strings.TrimSpace(name))
 		if err != nil {
 			return
 		}

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -40,6 +40,91 @@ import (
 	"github.com/ghodss/yaml"
 )
 
+func TestAddTo(t *testing.T) {
+	tests := map[string]struct {
+		fields              string
+		destination         map[string]interface{}
+		value               string
+		expectedValue       string
+		expectedDestination map[string]interface{}
+	}{
+		//
+		// start of test case
+		//
+		"Positive Test - Test by providing value to a new key hierarchy": {
+			fields:        "k1.k2",
+			destination:   map[string]interface{}{},
+			value:         "hi",
+			expectedValue: "hi",
+			expectedDestination: map[string]interface{}{
+				"k1": map[string]interface{}{
+					"k2": "hi",
+				},
+			},
+		},
+		//
+		// start of test case
+		//
+		"Positive Test - Test by providing value to an existing key hierarchy": {
+			fields: "k1.k2",
+			destination: map[string]interface{}{
+				"k1": map[string]interface{}{
+					"k2": "hi",
+				},
+			},
+			value:         "hello",
+			expectedValue: "hello",
+			expectedDestination: map[string]interface{}{
+				"k1": map[string]interface{}{
+					"k2": "hi, hello",
+				},
+			},
+		},
+		//
+		// start of test case
+		//
+		"Negative Test - Test by providing empty value to an existing key hierarchy": {
+			fields: "k1.k2",
+			destination: map[string]interface{}{
+				"k1": map[string]interface{}{
+					"k2": "hi",
+				},
+			},
+			value:         "",
+			expectedValue: "",
+			expectedDestination: map[string]interface{}{
+				"k1": map[string]interface{}{
+					"k2": "hi",
+				},
+			},
+		},
+		//
+		// start of test case
+		//
+		"Negative Test - Test by providing empty value to an empty destination": {
+			fields:              "k1.k2",
+			destination:         map[string]interface{}{},
+			value:               "",
+			expectedValue:       "",
+			expectedDestination: map[string]interface{}{},
+		},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := addTo(mock.fields, mock.destination, mock.value)
+
+			if actual != mock.expectedValue {
+				t.Fatalf("addTo test failed: expected '%s' actual '%s'", mock.expectedValue, actual)
+			}
+
+			if !reflect.DeepEqual(mock.expectedDestination, mock.destination) {
+				t.Fatalf("addTo test failed: expected destination '%#v' actual destination '%#v'", mock.expectedDestination, mock.destination)
+			}
+		})
+	}
+}
+
 func TestToYaml(t *testing.T) {
 	tests := map[string]struct {
 		data           interface{}
@@ -92,18 +177,18 @@ storage:
 
 	for name, mock := range tests {
 		t.Run(name, func(t *testing.T) {
-			actual := fromYaml(toYaml(mock.data))
+			actual := fromYaml(ToYaml(mock.data))
 			expected := fromYaml(mock.expected)
 
 			if mock.isErr {
 				actualErrMsg, _ := actual["Error"].(string)
 				if mock.expectedErrMsg != actualErrMsg {
-					t.Fatalf("toYaml test failed: expected error '%s': actual error '%s'", mock.expectedErrMsg, actualErrMsg)
+					t.Fatalf("toYaml test failed: expected error '%s' actual error '%s'", mock.expectedErrMsg, actualErrMsg)
 				}
 			}
 
 			if !mock.isErr && !reflect.DeepEqual(expected, actual) {
-				t.Fatalf("toYaml test failed: expected '%#v': actual '%#v'", expected, actual)
+				t.Fatalf("toYaml test failed: expected '%#v' actual '%#v'", expected, actual)
 			}
 		})
 	}

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -2137,6 +2137,37 @@ requiredDuringSchedulingIgnoredDuringExecution:
 requiredDuringSchedulingIgnoredDuringExecution:
   nodes: k8s-minion-1,lenovo-laptop,hp-laptop`,
 		},
+		//
+		// start of test scenario
+		//
+		"Positive test - suffix with number": {
+			ymlTpl: `{{- $count := "3" -}}
+all:
+{{- range $i, $e := until ($count|int) }}
+- pvc-{{$e}}
+{{- end -}}
+`,
+			ymlExpected: `all:
+- pvc-0
+- pvc-1
+- pvc-2
+`,
+		},
+		//
+		// start of test scenario
+		//
+		"Positive test - suffix with number - customized": {
+			ymlTpl: `{{- $count := "3" -}}
+all:
+{{- range $i, $e := untilStep 1 ($count|int) 1 }}
+- pvc-{{$e}}
+{{- end -}}
+`,
+			ymlExpected: `all:
+- pvc-1
+- pvc-2
+`,
+		},
 	}
 
 	for name, mock := range tests {

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -171,6 +171,10 @@ func (v *VolumeOperation) Delete() (*v1alpha1.CASVolume, error) {
 		return nil, fmt.Errorf("unable to delete volume: volume name not provided")
 	}
 
+	// TODO
+	// Get the PV details & extract the SC & then SC details
+	//  Get the CAS Template name for delete
+	//
 	// cas template to delete a cas volume
 	castName := v.volume.Annotations[string(v1alpha1.CASTemplateKeyForVolumeDelete)]
 	if len(castName) == 0 {
@@ -222,6 +226,10 @@ func (v *VolumeOperation) Read() (*v1alpha1.CASVolume, error) {
 		return nil, fmt.Errorf("unable to read volume: volume name not provided")
 	}
 
+	// TODO
+	// Get the PV details & extract the SC & then SC details
+	//  Get the CAS Template name for read
+	//
 	// cas template to read a cas volume
 	castName := v.volume.Annotations[string(v1alpha1.CASTemplateKeyForVolumeRead)]
 	if len(castName) == 0 {
@@ -297,6 +305,10 @@ func NewVolumeListOperation(volumes *v1alpha1.CASVolumeList) (*VolumeListOperati
 }
 
 func (v *VolumeListOperation) List() (*v1alpha1.CASVolumeList, error) {
+	// TODO
+	// Get the PV details & extract the SC & then SC details
+	//  Get the CAS Template name for list
+	//
 	// cas template to list cas volumes
 	castName := v.volumes.Annotations[string(v1alpha1.CASTemplateKeyForVolumeList)]
 	if len(castName) == 0 {


### PR DESCRIPTION
This PR does the following:

- pretty print of template values during runtask execution errors
  - this helps in debugging possible issues if any while running cas templates
- addTo is a new template function
  - this appends new values with existing ones at specified key
- fix rollback logic for repeatWith based RunTask
  - rollback will delete resources that was "put" via "repeatWith" RunTask
- fix repeatWith with "get" based RunTask action
  - lets repeatWith RunTask to work with "get" based action

Signed-off-by: AmitKumarDas <amit.das@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
