### PR TITLE
[Bug Fix]Acquire lease on SPC for add event pool creation

### DIFF
--- a/cmd/maya-apiserver/spc-watcher/handler.go
+++ b/cmd/maya-apiserver/spc-watcher/handler.go
@@ -74,7 +74,7 @@ func (c *Controller) spcEventHandler(operation string, spcGot *apis.StoragePoolC
 		newSpcLease = &spcLease{spcGot, SpcLeaseKey, c.clientset}
 		_, err := newSpcLease.GetLease()
 		if err != nil {
-			glog.Errorf("could not acquire lease on spc object:%v", err)
+			glog.Errorf("Could not acquire lease on spc object:%v", err)
 			return addEvent, err
 		}
 		err = CreateStoragePool(spcGot, false, 0)

--- a/cmd/maya-apiserver/spc-watcher/handler.go
+++ b/cmd/maya-apiserver/spc-watcher/handler.go
@@ -74,7 +74,8 @@ func (c *Controller) spcEventHandler(operation string, spcGot *apis.StoragePoolC
 		newSpcLease = &spcLease{spcGot, SpcLeaseKey, c.clientset}
 		_, err := newSpcLease.GetLease()
 		if err != nil {
-			return addEvent, fmt.Errorf("could not acquire lease on spc object:%v", err)
+			glog.Errorf("could not acquire lease on spc object:%v", err)
+			return addEvent, err
 		}
 		err = CreateStoragePool(spcGot, false, 0)
 

--- a/cmd/maya-apiserver/spc-watcher/handler.go
+++ b/cmd/maya-apiserver/spc-watcher/handler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The OpenEBS Authors
+Copyright 2018 The OpenEBS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -70,10 +70,11 @@ func (c *Controller) spcEventHandler(operation string, spcGot *apis.StoragePoolC
 		// CreateStoragePool function will create the storage pool
 		// It is a create event so resync should be false and pendingPoolcount is passed 0
 		// pendingPoolcount is not used when resync is false.
-		newSpcLease := &spcLease{spcGot, SpcLeaseKey, c.clientset}
+		var newSpcLease Leases
+		newSpcLease = &spcLease{spcGot, SpcLeaseKey, c.clientset}
 		_, err := newSpcLease.GetLease()
 		if err != nil {
-			return addEvent,fmt.Errorf("could not acquire lease on spc object:%v", err)
+			return addEvent, fmt.Errorf("could not acquire lease on spc object:%v", err)
 		}
 		err = CreateStoragePool(spcGot, false, 0)
 

--- a/cmd/maya-apiserver/spc-watcher/handler.go
+++ b/cmd/maya-apiserver/spc-watcher/handler.go
@@ -70,7 +70,12 @@ func (c *Controller) spcEventHandler(operation string, spcGot *apis.StoragePoolC
 		// CreateStoragePool function will create the storage pool
 		// It is a create event so resync should be false and pendingPoolcount is passed 0
 		// pendingPoolcount is not used when resync is false.
-		err := CreateStoragePool(spcGot, false, 0)
+		newSpcLease := &spcLease{spcGot, SpcLeaseKey, c.clientset}
+		_, err := newSpcLease.GetLease()
+		if err != nil {
+			return addEvent,fmt.Errorf("could not acquire lease on spc object:%v", err)
+		}
+		err = CreateStoragePool(spcGot, false, 0)
 
 		if err != nil {
 			glog.Error("Storagepool could not be created:", err)

--- a/cmd/maya-apiserver/spc-watcher/lease.go
+++ b/cmd/maya-apiserver/spc-watcher/lease.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The OpenEBS Authors
+Copyright 2018 The OpenEBS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	// SpcLeaseKey is the key that will we used to acquire lease on spc object.
+	// SpcLeaseKey is the key that will be used to acquire lease on spc object.
 	// It will be present in spc annotations
 	// If key has an empty value, that means no one has acquired a lease on spc object.
 	SpcLeaseKey = "openebs.io/spc-lease"
@@ -37,9 +37,9 @@ type Leases interface {
 	// GetLease will try to get a lease on spc, in case of failure it will return error
 	GetLease() (string, error)
 	// UpdateLease will update the lease value of the spc
-	UpdateLease() (string, error)
+	UpdateLease(leaseValue string) (*apis.StoragePoolClaim, error)
 	// RemoveLease will remove the acquired lease on the spc
-	RemoveLease() (string, error)
+	RemoveLease() (*apis.StoragePoolClaim)
 }
 
 // spcLease is the struct which will implement the Leases interface
@@ -57,39 +57,40 @@ func (sl *spcLease) GetLease() (string, error) {
 	leaseValue := sl.spcObject.Annotations[sl.leaseKey]
 	// If leaseValue is empty acquire lease.
 	if strings.TrimSpace(leaseValue) == "" {
-		_, newLeaseValue, err := sl.UpdateLease(SpcLeaseValue)
+		spcObject, err := sl.UpdateLease(SpcLeaseValue)
 		if err != nil {
 			return "", err
 		}
-		return newLeaseValue, nil
+		return spcObject.Annotations[sl.leaseKey], nil
 	}
 	// If leaseValue is not empty, lease cannot be acquired.
-	return "", fmt.Errorf("lease on spc already acquried")
+	return "", fmt.Errorf("lease on spc already acquired")
 }
 
-func (sl *spcLease) UpdateLease(leaseValue string) (*apis.StoragePoolClaim, string, error) {
+func (sl *spcLease) UpdateLease(leaseValue string) (*apis.StoragePoolClaim, error) {
 	newSpcObject := sl.spcObject
 	if newSpcObject.Annotations == nil {
-		// make a map that should contain the castemplate name
-		mapCastName := make(map[string]string)
+		// make a map that should contain the lease key in spc
+		mapLease := make(map[string]string)
 
-		// Fill the map with castemplate name
-		mapCastName[sl.leaseKey] = leaseValue
-		newSpcObject.Annotations = mapCastName
+		// Fill the map lease key with lease value
+		mapLease[sl.leaseKey] = leaseValue
+		newSpcObject.Annotations = mapLease
 
 	} else {
 		newSpcObject.Annotations[sl.leaseKey] = leaseValue
 	}
 	spcObject, err := sl.oecs.OpenebsV1alpha1().StoragePoolClaims().Update(sl.spcObject)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
-	return spcObject, spcObject.Annotations[sl.leaseKey], nil
+	return spcObject, nil
 }
+
 // Can be used for reconcile loop use cases
 // TODO Remove using patch instead of update
 func (sl *spcLease) RemoveLease() (*apis.StoragePoolClaim) {
-	spcObject, _, err := sl.UpdateLease("")
+	spcObject, err := sl.UpdateLease("")
 	if err != nil {
 		runtime.HandleError(fmt.Errorf("Lease could not be removed:%v", err))
 	}

--- a/cmd/maya-apiserver/spc-watcher/lease.go
+++ b/cmd/maya-apiserver/spc-watcher/lease.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2017 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package spc
+
+import (
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	"strings"
+	clientset "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset"
+	"fmt"
+	"k8s.io/apimachinery/pkg/util/runtime"
+)
+
+const (
+	// SpcLeaseKey is the key that will we used to acquire lease on spc object.
+	// It will be present in spc annotations
+	// If key has an empty value, that means no one has acquired a lease on spc object.
+	SpcLeaseKey = "openebs.io/spc-lease"
+	// SpcLeaseValue is the value of the SpcLeaseKey
+	SpcLeaseValue = "acquired"
+)
+
+// Leases is an interface which assists in getting and releasing lease over an spc object
+type Leases interface {
+	// GetLease will try to get a lease on spc, in case of failure it will return error
+	GetLease() (string, error)
+	// UpdateLease will update the lease value of the spc
+	UpdateLease() (string, error)
+	// RemoveLease will remove the acquired lease on the spc
+	RemoveLease() (string, error)
+}
+
+// spcLease is the struct which will implement the Leases interface
+type spcLease struct {
+	// spcObject is the storagepoolclaim object over which lease is to be taken
+	spcObject *apis.StoragePoolClaim
+	// leaseKey is lease key on current storagepoolclaim object
+	leaseKey string
+	// oecs is the openebs clientset
+	oecs clientset.Interface
+}
+
+func (sl *spcLease) GetLease() (string, error) {
+	// Get the lease value.
+	leaseValue := sl.spcObject.Annotations[sl.leaseKey]
+	// If leaseValue is empty acquire lease.
+	if strings.TrimSpace(leaseValue) == "" {
+		_, newLeaseValue, err := sl.UpdateLease(SpcLeaseValue)
+		if err != nil {
+			return "", err
+		}
+		return newLeaseValue, nil
+	}
+	// If leaseValue is not empty, lease cannot be acquired.
+	return "", fmt.Errorf("lease on spc already acquried")
+}
+
+func (sl *spcLease) UpdateLease(leaseValue string) (*apis.StoragePoolClaim, string, error) {
+	newSpcObject := sl.spcObject
+	if newSpcObject.Annotations == nil {
+		// make a map that should contain the castemplate name
+		mapCastName := make(map[string]string)
+
+		// Fill the map with castemplate name
+		mapCastName[sl.leaseKey] = leaseValue
+		newSpcObject.Annotations = mapCastName
+
+	} else {
+		newSpcObject.Annotations[sl.leaseKey] = leaseValue
+	}
+	spcObject, err := sl.oecs.OpenebsV1alpha1().StoragePoolClaims().Update(sl.spcObject)
+	if err != nil {
+		return nil, "", err
+	}
+	return spcObject, spcObject.Annotations[sl.leaseKey], nil
+}
+// Can be used for reconcile loop use cases
+// TODO Remove using patch instead of update
+func (sl *spcLease) RemoveLease() (*apis.StoragePoolClaim) {
+	spcObject, _, err := sl.UpdateLease("")
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("Lease could not be removed:%v", err))
+	}
+	return spcObject
+}

--- a/cmd/maya-apiserver/spc-watcher/lease.go
+++ b/cmd/maya-apiserver/spc-watcher/lease.go
@@ -29,12 +29,6 @@ const (
 	// It will be present in spc annotations
 	// If key has an empty value, that means no one has acquired a lease on spc object.
 	SpcLeaseKey = "openebs.io/spc-create-lease"
-	// PodNameEnvKey is the key to fetch name of the pod,which will be combined with PodNameSpaceEnvKey
-	// to be used as a value of SpcLeaseKey.
-	// e.g. "openebs.io/spc-lease":"openebs/maya-apiserver-6b4695c9f8-nbwl9"
-	PodNameEnvKey = "OPENEBS_MAYA_POD_NAME"
-	// PodNameSpaceEnvKey is the key to fetch the namespace of the pod
-	PodNameSpaceEnvKey = "OPENEBS_NAMESPACE"
 )
 
 // Leases is an interface which assists in getting and releasing lease over an spc object
@@ -103,7 +97,7 @@ func (sl *spcLease) RemoveLease() *apis.StoragePoolClaim {
 }
 
 func (sl *spcLease) getPodName() string {
-	podName := env.Get(PodNameEnvKey)
-	podNameSpace := env.Get(PodNameSpaceEnvKey)
+	podName := env.Get(string(env.EnvKeyForMayaPodName))
+	podNameSpace := env.Get(string(env.EnvKeyForOpenEBSNamespace))
 	return podNameSpace + "/" + podName
 }

--- a/cmd/maya-apiserver/spc-watcher/lease.go
+++ b/cmd/maya-apiserver/spc-watcher/lease.go
@@ -34,7 +34,7 @@ const (
 	// e.g. "openebs.io/spc-lease":"openebs/maya-apiserver-6b4695c9f8-nbwl9"
 	PodNameEnvKey = "OPENEBS_MAYA_POD_NAME"
 	// PodNameSpaceEnvKey is the key to fetch the namespace of the pod
-	PodNameSpaceEnvKey = "OPENEBS_MAYA_POD_NAMESPACE"
+	PodNameSpaceEnvKey = "OPENEBS_NAMESPACE"
 )
 
 // Leases is an interface which assists in getting and releasing lease over an spc object

--- a/cmd/maya-apiserver/spc-watcher/lease_test.go
+++ b/cmd/maya-apiserver/spc-watcher/lease_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The OpenEBS Authors
+Copyright 2018 The OpenEBS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import (
 	"github.com/golang/glog"
 )
 
-// SpcCreator will create face spc objects
+// SpcCreator will create fake spc objects
 func (focs *clientSet) SpcCreator(poolName string, SpcLeaseKeyPresent bool, SpcLeaseKeyValue string) (claim *apis.StoragePoolClaim) {
 	var spcObject *apis.StoragePoolClaim
 	if SpcLeaseKeyPresent {
@@ -66,18 +66,18 @@ func TestGetLease(t *testing.T) {
 		expectedResult string
 	}{
 		// TestCase#1
-		"SPC#1": {
+		"SPC#1 Lease acquired": {
 			fakestoragepoolclaim: focs.SpcCreator("pool1", true, "acquired"),
 			expectedResult:       "",
 		},
 
 		// TestCase#2
-		"SPC#2": {
+		"SPC#2 Lease not acquired": {
 			fakestoragepoolclaim: focs.SpcCreator("pool2", false, ""),
 			expectedResult:       "acquired",
 		},
-		// TestCase#1
-		"SPC#3": {
+		// TestCase#3
+		"SPC#3 Lease not acquired": {
 			fakestoragepoolclaim: focs.SpcCreator("pool3", true, ""),
 			expectedResult:       "acquired",
 		},
@@ -86,7 +86,8 @@ func TestGetLease(t *testing.T) {
 	// Iterate over whole map to run the test cases.
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			newSpcLease := spcLease{test.fakestoragepoolclaim, SpcLeaseKey, focs.oecs}
+			var newSpcLease spcLease
+			newSpcLease = spcLease{test.fakestoragepoolclaim, SpcLeaseKey, focs.oecs}
 			// newSpcLease is the function under test.
 			result, _ := newSpcLease.GetLease()
 			// If the result does not matches expectedResult, test case fails.
@@ -111,18 +112,18 @@ func TestRemoveLease(t *testing.T) {
 		expectedResult string
 	}{
 		// TestCase#1
-		"SPC#1": {
+		"SPC#1 Lease acquired": {
 			fakestoragepoolclaim: focs.SpcCreator("pool1", true, "acquired"),
 			expectedResult:       "",
 		},
 
 		// TestCase#2
-		"SPC#2": {
+		"SPC#2 Lease not acquired": {
 			fakestoragepoolclaim: focs.SpcCreator("pool2", false, ""),
 			expectedResult:       "",
 		},
-		// TestCase#1
-		"SPC#3": {
+		// TestCase#3
+		"SPC#3 Lease not acquired": {
 			fakestoragepoolclaim: focs.SpcCreator("pool3", true, ""),
 			expectedResult:       "",
 		},

--- a/cmd/maya-apiserver/spc-watcher/lease_test.go
+++ b/cmd/maya-apiserver/spc-watcher/lease_test.go
@@ -18,12 +18,12 @@ package spc
 import (
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 
+	openebsFakeClientset "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	openebsFakeClientset "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset/fake"
-
-	"testing"
 	"github.com/golang/glog"
+	"os"
+	"testing"
 )
 
 // SpcCreator will create fake spc objects
@@ -34,7 +34,7 @@ func (focs *clientSet) SpcCreator(poolName string, SpcLeaseKeyPresent bool, SpcL
 			ObjectMeta: metav1.ObjectMeta{
 				Name: poolName,
 				Annotations: map[string]string{
-					"openebs.io/spc-lease": SpcLeaseKeyValue,
+					SpcLeaseKey: SpcLeaseKeyValue,
 				},
 			},
 		}
@@ -67,19 +67,19 @@ func TestGetLease(t *testing.T) {
 	}{
 		// TestCase#1
 		"SPC#1 Lease acquired": {
-			fakestoragepoolclaim: focs.SpcCreator("pool1", true, "acquired"),
+			fakestoragepoolclaim: focs.SpcCreator("pool1", true, "openebs/maya-apiserver-6b4695c9f8-nbwl9"),
 			expectedResult:       "",
 		},
 
 		// TestCase#2
 		"SPC#2 Lease not acquired": {
 			fakestoragepoolclaim: focs.SpcCreator("pool2", false, ""),
-			expectedResult:       "acquired",
+			expectedResult:       "/pool2",
 		},
 		// TestCase#3
 		"SPC#3 Lease not acquired": {
 			fakestoragepoolclaim: focs.SpcCreator("pool3", true, ""),
-			expectedResult:       "acquired",
+			expectedResult:       "/pool3",
 		},
 	}
 
@@ -87,6 +87,8 @@ func TestGetLease(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			var newSpcLease spcLease
+			os.Setenv(PodNameEnvKey, test.fakestoragepoolclaim.Name)
+			os.Setenv(PodNameSpaceEnvKey, test.fakestoragepoolclaim.Namespace)
 			newSpcLease = spcLease{test.fakestoragepoolclaim, SpcLeaseKey, focs.oecs}
 			// newSpcLease is the function under test.
 			result, _ := newSpcLease.GetLease()
@@ -94,6 +96,8 @@ func TestGetLease(t *testing.T) {
 			if result != test.expectedResult {
 				t.Errorf("Test case failed: expected '%v' but got '%v' ", test.expectedResult, result)
 			}
+			os.Unsetenv(PodNameEnvKey)
+			os.Unsetenv(PodNameSpaceEnvKey)
 		})
 	}
 }
@@ -113,7 +117,7 @@ func TestRemoveLease(t *testing.T) {
 	}{
 		// TestCase#1
 		"SPC#1 Lease acquired": {
-			fakestoragepoolclaim: focs.SpcCreator("pool1", true, "acquired"),
+			fakestoragepoolclaim: focs.SpcCreator("pool1", true, "openebs/maya-apiserver-6b4695c9f8-nbwl9"),
 			expectedResult:       "",
 		},
 

--- a/cmd/maya-apiserver/spc-watcher/lease_test.go
+++ b/cmd/maya-apiserver/spc-watcher/lease_test.go
@@ -18,10 +18,10 @@ package spc
 import (
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 
-	openebsFakeClientset "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset/fake"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/golang/glog"
+	openebsFakeClientset "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset/fake"
+	env "github.com/openebs/maya/pkg/env/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"testing"
 )
@@ -87,8 +87,8 @@ func TestGetLease(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			var newSpcLease spcLease
-			os.Setenv(PodNameEnvKey, test.fakestoragepoolclaim.Name)
-			os.Setenv(PodNameSpaceEnvKey, test.fakestoragepoolclaim.Namespace)
+			os.Setenv(string(env.EnvKeyForMayaPodName), test.fakestoragepoolclaim.Name)
+			os.Setenv(string(env.EnvKeyForOpenEBSNamespace), test.fakestoragepoolclaim.Namespace)
 			newSpcLease = spcLease{test.fakestoragepoolclaim, SpcLeaseKey, focs.oecs}
 			// newSpcLease is the function under test.
 			result, _ := newSpcLease.GetLease()
@@ -96,8 +96,8 @@ func TestGetLease(t *testing.T) {
 			if result != test.expectedResult {
 				t.Errorf("Test case failed: expected '%v' but got '%v' ", test.expectedResult, result)
 			}
-			os.Unsetenv(PodNameEnvKey)
-			os.Unsetenv(PodNameSpaceEnvKey)
+			os.Unsetenv(string(env.EnvKeyForMayaPodName))
+			os.Unsetenv(string(env.EnvKeyForOpenEBSNamespace))
 		})
 	}
 }

--- a/cmd/maya-apiserver/spc-watcher/lease_test.go
+++ b/cmd/maya-apiserver/spc-watcher/lease_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2017 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package spc
+
+import (
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openebsFakeClientset "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset/fake"
+
+	"testing"
+	"github.com/golang/glog"
+)
+
+// SpcCreator will create face spc objects
+func (focs *clientSet) SpcCreator(poolName string, SpcLeaseKeyPresent bool, SpcLeaseKeyValue string) (claim *apis.StoragePoolClaim) {
+	var spcObject *apis.StoragePoolClaim
+	if SpcLeaseKeyPresent {
+		spcObject = &apis.StoragePoolClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: poolName,
+				Annotations: map[string]string{
+					"openebs.io/spc-lease": SpcLeaseKeyValue,
+				},
+			},
+		}
+	} else {
+		spcObject = &apis.StoragePoolClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: poolName,
+			},
+		}
+	}
+	spcGot, err := focs.oecs.OpenebsV1alpha1().StoragePoolClaims().Create(spcObject)
+	if err != nil {
+		glog.Error(err)
+	}
+	return spcGot
+}
+func TestGetLease(t *testing.T) {
+	// Get a fake openebs client set
+	focs := &clientSet{
+		oecs: openebsFakeClientset.NewSimpleClientset(),
+	}
+	// Make a map of string(key) to struct(value).
+	// Key of map describes test case behaviour.
+	// Value of map is the test object.
+	tests := map[string]struct {
+		// fakestoragepoolclaim holds the fake storagepoolcalim object in test cases.
+		fakestoragepoolclaim *apis.StoragePoolClaim
+		// expectedResult holds the expected result for the test case under run.
+		expectedResult string
+	}{
+		// TestCase#1
+		"SPC#1": {
+			fakestoragepoolclaim: focs.SpcCreator("pool1", true, "acquired"),
+			expectedResult:       "",
+		},
+
+		// TestCase#2
+		"SPC#2": {
+			fakestoragepoolclaim: focs.SpcCreator("pool2", false, ""),
+			expectedResult:       "acquired",
+		},
+		// TestCase#1
+		"SPC#3": {
+			fakestoragepoolclaim: focs.SpcCreator("pool3", true, ""),
+			expectedResult:       "acquired",
+		},
+	}
+
+	// Iterate over whole map to run the test cases.
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			newSpcLease := spcLease{test.fakestoragepoolclaim, SpcLeaseKey, focs.oecs}
+			// newSpcLease is the function under test.
+			result, _ := newSpcLease.GetLease()
+			// If the result does not matches expectedResult, test case fails.
+			if result != test.expectedResult {
+				t.Errorf("Test case failed: expected '%v' but got '%v' ", test.expectedResult, result)
+			}
+		})
+	}
+}
+func TestRemoveLease(t *testing.T) {
+	// Get a fake openebs client set
+	focs := &clientSet{
+		oecs: openebsFakeClientset.NewSimpleClientset(),
+	}
+	// Make a map of string(key) to struct(value).
+	// Key of map describes test case behaviour.
+	// Value of map is the test object.
+	tests := map[string]struct {
+		// fakestoragepoolclaim holds the fake storagepoolcalim object in test cases.
+		fakestoragepoolclaim *apis.StoragePoolClaim
+		// expectedResult holds the expected result for the test case under run.
+		expectedResult string
+	}{
+		// TestCase#1
+		"SPC#1": {
+			fakestoragepoolclaim: focs.SpcCreator("pool1", true, "acquired"),
+			expectedResult:       "",
+		},
+
+		// TestCase#2
+		"SPC#2": {
+			fakestoragepoolclaim: focs.SpcCreator("pool2", false, ""),
+			expectedResult:       "",
+		},
+		// TestCase#1
+		"SPC#3": {
+			fakestoragepoolclaim: focs.SpcCreator("pool3", true, ""),
+			expectedResult:       "",
+		},
+	}
+
+	// Iterate over whole map to run the test cases.
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			newSpcLease := spcLease{test.fakestoragepoolclaim, SpcLeaseKey, focs.oecs}
+			// newSpcLease is the function under test.
+			spcObject := newSpcLease.RemoveLease()
+			result := spcObject.Annotations[SpcLeaseKey]
+			// If the result does not matches expectedResult, test case fails.
+			if result != test.expectedResult {
+				t.Errorf("Test case failed: expected '%v' but got '%v' ", test.expectedResult, result)
+			}
+		})
+	}
+}

--- a/pkg/env/v1alpha1/env.go
+++ b/pkg/env/v1alpha1/env.go
@@ -28,6 +28,8 @@ const (
 	// EnvKeyForOpenEBSNamespace is the environment variable to get
 	// openebs namespace
 	EnvKeyForOpenEBSNamespace ENVKey = "OPENEBS_NAMESPACE"
+	// EnvKeyForMayaPodName is the environment variable to get maya-apiserver pod name
+	EnvKeyForMayaPodName ENVKey = "OPENEBS_MAYA_POD_NAME"
 	// EnvKeyForOpenEBSServiceAccount is the environment variable to get
 	// openebs serviceaccount
 	EnvKeyForOpenEBSServiceAccount ENVKey = "OPENEBS_SERVICE_ACCOUNT"


### PR DESCRIPTION
    This PR will do following:

    1. Add code for lease logic.
    2. Before creating a storagepool in
       case of add event of spc, lease will
       be acquired so that no two replica
       process the same request.

**Newly Added Files**
1.cmd/maya-apiserver/spc-watcher/lease.go
2.cmd/maya-apiserver/spc-watcher/lease_test.go

**Modified File**
1.cmd/maya-apiserver/spc-watcher/handler.go

**Env Variables Used**
1. "OPENEBS_MAYA_POD_NAME"
2.  "OPENEBS_NAMESPACE"
The PR is dependent on following PR (as it uses env variables exposed by downward api):
https://github.com/openebs/openebs/pull/1870

Signed-off-by: sonasingh46 <sonasingh46@gmail.com>
