### PR TITLE
Use env var fallback for missing cast names in sc.

### DIFF
--- a/pkg/apis/openebs.io/v1alpha1/cas_volume.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_volume.go
@@ -63,6 +63,9 @@ const (
 	// StorageClassKey is the key to fetch name of StorageClass
 	StorageClassKey CASKey = "openebs.io/storageclass"
 
+	// CASTypeKey is the key to fetch storage engine for the volume
+	CASTypeKey CASKey = "openebs.io/cas-type"
+
 	// StorageClassHeaderKey is the key to fetch name of StorageClass
 	// This key is present only in get request headers
 	StorageClassHeaderKey CASKey = "storageclass"

--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -35,15 +35,26 @@ const (
 	// to list cas volumes
 	CASTemplateToListVolumeENVK ENVKey = "OPENEBS_IO_CAS_TEMPLATE_TO_LIST_VOLUME"
 
-	// CASTemplateToCreateVolumeENVK is the ENV key that specifies the CAS Template
-	// to create cas volumes
-	CASTemplateToCreateVolumeENVK ENVKey = "OPENEBS_IO_CAS_TEMPLATE_TO_CREATE_VOLUME"
-	// CASTemplateToReadVolumeENVK is the ENV key that specifies the CAS Template
-	// to read cas volumes
-	CASTemplateToReadVolumeENVK ENVKey = "OPENEBS_IO_CAS_TEMPLATE_TO_READ_VOLUME"
-	// CASTemplateToDeleteVolumeENVK is the ENV key that specifies the CAS Template
-	// to delete cas volumes
-	CASTemplateToDeleteVolumeENVK ENVKey = "OPENEBS_IO_CAS_TEMPLATE_TO_DELETE_VOLUME"
+	// CASTemplateToCreateJivaVolumeENVK is the ENV key that specifies the CAS Template
+	// to create jiva cas volumes
+	CASTemplateToCreateJivaVolumeENVK ENVKey = "OPENEBS_IO_JIVA_CAS_TEMPLATE_TO_CREATE_VOLUME"
+	// CASTemplateToReadJivaVolumeENVK is the ENV key that specifies the CAS Template
+	// to read jiva cas volumes
+	CASTemplateToReadJivaVolumeENVK ENVKey = "OPENEBS_IO_JIVA_CAS_TEMPLATE_TO_READ_VOLUME"
+	// CASTemplateToDeleteJivaVolumeENVK is the ENV key that specifies the CAS Template
+	// to delete jiva cas volumes
+	CASTemplateToDeleteJivaVolumeENVK ENVKey = "OPENEBS_IO_JIVA_CAS_TEMPLATE_TO_DELETE_VOLUME"
+
+	// CASTemplateToCreateCStorVolumeENVK is the ENV key that specifies the CAS Template
+	// to create cstor cas volumes
+	CASTemplateToCreateCStorVolumeENVK ENVKey = "OPENEBS_IO_CSTOR_CAS_TEMPLATE_TO_CREATE_VOLUME"
+	// CASTemplateToReadCStorVolumeENVK is the ENV key that specifies the CAS Template
+	// to read cstor cas volumes
+	CASTemplateToReadCStorVolumeENVK ENVKey = "OPENEBS_IO_CSTOR_CAS_TEMPLATE_TO_READ_VOLUME"
+	// CASTemplateToDeleteCStorVolumeENVK is the ENV key that specifies the CAS Template
+	// to delete cstor cas volumes
+	CASTemplateToDeleteCStorVolumeENVK ENVKey = "OPENEBS_IO_CSTOR_CAS_TEMPLATE_TO_DELETE_VOLUME"
+
 	// CASTemplateToCreatePoolENVK is the ENV key that specifies the CAS Template
 	// to create storage pool
 	CASTemplateToCreatePoolENVK ENVKey = "OPENEBS_IO_CAS_TEMPLATE_TO_CREATE_POOL"

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -18,6 +18,7 @@ package volume
 
 import (
 	"fmt"
+	"github.com/openebs/maya/types/v1"
 
 	"strings"
 
@@ -153,10 +154,14 @@ func (v *VolumeOperation) Create() (*v1alpha1.CASVolume, error) {
 
 	// cas template to create a cas volume
 	castName := sc.Annotations[string(v1alpha1.CASTemplateKeyForVolumeCreate)]
+	// if cas template for the given operation is empty then fetch from environment variables
 	if len(castName) == 0 {
-		// get default create-volume CAS template for create volume operations
-		// from ENV variable
-		castName = util.Get(string(util.CASTemplateToCreateVolumeENVK))
+		// check for cas-type, if cstor, set to create cas template for cstor, jiva otherwise
+		if strings.ToLower(sc.Annotations[string(v1alpha1.CASTypeKey)]) == string(v1.CStorVolumeType) {
+			castName = util.Get(string(util.CASTemplateToCreateCStorVolumeENVK))
+		} else {
+			castName = util.Get(string(util.CASTemplateToCreateJivaVolumeENVK))
+		}
 	}
 	if len(castName) == 0 {
 		return nil, fmt.Errorf("unable to create volume: missing create cas template at '%s'", v1alpha1.CASTemplateKeyForVolumeCreate)
@@ -226,11 +231,14 @@ func (v *VolumeOperation) Delete() (*v1alpha1.CASVolume, error) {
 		return nil, err
 	}
 	castName := sc.Annotations[string(v1alpha1.CASTemplateKeyForVolumeDelete)]
+	// if cas template for the given operation is empty then fetch from environment variables
 	if len(castName) == 0 {
-		// get default delete-volume CAS template for delete volume operations
-		// from ENV variable
-		castName = util.Get(string(util.CASTemplateToDeleteVolumeENVK))
-
+		// check for cas-type, if cstor, set to delete cas template for cstor, jiva otherwise
+		if strings.ToLower(sc.Annotations[string(v1alpha1.CASTypeKey)]) == string(v1.CStorVolumeType) {
+			castName = util.Get(string(util.CASTemplateToDeleteCStorVolumeENVK))
+		} else {
+			castName = util.Get(string(util.CASTemplateToDeleteJivaVolumeENVK))
+		}
 	}
 	if len(castName) == 0 {
 		return nil, fmt.Errorf("unable to delete volume %s: missing cas template for delete volume at annotation '%s'", v.volume.Name, v1alpha1.CASTemplateKeyForVolumeDelete)
@@ -302,10 +310,14 @@ func (v *VolumeOperation) Read() (*v1alpha1.CASVolume, error) {
 
 	// extract read cas template name from sc annotation
 	castName := sc.Annotations[string(v1alpha1.CASTemplateKeyForVolumeRead)]
+	// check for cas-type, if cstor, set to read cas template for cstor, jiva otherwise
 	if len(castName) == 0 {
-		// get default read-volume CAS template for read volume operations
-		// from ENV variable
-		castName = util.Get(string(util.CASTemplateToReadVolumeENVK))
+		// check for cas-type, if cstor set to cstor read cas template otherwise, jiva
+		if strings.ToLower(sc.Annotations[string(v1alpha1.CASTypeKey)]) == string(v1.CStorVolumeType) {
+			castName = util.Get(string(util.CASTemplateToReadCStorVolumeENVK))
+		} else {
+			castName = util.Get(string(util.CASTemplateToReadJivaVolumeENVK))
+		}
 	}
 	if len(castName) == 0 {
 		return nil, fmt.Errorf("unable to read volume '%s': missing cas template for read '%s'", v.volume.Name, v1alpha1.CASTemplateKeyForVolumeRead)

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -19,6 +19,7 @@ package volume
 import (
 	"fmt"
 	"github.com/openebs/maya/types/v1"
+	v1_storage "k8s.io/api/storage/v1"
 
 	"strings"
 
@@ -153,16 +154,7 @@ func (v *VolumeOperation) Create() (*v1alpha1.CASVolume, error) {
 	casConfigSC := sc.Annotations[string(v1alpha1.CASConfigKey)]
 
 	// cas template to create a cas volume
-	castName := sc.Annotations[string(v1alpha1.CASTemplateKeyForVolumeCreate)]
-	// if cas template for the given operation is empty then fetch from environment variables
-	if len(castName) == 0 {
-		// check for cas-type, if cstor, set to create cas template for cstor, jiva otherwise
-		if strings.ToLower(sc.Annotations[string(v1alpha1.CASTypeKey)]) == string(v1.CStorVolumeType) {
-			castName = util.Get(string(util.CASTemplateToCreateCStorVolumeENVK))
-		} else {
-			castName = util.Get(string(util.CASTemplateToCreateJivaVolumeENVK))
-		}
-	}
+	castName := getCreateCASTemplate(sc)
 	if len(castName) == 0 {
 		return nil, fmt.Errorf("unable to create volume: missing create cas template at '%s'", v1alpha1.CASTemplateKeyForVolumeCreate)
 	}
@@ -230,16 +222,7 @@ func (v *VolumeOperation) Delete() (*v1alpha1.CASVolume, error) {
 	if err != nil {
 		return nil, err
 	}
-	castName := sc.Annotations[string(v1alpha1.CASTemplateKeyForVolumeDelete)]
-	// if cas template for the given operation is empty then fetch from environment variables
-	if len(castName) == 0 {
-		// check for cas-type, if cstor, set to delete cas template for cstor, jiva otherwise
-		if strings.ToLower(sc.Annotations[string(v1alpha1.CASTypeKey)]) == string(v1.CStorVolumeType) {
-			castName = util.Get(string(util.CASTemplateToDeleteCStorVolumeENVK))
-		} else {
-			castName = util.Get(string(util.CASTemplateToDeleteJivaVolumeENVK))
-		}
-	}
+	castName := getDeleteCASTemplate(sc)
 	if len(castName) == 0 {
 		return nil, fmt.Errorf("unable to delete volume %s: missing cas template for delete volume at annotation '%s'", v.volume.Name, v1alpha1.CASTemplateKeyForVolumeDelete)
 	}
@@ -309,16 +292,7 @@ func (v *VolumeOperation) Read() (*v1alpha1.CASVolume, error) {
 	}
 
 	// extract read cas template name from sc annotation
-	castName := sc.Annotations[string(v1alpha1.CASTemplateKeyForVolumeRead)]
-	// check for cas-type, if cstor, set to read cas template for cstor, jiva otherwise
-	if len(castName) == 0 {
-		// check for cas-type, if cstor set to cstor read cas template otherwise, jiva
-		if strings.ToLower(sc.Annotations[string(v1alpha1.CASTypeKey)]) == string(v1.CStorVolumeType) {
-			castName = util.Get(string(util.CASTemplateToReadCStorVolumeENVK))
-		} else {
-			castName = util.Get(string(util.CASTemplateToReadJivaVolumeENVK))
-		}
-	}
+	castName := getReadCASTemplate(sc)
 	if len(castName) == 0 {
 		return nil, fmt.Errorf("unable to read volume '%s': missing cas template for read '%s'", v.volume.Name, v1alpha1.CASTemplateKeyForVolumeRead)
 	}
@@ -432,4 +406,52 @@ func (v *VolumeListOperation) List() (*v1alpha1.CASVolumeList, error) {
 		vols.Items = append(vols.Items, tvols.Items...)
 	}
 	return vols, nil
+}
+
+func getCreateCASTemplate(sc *v1_storage.StorageClass) string {
+	castName := sc.Annotations[string(v1alpha1.CASTemplateKeyForVolumeCreate)]
+	// if cas template for the given operation is empty then fetch from environment variables
+	if len(castName) == 0 {
+		casType := strings.ToLower(sc.Annotations[string(v1alpha1.CASTypeKey)])
+		// check for cas-type, if cstor, set create cas template to cstor,
+		// if jiva or for jiva and if absent then default to jiva
+		if casType == string(v1.CStorVolumeType) {
+			castName = util.Get(string(util.CASTemplateToCreateCStorVolumeENVK))
+		} else if casType == string(v1.JivaVolumeType) || casType == "" {
+			castName = util.Get(string(util.CASTemplateToCreateJivaVolumeENVK))
+		}
+	}
+	return castName
+}
+
+func getReadCASTemplate(sc *v1_storage.StorageClass) string {
+	castName := sc.Annotations[string(v1alpha1.CASTemplateKeyForVolumeRead)]
+	// if cas template for the given operation is empty then fetch from environment variables
+	if len(castName) == 0 {
+		casType := strings.ToLower(sc.Annotations[string(v1alpha1.CASTypeKey)])
+		// check for cas-type, if cstor, set create cas template to cstor,
+		// if jiva or for jiva and if absent then default to jiva
+		if casType == string(v1.CStorVolumeType) {
+			castName = util.Get(string(util.CASTemplateToReadCStorVolumeENVK))
+		} else if casType == string(v1.JivaVolumeType) || casType == "" {
+			castName = util.Get(string(util.CASTemplateToReadJivaVolumeENVK))
+		}
+	}
+	return castName
+}
+
+func getDeleteCASTemplate(sc *v1_storage.StorageClass) string {
+	castName := sc.Annotations[string(v1alpha1.CASTemplateKeyForVolumeDelete)]
+	// if cas template for the given operation is empty then fetch from environment variables
+	if len(castName) == 0 {
+		casType := strings.ToLower(sc.Annotations[string(v1alpha1.CASTypeKey)])
+		// check for cas-type, if cstor, set create cas template to cstor,
+		// if jiva or for jiva and if absent then default to jiva
+		if casType == string(v1.CStorVolumeType) {
+			castName = util.Get(string(util.CASTemplateToDeleteCStorVolumeENVK))
+		} else if casType == string(v1.JivaVolumeType) || casType == "" {
+			castName = util.Get(string(util.CASTemplateToDeleteJivaVolumeENVK))
+		}
+	}
+	return castName
 }

--- a/pkg/volume/volume_test.go
+++ b/pkg/volume/volume_test.go
@@ -1,0 +1,174 @@
+package volume
+
+import (
+	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	"github.com/openebs/maya/pkg/util"
+	v1_storage "k8s.io/api/storage/v1"
+	"os"
+	"testing"
+)
+
+func TestGetCreateCASTemplate(t *testing.T) {
+	sc := &v1_storage.StorageClass{}
+	sc.Annotations = make(map[string]string)
+	tests := map[string]struct {
+		scCreateCASAnnotation string
+		scCASTypeAnnotation   string
+		envJivaCAST           string
+		envCStorCAST          string
+		expectedCAST          string
+	}{
+		"CAST annotation is present": {
+			"cast-create-from-annotation",
+			"",
+			"",
+			"",
+			"cast-create-from-annotation",
+		},
+		"CAST annotation is absent/empty and cas type is cstor": {
+			"",
+			"cstor",
+			"",
+			"cast-cstor-create-from-env",
+			"cast-cstor-create-from-env",
+		},
+		"CAST annotation is absent/empty and cas type is jiva": {
+			"",
+			"jiva",
+			"cast-jiva-create-from-env",
+			"",
+			"cast-jiva-create-from-env",
+		},
+		"CAST annotation is absent/empty and cas type unknown": {
+			"",
+			"unknown",
+			"cast-jiva-create-from-env",
+			"cast-cstor-create-from-env",
+			"",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			sc.Annotations[string(v1alpha1.CASTemplateKeyForVolumeCreate)] = test.scCreateCASAnnotation
+			sc.Annotations[string(v1alpha1.CASTypeKey)] = test.scCASTypeAnnotation
+			os.Setenv(string(util.CASTemplateToCreateCStorVolumeENVK), test.envCStorCAST)
+			os.Setenv(string(util.CASTemplateToCreateJivaVolumeENVK), test.envJivaCAST)
+
+			castName := getCreateCASTemplate(sc)
+
+			if castName != test.expectedCAST {
+				t.Fatalf("unexpected cast name, wanted %q got %q", test.expectedCAST, castName)
+			}
+		})
+	}
+}
+
+func TestGetReadCASTemplate(t *testing.T) {
+	sc := &v1_storage.StorageClass{}
+	sc.Annotations = make(map[string]string)
+	tests := map[string]struct {
+		scReadCASAnnotation string
+		scCASTypeAnnotation string
+		envJivaCAST         string
+		envCStorCAST        string
+		expectedCAST        string
+	}{
+		"CAST annotation is present": {
+			"cast-read-from-annotation",
+			"",
+			"",
+			"",
+			"cast-read-from-annotation",
+		},
+		"CAST annotation is absent/empty and cas type is cstor": {
+			"",
+			"cstor",
+			"",
+			"cast-cstor-read-from-env",
+			"cast-cstor-read-from-env",
+		},
+		"CAST annotation is absent/empty and cas type is jiva": {
+			"",
+			"jiva",
+			"cast-jiva-read-from-env",
+			"",
+			"cast-jiva-read-from-env",
+		},
+		"CAST annotation is absent/empty and cas type unknown": {
+			"",
+			"unknown",
+			"cast-jiva-read-from-env",
+			"cast-cstor-read-from-env",
+			"",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			sc.Annotations[string(v1alpha1.CASTemplateKeyForVolumeRead)] = test.scReadCASAnnotation
+			sc.Annotations[string(v1alpha1.CASTypeKey)] = test.scCASTypeAnnotation
+			os.Setenv(string(util.CASTemplateToReadCStorVolumeENVK), test.envCStorCAST)
+			os.Setenv(string(util.CASTemplateToReadJivaVolumeENVK), test.envJivaCAST)
+
+			castName := getReadCASTemplate(sc)
+
+			if castName != test.expectedCAST {
+				t.Fatalf("unexpected cast name, wanted %q got %q", test.expectedCAST, castName)
+			}
+		})
+	}
+}
+
+func TestGetDeleteCASTemplate(t *testing.T) {
+	sc := &v1_storage.StorageClass{}
+	sc.Annotations = make(map[string]string)
+	tests := map[string]struct {
+		scDeleteCASAnnotation string
+		scCASTypeAnnotation   string
+		envJivaCAST           string
+		envCStorCAST          string
+		expectedCAST          string
+	}{
+		"CAST annotation is present": {
+			"cast-read-from-annotation",
+			"",
+			"",
+			"",
+			"cast-read-from-annotation",
+		},
+		"CAST annotation is absent/empty and cas type is cstor": {
+			"",
+			"cstor",
+			"",
+			"cast-cstor-read-from-env",
+			"cast-cstor-read-from-env",
+		},
+		"CAST annotation is absent/empty and cas type is jiva": {
+			"",
+			"jiva",
+			"cast-jiva-read-from-env",
+			"",
+			"cast-jiva-read-from-env",
+		},
+		"CAST annotation is absent/empty and cas type unknown": {
+			"",
+			"unknown",
+			"cast-jiva-read-from-env",
+			"cast-cstor-read-from-env",
+			"",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			sc.Annotations[string(v1alpha1.CASTemplateKeyForVolumeDelete)] = test.scDeleteCASAnnotation
+			sc.Annotations[string(v1alpha1.CASTypeKey)] = test.scCASTypeAnnotation
+			os.Setenv(string(util.CASTemplateToDeleteCStorVolumeENVK), test.envCStorCAST)
+			os.Setenv(string(util.CASTemplateToDeleteJivaVolumeENVK), test.envJivaCAST)
+
+			castName := getDeleteCASTemplate(sc)
+
+			if castName != test.expectedCAST {
+				t.Fatalf("unexpected cast name, wanted %q got %q", test.expectedCAST, castName)
+			}
+		})
+	}
+}

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -132,7 +132,7 @@ const (
 	JivaVolumeType VolumeType = "jiva"
 
 	// CStorVolumeType represents a cstor volume
-	//CStorVolumeType VolumeType = "cstor"
+	CStorVolumeType VolumeType = "cstor"
 )
 
 // VolumeContext defines context of a volume


### PR DESCRIPTION
This commit does the following:
1. Add default castemplates for cstor read,create and delete
2. Rename jiva castemplates name for read,create and delete
3. Uncomment CStorVolume type
4. Introduce CASKey called CASTypeKey = "openebs.io/cas-type"
which would be used to fetch engine type from sc. This is the
same annotation key put in PV to define engine type.
5. If the castemplate is missing in SC annotation then switch
castemplate based on CASTypeKey. If CASTypeKey is not cstor
then default to jiva cas templates.

Signed-off-by: Prince Rachit Sinha <prince.rachit@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
