### PR TITLE
evaluate if resource is `namespaced` before install

### DIFF
--- a/pkg/client/k8s/v1alpha1/resource.go
+++ b/pkg/client/k8s/v1alpha1/resource.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2018 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"strings"
+)
+
+// ResourceCreator abstracts creating an unstructured instance in kubernetes
+// cluster
+type ResourceCreator func(obj *unstructured.Unstructured, subresources ...string) (*unstructured.Unstructured, error)
+
+// NewResourceCreator returns a new instance of ResourceCreator that is
+// capable of creating a resource in kubernetes cluster
+func NewResourceCreator(gvr schema.GroupVersionResource, namespace string) ResourceCreator {
+	return func(obj *unstructured.Unstructured, subresources ...string) (*unstructured.Unstructured, error) {
+		if obj == nil {
+			return nil, fmt.Errorf("nil resource instance: failed to create '%s' at namespace '%s'", gvr, namespace)
+		}
+
+		dynamic, err := NewDynamicGetter()()
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create '%s' '%s' at namespace '%s'", gvr, obj.GetName(), namespace)
+		}
+
+		unstruct, err := dynamic.Resource(gvr).Namespace(namespace).Create(obj, subresources...)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create '%s' '%s' at namespace '%s'", gvr, obj.GetName(), namespace)
+		}
+
+		return unstruct, nil
+	}
+}
+
+// ResourceGetter abstracts fetching an unstructured instance from kubernetes
+// cluster
+type ResourceGetter func(name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error)
+
+// NewResourceGetter returns a new instance of ResourceGetter that is capable
+// of fetching an unstructured instance from kubernetes cluster
+func NewResourceGetter(gvr schema.GroupVersionResource, namespace string) ResourceGetter {
+	return func(name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+		if len(strings.TrimSpace(name)) == 0 {
+			return nil, fmt.Errorf("missing resource name: failed to get '%s' from namespace '%s'", gvr, namespace)
+		}
+
+		dynamic, err := NewDynamicGetter()()
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get '%s' '%s' from namespace '%s'", gvr, name, namespace)
+		}
+
+		unstruct, err := dynamic.Resource(gvr).Namespace(namespace).Get(name, options, subresources...)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get '%s' '%s' from namespace '%s'", gvr, name, namespace)
+		}
+
+		return unstruct, nil
+	}
+}
+
+// ResourceUpdater abstracts updating an unstructured instance found in
+// kubernetes cluster
+type ResourceUpdater func(oldobj, newobj *unstructured.Unstructured, subresources ...string) (*unstructured.Unstructured, error)
+
+// NewResourceUpdater returns a new instance of ResourceUpdater that is capable
+// of updating an unstructured instance found in kubernetes cluster
+func NewResourceUpdater(gvr schema.GroupVersionResource, namespace string) ResourceUpdater {
+	return func(oldobj, newobj *unstructured.Unstructured, subresources ...string) (*unstructured.Unstructured, error) {
+		if oldobj == nil {
+			return nil, fmt.Errorf("nil old resource instance: failed to update '%s' at namespace '%s'", gvr, namespace)
+		}
+
+		if newobj == nil {
+			return nil, fmt.Errorf("nil new resource instance: failed to update '%s' at namespace '%s'", gvr, namespace)
+		}
+
+		dynamic, err := NewDynamicGetter()()
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to update '%s' '%s' at namespace '%s'", gvr, oldobj.GetName(), namespace)
+		}
+
+		resourceVersion := oldobj.GetResourceVersion()
+		newobj.SetResourceVersion(resourceVersion)
+
+		unstruct, err := dynamic.Resource(gvr).Namespace(namespace).Update(newobj, subresources...)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to update '%s' '%s' at namespace '%s'", gvr, oldobj.GetName(), namespace)
+		}
+
+		return unstruct, nil
+	}
+}
+
+// ResourceApplyOptions is used during a resource's apply operation
+type ResourceApplyOptions struct {
+	Getter  ResourceGetter
+	Creator ResourceCreator
+	Updater ResourceUpdater
+}
+
+// ResourceApplier abstracts applying an unstructured instance that may or may
+// not be available in kubernetes cluster
+type ResourceApplier func(obj *unstructured.Unstructured, subresources ...string) (*unstructured.Unstructured, error)
+
+// newResourceApplier returns a new instance of ResourceApplier that is capable
+// of applying an unstructured instance that may or may not be available in
+// kubernetes cluster
+func newResourceApplier(options ResourceApplyOptions) ResourceApplier {
+	return func(obj *unstructured.Unstructured, subresources ...string) (resource *unstructured.Unstructured, err error) {
+		if options.Getter == nil {
+			err = fmt.Errorf("nil resource getter instance: failed to apply resource")
+			return
+		}
+
+		if options.Creator == nil {
+			err = fmt.Errorf("nil resource creator instance: failed to apply resource")
+			return
+		}
+
+		if options.Updater == nil {
+			err = fmt.Errorf("nil resource updater instance: failed to apply resource")
+			return
+		}
+
+		if obj == nil {
+			err = fmt.Errorf("nil resource instance: failed to apply resource")
+			return
+		}
+
+		resource, err = options.Getter(obj.GetName(), metav1.GetOptions{})
+		if err != nil && apierrors.IsNotFound(errors.Cause(err)) {
+			return options.Creator(obj, subresources...)
+		}
+
+		if resource != nil {
+			return options.Updater(resource, obj, subresources...)
+		}
+
+		return
+	}
+}
+
+// NewResourceApplier returns a new instance of ResourceApplier that is capable
+// of applying any resource into kubernetes cluster
+func NewResourceApplier(gvr schema.GroupVersionResource, namespace string) ResourceApplier {
+	options := ResourceApplyOptions{
+		Getter:  NewResourceGetter(gvr, namespace),
+		Creator: NewResourceCreator(gvr, namespace),
+		Updater: NewResourceUpdater(gvr, namespace),
+	}
+
+	return newResourceApplier(options)
+}

