### PR TITLE
Create ZFS volume with compression, thin provisioning and with 4k blocksize by default

### DIFF
--- a/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
+++ b/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
@@ -76,6 +76,7 @@ func createVolumeBuilder(cStorVolumeReplica *apis.CStorVolumeReplica, fullVolNam
 	openebsTargetIP := "io.openebs:targetip=" + cStorVolumeReplica.Spec.TargetIP
 
 	createVolAttr = append(createVolAttr, "create",
+		"-b", "4K", "-s", "-o", "compression=on",
 		"-V", cStorVolumeReplica.Spec.Capacity, fullVolName,
 		"-o", openebsTargetIP, "-o", openebsVolname)
 


### PR DESCRIPTION
- added -s option for  enabling thin-provisioning
- using 4K as the default volblocksize instead of 32K
- enabling compression by default with option compression=on

Signed-off-by: moteesh <moteesh@gmail.com>
