### PR TITLE
Fix the bug that caused pool creation to get stuck

### DIFF
--- a/cmd/maya-apiserver/spc-watcher/runner.go
+++ b/cmd/maya-apiserver/spc-watcher/runner.go
@@ -79,6 +79,10 @@ func (c *Controller) processNextWorkItem() bool {
 		// put back on the workqueue and attempted again after a back-off
 		// period.
 		defer c.workqueue.Done(obj)
+
+		// Forget the object even it is not processed successfully
+		// the next reconcile will take care of it.
+		defer c.workqueue.Forget(obj)
 		var q *QueueLoad
 		var ok bool
 		// We expect strings to come off the workqueue. These are of the
@@ -99,9 +103,6 @@ func (c *Controller) processNextWorkItem() bool {
 		if err := c.syncHandler(q.Key, q.Operation, q.Object); err != nil {
 			return fmt.Errorf("Error syncing '%s': %s", q.Key, err.Error())
 		}
-		// Finally, if no error occurs we Forget this item so it does not
-		// get queued again until another change happens.
-		c.workqueue.Forget(obj)
 		glog.V(1).Infof("Successfully synced '%s'", q.Key)
 		return nil
 	}(obj)


### PR DESCRIPTION
This PR will fix the bug that caused pool creation to get stuck once there is failure in pool creation.
**BUG REPORT:**
Once a SPC yaml was applied and due to some reason it failed, the object was in workqueue.
Additionally, there is resync loop which tried the object to get pushed but as the object was already 
there in queue rateLimiting queue was not allowing it to get pushed and hence it was not processed.
**SOLVE:**
After every processing for the object, forget the object from queue even the processing was not successful. The resync loop will take care of things, and when the environment or resources(e.g. runtasks) that caused a unsuccessful processing get fixed , the resync loop will successfully process the object as the object was forgotten from queue and re added for processing. 
Signed-off-by: sonasingh46 <sonasingh46@gmail.com>
