### PR TITLE
[TA2152]Removes hardcoded delete cas template name.

### DIFF
--- a/cmd/maya-apiserver/spc-actions/storagepool_delete.go
+++ b/cmd/maya-apiserver/spc-actions/storagepool_delete.go
@@ -22,6 +22,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	"github.com/openebs/maya/pkg/storagepool"
+	"strings"
 )
 
 func DeleteStoragePool(spcGot *v1alpha1.StoragePoolClaim) error {
@@ -29,8 +30,8 @@ func DeleteStoragePool(spcGot *v1alpha1.StoragePoolClaim) error {
 	glog.Infof("Storagepool delete event received for storagepoolclaim %s", spcGot.Name)
 
 	casTemplateName := spcGot.Annotations[string(v1alpha1.SPDeleteCASTemplateCK)]
-	if casTemplateName == "" {
-		return errors.New("Aborting storagepool delete operation as no cas template is specified")
+	if strings.TrimSpace(casTemplateName) == "" {
+		return errors.New("aborting storagepool delete: missing cas template name for delete operation in storagepoolclaim annotations")
 	}
 
 	// Create an empty  CasPool object
@@ -53,6 +54,6 @@ func DeleteStoragePool(spcGot *v1alpha1.StoragePoolClaim) error {
 		return fmt.Errorf("Failed to delete cas template based storagepool: error '%s'", err.Error())
 	}
 
-	glog.Infof("Cas template based storagepool delete successfully: name '%s'", spcGot.Name)
+	glog.Infof("Cas template based storagepool deleted successfully: name '%s'", spcGot.Name)
 	return nil
 }

--- a/cmd/maya-apiserver/spc-actions/storagepool_delete.go
+++ b/cmd/maya-apiserver/spc-actions/storagepool_delete.go
@@ -17,15 +17,21 @@ limitations under the License.
 package storagepoolactions
 
 import (
+	"errors"
 	"fmt"
 	"github.com/golang/glog"
 	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	"github.com/openebs/maya/pkg/storagepool"
 )
 
-func DeleteStoragePool(key string) error {
-	// Business logic for deletion of storagepool cr
-	glog.Infof("Storagepool delete event received for storagepoolclaim %s", key)
+func DeleteStoragePool(spcGot *v1alpha1.StoragePoolClaim) error {
+	// Business logic for deletion of storagepool
+	glog.Infof("Storagepool delete event received for storagepoolclaim %s", spcGot.Name)
+
+	casTemplateName := spcGot.Annotations[string(v1alpha1.SPDeleteCASTemplateCK)]
+	if casTemplateName == "" {
+		return errors.New("Aborting storagepool delete operation as no cas template is specified")
+	}
 
 	// Create an empty  CasPool object
 	pool := &v1alpha1.CasPool{}
@@ -33,7 +39,10 @@ func DeleteStoragePool(key string) error {
 	// Fill the name in CasPool object
 	// This object contains pool information for performing storagepool deletion
 	// The information used here is the storagepoolclaim name
-	pool.StoragePoolClaim = key
+	pool.StoragePoolClaim = spcGot.Name
+
+	// Fill the cas template name that will be used for deletion
+	pool.CasDeleteTemplate = casTemplateName
 
 	storagepoolOps, err := storagepool.NewCasPoolOperation(pool)
 	if err != nil {
@@ -44,6 +53,6 @@ func DeleteStoragePool(key string) error {
 		return fmt.Errorf("Failed to delete cas template based storagepool: error '%s'", err.Error())
 	}
 
-	glog.Infof("Cas template based storagepool delete successfully: name '%s'", key)
+	glog.Infof("Cas template based storagepool delete successfully: name '%s'", spcGot.Name)
 	return nil
 }

--- a/cmd/maya-apiserver/spc-watcher/controller.go
+++ b/cmd/maya-apiserver/spc-watcher/controller.go
@@ -51,7 +51,7 @@ type Controller struct {
 	// spcSynced is used for caches sync to get populated
 	spcSynced cache.InformerSynced
 
-	// deletedIndexer holds deleted resource to be retrived after workqueue
+	// deletedIndexer holds deleted resource to be retreived after workqueue
 	deletedIndexer cache.Indexer
 
 	// workqueue is a rate limited work queue. This is used to queue work to be
@@ -101,6 +101,7 @@ func NewController(
 	spcInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			q.Operation = addEvent
+			q.Object = obj
 			controller.enqueueSpc(obj, q)
 
 		},
@@ -124,6 +125,7 @@ func NewController(
 					// Implement Logic for Update of SPC object
 					q.Operation = updateEvent
 				}
+				q.Object = new
 				controller.enqueueSpc(new, q)
 			}
 		},

--- a/cmd/maya-apiserver/spc-watcher/handler.go
+++ b/cmd/maya-apiserver/spc-watcher/handler.go
@@ -30,7 +30,7 @@ import (
 // converge the two. It then updates the Status block of the spcPoolUpdated resource
 // with the current status of the resource.
 func (c *Controller) syncHandler(key, operation string, object interface{}) error {
-	// getSpcResource will take a key as argument which conatins the namespace/name or simply name
+	// getSpcResource will take a key as argument which contains the namespace/name or simply name
 	// of the object and will fetch the object.
 	spcGot, err := c.getSpcResource(key)
 	if err != nil {
@@ -38,8 +38,8 @@ func (c *Controller) syncHandler(key, operation string, object interface{}) erro
 	}
 	// Check if the event is for delete and use the spc object that was pushed in the queue
 	// for utilising details from it e.g. delete cas template name for storagepool deletion.
-	if operation==deleteEvent{
-		if(object==nil){
+	if operation == deleteEvent {
+		if object == nil {
 			glog.Error("Nil storagepoolclaim object found for storage pool deletion")
 		}
 		spcGot = object.(*apis.StoragePoolClaim)

--- a/cmd/maya-apiserver/spc-watcher/handler.go
+++ b/cmd/maya-apiserver/spc-watcher/handler.go
@@ -29,16 +29,25 @@ import (
 // syncHandler compares the actual state with the desired, and attempts to
 // converge the two. It then updates the Status block of the spcPoolUpdated resource
 // with the current status of the resource.
-func (c *Controller) syncHandler(key, operation string) error {
+func (c *Controller) syncHandler(key, operation string, object interface{}) error {
 	// getSpcResource will take a key as argument which conatins the namespace/name or simply name
 	// of the object and will fetch the object.
 	spcGot, err := c.getSpcResource(key)
 	if err != nil {
 		return err
 	}
+	// Check if the event is for delete and use the spc object that was pushed in the queue
+	// for utilising details from it e.g. delete cas template name for storagepool deletion.
+	if operation==deleteEvent{
+		if(object==nil){
+			glog.Error("Nil storagepoolclaim object found for storage pool deletion")
+		}
+		spcGot = object.(*apis.StoragePoolClaim)
+	}
+
 	// Call the spcEventHandler which will take spc object , key(namespace/name of object) and type of operation we need to to for storage pool
 	// Type of operation for storage pool e.g. create, delete etc.
-	events, err := c.spcEventHandler(operation, spcGot, key)
+	events, err := c.spcEventHandler(operation, spcGot)
 	if events == ignoreEvent {
 		glog.Warning("None of the SPC handler was executed")
 		return nil
@@ -49,7 +58,7 @@ func (c *Controller) syncHandler(key, operation string) error {
 }
 
 // spcPoolEventHandler is to handle SPC related events.
-func (c *Controller) spcEventHandler(operation string, spcGot *apis.StoragePoolClaim, key string) (string, error) {
+func (c *Controller) spcEventHandler(operation string, spcGot *apis.StoragePoolClaim) (string, error) {
 	switch operation {
 	case addEvent:
 		// CreateStoragePool function will create the storage pool
@@ -71,7 +80,7 @@ func (c *Controller) spcEventHandler(operation string, spcGot *apis.StoragePoolC
 		break
 
 	case deleteEvent:
-		err := storagepoolactions.DeleteStoragePool(key)
+		err := storagepoolactions.DeleteStoragePool(spcGot)
 
 		if err != nil {
 			glog.Error("Storagepool could not be deleted:", err)

--- a/cmd/maya-apiserver/spc-watcher/runner.go
+++ b/cmd/maya-apiserver/spc-watcher/runner.go
@@ -98,7 +98,7 @@ func (c *Controller) processNextWorkItem() bool {
 		}
 		// Run the syncHandler, passing it the namespace/name string of the
 		//SPC resource to be synced.
-		if err := c.syncHandler(q.Key, q.Operation); err != nil {
+		if err := c.syncHandler(q.Key, q.Operation, q.Object); err != nil {
 			return fmt.Errorf("Error syncing '%s': %s", q.Key, err.Error())
 		}
 		// Finally, if no error occurs we Forget this item so it does not

--- a/cmd/maya-apiserver/spc-watcher/start.go
+++ b/cmd/maya-apiserver/spc-watcher/start.go
@@ -37,6 +37,7 @@ var (
 type QueueLoad struct {
 	Key       string
 	Operation string
+	Object interface{}
 }
 
 func Start() error {

--- a/cmd/maya-apiserver/spc-watcher/start.go
+++ b/cmd/maya-apiserver/spc-watcher/start.go
@@ -37,7 +37,7 @@ var (
 type QueueLoad struct {
 	Key       string
 	Operation string
-	Object interface{}
+	Object    interface{}
 }
 
 func Start() error {

--- a/pkg/apis/openebs.io/v1alpha1/cas_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_pool.go
@@ -22,9 +22,13 @@ type CasPool struct {
 	// StoragePoolClaim is the name of the storagepoolclaim object
 	StoragePoolClaim string
 
-	// CasCreateTemplate is the cas template that will be used for storagepool
-	// operations
+	// CasCreateTemplate is the cas template that will be used for storagepool create
+	// operation
 	CasCreateTemplate string
+
+	// CasDeleteTemplate is the cas template that will be used for storagepool delete
+	// operation
+	CasDeleteTemplate string
 
 	// Namespace can be passed via storagepoolclaim as labels to decide on the
 	// execution of namespaced resources with respect to storagepool

--- a/pkg/apis/openebs.io/v1alpha1/cas_template_keys.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_template_keys.go
@@ -19,9 +19,13 @@ package v1alpha1
 type CasKey string
 
 const (
-	// This the cas template annotation whose value is the name of
+	// This is the cas template annotation whose value is the name of
 	// cas template that will be used to provision a storagepool
 	SPCreateCASTemplateCK CasKey = "cas.openebs.io/create-pool-template"
+
+	// This is the cas template annotation whose value is the name of
+	// cas template that will be used to delete a storagepool
+	SPDeleteCASTemplateCK CasKey = "cas.openebs.io/delete-pool-template"
 )
 
 // TopLevelProperty represents the top level property that

--- a/pkg/storagepool/storagepool.go
+++ b/pkg/storagepool/storagepool.go
@@ -114,12 +114,9 @@ func (v *casPoolOperation) Delete() (*v1alpha1.CasPool, error) {
 	}
 
 	// cas template to delete a storagepool
-	// Need to decide on correct way of passing it.
-	castName := "cstor-pool-delete-default-0.7.0"
+	castName := v.pool.CasDeleteTemplate
 	if len(castName) == 0 {
-		// use the default delete cas template otherwise
-		//castName = string(v1alpha1.CASTemplateForDeleteCVD)
-		fmt.Println("No CAS template for delete")
+		fmt.Println("No CAS template for storagepool deletion found")
 	}
 
 	// fetch delete cas template specifications

--- a/pkg/storagepool/storagepool.go
+++ b/pkg/storagepool/storagepool.go
@@ -116,7 +116,7 @@ func (v *casPoolOperation) Delete() (*v1alpha1.CasPool, error) {
 	// cas template to delete a storagepool
 	castName := v.pool.CasDeleteTemplate
 	if len(castName) == 0 {
-		fmt.Println("No CAS template for storagepool deletion found")
+		return nil, fmt.Errorf("unable to delete storagepool: no cas template for delete found")
 	}
 
 	// fetch delete cas template specifications


### PR DESCRIPTION
This commit will remove the hardcoded cas template name from code.

The name of delete cas template should come as a part
of annotation in storagepoolclaim yaml
e.g.
cas.openebs.io/delete-pool-template: cstor-pool-delete-default-0.7.0

Signed-off-by: sonasingh46 <sonasingh46@gmail.com>