### PR TITLE
add default storage pool to provision jiva volumes

### DIFF
--- a/install/v1alpha1-0.7.0/jiva-pool/pool.yaml
+++ b/install/v1alpha1-0.7.0/jiva-pool/pool.yaml
@@ -1,0 +1,8 @@
+apiVersion: openebs.io/v1alpha1
+kind: StoragePool
+metadata:
+  name: jiva-pool-path-default-0.7.0
+  type: hostdir
+spec:
+  path: "/var/openebs"
+---

--- a/install/v1alpha1-0.7.0/jiva-volume/volume.yaml
+++ b/install/v1alpha1-0.7.0/jiva-volume/volume.yaml
@@ -27,7 +27,7 @@ spec:
   - name: ReplicaCount
     value: "1"
   - name: StoragePool
-    value: ssd
+    value: jiva-pool-path-default-0.7.0
   - name: TaintTolerations
     value: |-
       t1:


### PR DESCRIPTION
The storage pool defined as per this commit ensures the use of a default host path i.e. `/var/openebs` to place the volume replica files.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
