### PR TITLE
Fix replica status for cstor CASVolume in volume info command in mayactl

### DIFF
--- a/cmd/mayactl/app/command/volume.go
+++ b/cmd/mayactl/app/command/volume.go
@@ -293,3 +293,27 @@ func (volInfo *VolumeInfo) GetReplicaIP() string {
 	}
 	return ""
 }
+
+// GetStoragePool returns the name of the storage pool
+func (volInfo *VolumeInfo) GetStoragePool() string {
+	if val, ok := volInfo.Volume.ObjectMeta.Annotations["openebs.io/pool-names"]; ok {
+		return val
+	}
+	return ""
+}
+
+// GetCVRName returns the name of the CVR
+func (volInfo *VolumeInfo) GetCVRName() string {
+	if val, ok := volInfo.Volume.ObjectMeta.Annotations["openebs.io/cvr-names"]; ok {
+		return val
+	}
+	return ""
+}
+
+// GetNodeName returns the name of the node
+func (volInfo *VolumeInfo) GetNodeName() string {
+	if val, ok := volInfo.Volume.ObjectMeta.Annotations["openebs.io/node-names"]; ok {
+		return val
+	}
+	return ""
+}

--- a/cmd/mayactl/app/command/volume_info.go
+++ b/cmd/mayactl/app/command/volume_info.go
@@ -322,7 +322,8 @@ Replica Count :   {{.ReplicaCount}}
 			fmt.Println("Unable to display volume info, found error : ", err)
 		}
 		w.Flush()
+	} else {
+		fmt.Println("Unsupported Volume Type")
 	}
-	fmt.Println("Unsupported Volume Type")
 	return nil
 }

--- a/cmd/mayactl/app/command/volume_info.go
+++ b/cmd/mayactl/app/command/volume_info.go
@@ -323,5 +323,6 @@ Replica Count :   {{.ReplicaCount}}
 		}
 		w.Flush()
 	}
+	fmt.Println("Unsupported Volume Type")
 	return nil
 }

--- a/cmd/mayactl/app/command/volume_info.go
+++ b/cmd/mayactl/app/command/volume_info.go
@@ -276,13 +276,13 @@ Replica Count :   {{.ReplicaCount}}
 			fmt.Println("Unable to display volume info, found error : ", err)
 		}
 		w.Flush()
