### PR TITLE
cstor-sparse-pool creation based on flag

### DIFF
--- a/pkg/install/v1alpha1/cstor_pool_claim_0.7.0.go
+++ b/pkg/install/v1alpha1/cstor_pool_claim_0.7.0.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2018 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	env "github.com/openebs/maya/pkg/env/v1alpha1"
+)
+
+const (
+	CstorSparsePoolEnabled = "true"
+)
+
+// IsCstorSparsePoolEnabled reads from env variable to check wether cstor sparse pool
+// should be created by default or not.
+func IsCstorSparsePoolEnabled() bool {
+	return env.Get(string(CASDefaultCstorPool)) == CstorSparsePoolEnabled
+}
+
+// CstorPoolSpc070 returns the default storagepoolclaim yaml
+// corresponding to version 0.7.0 if cstor sparse pool creation is enabled as a part of
+// openebs installation
+func CstorPoolSpc070() (list ArtifactList) {
+	list.Items = append(list.Items, ParseArtifactListFromMultipleYamlConditional(cstorPoolSpcFor070, IsCstorSparsePoolEnabled)...)
+	return
+}
+
+// cstorPoolSpcFor070 returns all the yamls related to configuring a stoaragepoolclaim in string
+// format
+//
+// NOTE:
+//  This is an implementation of MultiYamlFetcher
+func cstorPoolSpcFor070() string {
+	return `
+---
+apiVersion: openebs.io/v1alpha1
+kind: StoragePoolClaim
+metadata:
+  name: cstor-sparse-pool
+  annotations:
+    cas.openebs.io/create-pool-template: cstor-pool-create-default-0.7.0
+    cas.openebs.io/delete-pool-template: cstor-pool-delete-default-0.7.0
+    cas.openebs.io/config: |
+      - name: PoolResourceLimits
+        value: false
+      #- name: PoolResourceLimits
+      #  value: |-
+      #      memory: 2Gi
+      #      cpu: 500m
+      #- name: AuxResourceLimits
+      #  value: |-
+      #      memory: 1Gi
+      #      cpu: 100m
+spec:
+  name: cstor-sparse-pool
+  type: sparse
+  maxPools: 3
+  poolSpec:
+    poolType: striped
+    cacheFile: /tmp/cstor-sparse-pool.cache
+    overProvisioning: false
+---
+`
+}

--- a/pkg/install/v1alpha1/cstor_pool_claim_0.7.0_test.go
+++ b/pkg/install/v1alpha1/cstor_pool_claim_0.7.0_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2018 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package v1alpha1
+
+import (
+	"os"
+	"testing"
+)
+
+func setEnv() {
+	os.Setenv(string(CASDefaultCstorPool), "true")
+}
+
+func unsetEnv() {
+	os.Unsetenv(string(CASDefaultCstorPool))
+}
+
+func TestIsCstorSparsePoolEnabled(t *testing.T) {
+	// Set env variable to enable sparse pool creation
+	setEnv()
+	result := IsCstorSparsePoolEnabled()
+	if result != true {
+		t.Errorf("Test failed as the env variable for cstor sparse pool creation is true but function returned false")
+	}
+	// Unset env variable to disable sparse pool creation
+	unsetEnv()
+	result = IsCstorSparsePoolEnabled()
+	if result == true {
+		t.Errorf("Test failed as the env variable for cstor sparse pool creation is unset but function returned true")
+	}
+}
+
+func TestCstorPoolSpc070(t *testing.T) {
+	// Set Env variable to enable sparse pool creation
+	setEnv()
+	listItems := CstorPoolSpc070()
+	if len(listItems.Items) == 0 {
+		t.Errorf("Expected non empty string list")
+	}
+	// Unset env variable to disable sparse pool creation
+	unsetEnv()
+	listItems = CstorPoolSpc070()
+	if len(listItems.Items) != 0 {
+		t.Errorf("Expected empty string list")
+	}
+}

--- a/pkg/install/v1alpha1/env.go
+++ b/pkg/install/v1alpha1/env.go
@@ -24,4 +24,9 @@ const (
 	// EnvKeyForInstallConfigName is the environment variable to get the
 	// the install config's name
 	EnvKeyForInstallConfigName InstallENVKey = "OPENEBS_IO_INSTALL_CONFIG_NAME"
+	// CASDefaultCstorPoolENVK is the ENV key that specifies wether default cstor pool
+	// should be configured or not
+	// If value is "true", default cstor pool will be configured else for "false"
+	// it will not be configured.
+	CASDefaultCstorPool InstallENVKey = "OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL"
 )

--- a/pkg/install/v1alpha1/registrar.go
+++ b/pkg/install/v1alpha1/registrar.go
@@ -24,6 +24,21 @@ import (
 // as a string
 type MultiYamlFetcher func() string
 
+// ArtifactListPredicate abstracts evaluating a condition against the provided
+// artifact
+type ArtifactListPredicate func() bool
+
+// ParseArtifactListFromMultipleYamlConditional will help in adding a list of yamls that should be installed
+// by the installer
+// ParseArtifactListFromMultipleYamlConditional acts on ArtifactListPredicate return value, if true the yaml
+// gets added to installation list else it is not added.
+func ParseArtifactListFromMultipleYamlConditional(multipleYamls MultiYamlFetcher, p ArtifactListPredicate) (artifacts []*Artifact) {
+	if p() {
+		return ParseArtifactListFromMultipleYamls(multipleYamls)
+	}
+	return
+}
+
 // ParseArtifactListFromMultipleYamls generates a list of Artifacts from the
 // yaml documents.
 //
@@ -46,6 +61,7 @@ func ParseArtifactListFromMultipleYamls(multipleYamls MultiYamlFetcher) (artifac
 // installed
 func RegisteredArtifactsFor070() (finallist ArtifactList) {
 	finallist.Items = append(finallist.Items, JivaPoolArtifactsFor070().Items...)
+	finallist.Items = append(finallist.Items, CstorPoolSpc070().Items...)
 	// TODO
 	// Below commented code will uncommented selectively
 	//finallist.Items = append(finallist.Items, CstorPoolArtifactsFor070().Items...)


### PR DESCRIPTION
This PR will do following :

1. Installer in maya will configure cstor-sparse-pool
   based on env variable.

**List of New Added Files:**
1. pkg/install/v1alpha1/cstor_pool_claim_0.7.0.go
2. pkg/install/v1alpha1/cstor_pool_claim_0.7.0_test.go

**List of Modified Files:**
1. pkg/install/v1alpha1/registrar.go
2. pkg/install/v1alpha1/env.go

**Environment Variables Used:**
1.  OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL


Signed-off-by: sonasingh46 <sonasingh46@gmail.com>
