### PR TITLE
Update label and annotations of volume schema

### DIFF
--- a/cmd/maya-apiserver/app/server/snapshot_endpoint.go
+++ b/cmd/maya-apiserver/app/server/snapshot_endpoint.go
@@ -71,7 +71,7 @@ func (v *volumeAPIOpsV1alpha1) snapshotCreate() (interface{}, error) {
 		return nil, err
 	}
 
-	ControllerIP := voldetails.Annotations["vsm.openebs.io/controller-ips"]
+	ControllerIP := voldetails.Annotations["openebs.io/controller-ips"]
 
 	var labelMap map[string]string
 	snapinfo, err := jiva.Snapshot(snap.Metadata.Name, ControllerIP, labelMap)
@@ -120,7 +120,7 @@ func (v *volumeAPIOpsV1alpha1) snapshotRevert() (interface{}, error) {
 		return nil, err
 	}
 
-	ControllerIP := voldetails.Annotations["vsm.openebs.io/controller-ips"]
+	ControllerIP := voldetails.Annotations["openebs.io/controller-ips"]
 
 	err = jiva.SnapshotRevert(snap.Metadata.Name, ControllerIP)
 	if err != nil {
@@ -156,7 +156,7 @@ func (v *volumeAPIOpsV1alpha1) snapshotList(volName string) (interface{}, error)
 		return nil, err
 	}
 
-	ControllerIP := voldetails.Annotations["vsm.openebs.io/controller-ips"]
+	ControllerIP := voldetails.Annotations["openebs.io/controller-ips"]
 
 	// list all created snapshot specific to particular volume
 	snapChain, err := jiva.SnapshotList(snap.Spec.VolumeName, ControllerIP)

--- a/cmd/mayactl/app/command/stats_helper.go
+++ b/cmd/mayactl/app/command/stats_helper.go
@@ -19,15 +19,15 @@ type Client interface {
 
 // Annotations describes volume struct
 type Annotations struct {
-	TargetPortal     string `json:"vsm.openebs.io/targetportals"`
-	ClusterIP        string `json:"vsm.openebs.io/cluster-ips"`
-	Iqn              string `json:"vsm.openebs.io/iqn"`
-	ReplicaCount     string `json:"vsm.openebs.io/replica-count"`
-	ControllerStatus string `json:"vsm.openebs.io/controller-status"`
-	ReplicaStatus    string `json:"vsm.openebs.io/replica-status"`
-	VolSize          string `json:"vsm.openebs.io/volume-size"`
-	ControllerIP     string `json:"vsm.openebs.io/controller-ips"`
-	Replicas         string `json:"vsm.openebs.io/replica-ips"`
+	TargetPortal     string `json:"openebs.io/targetportals"`
+	ClusterIP        string `json:"openebs.io/cluster-ips"`
+	Iqn              string `json:"openebs.io/iqn"`
+	ReplicaCount     string `json:"openebs.io/replica-count"`
+	ControllerStatus string `json:"openebs.io/controller-status"`
+	ReplicaStatus    string `json:"openebs.io/replica-status"`
+	VolSize          string `json:"openebs.io/volume-size"`
+	ControllerIP     string `json:"openebs.io/controller-ips"`
+	Replicas         string `json:"openebs.io/replica-ips"`
 }
 
 const (
@@ -89,23 +89,23 @@ func (annotations *Annotations) GetVolAnnotations(volName string, namespace stri
 
 	for key, value := range volume.ObjectMeta.Annotations {
 		switch key {
-		case "vsm.openebs.io/volume-size":
+		case "openebs.io/volume-size":
 			annotations.VolSize = value
-		case "vsm.openebs.io/iqn":
+		case "openebs.io/iqn":
 			annotations.Iqn = value
-		case "vsm.openebs.io/replica-count":
+		case "openebs.io/replica-count":
 			annotations.ReplicaCount = value
-		case "vsm.openebs.io/cluster-ips":
+		case "openebs.io/cluster-ips":
 			annotations.ClusterIP = value
-		case "vsm.openebs.io/replica-ips":
+		case "openebs.io/replica-ips":
 			annotations.Replicas = value
-		case "vsm.openebs.io/targetportals":
+		case "openebs.io/targetportals":
 			annotations.TargetPortal = value
-		case "vsm.openebs.io/controller-status":
+		case "openebs.io/controller-status":
 			annotations.ControllerStatus = value
-		case "vsm.openebs.io/replica-status":
+		case "openebs.io/replica-status":
 			annotations.ReplicaStatus = value
-		case "vsm.openebs.io/controller-ips":
+		case "openebs.io/controller-ips":
 			annotations.ControllerIP = value
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit will change the all the annotations and label key prefix to 'openebs.io' for mayactl commands.

**Special notes for your reviewer**:
Annotations are keep for sometime until we fix the mayactl code to use schema instead of annotations, which will be part of upcoming PR's in maya
```json
{  
   "items":[  
      {  
         "apiVersion":"v1alpha1",
         "kind":"CASVolume",
         "metadata":{  
            "annotations":{  
               "openebs.io/cluster-ips":"10.0.0.179",
               "openebs.io/iqn":"iqn.2016-09.com.openebs.jiva:default-percona-pvc",
               "openebs.io/replica-count":"1",
               "openebs.io/volume-size":"5G",
               "openebs.io/controller-ips":"172.17.0.6",
               "openebs.io/controller-status":"running,running",
               "openebs.io/replica-ips":"172.17.0.7",
               "openebs.io/replica-status":"running",
               "openebs.io/targetportals":"10.0.0.179:3260"
            },
            "name":"default-percona-pvc",
            "namespace":"default"
         },
         "spec":{  
            "capacity":"5G",
            "iqn":"iqn.2016-09.com.openebs.cstor:default-percona-pvc",
            "replicas":"1",
            "targetIP":"10.0.0.179",
            "targetPort":"3260",
            "targetPortal":"10.0.0.179:3260"
         },
         "status":{  
            "Message":"",
            "Phase":"",
            "Reason":""
         }
      }
   ],
   "kind":"CASVolumeList",
   "metadata":{  

   },
   "metalist":{  

   }
}
```

Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>