-	} else {
+	} else if v.GetCASType() == string(CstorStorageEngine) {
 
 		// Converting replica count character to int
 		replicaCount, err = strconv.Atoi(v.GetReplicaCount())
 		if err != nil {
 			fmt.Println("Invalid replica count")
-			return fmt.Errorf("%s", "Invalid replica count")
+			return nil
 		}
 
 		// Spitting the replica status
@@ -294,7 +294,7 @@ Replica Count :   {{.ReplicaCount}}
 		// Confirming replica status, poolname , cvrName, nodeName are equal to replica count
 		if replicaCount != len(replicaStatus) || replicaCount != len(poolName) || replicaCount != len(cvrName) || replicaCount != len(nodeName) {
 			fmt.Println("Invalid response received from maya-api service")
-			return fmt.Errorf("%s", "Invalid response received from maya-api service")
+			return nil
 		}
 
 		replicaInfo := []cstorReplicaInfo{}

--- a/cmd/mayactl/app/command/volume_info.go
+++ b/cmd/mayactl/app/command/volume_info.go
@@ -181,9 +181,9 @@ Replica Details :
 		cstorReplicaTemplate = `
 Replica Details :
 -----------------
-{{ printf "%s\t" "NAME"}} {{ printf "%s\t" "ACCESS MODE"}} {{ printf "%s\t" "STATUS"}} {{ printf "%s\t" "POOL NAME"}} {{ printf "%s\t" "POOL IP"}} {{ printf "%s\t" "NODE"}}
-{{ printf "----\t -----------\t ------\t ---------\t -------\t -----" }} {{range $key, $value := .}}
-{{ printf "%s\t" $value.Name }} {{ printf "%s\t" $value.AccessMode }} {{ printf "%s\t" $value.Status }} {{ printf "%s\t" $value.PoolName }} {{ printf "%s\t" $value.IP }} {{ $value.NodeName }} {{end}}
+{{ printf "%s\t" "NAME"}} {{ printf "%s\t" "STATUS"}} {{ printf "%s\t" "POOL NAME"}} {{ printf "%s\t" "NODE"}}
+{{ printf "----\t ------\t ---------\t -----" }} {{range $key, $value := .}}
+{{ printf "%s\t" $value.Name }} {{ printf "%s\t" $value.Status }} {{ printf "%s\t" $value.PoolName }} {{ $value.NodeName }} {{end}}
 `
 
 		portalTemplate = `
@@ -299,7 +299,7 @@ Replica Count :   {{.ReplicaCount}}
 
 		replicaInfo := []cstorReplicaInfo{}
 
-		// Iteratin over the values replica values and appending to the structure
+		// Iterating over the values replica values and appending to the structure
 		for i := 0; i < replicaCount; i++ {
 			replicaInfo = append(replicaInfo, cstorReplicaInfo{
 				Name:       cvrName[i],

--- a/cmd/mayactl/app/command/volume_info_test.go
+++ b/cmd/mayactl/app/command/volume_info_test.go
@@ -688,12 +688,120 @@ func TestDisplayVolumeInfo(t *testing.T) {
 			},
 			output: nil,
 		},
+		"Cstor Volume": {
+			cmdOptions: &CmdVolumeOptions{
+				volName: "vol1",
+			},
+			collection: client.ReplicaCollection{
+				Data: []client.Replica{
+					{
+						Address: "10.10.10.13",
+						Mode:    "RW",
+					},
+				},
+			},
+			volume: VolumeInfo{
+				Volume: v1alpha1.CASVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"openebs.io/controller-ips":    "10.32.2.13",
+							"openebs.io/controller-status": "running,running,running",
+							"openebs.io/cvr-names":         "default-cstor-volume-3227802448-cstor-sparse-pool-g7e8,default-cstor-volume-3227802448-cstor-sparse-pool-l9dp,default-cstor-volume-3227802448-cstor-sparse-pool-yq8t",
+							"openebs.io/node-names":        "gke-ashish-dev-default-pool-1fe155b7-rvqd,gke-ashish-dev-default-pool-1fe155b7-qv7v,gke-ashish-dev-default-pool-1fe155b7-w75t",
+							"openebs.io/pool-names":        "cstor-sparse-pool-g7e8,cstor-sparse-pool-l9dp,cstor-sparse-pool-yq8t",
+						},
+					},
+					Spec: v1alpha1.CASVolumeSpec{
+						Capacity:     "5G",
+						CasType:      "cstor",
+						Iqn:          "iqn.2016-09.com.openebs.jiva:<no value>",
+						Replicas:     "3",
+						TargetIP:     "<no value>",
+						TargetPort:   "3260",
+						TargetPortal: "<no value>:3260",
+					},
+				},
+			},
+			output: nil,
+		},
+		"Cstor Volume when invalid replica": {
+			cmdOptions: &CmdVolumeOptions{
+				volName: "vol1",
+			},
+			collection: client.ReplicaCollection{
+				Data: []client.Replica{
+					{
+						Address: "10.10.10.13",
+						Mode:    "RW",
+					},
+				},
+			},
+			volume: VolumeInfo{
+				Volume: v1alpha1.CASVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"openebs.io/controller-ips":    "10.32.2.13",
+							"openebs.io/controller-status": "running,running,running",
+							"openebs.io/cvr-names":         "default-cstor-volume-3227802448-cstor-sparse-pool-g7e8,default-cstor-volume-3227802448-cstor-sparse-pool-l9dp,default-cstor-volume-3227802448-cstor-sparse-pool-yq8t",
+							"openebs.io/node-names":        "gke-ashish-dev-default-pool-1fe155b7-rvqd,gke-ashish-dev-default-pool-1fe155b7-qv7v,gke-ashish-dev-default-pool-1fe155b7-w75t",
+							"openebs.io/pool-names":        "cstor-sparse-pool-g7e8,cstor-sparse-pool-l9dp,cstor-sparse-pool-yq8t",
+						},
+					},
+					Spec: v1alpha1.CASVolumeSpec{
+						Capacity:     "5G",
+						CasType:      "cstor",
+						Iqn:          "iqn.2016-09.com.openebs.jiva:<no value>",
+						Replicas:     "as",
+						TargetIP:     "<no value>",
+						TargetPort:   "3260",
+						TargetPortal: "<no value>:3260",
+					},
+				},
+			},
+			output: nil,
+		},
+		"Cstor Volume when replica count is not equal to status": {
+			cmdOptions: &CmdVolumeOptions{
+				volName: "vol1",
+			},
+			collection: client.ReplicaCollection{
+				Data: []client.Replica{
+					{
+						Address: "10.10.10.13",
+						Mode:    "RW",
+					},
+				},
+			},
+			volume: VolumeInfo{
+				Volume: v1alpha1.CASVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"openebs.io/controller-ips":    "10.32.2.13",
+							"openebs.io/controller-status": "running,running,running",
+							"openebs.io/cvr-names":         "default-cstor-volume-3227802448-cstor-sparse-pool-g7e8,default-cstor-volume-3227802448-cstor-sparse-pool-l9dp,default-cstor-volume-3227802448-cstor-sparse-pool-yq8t",
+							"openebs.io/node-names":        "gke-ashish-dev-default-pool-1fe155b7-rvqd,gke-ashish-dev-default-pool-1fe155b7-qv7v,gke-ashish-dev-default-pool-1fe155b7-w75t",
+							"openebs.io/pool-names":        "cstor-sparse-pool-g7e8,cstor-sparse-pool-l9dp,cstor-sparse-pool-yq8t",
+						},
+					},
+					Spec: v1alpha1.CASVolumeSpec{
+						Capacity:     "5G",
+						CasType:      "cstor",
+						Iqn:          "iqn.2016-09.com.openebs.jiva:<no value>",
+						Replicas:     "4",
+						TargetIP:     "<no value>",
+						TargetPort:   "3260",
+						TargetPortal: "<no value>:3260",
+					},
+				},
+			},
+			output: nil,
+		},
 	}
 
 	for name, tt := range validInfo {
 		t.Run(name, func(t *testing.T) {
 			if got := tt.cmdOptions.DisplayVolumeInfo(&tt.volume, tt.collection); got != tt.output {
-				t.Fatalf("DisplayInfo(%v, %v) => %v, want %v", tt.volume, tt.collection, got, tt.output)
+				t.Fatalf("Test %v DisplayInfo(%v, %v) => %v, want %v", name, tt.volume, tt.collection, got, tt.output)
 			}
 		})
 	}

--- a/cmd/mayactl/app/command/volume_info_test.go
+++ b/cmd/mayactl/app/command/volume_info_test.go
@@ -796,6 +796,42 @@ func TestDisplayVolumeInfo(t *testing.T) {
 			},
 			output: nil,
 		},
+		"Unsupported volume type": {
+			cmdOptions: &CmdVolumeOptions{
+				volName: "vol1",
+			},
+			collection: client.ReplicaCollection{
+				Data: []client.Replica{
+					{
+						Address: "10.10.10.13",
+						Mode:    "RW",
+					},
+				},
+			},
+			volume: VolumeInfo{
+				Volume: v1alpha1.CASVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"openebs.io/controller-ips":    "10.32.2.13",
+							"openebs.io/controller-status": "running,running,running",
+							"openebs.io/cvr-names":         "default-cstor-volume-3227802448-cstor-sparse-pool-g7e8,default-cstor-volume-3227802448-cstor-sparse-pool-l9dp,default-cstor-volume-3227802448-cstor-sparse-pool-yq8t",
+							"openebs.io/node-names":        "gke-ashish-dev-default-pool-1fe155b7-rvqd,gke-ashish-dev-default-pool-1fe155b7-qv7v,gke-ashish-dev-default-pool-1fe155b7-w75t",
+							"openebs.io/pool-names":        "cstor-sparse-pool-g7e8,cstor-sparse-pool-l9dp,cstor-sparse-pool-yq8t",
+						},
+					},
+					Spec: v1alpha1.CASVolumeSpec{
+						Capacity:     "5G",
+						CasType:      "alienVolume",
+						Iqn:          "iqn.2016-09.com.openebs.jiva:<no value>",
+						Replicas:     "4",
+						TargetIP:     "<no value>",
+						TargetPort:   "3260",
+						TargetPortal: "<no value>:3260",
+					},
+				},
+			},
+			output: nil,
+		},
 	}
 
 	for name, tt := range validInfo {

--- a/cmd/mayactl/app/command/volume_test.go
+++ b/cmd/mayactl/app/command/volume_test.go
@@ -576,3 +576,117 @@ func TestGetReplicaIP(t *testing.T) {
 		})
 	}
 }
+
+func TestGetStoragePool(t *testing.T) {
+	tests := map[string]struct {
+		expectedOutput string
+		Volume         VolumeInfo
+	}{
+		"Fetching StoragePool from openebs.io/openebs.io/pool-names": {
+			Volume: VolumeInfo{
+				Volume: v1alpha1.CASVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"openebs.io/pool-names": "cstor-sparse-pool-g7e8,cstor-sparse-pool-l9dp,cstor-sparse-pool-yq8t",
+						},
+					},
+				},
+			},
+			expectedOutput: "cstor-sparse-pool-g7e8,cstor-sparse-pool-l9dp,cstor-sparse-pool-yq8t",
+		},
+		"Fetching StoragePool when no key is present": {
+			Volume: VolumeInfo{
+				Volume: v1alpha1.CASVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			expectedOutput: "",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tt.Volume.GetStoragePool()
+			if got != tt.expectedOutput {
+				t.Fatalf("Test: %v Expected: %v but got: %v", name, tt.expectedOutput, got)
+			}
+		})
+	}
+}
+
+func TestGetCVRName(t *testing.T) {
+	tests := map[string]struct {
+		expectedOutput string
+		Volume         VolumeInfo
+	}{
+		"Fetching CVRName from openebs.io/cvr-names": {
+			Volume: VolumeInfo{
+				Volume: v1alpha1.CASVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"openebs.io/cvr-names": "default-cstor-volume-3227802448-cstor-sparse-pool-g7e8,default-cstor-volume-3227802448-cstor-sparse-pool-l9dp,default-cstor-volume-3227802448-cstor-sparse-pool-yq8t",
+						},
+					},
+				},
+			},
+			expectedOutput: "default-cstor-volume-3227802448-cstor-sparse-pool-g7e8,default-cstor-volume-3227802448-cstor-sparse-pool-l9dp,default-cstor-volume-3227802448-cstor-sparse-pool-yq8t",
+		},
+		"Fetching CVRName when no key is present": {
+			Volume: VolumeInfo{
+				Volume: v1alpha1.CASVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			expectedOutput: "",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tt.Volume.GetCVRName()
+			if got != tt.expectedOutput {
+				t.Fatalf("Test: %v Expected: %v but got: %v", name, tt.expectedOutput, got)
+			}
+		})
+	}
+}
+
+func TestGetNodeName(t *testing.T) {
+	tests := map[string]struct {
+		expectedOutput string
+		Volume         VolumeInfo
+	}{
+		"Fetching Node Name from openebs.io/node-names": {
+			Volume: VolumeInfo{
+				Volume: v1alpha1.CASVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"openebs.io/node-names": "gke-ashish-dev-default-pool-1fe155b7-rvqd,gke-ashish-dev-default-pool-1fe155b7-qv7v,gke-ashish-dev-default-pool-1fe155b7-w75t",
+						},
+					},
+				},
+			},
+			expectedOutput: "gke-ashish-dev-default-pool-1fe155b7-rvqd,gke-ashish-dev-default-pool-1fe155b7-qv7v,gke-ashish-dev-default-pool-1fe155b7-w75t",
+		},
+		"Fetching Node Name when no key is present": {
+			Volume: VolumeInfo{
+				Volume: v1alpha1.CASVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			expectedOutput: "",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tt.Volume.GetNodeName()
+			if got != tt.expectedOutput {
+				t.Fatalf("Test: %v Expected: %v but got: %v", name, tt.expectedOutput, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
-> This PR fixes replica status for cstor CASVolumes in volume info command in mayactl.

**Special notes for your reviewer**:
-> Currently Pool IP and access modes are not available. Need to add runtask for that .
-> Preview of ```mayactl volume info``` for cstor:
```
Portal Details :
----------------
IQN           :   iqn.2016-09.com.openebs.cstor:default-cstor-volume-3602380723
Volume        :   default-cstor-volume-3602380723
Portal        :   10.35.251.53:3260
Size          :   4G
Status        :   running,running,running
Replica Count :   3

Replica Details :
-----------------
NAME                                                       STATUS      POOL NAME                  NODE    
----                                                       ------      ---------                  ----- 
default-cstor-volume-3602380723-cstor-sparse-pool-7ey7     Running     cstor-sparse-pool-7ey7     gke-ashish-dev-default-pool-1fe155b7-w75t 
default-cstor-volume-3602380723-cstor-sparse-pool-j1la     Running     cstor-sparse-pool-j1la     gke-ashish-dev-default-pool-1fe155b7-qv7v 
default-cstor-volume-3602380723-cstor-sparse-pool-kv3n     Running     cstor-sparse-pool-kv3n     gke-ashish-dev-default-pool-1fe155b7-rvqd 

```