--- a/pkg/client/k8s/v1alpha1/unstructured.go
+++ b/pkg/client/k8s/v1alpha1/unstructured.go
@@ -30,11 +30,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"fmt"
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -62,6 +59,26 @@ func (k kind) resource() (resource string) {
 		return resource + "s"
 	}
 	return
+}
+
+// isNamespaced flags if the kind is namespaced or not
+func (k kind) isNamespaced() (no bool) {
+	ks := strings.ToLower(string(k))
+	switch ks {
+	case "storageclass":
+		return no
+	case "persistentvolumes":
+		return no
+	case "castemplates":
+		return no
+	case "cstorpools":
+		return no
+	case "storagepools":
+		return no
+	default:
+		return !no
+	}
+	return !no
 }
 
 // GroupVersionResourceFromGVK returns the GroupVersionResource of the provided
@@ -128,33 +145,47 @@ func CreateUnstructuredFromJson(document string) (*unstructured.Unstructured, er
 // UnstructuredMiddleware abstracts updating given unstructured instance
 type UnstructuredMiddleware func(given *unstructured.Unstructured) (updated *unstructured.Unstructured)
 
+// UnstructuredPredicate abstracts evaluating a condition against the provided
+// unstructured instance
+type UnstructuredPredicate func(given *unstructured.Unstructured) bool
+
+// IsNamespaceScoped flags if the given unstructured instance is namespace
+// scoped
+//
+// NOTE:
+//  This is a UnstructuredPredicate implementation
+func IsNamespaceScoped(given *unstructured.Unstructured) bool {
+	return kind(given.GetKind()).isNamespaced()
+}
+
 // UnstructuredOptions provides a set of properties that can be used as a
 // utility for various operations related to unstructured instance
 type UnstructuredOptions struct {
 	Namespace string
 }
 
-// WithOptionsUpdater abstracts updating Unstructured instance based on
-// provided options
-type WithOptionsUpdater func(options UnstructuredOptions) UnstructuredMiddleware
+// UpdateNamespaceP updates the unstructured's namespace conditionally
+func UpdateNamespaceP(o UnstructuredOptions, p UnstructuredPredicate) UnstructuredMiddleware {
+	return func(given *unstructured.Unstructured) (updated *unstructured.Unstructured) {
+		if p(given) {
+			return UpdateNamespace(o)(given)
+		}
+		return given
+	}
+}
 
 // UpdateNamespace updates the unstructured's namespace
-//
-// NOTE:
-//  This is an implementation of WithOptionsUpdater
-func UpdateNamespace(options UnstructuredOptions) UnstructuredMiddleware {
-	return func(unstructured *unstructured.Unstructured) *unstructured.Unstructured {
-		if unstructured == nil {
-			return unstructured
+func UpdateNamespace(o UnstructuredOptions) UnstructuredMiddleware {
+	return func(given *unstructured.Unstructured) (updated *unstructured.Unstructured) {
+		if given == nil {
+			return given
 		}
-
-		namespace := strings.TrimSpace(options.Namespace)
+		namespace := strings.TrimSpace(o.Namespace)
 		if len(namespace) == 0 {
-			return unstructured
+			return given
 		}
-
-		unstructured.SetNamespace(namespace)
-		return unstructured
+		given.SetNamespace(namespace)
+		return given
 	}
 }
 
@@ -168,10 +199,6 @@ func UnstructuredUpdater(updaters []UnstructuredMiddleware) UnstructuredMiddlewa
 		return given
 	}
 }
-
-// UnstructuredPredicate abstracts evaluating a condition against the provided
-// unstructured instance
-type UnstructuredPredicate func(given *unstructured.Unstructured) bool
 
 // UnstructList represents a list of unstructured instances
 type UnstructList struct {
@@ -204,150 +231,4 @@ func (u UnstructList) MapIf(m UnstructuredMiddleware, p UnstructuredPredicate) (
 		}
 	}
 	return
-}
-
-// ResourceCreator abstracts creating an unstructured instance in kubernetes
-// cluster
-type ResourceCreator func(obj *unstructured.Unstructured, subresources ...string) (*unstructured.Unstructured, error)
-
-// NewResourceCreator returns a new instance of ResourceCreator that is
-// capable of creating a resource in kubernetes cluster
-func NewResourceCreator(gvr schema.GroupVersionResource, namespace string) ResourceCreator {
-	return func(obj *unstructured.Unstructured, subresources ...string) (*unstructured.Unstructured, error) {
-		if obj == nil {
-			return nil, fmt.Errorf("nil resource instance: failed to create '%s' at namespace '%s'", gvr, namespace)
-		}
-
-		dynamic, err := NewDynamicGetter()()
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create '%s' '%s' at namespace '%s'", gvr, obj.GetName(), namespace)
-		}
-
-		unstruct, err := dynamic.Resource(gvr).Namespace(namespace).Create(obj, subresources...)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create '%s' '%s' at namespace '%s'", gvr, obj.GetName(), namespace)
-		}
-
-		return unstruct, nil
-	}
-}
-
-// ResourceGetter abstracts fetching an unstructured instance from kubernetes
-// cluster
-type ResourceGetter func(name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error)
-
-// NewResourceGetter returns a new instance of ResourceGetter that is capable
-// of fetching an unstructured instance from kubernetes cluster
-func NewResourceGetter(gvr schema.GroupVersionResource, namespace string) ResourceGetter {
-	return func(name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
-		if len(strings.TrimSpace(name)) == 0 {
-			return nil, fmt.Errorf("missing resource name: failed to get '%s' from namespace '%s'", gvr, namespace)
-		}
-
-		dynamic, err := NewDynamicGetter()()
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get '%s' '%s' from namespace '%s'", gvr, name, namespace)
-		}
-
-		unstruct, err := dynamic.Resource(gvr).Namespace(namespace).Get(name, options, subresources...)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get '%s' '%s' from namespace '%s'", gvr, name, namespace)
-		}
-
-		return unstruct, nil
-	}
-}
-
-// ResourceUpdater abstracts updating an unstructured instance found in
-// kubernetes cluster
-type ResourceUpdater func(oldobj, newobj *unstructured.Unstructured, subresources ...string) (*unstructured.Unstructured, error)
-
-// NewResourceUpdater returns a new instance of ResourceUpdater that is capable
-// of updating an unstructured instance found in kubernetes cluster
-func NewResourceUpdater(gvr schema.GroupVersionResource, namespace string) ResourceUpdater {
-	return func(oldobj, newobj *unstructured.Unstructured, subresources ...string) (*unstructured.Unstructured, error) {
-		if oldobj == nil {
-			return nil, fmt.Errorf("nil old resource instance: failed to update '%s' at namespace '%s'", gvr, namespace)
-		}
-
-		if newobj == nil {
-			return nil, fmt.Errorf("nil new resource instance: failed to update '%s' at namespace '%s'", gvr, namespace)
-		}
-
-		dynamic, err := NewDynamicGetter()()
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to update '%s' '%s' at namespace '%s'", gvr, oldobj.GetName(), namespace)
-		}
-
-		resourceVersion := oldobj.GetResourceVersion()
-		newobj.SetResourceVersion(resourceVersion)
-
-		unstruct, err := dynamic.Resource(gvr).Namespace(namespace).Update(newobj, subresources...)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to update '%s' '%s' at namespace '%s'", gvr, oldobj.GetName(), namespace)
-		}
-
-		return unstruct, nil
-	}
-}
-
-// ResourceApplyOptions is used during a resource's apply operation
-type ResourceApplyOptions struct {
-	Getter  ResourceGetter
-	Creator ResourceCreator
-	Updater ResourceUpdater
-}
-
-// ResourceApplier abstracts applying an unstructured instance that may or may
-// not be available in kubernetes cluster
-type ResourceApplier func(obj *unstructured.Unstructured, subresources ...string) (*unstructured.Unstructured, error)
-
-// newResourceApplier returns a new instance of ResourceApplier that is capable
-// of applying an unstructured instance that may or may not be available in
-// kubernetes cluster
-func newResourceApplier(options ResourceApplyOptions) ResourceApplier {
-	return func(obj *unstructured.Unstructured, subresources ...string) (resource *unstructured.Unstructured, err error) {
-		if options.Getter == nil {
-			err = fmt.Errorf("nil resource getter instance: failed to apply resource")
-			return
-		}
-
-		if options.Creator == nil {
-			err = fmt.Errorf("nil resource creator instance: failed to apply resource")
-			return
-		}
-
-		if options.Updater == nil {
-			err = fmt.Errorf("nil resource updater instance: failed to apply resource")
-			return
-		}
-
-		if obj == nil {
-			err = fmt.Errorf("nil resource instance: failed to apply resource")
-			return
-		}
-
-		resource, err = options.Getter(obj.GetName(), metav1.GetOptions{})
-		if err != nil && apierrors.IsNotFound(errors.Cause(err)) {
-			return options.Creator(obj, subresources...)
-		}
-
-		if resource != nil {
-			return options.Updater(resource, obj, subresources...)
-		}
-
-		return
-	}
-}
-
-// NewResourceApplier returns a new instance of ResourceApplier that is capable
-// of applying any resource into kubernetes cluster
-func NewResourceApplier(gvr schema.GroupVersionResource, namespace string) ResourceApplier {
-	options := ResourceApplyOptions{
-		Getter:  NewResourceGetter(gvr, namespace),
-		Creator: NewResourceCreator(gvr, namespace),
-		Updater: NewResourceUpdater(gvr, namespace),
-	}
-
-	return newResourceApplier(options)
 }

