### PR TITLE
Add openebs config support in spc via annotations

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -123,7 +123,7 @@ func (c *CStorVolumeReplicaController) cVREventHandler(operation common.QueueOpe
 
 		err := volumereplica.DeleteVolume(fullVolName)
 		if err != nil {
-			glog.Errorf("Error in deleting volume %q: %s", cVR.ObjectMeta.Name,err)
+			glog.Errorf("Error in deleting volume %q: %s", cVR.ObjectMeta.Name, err)
 			c.recorder.Event(cVR, corev1.EventTypeWarning, string(common.FailureDestroy), string(common.MessageResourceFailDestroy))
 			return string(apis.CVRStatusDeletionFailed), err
 		}

--- a/cmd/maya-apiserver/spc-watcher/storagepool_create.go
+++ b/cmd/maya-apiserver/spc-watcher/storagepool_create.go
@@ -124,6 +124,7 @@ func newCasPool(spcGot *apis.StoragePoolClaim, reSync bool, pendingPoolCount int
 	pool.Type = spcGot.Spec.Type
 	pool.ReSync = reSync
 	pool.PendingPoolCount = pendingPoolCount
+	pool.Annotations = spcGot.Annotations
 
 	// Fill the object with the disks list
 	pool.DiskList = spcGot.Spec.Disks.DiskList

--- a/pkg/apis/openebs.io/v1alpha1/cas_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_pool.go
@@ -13,7 +13,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1alpha1
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 // CasPool is a type which will be utilised by CAS engine to perform
 // storagepool related operation
@@ -42,7 +46,10 @@ const (
 	MirroredDiskCountCPV CasPoolValInt = 2
 )
 
+// TODO : Restructure the CasPool struct
 type CasPool struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// StoragePoolClaim is the name of the storagepoolclaim object
 	StoragePoolClaim string
 

--- a/pkg/storagepool/storagepool.go
+++ b/pkg/storagepool/storagepool.go
@@ -74,9 +74,9 @@ func (v *casPoolOperation) Create() (*v1alpha1.CasPool, error) {
 	if len(castName) == 0 {
 		return nil, fmt.Errorf("Unable to create storagepool: missing create cas template")
 	}
-
+	// extract the cas openebs config from storagepoolclaim
+	openebsConfig := v.pool.Annotations[string(v1alpha1.CASConfigKey)]
 	// fetch CASTemplate specifications
-	//cast, err := v.k8sClient.GetOEV1alpha1CAST(castName, mach_apis_meta_v1.GetOptions{})
 	cast, err := v.k8sClient.GetOEV1alpha1CAST(castName, mach_apis_meta_v1.GetOptions{})
 	if err != nil {
 		return nil, err
@@ -84,6 +84,7 @@ func (v *casPoolOperation) Create() (*v1alpha1.CasPool, error) {
 	// provision cas storagepool via cas template engine
 	cc, err := NewCASStoragePoolEngine(
 		cast,
+		openebsConfig,
 		string(v1alpha1.StoragePoolTLP),
 		map[string]interface{}{
 			string(v1alpha1.OwnerCTP):    v.pool.StoragePoolClaim,


### PR DESCRIPTION
This PR will help to read openebs configs from spc (passed via annotations in spc)
to overwrite the default configs that can be used in run tasks.
The priority of openebs config will prevail over default config.
Signed-off-by: sonasingh46 <sonasingh46@gmail.com>