### PR TITLE
[cstor-integration][TA2099] Add capacity stats

### DIFF
--- a/cmd/maya-exporter/app/collector/cstorcollector.go
+++ b/cmd/maya-exporter/app/collector/cstorcollector.go
@@ -154,9 +154,11 @@ func (c *Cstor) set(m *Metrics) error {
 	volStats = c.parser(newResp)
 	m.reads.Set(volStats.reads)
 	m.writes.Set(volStats.writes)
+	m.sectorSize.Set(volStats.sectorSize)
 	m.totalReadBytes.Set(volStats.totalReadBytes)
 	m.totalWriteBytes.Set(volStats.totalWriteBytes)
 	m.sizeOfVolume.Set(volStats.size)
+	m.actualUsed.Set(volStats.actualSize)
 	volName := strings.TrimPrefix(newResp.Iqn, "iqn.2017-08.OpenEBS.cstor:")
 	// currently volumeUpTime, portal address is not available
 	// from the cstor.
@@ -176,6 +178,10 @@ func (c *Cstor) parser(stats v1.VolumeStats) VolumeStats {
 	volStats.writes, _ = stats.Writes.Float64()
 	volStats.totalReadBytes, _ = stats.TotalReadBytes.Float64()
 	volStats.totalWriteBytes, _ = stats.TotalWriteBytes.Float64()
+	volStats.sectorSize, _ = stats.SectorSize.Float64()
+	aUsed, _ := stats.UsedLogicalBlocks.Float64()
+	aUsed = aUsed * volStats.sectorSize
+	volStats.actualSize, _ = v1.DivideFloat64(aUsed, v1.BytesToGB)
 	size, _ := stats.Size.Float64()
 	size, _ = v1.DivideFloat64(size, v1.BytesToGB)
 	volStats.size = size

--- a/cmd/maya-exporter/app/collector/cstorcollector_test.go
+++ b/cmd/maya-exporter/app/collector/cstorcollector_test.go
@@ -19,11 +19,11 @@ import (
 )
 
 var (
-	SplittedResponse             = "{ \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\" }"
+	SplittedResponse             = "{ \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\" }"
 	NilCstorResponse             = "OK IOSTATS\r\n"
-	CstorResponse                = "IOSTATS  { \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\" }\r\nOK IOSTATS\r\n"
-	JSONFormatedResponse         = "{ \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\" }"
-	ImproperJSONFormatedResponse = `IOSTATS  { \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\" }\r\nOK IOSTATS\r\n`
+	CstorResponse                = "IOSTATS  { \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\" }\r\nOK IOSTATS\r\n"
+	JSONFormatedResponse         = "{ \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\" }"
+	ImproperJSONFormatedResponse = `IOSTATS  { \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\" }\r\nOK IOSTATS\r\n`
 )
 
 func TestNewResponse(t *testing.T) {
@@ -34,12 +34,14 @@ func TestNewResponse(t *testing.T) {
 		"[Success]Unmarshal Response into Metrics struct": {
 			response: JSONFormatedResponse,
 			output: v1.VolumeStats{
-				Size:            "10737418240",
-				Iqn:             "iqn.2017-08.OpenEBS.cstor:vol1",
-				Writes:          "0",
-				Reads:           "0",
-				TotalReadBytes:  "0",
-				TotalWriteBytes: "0",
+				Size:              "10737418240",
+				Iqn:               "iqn.2017-08.OpenEBS.cstor:vol1",
+				Writes:            "0",
+				Reads:             "0",
+				TotalReadBytes:    "0",
+				TotalWriteBytes:   "0",
+				UsedLogicalBlocks: "19",
+				SectorSize:        "512",
 			},
 		},
 		"[Failure]Unmarshal Response returns empty Metrics": {


### PR DESCRIPTION
1. Why is this change necessary?
-  As per the earlier commit capacity stats such as used size and sectorsize
   details were not there in the metrics.

2. How does it address the issue?
-  This commit adds such details.

3. What side effects does this change have?
-  None

4. How to verify this change?
-  Deploy the maya-exporter on the cluster as sidecar and you should be
   able to get the metrics.

5. Any specific message for reviewer ?
-  No

Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>