### PR TITLE
add env as template function to artifacts

### DIFF
--- a/pkg/client/k8s/v1alpha1/unstructured.go
+++ b/pkg/client/k8s/v1alpha1/unstructured.go
@@ -64,8 +64,8 @@ func (k kind) resource() (resource string) {
 // isNamespaced flags if the kind is namespaced or not
 //
 // NOTE:
-//  This may not be the best of approaches to flag a resource as namespaced or 
-// not. However, this fits the current requirement. This might need a revisit 
+//  This may not be the best of approaches to flag a resource as namespaced or
+// not. However, this fits the current requirement. This might need a revisit
 // depending on future requirements.
 func (k kind) isNamespaced() (no bool) {
 	ks := strings.ToLower(string(k))

--- a/pkg/install/v1alpha1/cstor_pool_0.7.0.go
+++ b/pkg/install/v1alpha1/cstor_pool_0.7.0.go
@@ -53,8 +53,8 @@ spec:
   # RunNamespace is the namespace where namespaced resources related to pool 
   # will be placed
   - name: RunNamespace
-    value: {{.installer.namespace}}
-  taskNamespace: {{.installer.namespace}}
+    value: {{env "OPENEBS_NAMESPACE"}}
+  taskNamespace: {{env "OPENEBS_NAMESPACE"}}
   run:
     tasks:
     # Following are the list of run tasks executed in this order to 
@@ -74,8 +74,8 @@ spec:
   defaultConfig:
     # RunNamespace is the namespace to use to delete pool resources
   - name: RunNamespace
-    value: {{.installer.namespace}}
-  taskNamespace: {{.installer.namespace}}
+    value: {{env "OPENEBS_NAMESPACE"}}
+  taskNamespace: {{env "OPENEBS_NAMESPACE"}}
   run:
     tasks:
     # Following are run tasks executed in this order to delete a storage pool

--- a/pkg/install/v1alpha1/cstor_volume_0.7.0.go
+++ b/pkg/install/v1alpha1/cstor_volume_0.7.0.go
@@ -45,7 +45,7 @@ spec:
     value: openebs/m-exporter:ci
   - name: ReplicaCount
     value: "3"
-  taskNamespace: {{.installer.namespace}}
+  taskNamespace: {{env "OPENEBS_NAMESPACE"}}
   run:
     tasks:
     - cstor-volume-create-listcstorpoolcr-default-0.7.0
@@ -60,7 +60,7 @@ kind: CASTemplate
 metadata:
   name: cstor-volume-delete-default-0.7.0
 spec:
-  taskNamespace: {{.installer.namespace}}
+  taskNamespace: {{env "OPENEBS_NAMESPACE"}}
   run:
     tasks:
     - cstor-volume-delete-listcstorvolumecr-default-0.7.0
@@ -78,7 +78,7 @@ kind: CASTemplate
 metadata:
   name: cstor-volume-read-default-0.7.0
 spec:
-  taskNamespace: {{.installer.namespace}}
+  taskNamespace: {{env "OPENEBS_NAMESPACE"}}
   run:
     tasks:
     - cstor-volume-read-listtargetservice-default-0.7.0
@@ -91,7 +91,7 @@ kind: CASTemplate
 metadata:
   name: cstor-volume-list-default-0.7.0
 spec:
-  taskNamespace: {{.installer.namespace}}
+  taskNamespace: {{env "OPENEBS_NAMESPACE"}}
   run:
     tasks:
     - cstor-volume-list-listtargetservice-default-0.7.0

--- a/pkg/install/v1alpha1/installer.go
+++ b/pkg/install/v1alpha1/installer.go
@@ -93,7 +93,7 @@ func (i *simpleInstaller) Install() []error {
 		}
 
 		// run the list of artifacts through templating if it is a CASTemplate
-		list, errs := list.MapIf(i.artifactTemplater, IsCASTemplate)
+		list, errs := list.MapIf(i.artifactTemplater, IsNotRunTask)
 		if len(errs) != 0 {
 			i.addErrors(errs)
 		}
@@ -130,18 +130,12 @@ func SimpleInstaller() Installer {
 	// namespace that is configured for this openebs component
 	openebsNS := env.Get(string(commonenv.EnvKeyForOpenEBSNamespace))
 
-	// this is the serviceaccount of the pod where this binary is running i.e.
-	// serviceaccount that is configured for this openebs component
-
-	openebsSA := env.Get(string(commonenv.EnvKeyForOpenEBSServiceAccount))
 	// cmGetter to fetch install related config i.e. a config map
-
 	cmGetter := k8s.NewConfigMapGetter(openebsNS)
 	c := WithConfigMapConfigGetter(cmGetter)
 
-	// templating values to template the artifacts before installation
-	v := NewTemplateKeyValueList().AddNamespace(openebsNS).AddServiceAccount(openebsSA)
-	t := ArtifactTemplater(v.Values(), template.TemplateIt)
+	// templater to template the artifacts before installation
+	t := ArtifactTemplater(NewTemplateKeyValueList().Values(), template.TextTemplate)
 
 	// a condition based namespace updater
 	u := k8s.UpdateNamespaceP(

--- a/pkg/install/v1alpha1/jiva_volume_0.7.0.go
+++ b/pkg/install/v1alpha1/jiva_volume_0.7.0.go
@@ -36,7 +36,7 @@ kind: CASTemplate
 metadata:
   name: jiva-volume-read-default-0.7.0
 spec:
-  taskNamespace: {{.installer.namespace}}
+  taskNamespace: {{env "OPENEBS_NAMESPACE"}}
   run:
     tasks:
     - jiva-volume-read-listtargetservice-default-0.7.0
@@ -58,6 +58,8 @@ spec:
     value: openebs/m-exporter:ci
   - name: ReplicaCount
     value: "3"
+  - name: ReplicaNodeSelector
+    value: {{env "DEFAULT_REPLICA_NODE_SELECTOR" | default "false"}}
   - name: StoragePool
     value: default
   - name: VolumeMonitor
@@ -118,7 +120,7 @@ spec:
         operator: In
         values:
         - some-node-label-value
-  taskNamespace: {{.installer.namespace}}
+  taskNamespace: {{env "OPENEBS_NAMESPACE"}}
   run:
     tasks:
     - jiva-volume-create-getstorageclass-default-0.7.0
@@ -133,7 +135,7 @@ kind: CASTemplate
 metadata:
   name: jiva-volume-delete-default-0.7.0
 spec:
-  taskNamespace: {{.installer.namespace}}
+  taskNamespace: {{env "OPENEBS_NAMESPACE"}}
   run:
     tasks:
     - jiva-volume-delete-listtargetservice-default-0.7.0
@@ -149,7 +151,7 @@ kind: CASTemplate
 metadata:
   name: jiva-volume-list-default-0.7.0
 spec:
-  taskNamespace: {{.installer.namespace}}
+  taskNamespace: {{env "OPENEBS_NAMESPACE"}}
   run:
     tasks:
     - jiva-volume-list-listtargetservice-default-0.7.0

--- a/pkg/install/v1alpha1/registrar.go
+++ b/pkg/install/v1alpha1/registrar.go
@@ -64,9 +64,9 @@ func RegisteredArtifactsFor070() (list ArtifactList) {
 	list.Items = append(list.Items, CstorSparsePoolSpc070().Items...)
 	// TODO
 	// Below commented code will uncommented selectively
-	//finallist.Items = append(finallist.Items, CstorPoolArtifactsFor070().Items...)
-	//finallist.Items = append(finallist.Items, CstorVolumeArtifactsFor070().Items...)
-	//finallist.Items = append(finallist.Items, JivaVolumeArtifactsFor070().Items...)
+	//list.Items = append(list.Items, CstorPoolArtifactsFor070().Items...)
+	//list.Items = append(list.Items, CstorVolumeArtifactsFor070().Items...)
+	//list.Items = append(list.Items, JivaVolumeArtifactsFor070().Items...)
 
 	return
 }

--- a/pkg/install/v1alpha1/template_values.go
+++ b/pkg/install/v1alpha1/template_values.go
@@ -44,16 +44,16 @@ func (l TemplateKeyValueList) AddServiceAccount(value string) TemplateKeyValueLi
 }
 
 // Values creates template values to be applied over install related artifacts
-func (l TemplateKeyValueList) Values() map[string]interface{} {
+func (l TemplateKeyValueList) Values() (final map[string]interface{}) {
+	final = map[string]interface{}{}
 	if len(l.Items) == 0 {
-		return nil
+		final["installer"] = nil
+		return
 	}
-	val := map[string]interface{}{}
+	nested := map[string]interface{}{}
 	for _, kv := range l.Items {
-		val[kv.Key] = kv.Value
+		nested[kv.Key] = kv.Value
 	}
-
-	return map[string]interface{}{
-		"installer": val,
-	}
+	final["installer"] = nested
+	return
 }


### PR DESCRIPTION
This commit has following features:
- Adds sprig template functions to render the artifacts before installing the same
- The sprig template function that is currently used in artifact is `env`
- A sample usage is shown below:
```yaml
{{env "OPENEBS_IO_REPLICA_NODE_SELECTOR" | default "false"}}
```

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
