### PR TITLE
Use disk path if dev link is not present.

### DIFF
--- a/pkg/install/v1alpha1/cstor_pool_0.7.0.go
+++ b/pkg/install/v1alpha1/cstor_pool_0.7.0.go
@@ -156,11 +156,11 @@ spec:
       {{ end }}
       {{ end }}
   post: |
-    {{if eq .TaskResult.getspcinfo.type "disk"}}
+    {{- $diskDevLink:= jsonpath .JsonResult "{@.spec.devlinks[0].links[0]}"}}
+    {{if $diskDevLink }}
     {{- $nodeDiskdevlinkList := jsonpath .JsonResult "pkey=node,{@.metadata.labels.kubernetes\\.io/hostname}={@.spec.devlinks[0].links[0]};" | trim | default "" | splitList ";" -}}
     {{- $nodeDiskdevlinkList | keyMap "nodeDiskdevlinkMap" .ListItems | noop -}}
-    {{end}}
-    {{if eq .TaskResult.getspcinfo.type "sparse"}}
+    {{else}}
     {{- $nodeDiskdevlinkList := jsonpath .JsonResult "pkey=node,{@.metadata.labels.kubernetes\\.io/hostname}={@.spec.path};" | trim | default "" | splitList ";" -}}
     {{- $nodeDiskdevlinkList | keyMap "nodeDiskdevlinkMap" .ListItems | noop -}}
     {{end}}


### PR DESCRIPTION
For some of the vendors like AWS EBS Volumes we do not have a dev link.
This PR update the run task which will do following:
1. If disk dev-link is not present in the disk then it will use disk path to provision
    storage pool. 
Signed-off-by: sonasingh46 <sonasingh46@gmail.com>
