### PR TITLE
Modify cstorvolume uid to name and modify error log

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/common/common.go
+++ b/cmd/cstor-pool-mgmt/controller/common/common.go
@@ -172,7 +172,7 @@ func CheckForCStorPoolCRD(clientset clientset.Interface) {
 	for {
 		_, err := clientset.OpenebsV1alpha1().CStorPools().List(metav1.ListOptions{})
 		if err != nil {
-			glog.Errorf("CStorPool CRD not found. Retrying after %v", CRDRetryInterval)
+			glog.Errorf("CStorPool CRD not found. Retrying after %v, error: %v", CRDRetryInterval, err)
 			time.Sleep(CRDRetryInterval)
 			continue
 		}
@@ -190,7 +190,7 @@ func CheckForCStorVolumeReplicaCRD(clientset clientset.Interface) {
 		// for default namespace works fine, then CR list api works for all namespaces.
 		_, err := clientset.OpenebsV1alpha1().CStorVolumeReplicas(string(defaultNameSpace)).List(metav1.ListOptions{})
 		if err != nil {
-			glog.Errorf("CStorVolumeReplica CRD not found. Retrying after %v", CRDRetryInterval)
+			glog.Errorf("CStorVolumeReplica CRD not found. Retrying after %v, error: %v", CRDRetryInterval, err)
 			time.Sleep(CRDRetryInterval)
 			continue
 		}

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -81,7 +81,7 @@ func (c *CStorVolumeReplicaController) cVREventHandler(operation common.QueueOpe
 		return string(apis.CVRStatusOffline), fmt.Errorf("Pool not present")
 	}
 
-	fullVolName := string(pool.PoolPrefix) + cVR.Labels["cstorpool.openebs.io/uid"] + "/" + cVR.Labels["cstorvolume.openebs.io/uid"]
+	fullVolName := string(pool.PoolPrefix) + cVR.Labels["cstorpool.openebs.io/uid"] + "/" + cVR.Labels["cstorvolume.openebs.io/name"]
 	glog.Infof("fullVolName: %v", fullVolName)
 
 	switch operation {
@@ -144,7 +144,7 @@ func (c *CStorVolumeReplicaController) cVRAddEventHandler(cVR *apis.CStorVolumeR
 		glog.Infof("cVR creation successful: %v, %v", cVR.ObjectMeta.Name, string(cVR.GetUID()))
 		return string(apis.CVRStatusOnline), nil
 	}
-	return string(apis.CVRStatusOffline), fmt.Errorf("VolumeReplica offline: %v, %v", cVR.Name, cVR.Labels["cstorvolume.openebs.io/uid"])
+	return string(apis.CVRStatusOffline), fmt.Errorf("VolumeReplica offline: %v, %v", cVR.Name, cVR.Labels["cstorvolume.openebs.io/name"])
 }
 
 // getVolumeReplicaResource returns object corresponding to the resource key

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -81,6 +81,8 @@ func (c *CStorVolumeReplicaController) cVREventHandler(operation common.QueueOpe
 		return string(apis.CVRStatusOffline), fmt.Errorf("Pool not present")
 	}
 
+	// cStorVolumeReplica is created with command which requires fullVolName which is in
+	// the form of poolname/volname.
 	fullVolName := string(pool.PoolPrefix) + cVR.Labels["cstorpool.openebs.io/uid"] + "/" + cVR.Labels["cstorvolume.openebs.io/name"]
 	glog.Infof("fullVolName: %v", fullVolName)
 

--- a/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
+++ b/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
@@ -37,7 +37,7 @@ var RunnerVar util.Runner
 // CheckValidVolumeReplica checks for validity of cStor replica resource.
 func CheckValidVolumeReplica(cVR *apis.CStorVolumeReplica) error {
 	var err error
-	if len(cVR.Labels["cstorvolume.openebs.io/uid"]) == 0 {
+	if len(cVR.Labels["cstorvolume.openebs.io/name"]) == 0 {
 		err = fmt.Errorf("Volume Name/UID cannot be empty")
 		return err
 	}

--- a/cmd/cstor-pool-mgmt/volumereplica/volumreplica_test.go
+++ b/cmd/cstor-pool-mgmt/volumereplica/volumreplica_test.go
@@ -212,7 +212,7 @@ func TestCheckValidVolumeReplica(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "VolumeReplicaResource1",
 					Labels: map[string]string{
-						"cstorvolume.openebs.io/uid": "cstor-ab12",
+						"cstorvolume.openebs.io/name": "cstor-ab12",
 					},
 				},
 				Spec: apis.CStorVolumeReplicaSpec{
@@ -227,7 +227,7 @@ func TestCheckValidVolumeReplica(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "VolumeReplicaResource2",
 					Labels: map[string]string{
-						"cstorvolume.openebs.io/uid": "cstor-ab12",
+						"cstorvolume.openebs.io/name": "cstor-ab12",
 					},
 				},
 				Spec: apis.CStorVolumeReplicaSpec{
@@ -242,7 +242,7 @@ func TestCheckValidVolumeReplica(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "VolumeReplicaResource2",
 					Labels: map[string]string{
-						"cstorvolume.openebs.io/uid": "cstor-ab12",
+						"cstorvolume.openebs.io/name": "cstor-ab12",
 					},
 				},
 				Spec: apis.CStorVolumeReplicaSpec{


### PR DESCRIPTION
1. Why is this change necessary ?
   fixes: openebs/openebs#1698

2. How does this change address the issue ?
   This change involves change in making using of cstorvolume
name instead of uid.

3. How to verify this change ?
   When CRD is not found, the error log can be verified. To connect target and replicas, the name
must be common.

Signed-off-by: gkGaneshR <gkganesh126@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

