### PR TITLE
[Bug-Fix]Fix cas template annotations bug.

### DIFF
--- a/cmd/maya-apiserver/spc-watcher/storagepool_create.go
+++ b/cmd/maya-apiserver/spc-watcher/storagepool_create.go
@@ -109,12 +109,9 @@ func newCasPool(spcGot *apis.StoragePoolClaim, reSync bool, pendingPoolCount int
 	// The name of cas template should be provided as annotation in storagepoolclaim yaml
 	// so that it can be used.
 
-	// Check for cas template
+	// Fill spc annotations to CasPool
 	casTemplateName := spcGot.Annotations[string(v1alpha1.SPCreateCASTemplateCK)]
-	if casTemplateName == "" {
-		return errors.New("aborting storagepool create operation as no cas template is specified"), nil
-	}
-	// Create an empty CasPool object and fill storagepoolclaim details
+
 	pool := &v1alpha1.CasPool{}
 	pool.StoragePoolClaim = spcGot.Name
 	pool.CasCreateTemplate = casTemplateName


### PR DESCRIPTION
PR Description:

    1. Name of cas templates is required to create and delete
       storage pool.

    2. The name of cas template can be fetched from :
       I.  Via SPC annotations.
       II. Via env variable.
       The priority is(Decreasing priority).
       Via SPC annotations--> Via env variable.

    3. The validation for presence of annotations of CAS
       template names for create and delete of pool in spc
       watcher needs to be stripped off to support the above
       priority based fetching.

    4. Although handling for non availaiblity of CAS templates
       is handled i.e. if not found at any of the places.

Refer to following PR for more details:
https://github.com/openebs/maya/pull/481/files

Signed-off-by: sonasingh46 <sonasingh46@gmail.com>