### PR TITLE
Change the key of CAS Template for pool creation

### DIFF
--- a/cmd/maya-apiserver/spc-actions/storagepool_create.go
+++ b/cmd/maya-apiserver/spc-actions/storagepool_create.go
@@ -64,7 +64,7 @@ func CreateStoragePool(spcGot *apis.StoragePoolClaim) (error) {
 	// so that it can be used.
 
 	// Check for cas template
-	casTemplateName := spcGot.Annotations[string(v1alpha1.SPCASTemplateCK)]
+	casTemplateName := spcGot.Annotations[string(v1alpha1.SPCreateCASTemplateCK)]
 	if(casTemplateName==""){
 		return errors.New("Aborting storagepool create operation as no cas template is specified")
 	}

--- a/pkg/apis/openebs.io/v1alpha1/cas_template_keys.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_template_keys.go
@@ -21,7 +21,7 @@ type CasKey string
 const(
 	// This the cas template annotation whose value is the name of
 	// cas template that will be used to provision a storagepool
-	SPCASTemplateCK CasKey = "openebs.io/create-template"
+	SPCreateCASTemplateCK CasKey = "cas.openebs.io/create-pool-template"
 )
 
 // TopLevelProperty represents the top level property that


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Change the key of CAS Template for pool creation**
    
    The name of cas template for create/delete should
    be present on spc yaml as annotaions.
    
    Annotation is a key-value pair.
    
    Previous setup was following :
    [Key]: [Value]
    openebs.io/create-template:[Name of the cas template]
    
    This commit will change the Key for create cas template to following:
    [Key]: [Value]
    cas.openebs.io/create-pool-template: [Name of the cas template]
    
    After merging the commit, the SPC yaml should use the updated key
    only for successful creation of pool.

