### PR TITLE
Fix the get pv from CAS templates

### DIFF
--- a/pkg/client/k8s/k8s.go
+++ b/pkg/client/k8s/k8s.go
@@ -484,7 +484,6 @@ func (k *K8sClient) GetPV(name string, opts mach_apis_meta_v1.GetOptions) (*api_
 func (k *K8sClient) GetCoreV1PersistentVolumeAsRaw(name string) (result []byte, err error) {
 	result, err = k.cs.CoreV1().RESTClient().
 		Get().
-		Namespace(k.ns).
 		Resource("persistentvolumes").
 		Name(name).
 		VersionedParams(&mach_apis_meta_v1.GetOptions{}, scheme.ParameterCodec).


### PR DESCRIPTION
PersistentVolume are not namespaced. Removed the passing of namespace parameter to the K8s API. 

Signed-off-by: kmova <kiran.mova@openebs.io>
