### PR TITLE
enhance transforming kubernetes kind value to resource value

### DIFF
--- a/pkg/client/k8s/v1alpha1/unstructured.go
+++ b/pkg/client/k8s/v1alpha1/unstructured.go
@@ -41,6 +41,29 @@ import (
 	"strings"
 )
 
+// kind represents the name of the kubernetes kind
+type kind string
+
+// resource converts the name of the kubernetes kind to corresponding kubernetes
+// resource's name
+//
+// NOTE:
+//  This may not be the best of approaches to get name of a resource. However,
+// this fits the current requirement. This might need a revisit depending on
+// future requirements.
+func (k kind) resource() (resource string) {
+	resource = strings.ToLower(string(k))
+	switch resource {
+	case "":
+		return
+	case "storageclass":
+		return "storageclasses"
+	default:
+		return resource + "s"
+	}
+	return
+}
+
 // GroupVersionResourceFromGVK returns the GroupVersionResource of the provided
 // unstructured instance by making use of this instance's GroupVersionKind info
 //
@@ -55,7 +78,7 @@ func GroupVersionResourceFromGVK(unstructured *unstructured.Unstructured) (gvr s
 
 	gvr.Group = strings.ToLower(gvk.Group)
 	gvr.Version = strings.ToLower(gvk.Version)
-	gvr.Resource = strings.ToLower(gvk.Kind) + "s"
+	gvr.Resource = kind(gvk.Kind).resource()
 
 	return
 }


### PR DESCRIPTION
This commit has following fix:
- Enhances the logic to transform the value of a resource
kind to its corresponding resource value
- e.g. kind 'pod' becomes resource 'pods'
- e.g. kind 'storageclass' becomes resource 'storageclasses'

NOTE:
Installer code makes use of client-go's dynamic package which in turn needs the use of GroupVersionResource. In addition, installer code takes yaml as input and tries to convert that to an unstructured instance before applying the same into kubernetes cluster. Since installer does not have a mechanism to get the resource value, it tries to build it based on kind's value.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
