### PR TITLE
Use patch instead of update for cvr finalizer.

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -17,6 +17,7 @@ limitations under the License.
 package replicacontroller
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"reflect"
@@ -29,9 +30,30 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 )
+
+// CVRPatch struct represent the struct used to patch
+// the cvr object
+type CVRPatch struct {
+	// Op defines the operation
+	Op string `json:"op"`
+	// Path defines the key path
+	// eg. for
+	// {
+	//  	"Name": "openebs"
+	//	    Category: {
+	//		  "Inclusive": "v1",
+	//		  "Rank": "A"
+	//	     }
+	// }
+	// The path of 'Inclusive' would be
+	// "/Name/Category/Inclusive"
+	Path  string `json:"path"`
+	Value string `json:"value"`
+}
 
 // syncHandler compares the actual state with the desired, and attempts to
 // converge the two. It then updates the Status block of the CStorReplicaUpdated resource
@@ -40,6 +62,9 @@ func (c *CStorVolumeReplicaController) syncHandler(key string, operation common.
 	cVRGot, err := c.getVolumeReplicaResource(key)
 	if err != nil {
 		return err
+	}
+	if cVRGot == nil {
+		return fmt.Errorf("cannot retrieve cStorVolumeReplica %q", key)
 	}
 	status, err := c.cVREventHandler(operation, cVRGot)
 	if status == "" {
@@ -98,6 +123,7 @@ func (c *CStorVolumeReplicaController) cVREventHandler(operation common.QueueOpe
 
 		err := volumereplica.DeleteVolume(fullVolName)
 		if err != nil {
+			glog.Errorf("Error in deleting volume %q: %s", err)
 			c.recorder.Event(cVR, corev1.EventTypeWarning, string(common.FailureDestroy), string(common.MessageResourceFailDestroy))
 			return string(apis.CVRStatusDeletionFailed), err
 		}
@@ -173,11 +199,22 @@ func (c *CStorVolumeReplicaController) getVolumeReplicaResource(key string) (*ap
 
 // removeFinalizer is to remove finalizer of CStorVolumeReplica resource.
 func (c *CStorVolumeReplicaController) removeFinalizer(cVR *apis.CStorVolumeReplica) error {
-	if len(cVR.Finalizers) > 0 {
-		cVR.Finalizers = []string{}
-	}
-	_, err := c.clientset.OpenebsV1alpha1().CStorVolumeReplicas(cVR.Namespace).Update(cVR)
+	glog.Errorf("Removing finalizers for %s", cVR.Name)
+	// The Patch method requires an array of elements
+	// therefore creating array of one element
+	cvrPatch := make([]CVRPatch, 1)
+	// setting operation as remove
+	cvrPatch[0].Op = "remove"
+	// object to be removed is finalizers
+	cvrPatch[0].Path = "/metadata/finalizers"
+	cvrPatchJSON, err := json.Marshal(cvrPatch)
 	if err != nil {
+		glog.Errorf("Error marshaling cvrPatch object: %s", err)
+		return err
+	}
+	_, err = c.clientset.OpenebsV1alpha1().CStorVolumeReplicas(cVR.Namespace).Patch(cVR.Name, types.JSONPatchType, cvrPatchJSON)
+	if err != nil {
+		glog.Errorf("Finalizer patch failed for %s: %s", cVR.Name, err)
 		return err
 	}
 	glog.Infof("Removed Finalizer: %v, %v", cVR.ObjectMeta.Name, string(cVR.GetUID()))

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/new_replica_controller.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/new_replica_controller.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/openebs/maya/cmd/cstor-pool-mgmt/controller/common"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+
 	//clientset "github.com/openebs/maya/pkg/client/clientset/versioned"
 	clientset "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset"
 	//openebsScheme "github.com/openebs/maya/pkg/client/clientset/versioned/scheme"

--- a/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
+++ b/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
@@ -105,6 +105,11 @@ func DeleteVolume(fullVolName string) error {
 	deleteVolStr := []string{"destroy", fullVolName}
 	stdoutStderr, err := RunnerVar.RunCombinedOutput(VolumeReplicaOperator, deleteVolStr...)
 	if err != nil {
+		// If volume is missing then do not return error
+		if strings.Contains(err.Error(), "dataset does not exist") {
+			glog.Infof("Assuming volume deletion successful for error: %v", string(stdoutStderr))
+			return nil
+		}
 		glog.Errorf("Unable to delete volume : %v", string(stdoutStderr))
 		return err
 	}


### PR DESCRIPTION
Subsequent delete calls causes the resource version
of the cstorvolumereplica to change.

When the first delete call is made the fetched cvr's
finalizer field is updated locally, meanwhile another
request arrives and the resource version of cvr in
k8s changes.

When the code tries to update cvr using the first
object it fetched the update fails due to rv mismatch.

To overcome this issue I have changed the update call
to patch. This would not be affected by multiple calls.

Signed-off-by: Prince Rachit Sinha <prince.rachit@mayadata.io>

Changes:
modified:   cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
modified:   cmd/cstor-pool-mgmt/controller/replica-controller/new_replica_controller.go
modified:   cmd/cstor-pool-mgmt/volumereplica/volumereplica.go

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