--- a/pkg/client/k8s/v1alpha1/unstructured.go
+++ b/pkg/client/k8s/v1alpha1/unstructured.go
@@ -62,18 +62,25 @@ func (k kind) resource() (resource string) {
 }
 
 // isNamespaced flags if the kind is namespaced or not
+//
+// NOTE:
+//  This may not be the best of approaches to flag a resource as namespaced or 
+// not. However, this fits the current requirement. This might need a revisit 
+// depending on future requirements.
 func (k kind) isNamespaced() (no bool) {
 	ks := strings.ToLower(string(k))
 	switch ks {
 	case "storageclass":
 		return no
-	case "persistentvolumes":
+	case "persistentvolume":
 		return no
-	case "castemplates":
+	case "castemplate":
 		return no
-	case "cstorpools":
+	case "storagepoolclaim":
 		return no
-	case "storagepools":
+	case "cstorpool":
+		return no
+	case "storagepool":
 		return no
 	default:
 		return !no

--- a/pkg/install/v1alpha1/cstor_sparse_pool_claim_0.7.0.go
+++ b/pkg/install/v1alpha1/cstor_sparse_pool_claim_0.7.0.go
@@ -44,6 +44,27 @@ func CstorSparsePoolSpc070() (list ArtifactList) {
 func cstorSparsePoolSpcFor070() string {
 	return `
 ---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-cstor-sparse
+  annotations:
+    cas.openebs.io/create-volume-template: cstor-volume-create-default-0.7.0
+    cas.openebs.io/delete-volume-template: cstor-volume-delete-default-0.7.0
+    cas.openebs.io/read-volume-template: cstor-volume-read-default-0.7.0
+    cas.openebs.io/config: |
+      - name: StoragePoolClaim
+        value: "cstor-sparse-pool"
+      #- name: TargetResourceLimits
+      #  value: |-
+      #      memory: 1Gi
+      #      cpu: 200m
+      #- name: AuxResourceLimits
+      #  value: |-
+      #      memory: 0.5Gi
+      #      cpu: 50m
+provisioner: openebs.io/provisioner-iscsi
+---
 apiVersion: openebs.io/v1alpha1
 kind: StoragePoolClaim
 metadata:


### PR DESCRIPTION
This commit has below fixes:
- Introduces new predicate w.r.t unstructured instances
- This predicate evaluates if the unstructured instance is namespaced scope
- sparse pool related storageclass resource is added

Other changes:
- The unstructured.go file is split into unstructured.go & resource.go
- installer.go file has been made more informative via comments

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
