### PR TITLE
Added error logs in the healthcheck code of zrepl pool watcher

### DIFF
--- a/cmd/cstor-pool-mgmt/pool/pool.go
+++ b/cmd/cstor-pool-mgmt/pool/pool.go
@@ -171,6 +171,7 @@ func CheckForZreplInitial(ZreplRetryInterval time.Duration) {
 			glog.Infof("Waiting for zpool replication container to start...")
 			continue
 		}
+		glog.Errorf("Error in CheckForZreplInitial : %v", err)
 		break
 	}
 }
@@ -183,6 +184,7 @@ func CheckForZreplContinuous(ZreplRetryInterval time.Duration) {
 			time.Sleep(ZreplRetryInterval)
 			continue
 		}
+		glog.Errorf("Error in CheckForZreplContinuous : %v", err)
 		break
 	}
 }

--- a/cmd/cstor-pool-mgmt/pool/pool.go
+++ b/cmd/cstor-pool-mgmt/pool/pool.go
@@ -168,7 +168,7 @@ func CheckForZreplInitial(ZreplRetryInterval time.Duration) {
 		_, err := RunnerVar.RunCombinedOutput(PoolOperator, "status")
 		if err != nil {
 			time.Sleep(ZreplRetryInterval)
-			glog.Errorf("zpool status returned err : %v", err)
+			glog.Errorf("zpool status returned error in zrepl startup : %v", err)
 			glog.Infof("Waiting for zpool replication container to start...")
 			continue
 		}
@@ -184,7 +184,7 @@ func CheckForZreplContinuous(ZreplRetryInterval time.Duration) {
 			time.Sleep(ZreplRetryInterval)
 			continue
 		}
-		glog.Errorf("Error in CheckForZreplContinuous : %v", err)
+		glog.Errorf("zpool status returned error in zrepl healthcheck : %v", err)
 		break
 	}
 }

--- a/cmd/cstor-pool-mgmt/pool/pool.go
+++ b/cmd/cstor-pool-mgmt/pool/pool.go
@@ -168,7 +168,8 @@ func CheckForZreplInitial(ZreplRetryInterval time.Duration) {
 		_, err := RunnerVar.RunCombinedOutput(PoolOperator, "status")
 		if err != nil {
 			time.Sleep(ZreplRetryInterval)
-			glog.Infof("Waiting for zpool replication container to start. err = %v", err)
+			glog.Errorf("zpool status returned err : %v", err)
+			glog.Infof("Waiting for zpool replication container to start...")
 			continue
 		}
 		break
@@ -182,9 +183,8 @@ func CheckForZreplContinuous(ZreplRetryInterval time.Duration) {
 		if err == nil {
 			time.Sleep(ZreplRetryInterval)
 			continue
-		} else {
-			glog.Errorf("Error in CheckForZreplContinuous : %v", err)
 		}
+		glog.Errorf("Error in CheckForZreplContinuous : %v", err)
 		break
 	}
 }

--- a/cmd/cstor-pool-mgmt/pool/pool.go
+++ b/cmd/cstor-pool-mgmt/pool/pool.go
@@ -196,7 +196,7 @@ func LabelClear(disks []string) error {
 		labelClearStr := []string{"labelclear", "-f", disk}
 		stdoutStderr, err := RunnerVar.RunCombinedOutput(PoolOperator, labelClearStr...)
 		if err != nil {
-			glog.Errorf("Unable to clear label: %v", string(stdoutStderr))
+			glog.Errorf("Unable to clear label: %v, err = %v", string(stdoutStderr), err)
 			failLabelClear = true
 		}
 	}

--- a/cmd/cstor-pool-mgmt/pool/pool.go
+++ b/cmd/cstor-pool-mgmt/pool/pool.go
@@ -168,10 +168,9 @@ func CheckForZreplInitial(ZreplRetryInterval time.Duration) {
 		_, err := RunnerVar.RunCombinedOutput(PoolOperator, "status")
 		if err != nil {
 			time.Sleep(ZreplRetryInterval)
-			glog.Infof("Waiting for zpool replication container to start...")
+			glog.Infof("Waiting for zpool replication container to start. err = %v", err)
 			continue
 		}
-		glog.Errorf("Error in CheckForZreplInitial : %v", err)
 		break
 	}
 }
@@ -183,8 +182,9 @@ func CheckForZreplContinuous(ZreplRetryInterval time.Duration) {
 		if err == nil {
 			time.Sleep(ZreplRetryInterval)
 			continue
+		} else {
+			glog.Errorf("Error in CheckForZreplContinuous : %v", err)
 		}
-		glog.Errorf("Error in CheckForZreplContinuous : %v", err)
 		break
 	}
 }


### PR DESCRIPTION
added error logs in CheckForZreplInitial and CheckForZreplContinuous methods to print the error message upon failure.

Signed-off-by: moteesh <moteesh@gmail.com>

