### PR TITLE
[WIP][US2908]Auto pool provisioning for cstor

### DIFF
--- a/cmd/maya-apiserver/spc-actions/select_disk.go
+++ b/cmd/maya-apiserver/spc-actions/select_disk.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2017 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storagepoolactions
+
+import (
+	mach_apis_meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	//openebs "github.com/openebs/maya/pkg/client/clientset/versioned"
+	openebs "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset"
+	"github.com/golang/glog"
+	"fmt"
+	"github.com/openebs/maya/pkg/client/k8s"
+	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+)
+
+// clientset struct holds the interface of internalclientset
+// i.e. openebs.
+// This struct will be binded to method ListDisk and is useful in mocking
+// and unit testing.
+type clientSet struct {
+	oecs openebs.Interface
+}
+
+// nodeDisk struct will be used as a value for a map nodeDiskMap (map defined in ListDisk function)
+// The struct will be useful in forming the data structure nodeDiskMap which will be manipulated
+// to efficiently select the nodes and disk for dynamic pool provisioning.
+type nodeDisk struct {
+	// diskCount is the count of usable disks that can be used in storagepool provisioning.
+	diskCount int
+	//diskList is the list of usable disks that can be used in storagepool provisioning.
+	diskList []string
+}
+
+// spareAllotment holds the value for the remaining node allotments
+// for pool provisioning.
+var spareAllotment int16
+
+// getDiskList is a wrapper function which will receive list of disks
+// that can be used for dynamic pool provisioning at runtime.
+// The function finally returns the disk list to the caller (i.e. getCasPoolDisk function).
+func getDiskList(cp *v1alpha1.CasPool) ([]string, error) {
+
+	// Get kubernetes clientset
+	// namespaces is not required, hence passed empty.
+	newK8sClient, err := k8s.NewK8sClient("")
+
+	if err != nil {
+		return nil, err
+	}
+	// Get openebs clientset using a getter method (i.e. GetOECS() ) as
+	// the openebs clientset is not exported.
+	newOecsClient := newK8sClient.GetOECS()
+
+	// Create instance of clientset struct defined above which binds
+	// ListDisk method and fill it with openebs clienset (i.e.newOecsClient ).
+	newClientSet := clientSet{
+		oecs: newOecsClient,
+	}
+
+	// if no minimum pools were specified it will default to 1.
+	if cp.MinPools <= 0 {
+		glog.Warning("invalid or 0 min pool specified, defaulting to 1")
+		cp.MinPools = 1
+	}
+
+	// nodeDiskAlloter will try to return a list of disks so that maxpool number of storagepool
+	// is provisioned.
+	diskList, err := newClientSet.nodeDiskAlloter(cp)
+	if err != nil {
+		return nil, err
+	}
+
+	return diskList, nil
+}
+
+// nodeDiskAlloter will try to allot nodes for pool creation as specified in
+// maxPool field of the storagepoolclaim.
+
+// For exapmle, if maxPool=5 and minPool=3, it will try to search for 5 nodes that will qualify for
+// pool provisioning. At least 3 node should qualify else pool will not be provisioned and pool creation
+// will be aborted gracefully with proper log messages.
+
+// If no minPool field is present,at least one node must qalify for pool provisioning.
+
+// modeDiskAlloter can be made more intelligent as per the required pool constraints for alloting nodes.
+func (k *clientSet) nodeDiskAlloter(cp *v1alpha1.CasPool) ([]string, error) {
+
+	// assign maxPools to spareAllotment as right now maxPool is the number of allotments
+	// that needs to be done.
+	spareAllotment = cp.MaxPools
+
+	// Request kube-apiserver for the list of disk (powered by NDM)
+	// Currently, all the disks are returned,but the disk that is already a part of pool
+	// should not be returned.
+	listDisk, err := k.oecs.OpenebsV1alpha1().Disks().List(mach_apis_meta_v1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error in getting the disk list:", err)
+	}
+	if listDisk == nil {
+		return nil, fmt.Errorf("no disk object found")
+	}
+	nodeDiskMap := nodeSelector(listDisk, cp.PoolType)
+	gotAllotment := cp.MaxPools - spareAllotment
+	if spareAllotment > cp.MaxPools-cp.MinPools {
+		return nil, fmt.Errorf("no node qualified for pool:only %d node could be alloted but required is %d", gotAllotment, cp.MinPools)
+	}
+	if gotAllotment < cp.MaxPools {
+		glog.Warning("partial node allotment done:spared node allotment:", spareAllotment)
+	}
+	selectedDisk := diskSelector(nodeDiskMap, cp.PoolType)
+	return selectedDisk, nil
+}
+
+// nodeSelector function will select candidate nodes that will qualify for storagepool provisioning in accordance
+// with the pool constraints.
+
+// NOTE: Not all the selected nodes may qualify.
+
+// Finally diskSelector function will vote for qualified nodes.
+
+func nodeSelector(listDisk *v1alpha1.DiskList, poolType string) (map[string]*nodeDisk) {
+
+	// nodeDiskMap is the data structure holding host name as key
+	// and nodeDisk struct as value
+	nodeDiskMap := make(map[string]*nodeDisk)
+	for _, value := range listDisk.Items {
+		// if no more allotment is required, stop processing
+		if spareAllotment == 0 {
+			glog.Info("required pool allotment done")
+			break
+		}
+		if nodeDiskMap[value.Labels[string(v1alpha1.HostNameCPK)]] == nil {
+			// Entry to this block means first time the hostname will be mapped for the first time.
+			// Obviously, this entry of hostname(node) is for a usable disk and initialize diskCount to 1.
+			nodeDiskMap[value.Labels[string(v1alpha1.HostNameCPK)]] = &nodeDisk{diskList: []string{value.Name}, diskCount: 1}
+			// If pool type is striped the node qualifies for pool creation hence spareAllotment decremented.
+			if poolType == string(v1alpha1.PoolTypeStripedCPK) {
+				spareAllotment --
+			}
+		} else {
+			// Entry to this block means the hostname was already mapped and it has more than one disk and at least two disks.
+			nodeDisk := nodeDiskMap[value.Labels[string(v1alpha1.HostNameCPK)]]
+			// Increment the disk count
+			nodeDisk.diskCount ++
+			// Add the current disk to the diskList for this node.
+			nodeDisk.diskList = append(nodeDisk.diskList, value.Name)
+			// If pool type is mirrored the node qualifies for pool creation hence spareAllotment decremented.
+			if poolType == string(v1alpha1.PoolTypeMirroredCPK) {
+				if nodeDisk.diskCount == int(v1alpha1.MirroredDiskCountCPK) {
+					spareAllotment --
+				}
+			}
+		}
+
+	}
+	return nodeDiskMap
+}
+
+// diskSelector is the function that will select the required number of disks from qualified nodes
+// so as to provision storagepool
+
+func diskSelector(nodeDiskMap map[string]*nodeDisk, poolType string) ([]string) {
+
+	// selectedDisk will hold a list of disk that will be used to provision storage pool, after a
+	// minimum number of node qualifies
+	var selectedDisk []string
+
+	// requiredDiskCount will hold the required number of disk that should be selcted from a qualified
+	// node for specific pool type
+	var requiredDiskCount int
+
+	// Range over the nodeDiskMap map to get the list of disks
+	for _, val := range nodeDiskMap {
+		// If pool type is striped, 1 disk should be selected
+		if poolType == string(v1alpha1.PoolTypeStripedCPK) {
+			requiredDiskCount = int(v1alpha1.StripedDiskCountCPK)
+		}
+		// If pool type is striped, 2 disks should be selected
+		if poolType == string(v1alpha1.PoolTypeMirroredCPK) {
+			requiredDiskCount = int(v1alpha1.MirroredDiskCountCPK)
+			// If the current disk count on the node is less than the required disks
+			// then this is a dirty node and it will not qualify.
+			if len(val.diskList) < requiredDiskCount {
+				continue
+			}
+		}
+		// Select the required disk from qualified nodes.
+		for i := 0; i < requiredDiskCount; i++ {
+			selectedDisk = append(selectedDisk, val.diskList[i])
+		}
+	}
+	return selectedDisk
+}

