### PR TITLE
refactor(cast): remove unused parameters from SPC

### DIFF
--- a/pkg/install/v1alpha1/cstor_pool_0.7.0.go
+++ b/pkg/install/v1alpha1/cstor_pool_0.7.0.go
@@ -125,8 +125,6 @@ spec:
     # For backward compatibility, getspcinfo.disk is saved as a task result
     {{- jsonpath .JsonResult "{range .spec.disks.diskList[*]}{$},{end}" | trim | saveAs "getspcinfo.disk" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.spec.poolSpec.poolType}" | trim | saveAs "getspcinfo.poolType" .TaskResult | noop -}}
-    {{- jsonpath .JsonResult "{.spec.poolSpec.cacheFile}" | trim | saveAs "getspcinfo.cacheFile" .TaskResult | noop -}}
-    {{- jsonpath .JsonResult "{.spec.poolSpec.overProvisioning}" | trim | saveAs "getspcinfo.overProvisioning" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.spec.type}" | trim | saveAs "getspcinfo.type" .TaskResult | noop -}}
 ---
 apiVersion: openebs.io/v1alpha1

--- a/pkg/install/v1alpha1/cstor_sparse_pool_claim_0.7.0.go
+++ b/pkg/install/v1alpha1/cstor_sparse_pool_claim_0.7.0.go
@@ -94,8 +94,6 @@ spec:
   maxPools: 3
   poolSpec:
     poolType: striped
-    cacheFile: /tmp/cstor-sparse-pool.cache
-    overProvisioning: false
 ---
 `
 }


### PR DESCRIPTION
cacheFile option provided in the SPC is ignored, and
a unique cacheFile path is auto generated using the SPC uuid
and provided to cstor-pool. The hardcoded value in SPC is
unusable, since it has to be unique across pools.

overProvisioning is always hardcoded to false. Providing
this option in the SPC will given an impression to user
that it can be enabled/disabled. Until this feature is
supported, removed the need to specify it via SPC.

Signed-off-by: kmova <kiran.mova@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
