### PR TITLE
 Extend error message and  print response error

### DIFF
--- a/cmd/mayactl/app/command/volume_create_test.go
+++ b/cmd/mayactl/app/command/volume_create_test.go
@@ -31,21 +31,21 @@ func TestIsVolumeExist(t *testing.T) {
 			volname: "test2",
 			fakeHandler: utiltesting.FakeHandler{
 				StatusCode:   400,
-				ResponseBody: string("HTTP Error 400 - Bad Request"),
+				ResponseBody: string("HTTP Error 400 : Bad Request"),
 				T:            t,
 			},
 			addr:           "MAPI_ADDR",
-			expectedOutput: fmt.Errorf("Server status error: Bad Request"),
+			expectedOutput: fmt.Errorf("HTTP Error 400 : Bad Request"),
 		},
 		"Getting status error 404": {
 			volname: "test3",
 			fakeHandler: utiltesting.FakeHandler{
 				StatusCode:   404,
-				ResponseBody: string("HTTP Error 404 - Not Found"),
+				ResponseBody: string("HTTP Error 404 : Not Found"),
 				T:            t,
 			},
 			addr:           "MAPI_ADDR",
-			expectedOutput: fmt.Errorf("Server status error: Not Found"),
+			expectedOutput: fmt.Errorf("HTTP Error 404 : Not Found"),
 		},
 		"Creating volume which already exist": {
 			volname: "test5",

--- a/cmd/mayactl/app/command/volumes_list.go
+++ b/cmd/mayactl/app/command/volumes_list.go
@@ -59,7 +59,7 @@ func (c *CmdVolumeOptions) RunVolumesList(cmd *cobra.Command) error {
 	var cvols v1alpha1.CASVolumeList
 	err := mapiserver.ListVolumes(&cvols)
 	if err != nil {
-		return err
+		return fmt.Errorf("Volume list error: %s", err)
 	}
 
 	out := make([]string, len(cvols.Items)+1)

--- a/pkg/client/mapiserver/volumes_list.go
+++ b/pkg/client/mapiserver/volumes_list.go
@@ -13,7 +13,7 @@ const (
 // ListVolumes and return them as obj
 func ListVolumes(obj interface{}) error {
 
-	body, err := getRequest(GetURL()+listVolumePath, "", false)
+	body, err := getRequest(GetURL()+listVolumePath, "", true)
 	if err != nil {
 		return err
 	}

--- a/pkg/client/mapiserver/volumes_list_test.go
+++ b/pkg/client/mapiserver/volumes_list_test.go
@@ -2,7 +2,6 @@ package mapiserver
 
 import (
 	"fmt"
-	"net/http"
 	"net/http/httptest"
 	"os"
 	"reflect"
@@ -37,10 +36,10 @@ func TestListVolumes(t *testing.T) {
 		"BadRequest": {
 			fakeHandler: utiltesting.FakeHandler{
 				StatusCode:   404,
-				ResponseBody: string(response),
+				ResponseBody: "HTTP Error 404 : Not Found",
 				T:            t,
 			},
-			err:  fmt.Errorf("Server status error: %v", http.StatusText(404)),
+			err:  fmt.Errorf("HTTP Error 404 : Not Found"),
 			addr: "MAPI_ADDR",
 		},
 		"EmptyResponse": {
@@ -48,7 +47,7 @@ func TestListVolumes(t *testing.T) {
 				StatusCode: 204,
 				T:          t,
 			},
-			err:  fmt.Errorf("Server status error: %v", http.StatusText(204)),
+			err:  fmt.Errorf(""),
 			addr: "MAPI_ADDR",
 		},
 	}


### PR DESCRIPTION
This commit will enhance the error logging , will read the response from http response body and print in case of http response status is not OK(200) 
Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>
