### PR TITLE
Add go template and namespace to volume list command

### DIFF
--- a/cmd/mayactl/app/command/volume.go
+++ b/cmd/mayactl/app/command/volume.go
@@ -320,3 +320,19 @@ func (volInfo *VolumeInfo) GetNodeName() string {
 	}
 	return ""
 }
+
+// GetVolumeStatus returns the status of the volume
+func (volInfo *VolumeInfo) GetVolumeStatus() string {
+	if len(volInfo.Volume.Status.Reason) > 0 {
+		return volInfo.Volume.Status.Reason
+	}
+	return volumeStatusOK
+}
+
+// GetVolumeNamespace returns the status of the volume
+func (volInfo *VolumeInfo) GetVolumeNamespace() string {
+	if len(volInfo.Volume.ObjectMeta.Namespace) > 0 {
+		return volInfo.Volume.ObjectMeta.Namespace
+	}
+	return "N/A"
+}

--- a/cmd/mayactl/app/command/volume_create.go
+++ b/cmd/mayactl/app/command/volume_create.go
@@ -19,7 +19,6 @@ package command
 import (
 	"fmt"
 
-	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	"github.com/openebs/maya/pkg/client/mapiserver"
 	"github.com/openebs/maya/pkg/util"
 	"github.com/spf13/cobra"
@@ -71,8 +70,7 @@ func (c *CmdVolumeOptions) RunVolumeCreate(cmd *cobra.Command) error {
 
 // IsVolumeExist checks whether the volume already exists or not
 func IsVolumeExist(volname string) error {
-	var cvols v1alpha1.CASVolumeList
-	err := mapiserver.ListVolumes(&cvols)
+	cvols, err := mapiserver.ListVolumes()
 	if err != nil {
 		return err
 	}

--- a/cmd/mayactl/app/command/volume_test.go
+++ b/cmd/mayactl/app/command/volume_test.go
@@ -690,3 +690,69 @@ func TestGetNodeName(t *testing.T) {
 		})
 	}
 }
+
+func TestGetVolumeNamespace(t *testing.T) {
+	tests := map[string]struct {
+		expectedOutput string
+		Volume         VolumeInfo
+	}{
+		"Fetching volume namespace when present in response": {
+			Volume: VolumeInfo{
+				Volume: v1alpha1.CASVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
+				},
+			},
+			expectedOutput: "default",
+		},
+		"Fetching volume namespace when not present in response": {
+			Volume: VolumeInfo{
+				Volume: v1alpha1.CASVolume{
+					ObjectMeta: metav1.ObjectMeta{},
+				},
+			},
+			expectedOutput: "N/A",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tt.Volume.GetVolumeNamespace()
+			if got != tt.expectedOutput {
+				t.Fatalf("Test: %v Expected: %v but got: %v", name, tt.expectedOutput, got)
+			}
+		})
+	}
+}
+
+func TestGetVolumeStatus(t *testing.T) {
+	tests := map[string]struct {
+		expectedOutput string
+		Volume         VolumeInfo
+	}{
+		"Fetching volume status when reason is empty": {
+			Volume: VolumeInfo{
+				Volume: v1alpha1.CASVolume{},
+			},
+			expectedOutput: "Running",
+		},
+		"Fetching volume status when reason is not empty": {
+			Volume: VolumeInfo{
+				Volume: v1alpha1.CASVolume{
+					Status: v1alpha1.CASVolumeStatus{
+						Reason: "Some Error",
+					},
+				},
+			},
+			expectedOutput: "Some Error",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tt.Volume.GetVolumeStatus()
+			if got != tt.expectedOutput {
+				t.Fatalf("Test: %v Expected: %v but got: %v", name, tt.expectedOutput, got)
+			}
+		})
+	}
+}

--- a/pkg/client/mapiserver/volumes_list.go
+++ b/pkg/client/mapiserver/volumes_list.go
@@ -3,6 +3,8 @@ package mapiserver
 import (
 	"encoding/json"
 	"time"
+
+	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 )
 
 const (
@@ -11,12 +13,16 @@ const (
 )
 
 // ListVolumes and return them as obj
-func ListVolumes(obj interface{}) error {
+func ListVolumes() (v1alpha1.CASVolumeList, error) {
+
+	cvols := v1alpha1.CASVolumeList{}
 
 	body, err := getRequest(GetURL()+listVolumePath, "", true)
 	if err != nil {
-		return err
+		return cvols, err
 	}
 
-	return json.Unmarshal(body, &obj)
+	err = json.Unmarshal(body, &cvols)
+
+	return cvols, err
 }

--- a/pkg/client/mapiserver/volumes_list_test.go
+++ b/pkg/client/mapiserver/volumes_list_test.go
@@ -58,10 +58,10 @@ func TestListVolumes(t *testing.T) {
 			os.Setenv(tt.addr, server.URL)
 			defer os.Unsetenv(tt.addr)
 			defer server.Close()
-			got := ListVolumes(&vsm)
+			_, got := ListVolumes()
 
 			if !reflect.DeepEqual(got, tt.err) {
-				t.Fatalf("ListVolumes(%v) => got %v, want %v ", vsm, got, tt.err)
+				t.Fatalf("Test Name: %q\nListVolumes(%v) => got %v, want %v ", name, vsm, got, tt.err)
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
-> Adds go template and namespace column to mayactl volume list command.
-> If the namespace is not present `N/A` is shown in place of it.
-> Refactored mayactl volume list code.

**Special notes for your reviewer**:
-> Output of mayactl volume list:
```
root@maya-apiserver-5d76b8b885-5mj7z:/tmp# ./mayactl volume list

NAMESPACE     NAME                                      STATUS      TYPE
---------     ----                                      ------      ----
default       default-jiva-testvolume-1-1345041197      Running     Jiva
N/A           default-cstor-testvolume-1-3090243722     Running     Cstor
```