### PR TITLE
feat(policies): add policies to customize client fstype and lun

### DIFF
--- a/pkg/apis/openebs.io/v1alpha1/cas_volume.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_volume.go
@@ -188,6 +188,10 @@ type CASVolumeSpec struct {
 	Replicas string `json:"replicas"`
 	// CasType will hold the storage engine used to provision this volume
 	CasType string `json:"casType"`
+	// FSType will specify the format type - ext4(default), xfs of PV
+	FSType string `json:"fsType"`
+	// Lun will specify the lun number 0, 1.. on iSCSI Volume. (default: 0) 
+	Lun int32 `json:"lun"`
 }
 
 // CASVolumeStatus provides status of a cas volume

--- a/pkg/install/v1alpha1/cstor_volume_0.7.0.go
+++ b/pkg/install/v1alpha1/cstor_volume_0.7.0.go
@@ -232,10 +232,11 @@ spec:
     kind: CStorVolume
     metadata:
       name: {{ .Volume.owner }}
-      labels:
-        openebs.io/persistent-volume: {{ .Volume.owner }}
+      annotations:
         openebs.io/fs-type: {{ .Config.FSType.value }}
         openebs.io/lun: {{ .Config.Lun.value }}
+      labels:
+        openebs.io/persistent-volume: {{ .Volume.owner }}
     spec:
       targetIP: {{ .TaskResult.cvolcreateputsvc.clusterIP }}
       capacity: {{ .Volume.capacity }}


### PR DESCRIPTION
Some of the applications require 'xfs' as a filesystem on the
OpenEBS iSCSI PVs. This PR allows the user to specify a custom
format type `FSType` under StorageClass->`openebs.io/config`

The FSType value will be used by the provisioner to pass it
in the PV. Modified the CAS Volume to send the FSType in read
response.

Similarly the default LUN to connect to is also sent via the
CAS Volume to provisioner.

Signed-off-by: kmova <kiran.mova@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