--- a/cmd/maya-apiserver/spc-actions/select_disk.go
+++ b/cmd/maya-apiserver/spc-actions/select_disk.go
@@ -116,7 +116,7 @@ func (k *clientSet) nodeDiskAlloter(cp *v1alpha1.CasPool) ([]string, error) {
 		return nil, errors.New("no disk object found")
 	}
 
-	nodeDiskMap,spareAllotment := nodeSelector(listDisk, cp.PoolType,spareAllotment)
+	nodeDiskMap, spareAllotment := nodeSelector(listDisk, cp.PoolType, spareAllotment)
 	gotAllotment := cp.MaxPools - spareAllotment
 	if spareAllotment > cp.MaxPools-cp.MinPools {
 		return nil, fmt.Errorf("no node qualified for pool:only %d node could be alloted but required is %d", gotAllotment, cp.MinPools)
@@ -135,7 +135,7 @@ func (k *clientSet) nodeDiskAlloter(cp *v1alpha1.CasPool) ([]string, error) {
 
 // Finally diskSelector function will vote for qualified nodes.
 
-func nodeSelector(listDisk *v1alpha1.DiskList, poolType string,spareAllotment int16) (map[string]*nodeDisk,int16){
+func nodeSelector(listDisk *v1alpha1.DiskList, poolType string, spareAllotment int16) (map[string]*nodeDisk, int16) {
 
 	// nodeDiskMap is the data structure holding host name as key
 	// and nodeDisk struct as value
@@ -170,7 +170,7 @@ func nodeSelector(listDisk *v1alpha1.DiskList, poolType string,spareAllotment in
 		}
 
 	}
-	return nodeDiskMap,spareAllotment
+	return nodeDiskMap, spareAllotment
 }
 
 // diskSelector is the function that will select the required number of disks from qualified nodes
@@ -211,7 +211,7 @@ func diskSelector(nodeDiskMap map[string]*nodeDisk, poolType string) []string {
 
 // diskFilterConstraint will form labels that will be used to filter disks
 
-func diskFilterConstraint(diskType string) (string) {
+func diskFilterConstraint(diskType string) string {
 	var label string
 	if diskType == string(v1alpha1.TypeSparseCPK) {
 		label = string(v1alpha1.DiskTypeCPK) + "=" + string(v1alpha1.TypeSparseCPK)

--- a/cmd/maya-apiserver/spc-actions/select_disk.go
+++ b/cmd/maya-apiserver/spc-actions/select_disk.go
@@ -90,7 +90,7 @@ func (k *clientSet) nodeDiskAlloter(cp *v1alpha1.CasPool) ([]string, error) {
 
 	// spareAllotment holds the value for the remaining node allotments
 	// for pool provisioning.
-	var spareAllotment int16
+	var spareAllotment int
 
 	// assign maxPools to spareAllotment as right now maxPool is the number of allotments
 	// that needs to be done.
@@ -109,7 +109,7 @@ func (k *clientSet) nodeDiskAlloter(cp *v1alpha1.CasPool) ([]string, error) {
 		return nil, errors.New("no disk object found")
 	}
 
-	nodeDiskMap, spareAllotment := k.nodeSelector(listDisk, cp.PoolType, spareAllotment, cp.StoragePoolClaim)
+	nodeDiskMap, spareAllotment := k.nodeSelector(listDisk, cp.PoolType, spareAllotment)
 	gotAllotment := cp.MaxPools - spareAllotment
 	if spareAllotment > cp.MaxPools-cp.MinPools {
 		return nil, fmt.Errorf("no node qualified for pool:only %d node could be alloted but required is %d", gotAllotment, cp.MinPools)
@@ -128,18 +128,18 @@ func (k *clientSet) nodeDiskAlloter(cp *v1alpha1.CasPool) ([]string, error) {
 
 // Finally diskSelector function will vote for qualified nodes.
 
-func (k *clientSet) nodeSelector(listDisk *v1alpha1.DiskList, poolType string, spareAllotment int16, spc string) (map[string]*nodeDisk, int16) {
+func (k *clientSet) nodeSelector(listDisk *v1alpha1.DiskList, poolType string, spareAllotment int) (map[string]*nodeDisk, int) {
 
 	// Get the list of disk that has been used already for pool provisioning
-	splist, err := k.oecs.OpenebsV1alpha1().StoragePools().List(mach_apis_meta_v1.ListOptions{LabelSelector: string(v1alpha1.StoragePoolClaimCPK) + "=" + spc})
+	spList, err := k.oecs.OpenebsV1alpha1().StoragePools().List(mach_apis_meta_v1.ListOptions{})
 	if err != nil {
 		glog.Error("unable to get the list of used disks:", err)
 	}
 	// Form a map that will hold all the used disk
 	usedDiskMap := make(map[string]int)
-	for _, sp := range splist.Items {
-		for _, useddisk := range sp.Spec.Disks.DiskList {
-			usedDiskMap[useddisk]++
+	for _, sp := range spList.Items {
+		for _, usedDisk := range sp.Spec.Disks.DiskList {
+			usedDiskMap[usedDisk]++
 		}
 
 	}

--- a/cmd/maya-apiserver/spc-actions/select_disk_test.go
+++ b/cmd/maya-apiserver/spc-actions/select_disk_test.go
@@ -34,18 +34,28 @@ func TestNodeDiskAlloter(t *testing.T) {
 	}
 
 	// Create some fake disk objects over nodes.
-	// For example, create 4 disk for each of 5 nodes.
-	// That meant 4*5 i.e. 20 disk objects should be created
+	// For example, create 6 disk (out of 6 disks 2 disks are sparse disks)for each of 5 nodes.
+	// That meant 6*5 i.e. 30 disk objects should be created
 
 	// diskObjectList will hold the list of disk objects
-	var diskObjectList [20]*v1alpha1.Disk
+	var diskObjectList [30]*v1alpha1.Disk
+
+	sparseDiskCount := 2
+	var diskLabel string
 
 	// nodeIdentifer will help in naming a node and attaching multiple disks to a single node.
 	nodeIdentifer := 0
-	for diskListIndex := 0; diskListIndex < 20; diskListIndex++ {
+	for diskListIndex := 0; diskListIndex < 30; diskListIndex++ {
 		diskIdentifier := strconv.Itoa(diskListIndex)
-		if diskListIndex%4 == 0 {
+		if diskListIndex%6 == 0 {
 			nodeIdentifer++
+			sparseDiskCount = 0
+		}
+		if sparseDiskCount != 2 {
+			diskLabel = "sparse"
+			sparseDiskCount++
+		} else {
+			diskLabel = "disk"
 		}
 		diskObjectList[diskListIndex] = &v1alpha1.Disk{
 			TypeMeta: metav1.TypeMeta{},
@@ -53,6 +63,7 @@ func TestNodeDiskAlloter(t *testing.T) {
 				Name: "disk" + diskIdentifier,
 				Labels: map[string]string{
 					"kubernetes.io/hostname": "gke-ashu-cstor-default-pool-a4065fd6-vxsh" + strconv.Itoa(nodeIdentifer),
+					"ndm.io/disk-type":       diskLabel,
 				},
 			},
 		}
@@ -74,6 +85,7 @@ func TestNodeDiskAlloter(t *testing.T) {
 			PoolType: "striped",
 			MaxPools: 3,
 			MinPools: 3,
+			Type:     "disk",
 		},
 			3,
 			false,
@@ -82,6 +94,7 @@ func TestNodeDiskAlloter(t *testing.T) {
 		"CasPool2": {&v1alpha1.CasPool{
 			PoolType: "striped",
 			MaxPools: 3,
+			Type:     "disk",
 		},
 			3,
 			false,
@@ -91,6 +104,7 @@ func TestNodeDiskAlloter(t *testing.T) {
 			PoolType: "mirrored",
 			MaxPools: 3,
 			MinPools: 3,
+			Type:     "disk",
 		},
 			6,
 			false,
@@ -100,6 +114,7 @@ func TestNodeDiskAlloter(t *testing.T) {
 			PoolType: "mirrored",
 			MaxPools: 6,
 			MinPools: 6,
+			Type:     "disk",
 		},
 			0,
 			true,
@@ -109,6 +124,7 @@ func TestNodeDiskAlloter(t *testing.T) {
 			PoolType: "striped",
 			MaxPools: 6,
 			MinPools: 6,
+			Type:     "disk",
 		},
 			0,
 			true,
@@ -118,8 +134,29 @@ func TestNodeDiskAlloter(t *testing.T) {
 			PoolType: "striped",
 			MaxPools: 6,
 			MinPools: 2,
+			Type:     "disk",
 		},
 			5,
+			false,
+		},
+		// Test Case #7
+		"CasPool7 of sparse type": {&v1alpha1.CasPool{
+			PoolType: "striped",
+			MaxPools: 6,
+			MinPools: 2,
+			Type:     "sparse",
+		},
+			5,
+			false,
+		},
+		// Test Case #7
+		"CasPool8 of sparse type": {&v1alpha1.CasPool{
+			PoolType: "mirrored",
+			MaxPools: 6,
+			MinPools: 2,
+			Type:     "sparse",
+		},
+			10,
 			false,
 		},
 	}

--- a/cmd/maya-apiserver/spc-actions/select_disk_test.go
+++ b/cmd/maya-apiserver/spc-actions/select_disk_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2018 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storagepoolactions
+
+import (
+	"testing"
+	//openebsFakeClientset "github.com/openebs/maya/pkg/client/clientset/versioned/fake"
+	openebsFakeClientset "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset/fake"
+	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strconv"
+	"github.com/golang/glog"
+)
+
+func TestNodeDiskAlloter(t *testing.T) {
+
+	// Get a fake openebs client set
+	focs := &clientSet{
+		oecs: openebsFakeClientset.NewSimpleClientset(),
+	}
+
+	// Create some fake disk objects over nodes.
+	// For example, create 4 disk for each of 5 nodes.
+	// That meant 4*5 i.e. 20 disk objects should be created
+
+	// diskObjectList will hold the list of disk objects
+	var diskObjectList [20]*v1alpha1.Disk
+
+	// nodeIdentifer will help in naming a node and attaching multiple disks to a single node.
+	nodeIdentifer := 0
+	for diskListIndex := 0; diskListIndex < 20; diskListIndex++ {
+		diskIdentifier := strconv.Itoa(diskListIndex)
+		if diskListIndex%4 == 0 {
+			nodeIdentifer ++
+		}
+		diskObjectList[diskListIndex] = &v1alpha1.Disk{
+			TypeMeta: metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "disk" + diskIdentifier,
+				Labels: map[string]string{
+					"kubernetes.io/hostname": "gke-ashu-cstor-default-pool-a4065fd6-vxsh" + strconv.Itoa(nodeIdentifer),
+				},
+			},
+		}
+		_, err := focs.oecs.OpenebsV1alpha1().Disks().Create(diskObjectList[diskListIndex])
+		if err != nil {
+			glog.Error(err)
+		}
+	}
+	tests := map[string]struct {
+		// fakeCasPool holds the fake fakeCasPool object in test cases.
+		fakeCasPool *v1alpha1.CasPool
+		// expectedDiskListLength holds the length of disk list
+		expectedDiskListLength int
+		// err is a bool , true signifies presence of error and vice-versa
+		err bool
+	}{
+		// Test Case #1
+		"CasPool1": {&v1alpha1.CasPool{
+			PoolType: "striped",
+			MaxPools: 3,
+			MinPools: 3,
+		},
+			3,
+			false,
+		},
+		// Test Case #2
+		"CasPool2": {&v1alpha1.CasPool{
+			PoolType: "striped",
+			MaxPools: 3,
+		},
+			3,
+			false,
+		},
+		// Test Case #3
+		"CasPool3": {&v1alpha1.CasPool{
+			PoolType: "mirrored",
+			MaxPools: 3,
+			MinPools: 3,
+		},
+			6,
+			false,
+		},
+		// Test Case #4
+		"CasPool4": {&v1alpha1.CasPool{
+			PoolType: "mirrored",
+			MaxPools: 6,
+			MinPools: 6,
+		},
+			0,
+			true,
+		},
+		// Test Case #5
+		"CasPool5": {&v1alpha1.CasPool{
+			PoolType: "striped",
+			MaxPools: 6,
+			MinPools: 6,
+		},
+			0,
+			true,
+		},
+		// Test Case #6
+		"CasPool6": {&v1alpha1.CasPool{
+			PoolType: "striped",
+			MaxPools: 6,
+			MinPools: 2,
+		},
+			5,
+			false,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			diskList, err := focs.nodeDiskAlloter(test.fakeCasPool)
+			gotErr := false
+			if err != nil {
+				gotErr = true
+			}
+			if gotErr != test.err {
+				t.Fatalf("Test case failed as the expected error %v but got %v", test.err, gotErr)
+			}
+			if len(diskList) != test.expectedDiskListLength {
+				t.Errorf("Test case failed as the expected disk list length is %d but got %d", test.expectedDiskListLength, len(diskList))
+			}
+		})
+	}
+}

--- a/cmd/maya-apiserver/spc-actions/select_disk_test.go
+++ b/cmd/maya-apiserver/spc-actions/select_disk_test.go
@@ -19,11 +19,11 @@ package storagepoolactions
 import (
 	"testing"
 	//openebsFakeClientset "github.com/openebs/maya/pkg/client/clientset/versioned/fake"
-	openebsFakeClientset "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset/fake"
+	"github.com/golang/glog"
 	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	openebsFakeClientset "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strconv"
-	"github.com/golang/glog"
 )
 
 func TestNodeDiskAlloter(t *testing.T) {
@@ -45,7 +45,7 @@ func TestNodeDiskAlloter(t *testing.T) {
 	for diskListIndex := 0; diskListIndex < 20; diskListIndex++ {
 		diskIdentifier := strconv.Itoa(diskListIndex)
 		if diskListIndex%4 == 0 {
-			nodeIdentifer ++
+			nodeIdentifer++
 		}
 		diskObjectList[diskListIndex] = &v1alpha1.Disk{
 			TypeMeta: metav1.TypeMeta{},

--- a/cmd/maya-apiserver/spc-actions/storagepool_create.go
+++ b/cmd/maya-apiserver/spc-actions/storagepool_create.go
@@ -158,10 +158,14 @@ func getCasPoolDisk(cp *apis.CasPool) (error, []string) {
 		cp.MinPools = 1
 	}
 	// If it is a resync event, MaxPool is the spared pool to be provisioned
-	// and min pool that should be provisioned is 1
 	if cp.ReSync {
-		cp.MaxPools = int16(cp.SparePoolCount)
-		cp.MinPools = 1
+		cp.MaxPools = cp.SparePoolCount
+		// if min pool was not provisioned try to provision again the minimum number of pool
+		// else set min pool to 1 as in this case min pool was provisioned.
+		if !(cp.MaxPools == cp.SparePoolCount) {
+			cp.MinPools = 1
+		}
+
 	}
 	// getDiskList will get the disks to be used for storagepool provisioning
 	newDisksList, err := getDiskList(cp)

--- a/cmd/maya-apiserver/spc-actions/storagepool_create.go
+++ b/cmd/maya-apiserver/spc-actions/storagepool_create.go
@@ -97,6 +97,10 @@ func newCasPool(spcGot *apis.StoragePoolClaim) (error, *apis.CasPool) {
 		return fmt.Errorf("aborting storagepool create operation as specified poolType is %s which is invalid", poolType), nil
 	}
 
+	diskType := spcGot.Spec.Type
+	if !(diskType == string(v1alpha1.TypeSparseCPK) || diskType == string(v1alpha1.TypeDiskCPK)) {
+		return fmt.Errorf("aborting storagepool create operation as specified type is %s which is invalid", diskType), nil
+	}
 	// The name of cas template should be provided as annotation in storagepoolclaim yaml
 	// so that it can be used.
 
@@ -112,6 +116,7 @@ func newCasPool(spcGot *apis.StoragePoolClaim) (error, *apis.CasPool) {
 	pool.PoolType = spcGot.Spec.PoolSpec.PoolType
 	pool.MinPools = spcGot.Spec.MinPools
 	pool.MaxPools = spcGot.Spec.MaxPools
+	pool.Type = spcGot.Spec.Type
 
 	// Fill the object with the disks list
 	pool.DiskList = spcGot.Spec.Disks.DiskList

--- a/cmd/maya-apiserver/spc-watcher/controller.go
+++ b/cmd/maya-apiserver/spc-watcher/controller.go
@@ -44,6 +44,7 @@ const (
 	updateEvent = "update"
 	deleteEvent = "delete"
 	ignoreEvent = "ignore"
+	syncEvent   = "sync"
 )
 
 // Controller is the controller implementation for SPC resources
@@ -150,7 +151,12 @@ func (c *Controller) updateSpc(oldSpc, newSpc interface{}) {
 
 	if spcObjectNew.ObjectMeta.ResourceVersion == spcObjectOld.ObjectMeta.ResourceVersion {
 		// If Resource Version is same it means the object has not got updated.
-		c.queueLoad.Operation = ignoreEvent
+		// Enqueue the object as part of sync event to achieve the reconciliation loop for storagepool
+		// Reconciliation will try to converge the pool to itse desired state
+		// If the storagepool is already in the desired state, it will do nothing.
+		c.queueLoad.Operation = syncEvent
+		c.queueLoad.Object = spcObjectNew
+		c.enqueueSpc(&c.queueLoad)
 	} else {
 		// Suppressing delete event here as the event is already captured in
 		// deleteSpc hook.

--- a/cmd/maya-apiserver/spc-watcher/controller_test.go
+++ b/cmd/maya-apiserver/spc-watcher/controller_test.go
@@ -237,7 +237,13 @@ func TestUpdateSpc(t *testing.T) {
 					ResourceVersion: "111232",
 				},
 			},
-			expectedQueueLoad: QueueLoad{"", ignoreEvent, nil},
+			expectedQueueLoad: QueueLoad{"pool1", syncEvent, &apis.StoragePoolClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "pool1",
+					ResourceVersion: "111232",
+				},
+			},
+			},
 		},
 
 		// TestCase#2

--- a/cmd/maya-apiserver/spc-watcher/handler.go
+++ b/cmd/maya-apiserver/spc-watcher/handler.go
@@ -20,11 +20,11 @@ import (
 	"github.com/golang/glog"
 	"github.com/openebs/maya/cmd/maya-apiserver/spc-actions"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	"github.com/openebs/maya/pkg/client/k8s"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
-	"github.com/openebs/maya/pkg/client/k8s"
 )
 
 // syncHandler compares the actual state with the desired, and attempts to
@@ -149,7 +149,7 @@ func (c *Controller) getSpcResource(key string) (*apis.StoragePoolClaim, error) 
 	return spcGot, nil
 }
 
-func syncSpc(spcGot *apis.StoragePoolClaim) (error) {
+func syncSpc(spcGot *apis.StoragePoolClaim) error {
 	glog.Infof("Syncing storagepoolclaim %s", spcGot.Name)
 	// Get kubernetes clientset
 	// namespaces is not required, hence passed empty.
@@ -166,7 +166,7 @@ func syncSpc(spcGot *apis.StoragePoolClaim) (error) {
 	currentPoolCount := len(cspList.Items)
 
 	// If current pool count is less than maxpool count, try to converge to maxpool
-	if (currentPoolCount < int(spcGot.Spec.MaxPools)) {
+	if currentPoolCount < int(spcGot.Spec.MaxPools) {
 		glog.Infof("Converging storagepoolclaim %s to desired state:current pool count is %d,desired pool count is %d", spcGot.Name, currentPoolCount, spcGot.Spec.MaxPools)
 		// sparePoolCount holds the spared pool that should be provisioned to get the desired state.
 		sparePoolCount := int(spcGot.Spec.MaxPools) - currentPoolCount

--- a/cmd/maya-apiserver/spc-watcher/handler.go
+++ b/cmd/maya-apiserver/spc-watcher/handler.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
+	"github.com/openebs/maya/pkg/client/k8s"
 )
 
 // syncHandler compares the actual state with the desired, and attempts to
@@ -68,7 +69,9 @@ func (c *Controller) spcEventHandler(operation string, spcGot *apis.StoragePoolC
 	switch operation {
 	case addEvent:
 		// CreateStoragePool function will create the storage pool
-		err := storagepoolactions.CreateStoragePool(spcGot)
+		// It is a create event so resync should be false and sparepoolcount is passed 0
+		// sparepoolcount is not used when resync is false.
+		err := storagepoolactions.CreateStoragePool(spcGot, false, 0)
 
 		if err != nil {
 			glog.Error("Storagepool could not be created:", err)
@@ -84,7 +87,13 @@ func (c *Controller) spcEventHandler(operation string, spcGot *apis.StoragePoolC
 		// Hook Update Business Logic Here
 		return updateEvent, nil
 		break
-
+	case syncEvent:
+		err := syncSpc(spcGot)
+		if err != nil {
+			glog.Errorf("Storagepool %s could not be synced:%v", spcGot.Name, err)
+		}
+		return syncEvent, nil
+		break
 	case deleteEvent:
 		err := storagepoolactions.DeleteStoragePool(spcGot)
 
@@ -138,4 +147,34 @@ func (c *Controller) getSpcResource(key string) (*apis.StoragePoolClaim, error) 
 		return nil, err
 	}
 	return spcGot, nil
+}
+
+func syncSpc(spcGot *apis.StoragePoolClaim) (error) {
+	glog.Infof("Syncing storagepoolclaim %s", spcGot.Name)
+	// Get kubernetes clientset
+	// namespaces is not required, hence passed empty.
+	newK8sClient, err := k8s.NewK8sClient("")
+	if err != nil {
+		return err
+	}
+	// Get openebs clientset using a getter method (i.e. GetOECS() ) as
+	// the openebs clientset is not exported.
+	newOecsClient := newK8sClient.GetOECS()
+
+	// Get the current count of provisione pool for the storagepool claim
+	cspList, err := newOecsClient.OpenebsV1alpha1().CStorPools().List(metav1.ListOptions{LabelSelector: string(apis.StoragePoolClaimCPK) + "=" + spcGot.Name})
+	currentPoolCount := len(cspList.Items)
+
+	// If current pool count is less than maxpool count, try to converge to maxpool
+	if (currentPoolCount < int(spcGot.Spec.MaxPools)) {
+		glog.Infof("Converging storagepoolclaim %s to desired state:current pool count is %d,desired pool count is %d", spcGot.Name, currentPoolCount, spcGot.Spec.MaxPools)
+		// sparePoolCount holds the spared pool that should be provisioned to get the desired state.
+		sparePoolCount := int(spcGot.Spec.MaxPools) - currentPoolCount
+		// Call the storage pool create logic to proviison the spare pools.
+		err := storagepoolactions.CreateStoragePool(spcGot, true, sparePoolCount)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/install/v1alpha1-0.7.0/cstor-pool/pool.yaml
+++ b/install/v1alpha1-0.7.0/cstor-pool/pool.yaml
@@ -67,7 +67,6 @@ data:
     objectName: {{.Storagepool.owner}}
     action: get
   post: |
-    {{- jsonpath .JsonResult "{range .spec.disks.diskList[*]}{$},{end}" | trim | saveAs "getspcinfo.disk" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.spec.poolSpec.poolType}" | trim | saveAs "getspcinfo.poolType" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.spec.poolSpec.cacheFile}" | trim | saveAs "getspcinfo.cacheFile" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.spec.poolSpec.overProvisioning}" | trim | saveAs "getspcinfo.overProvisioning" .TaskResult | noop -}}
@@ -86,13 +85,19 @@ data:
     action: get
     repeatWith:
       metas:
-      {{- $diskList := .TaskResult.getspcinfo.disk | replace "," " "| trim | split " "}}
+      {{- $diskList := .Storagepool.diskList}}
       {{ range $k,$v := $diskList }}
       - objectName: {{$v}}
       {{ end }}
   post: |
-    {{- $nodesList := jsonpath .JsonResult `pkey=nodes,{@.metadata.labels.kubernetes\.io/hostname}={@.spec.devlinks[0].links[1]};` | trim | default "" | splitList ";" -}}
+    {{if eq .TaskResult.getspcinfo.type "disk"}}
+    {{- $nodesList := jsonpath .JsonResult `pkey=nodes,{@.metadata.labels.kubernetes\.io/hostname}={@.spec.devlinks[0].links[0]};` | trim | default "" | splitList ";" -}}
     {{- $nodesList | keyMap "cstorNodePoolList" .ListItems | noop -}}
+    {{end}}
+    {{if eq .TaskResult.getspcinfo.type "sparse"}}
+    {{- $nodesList := jsonpath .JsonResult `pkey=nodes,{@.metadata.labels.kubernetes\.io/hostname}={@.spec.path};` | trim | default "" | splitList ";" -}}
+    {{- $nodesList | keyMap "cstorNodePoolList" .ListItems | noop -}}
+    {{end}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -120,7 +125,7 @@ data:
     metadata:
       name: {{.Storagepool.owner}}-{{randAlphaNum 4 |lower }}
       labels:
-        openebs.io/storagepoolclaim: {{.Storagepool.owner}}
+        openebs.io/storage-pool-claim: {{.Storagepool.owner}}
         kubernetes.io/hostname: {{ .ListItems.currentRepeatResource }}
     spec:
       disks:
@@ -159,8 +164,8 @@ data:
     metadata:
       name: {{ pluck .ListItems.currentRepeatResource .ListItems.cstorNodeUidList.nodesUid |first | splitList " " | last}}
       labels:
-        openebs.io/storagepoolclaim: {{.Storagepool.owner}}
-        openebs.io/cstorPool: {{ pluck .ListItems.currentRepeatResource .ListItems.cstorNodeUidList.nodesUid |first | splitList " " | last}}
+        openebs.io/storage-pool-claim: {{.Storagepool.owner}}
+        openebs.io/cstor-pool: {{ pluck .ListItems.currentRepeatResource .ListItems.cstorNodeUidList.nodesUid |first | splitList " " | last}}
         app: cstor-pool
     spec:
       replicas: 1
@@ -192,6 +197,8 @@ data:
               mountPath: /dev
             - name: tmp
               mountPath: /tmp
+            - name: sparse
+              mountPath: /var/openebs
             - name: udev
               mountPath: /run/udev
               # To avoid clash between terminating and restarting pod 
@@ -212,6 +219,8 @@ data:
               mountPath: /dev
             - name: tmp
               mountPath: /tmp
+            - name: sparse
+              mountPath: /var/openebs
             - name: udev
               mountPath: /run/udev
             env:
@@ -230,6 +239,10 @@ data:
               # From host, dir called /var/openebs/shared-<uid> is created to avoid clash if two replicas run on same node.
               path: /var/openebs/shared-a2b
               type: {{ .Config.HostPathType.value }}
+          - name: sparse
+            hostPath:
+              path: /var/openebs
+              type: Directory
           - name: udev
             hostPath:
               path: /run/udev
@@ -254,14 +267,13 @@ data:
   post: |
     {{- jsonpath .JsonResult `{.metadata.name}` | trim | addTo "createputstoragepool.objectName" .TaskResult | noop -}}
   task: |
-    {{- $diskList := .TaskResult.getspcinfo.disk | replace "," " "| trim | split " " }}
     apiVersion: openebs.io/v1alpha1
     kind: StoragePool
     metadata:
       name: {{ pluck .ListItems.currentRepeatResource .ListItems.cstorNodeUidList.nodesUid |first | splitList " " | last }}
       labels:
-        openebs.io/storagepoolclaim: {{.Storagepool.owner}}
-        openebs.io/cstorpool: {{ pluck .ListItems.currentRepeatResource .ListItems.cstorNodeUidList.nodesUid |first | splitList " " | last}}
+        openebs.io/storage-pool-claim: {{.Storagepool.owner}}
+        openebs.io/cstor-pool: {{ pluck .ListItems.currentRepeatResource .ListItems.cstorNodeUidList.nodesUid |first | splitList " " | last}}
         kubernetes.io/hostname: {{ .ListItems.currentRepeatResource }}
     spec:
       disks:
@@ -302,7 +314,7 @@ data:
     kind: CStorPool
     action: list
     options: |-
-      labelSelector: openebs.io/storagepoolclaim={{.Storagepool.owner}}
+      labelSelector: openebs.io/storage-pool-claim={{.Storagepool.owner}}
   post: |
     {{- $csps := jsonpath .JsonResult `{range .items[*]}pkey=csps,{@.metadata.name}=;{end}` | trim | default "" | splitList ";" -}}
     {{- $csps | notFoundErr "cstor pool cr not found" | saveIf "deletelistcsp.notFoundErr" .TaskResult | noop -}}
@@ -336,7 +348,7 @@ data:
     kind: Deployment
     action: list
     options: |-
-      labelSelector: openebs.io/storagepoolclaim={{.Storagepool.owner}}
+      labelSelector: openebs.io/storage-pool-claim={{.Storagepool.owner}}
   post: |
     {{- $csds := jsonpath .JsonResult `{range .items[*]}pkey=csds,{@.metadata.name}=;{end}` | trim | default "" | splitList ";" -}}
     {{- $csds | notFoundErr "cstor pool deployment not found" | saveIf "cstorpoollistdeploy.notFoundErr" .TaskResult | noop -}}
@@ -370,7 +382,7 @@ data:
     kind: StoragePool
     action: list
     options: |-
-      labelSelector: openebs.io/storagepoolclaim={{.Storagepool.owner}}
+      labelSelector: openebs.io/storage-pool-claim={{.Storagepool.owner}}
   post: |
     {{- $sps := jsonpath .JsonResult `{range .items[*]}pkey=sps,{@.metadata.name}="";{end}` | trim | default "" | splitList ";" -}}
     {{- $sps | notFoundErr "storge pool cr not found" | saveIf "deletelistcsp.notFoundErr" .TaskResult | noop -}}

--- a/pkg/apis/openebs.io/v1alpha1/cas_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_pool.go
@@ -23,6 +23,8 @@ type CasPoolVals int
 const (
 	// HostNameCPK is the kubernetes host name label
 	HostNameCPK CasPoolKey = "kubernetes.io/hostname"
+	// StoragePoolClaimCPK is the storage pool claim label
+	StoragePoolClaimCPK CasPoolKey = "openebs.io/storage-pool-claim"
 	// DiskTypeCPK is the node-disk-manager disk type e.g. 'sparse' or 'disk'
 	DiskTypeCPK CasPoolKey = "ndm.io/disk-type"
 	// PoolTypeMirroredCPK is a key for mirrored for pool
@@ -69,4 +71,10 @@ type CasPool struct {
 
 	// Type is the CasPool type e.g. sparse or openebs-cstor
 	Type string
+
+	// reSync will decide whether the event is a reconciliation event
+	ReSync bool
+
+	// SparePoolCount is the number of pools that will be tried for creation as a part of reconciliation.
+	SparePoolCount int
 }

--- a/pkg/apis/openebs.io/v1alpha1/cas_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_pool.go
@@ -17,6 +17,21 @@ package v1alpha1
 
 // CasPool is a type which will be utilised by CAS engine to perform
 // storagepool related operation
+type CasPoolKey string
+type CasPoolVals int
+
+const (
+	// HostNameCPK is the kubernetes host name label
+	HostNameCPK CasPoolKey = "kubernetes.io/hostname"
+	// PoolTypeMirroredCPK is a key for mirrored for pool
+	PoolTypeMirroredCPK CasPoolKey = "mirrored"
+	// PoolTypeMirroredCPK is a key for striped for pool
+	PoolTypeStripedCPK CasPoolKey = "striped"
+	// StripedDiskCountCPK is the count for striped type pool
+	StripedDiskCountCPK CasPoolVals = 1
+	// MirroredDiskCountCPK is the count for mirrored type pool
+	MirroredDiskCountCPK CasPoolVals = 2
+)
 
 type CasPool struct {
 	// StoragePoolClaim is the name of the storagepoolclaim object
@@ -33,4 +48,16 @@ type CasPool struct {
 	// Namespace can be passed via storagepoolclaim as labels to decide on the
 	// execution of namespaced resources with respect to storagepool
 	Namespace string
+
+	// DiskList is the list of disks over which a storagepool will be provisioned
+	DiskList []string
+
+	// PoolType is the type of pool to be provisioned e.g. striped or mirrored
+	PoolType string
+
+	// MaxPool is the maximum number of pool that should be provisioned
+	MaxPools int16
+
+	// MinPool is the minimum number of pool that should be provisioned
+	MinPools int16
 }

--- a/pkg/apis/openebs.io/v1alpha1/cas_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_pool.go
@@ -64,10 +64,10 @@ type CasPool struct {
 	PoolType string
 
 	// MaxPool is the maximum number of pool that should be provisioned
-	MaxPools int16
+	MaxPools int
 
 	// MinPool is the minimum number of pool that should be provisioned
-	MinPools int16
+	MinPools int
 
 	// Type is the CasPool type e.g. sparse or openebs-cstor
 	Type string

--- a/pkg/apis/openebs.io/v1alpha1/cas_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_pool.go
@@ -23,10 +23,16 @@ type CasPoolVals int
 const (
 	// HostNameCPK is the kubernetes host name label
 	HostNameCPK CasPoolKey = "kubernetes.io/hostname"
+	// DiskTypeCPK is the node-disk-manager disk type e.g. 'sparse' or 'disk'
+	DiskTypeCPK CasPoolKey = "ndm.io/disk-type"
 	// PoolTypeMirroredCPK is a key for mirrored for pool
 	PoolTypeMirroredCPK CasPoolKey = "mirrored"
 	// PoolTypeMirroredCPK is a key for striped for pool
 	PoolTypeStripedCPK CasPoolKey = "striped"
+	// TypeSparseCPK is a key for sparse disk pool
+	TypeSparseCPK CasPoolKey = "sparse"
+	// TypeDiskCPK is a key for physical disk pool
+	TypeDiskCPK CasPoolKey = "disk"
 	// StripedDiskCountCPK is the count for striped type pool
 	StripedDiskCountCPK CasPoolVals = 1
 	// MirroredDiskCountCPK is the count for mirrored type pool
@@ -60,4 +66,7 @@ type CasPool struct {
 
 	// MinPool is the minimum number of pool that should be provisioned
 	MinPools int16
+
+	// Type is the CasPool type e.g. sparse or openebs-cstor
+	Type string
 }

--- a/pkg/apis/openebs.io/v1alpha1/cas_template_keys.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_template_keys.go
@@ -109,7 +109,8 @@ const (
 	// NOTE:
 	//  The corresponding value will be accessed as
 	// {{ .Storagepool.owner }}
-	OwnerCTP StoragePoolTLPProperty = "owner"
+	OwnerCTP    StoragePoolTLPProperty = "owner"
+	DiskListCTP StoragePoolTLPProperty = "diskList"
 )
 
 // VolumeTLPProperty is used to define properties that comes

--- a/pkg/apis/openebs.io/v1alpha1/register.go
+++ b/pkg/apis/openebs.io/v1alpha1/register.go
@@ -5,7 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	openebsio "github.com/openebs/maya/pkg/apis/openebs.io"
+	"github.com/openebs/maya/pkg/apis/openebs.io"
 )
 
 // SchemeGroupVersion is group version used to register these objects
@@ -45,6 +45,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&CASTemplateList{},
 		&CStorVolume{},
 		&CStorVolumeList{},
+		&Disk{},
+		&DiskList{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil

--- a/pkg/apis/openebs.io/v1alpha1/storage_pool_claim.go
+++ b/pkg/apis/openebs.io/v1alpha1/storage_pool_claim.go
@@ -28,10 +28,10 @@ import (
 
 // StoragePoolClaim describes a StoragePoolClaim custom resource.
 type StoragePoolClaim struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              StoragePoolClaimSpec   `json:"spec"`
-	Status            StoragePoolClaimStatus `json:"status"`
+	metav1.TypeMeta               `json:",inline"`
+	metav1.ObjectMeta             `json:"metadata,omitempty"`
+	Spec   StoragePoolClaimSpec   `json:"spec"`
+	Status StoragePoolClaimStatus `json:"status"`
 }
 
 // StoragePoolClaimSpec is the spec for a StoragePoolClaimSpec resource
@@ -44,6 +44,7 @@ type StoragePoolClaimSpec struct {
 	NodeSelector []string      `json:"nodeSelector"`
 	Capacity     string        `json:"capacity"`
 	MaxPools     int16         `json:"maxPools"`
+	MinPools     int16         `json:"minPools"`
 	Disks        DiskAttr      `json:"disks"`
 	PoolSpec     CStorPoolAttr `json:"poolSpec"`
 }

--- a/pkg/apis/openebs.io/v1alpha1/storage_pool_claim.go
+++ b/pkg/apis/openebs.io/v1alpha1/storage_pool_claim.go
@@ -43,8 +43,8 @@ type StoragePoolClaimSpec struct {
 	Type         string        `json:"type"`
 	NodeSelector []string      `json:"nodeSelector"`
 	Capacity     string        `json:"capacity"`
-	MaxPools     int16         `json:"maxPools"`
-	MinPools     int16         `json:"minPools"`
+	MaxPools     int           `json:"maxPools"`
+	MinPools     int           `json:"minPools"`
 	Disks        DiskAttr      `json:"disks"`
 	PoolSpec     CStorPoolAttr `json:"poolSpec"`
 }

--- a/pkg/client/k8s/k8s.go
+++ b/pkg/client/k8s/k8s.go
@@ -202,6 +202,8 @@ func NewK8sClient(ns string) (*K8sClient, error) {
 	}, nil
 }
 
+// GetOECS() is a getter method for fetching openebs clientset as
+// the openebs clientset is not exported.
 func (k *K8sClient) GetOECS() *openebs.Clientset {
 	return k.oecs
 }

--- a/pkg/client/k8s/k8s.go
+++ b/pkg/client/k8s/k8s.go
@@ -202,6 +202,10 @@ func NewK8sClient(ns string) (*K8sClient, error) {
 	}, nil
 }
 
+func (k *K8sClient) GetOECS() *openebs.Clientset {
+	return k.oecs
+}
+
 // scOps is a utility function that provides a instance capable of
 // executing various K8s StorageClass related operations
 func (k *K8sClient) storageV1SCOps() typed_storage_v1.StorageClassInterface {

--- a/pkg/storagepool/storagepool.go
+++ b/pkg/storagepool/storagepool.go
@@ -86,7 +86,8 @@ func (v *casPoolOperation) Create() (*v1alpha1.CasPool, error) {
 		cast,
 		string(v1alpha1.StoragePoolTLP),
 		map[string]interface{}{
-			string(v1alpha1.OwnerCTP): v.pool.StoragePoolClaim,
+			string(v1alpha1.OwnerCTP):    v.pool.StoragePoolClaim,
+			string(v1alpha1.DiskListCTP): v.pool.DiskList,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
This commit will do following:

1. Enhance maya apiserver for dynamic pool
   provisioning for cstor.

2. Add unit test for new code

3. Fix code format.

Previously, storagepool could be provisioned only after entering disk names in storagepoolclaim yaml.
This PR will enhance maya apiserver to provision a storagepool(cstor) automatically.
Thus we have two ways to provision a storagepool i.e. manually and automatically.

The yaml will look like following for auto/dynamic provisioning for physical disks:
```yaml
apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: pool1
  annotations:
    cas.openebs.io/create-pool-template: cstor-pool-create-default-0.7.0
    cas.openebs.io/delete-pool-template: cstor-pool-delete-default-0.7.0
spec:
  name: pool1
  type: disk
  # required in case of auto provisioning
  maxPools: 3 
  # If not provided, defaults to 1 (recommended but not required)
  minPools: 3
  poolSpec:
    # poolType can be 'striped' or 'mirrored' (required for both manual as well dynamic pool provisioning)
    poolType: striped
    cacheFile: /tmp/pool1.cache
    overProvisioning: false
```
The yaml will look like following for auto/dynamic provisioning for SPARSE pool:
```yaml
apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: pool1
  annotations:
    cas.openebs.io/create-pool-template: cstor-pool-create-default-0.7.0
    cas.openebs.io/delete-pool-template: cstor-pool-delete-default-0.7.0
spec:
  name: pool1
  type: sparse
  # required in case of auto provisioning
  maxPools: 3 
  # If not provided, defaults to 1 (recommended but not required)
  minPools: 3
  poolSpec:
    # poolType can be 'striped' or 'mirrored' (required for both manual as well dynamic pool provisioning)
    poolType: striped
    cacheFile: /tmp/pool1.cache
    overProvisioning: false
```

Manual way of provisioning will still work. The yaml for manual provisioning will look like following:
```yaml
apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: cstor-pool-demo
  annotations:
    cas.openebs.io/create-pool-template: cstor-pool-create-default-0.7.0
    cas.openebs.io/delete-pool-template: cstor-pool-delete-default-0.7.0
spec:
  name: pool1
  type: disk
  poolSpec:
    poolType: striped
    cacheFile: /tmp/pool1.cache
    overProvisioning: false
  disks:
    #Enter you choice of disk in the diskList below.
    diskList:
      - disk-2709a1cba9cea9407b92bc1f7d1a1bde
      - disk-427145375f85e8a488eeb8bbfae45118
      - disk-9c2d7f59bf1a5e5d3b08a8d37fef5af8
```
A working image of this PR is following:
``` sonasingh46/m-apiserver:v12.1```
**Reconciliation for StoragePool**:
1.Automatic way of pool provisioning will support reconciliation i.e. maya will always try to get the maxPool specified on storagepoolclaim.
2. Manual way of provisioning will not have any kind of such reconciliation.
3.minPool number of pool at least will be created or no pools will be provisioned.
e.g
maxPool=10 and minPool=6
Maya will always try to get to a pool count of 10 but any single shot of provisioning in any one part of reconciliation loop must provision at least 6 pools. Once minPool count is reached even if the count of pool increases by only 1 maya will do that. 
**CHANGE SUMMARY:**
**1. List of newly added files:**
1.  cmd/maya-apiserver/spc-actions/select_disk.go

``` This file contains the logic for disk selection.
Defines a struct `nodeDisk` which is describe below.SEE point 7.
Following functions are present:
 ```

```
1.getDiskList() : This function receives CasPool object and return disk list.
Gets kubernetes and openebs clientset.
Defaults field `minPool` to 1  for incorrect value or if no value is passed.
Calls nodeDiskAlloter() function which is passed CasPool object.
```
```
2.nodediskAlloter(): Receives CasPool object and return list disk to caller.
This function is a wrapper that works in conjunction with utility functions 
nodeSelector(), diskSelector() and diskFilterConstraint() to search for eligible 
nodes along with the disks for pool creation.
```

```
3.nodeSelector(): This function selects candidate nodes that will participate 
in pool creation.  
A selected node may not have the potential for pool creation which 
is finally decided in diskSelector(). 
```

```
4.diskSelector(): This function selects disks from candidate nodes based on pool type
 e.g. mirrored,striped etc to get the nodes and disks that qualify for pool creation.
```

```
5.diskFilterConstraint(): This function create labels that is used by nodediskAlloter() 
function to get filtered disks that has potential to participate in pool creation.
```

```
6.The functions uses `nodeDiskMap` data structure for performing the algorithmic 
computation.
```

```
7.nodeDiskMap` is map whose key is host name and value is struct `nodeDisk` 
which contans two fields i.e. `diskCount` which is the count of disk on the node/host 
and `diskList` which contains  the list of disk names attached to the node.
```

``` 
More details regarding above can be found in code comments.
```

2.cmd/maya-apiserver/spc-actions/select_disk_test.go
```Unit tests for select_disk.go ```

**2. List of modified files:**
     1. cmd/maya-apiserver/spc-actions/storagepool_create.go
**Changes**:
```Introduction of new function `newCasPool()` which forms a CasPool object by using storagepoolclaim object. CasPool object describes pool, and its specification and constraints for provisioning.```
```Introduction of new wrapper function getCasPoolDisk() which is called only in case of dynamic/automatic pool provisioning.It will operate on formed CasPool object to perform validation that is required for dynamic provisioning and pass the object to the function known as getDiskList().```
```getDiskList() function is the entry point for nodeDiskAlloter module which runs an algorithm to get the required disks that should be used for pool provisioning.```
```getDisklist() and nodeDiskAlloter module is described above in some more detail.```
```Some existing code is only refactored for readability, modularisation, validations etc.```   
     2. install/v1alpha1-0.7.0/cstor-pool/pool.yaml
**Changes**:
```Run tasks has been updated to handle dynnamic pool provisioning as well as pool provisioning for sparse disks.```
     3. pkg/apis/openebs.io/v1alpha1/cas_pool.go
**Changes**:
```Here, some constants and labels are defined for pool related works. As well CasPool struct has been added with some new properties.These properties describes a CasPool ```
     4. pkg/apis/openebs.io/v1alpha1/cas_template_keys.go
**Changes**:
```Add diskList as storagepool top level property which can be used in run tasks after it is passed to engine. This property is used as a key which will have value while passing to engine. SEE POINT 8 BELOW```
     5. pkg/apis/openebs.io/v1alpha1/register.go
**Changes**:
``` Register disk object in SchemeGroupVersion  which is required for client-go interactions with disk object.```
     6. pkg/apis/openebs.io/v1alpha1/storage_pool_claim.go
 **Changes**:
```Add a new field `minPool` to storagePoolClaim struct and correct code formatting. `minPool` is the number of pools that must be provisioned for successful pool creation else it will gracefully terminate pool creation.```
     7. pkg/client/k8s/k8s.go
 **Changes**:
```Introduction of a new function `GetOECS()` which will help to get openebs clientset as we have not exported the clientset. Previously disk list was not passed to engine.```
     8. pkg/storagepool/storagepool.go
      **Changes**:
```Instantiation of engine by passing the disk lists as a value for storagepool top level property(storagepool top level property is key) which is used for pool provisioning.This is the basic struct for passing values to engine `key: value`. This key value pair is passed as a value in a map as a whole object in engine.```
       

**NOTE** : As of now there is no way to know which disks has already been used for pool creation.
So if a storagepoolclaim yaml is applied and there are some disk that is already a part of pool and 
that disk get selected for pool provisioning then the pool creation will fail. [WIP]

Signed-off-by: sonasingh46 <sonasingh46@gmail.com>