### PR TITLE
refactor(install): include CRDs and default SP, SCs into maya installer

### DIFF
--- a/ci/install_openebs.sh
+++ b/ci/install_openebs.sh
@@ -25,6 +25,10 @@ kubectl get sp
 #Print the default StoragePoolClaim Created
 kubectl get spc
 
+#Print the default StorageClasses Created
+kubectl get sc
+
+
 for i in $(seq 1 50) ; do
     replicas=$(kubectl get deployment -n openebs openebs-provisioner -o json | jq ".status.readyReplicas")
     if [ "$replicas" == "1" ]; then
@@ -58,8 +62,8 @@ sleep 10
 kubectl create -f https://raw.githubusercontent.com/openebs/openebs/master/k8s/sample-pv-yamls/pvc-sparse-claim-cstor.yaml
 
 sleep 30
-echo "--------------------- List PVC,PV and pods ---------------------------"
-kubectl get pvc,pv
+echo "--------------------- List SC,PVC,PV and pods ---------------------------"
+kubectl get sc,pvc,pv
 kubectl get pods --all-namespaces
 
 JIVACTRL=$(kubectl get deploy -l openebs.io/controller=jiva-controller --no-headers | awk {'print $1'})

--- a/pkg/client/k8s/v1alpha1/unstructured.go
+++ b/pkg/client/k8s/v1alpha1/unstructured.go
@@ -70,6 +70,8 @@ func (k kind) resource() (resource string) {
 func (k kind) isNamespaced() (no bool) {
 	ks := strings.ToLower(string(k))
 	switch ks {
+	case "customresourcedefinition":
+		return no
 	case "storageclass":
 		return no
 	case "persistentvolume":

--- a/pkg/install/v1alpha1/cstor_sparse_pool_claim_0.7.0.go
+++ b/pkg/install/v1alpha1/cstor_sparse_pool_claim_0.7.0.go
@@ -28,20 +28,20 @@ func IsCstorSparsePoolEnabled() (enabled bool) {
 	return
 }
 
-// CstorSparsePoolSpc070 returns the default storagepoolclaim yaml corresponding
-// to version 0.7.0 if cstor sparse pool creation is enabled as a part of
-// openebs installation
-func CstorSparsePoolSpc070() (list ArtifactList) {
-	list.Items = append(list.Items, ParseArtifactListFromMultipleYamlConditional(cstorSparsePoolSpcFor070, IsCstorSparsePoolEnabled)...)
+// CstorSparsePoolSpcArtifactsFor070 returns the default storagepoolclaim 
+// and storageclass yaml corresponding to version 0.7.0 if cstor 
+// sparse pool creation is enabled as a part of openebs installation
+func CstorSparsePoolSpcArtifactsFor070() (list ArtifactList) {
+	list.Items = append(list.Items, ParseArtifactListFromMultipleYamlConditional(cstorSparsePoolSpcArtifactsFor070, IsCstorSparsePoolEnabled)...)
 	return
 }
 
-// cstorPoolSpcFor070 returns all the yamls related to configuring a stoaragepoolclaim in string
-// format
+// cstorPoolSpcForArtifacts070 returns all the yamls related to configuring 
+// a stoaragepoolclaim and storageclass in string format
 //
 // NOTE:
 //  This is an implementation of MultiYamlFetcher
-func cstorSparsePoolSpcFor070() string {
+func cstorSparsePoolSpcArtifactsFor070() string {
 	return `
 ---
 apiVersion: storage.k8s.io/v1

--- a/pkg/install/v1alpha1/cstor_sparse_pool_claim_0.7.0_test.go
+++ b/pkg/install/v1alpha1/cstor_sparse_pool_claim_0.7.0_test.go
@@ -120,7 +120,7 @@ func TestCstorSparsePoolSpc070(t *testing.T) {
 				t.Fatalf("Test '%s' failed %+v", name, err)
 			}
 
-			l := CstorSparsePoolSpc070()
+			l := CstorSparsePoolSpcArtifactsFor070()
 			actual := len(l.Items)
 			if actual != mock.expected {
 				t.Fatalf("Test '%s' failed: expected '%d' actual '%d'", name, mock.expected, actual)

--- a/pkg/install/v1alpha1/jiva_pool_0.7.0.go
+++ b/pkg/install/v1alpha1/jiva_pool_0.7.0.go
@@ -42,8 +42,9 @@ spec:
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: openebs-standard
+  name: openebs-jiva-default
   annotations:
+    openebs.io/cas-type: jiva
     cas.openebs.io/config: |
       - name: ReplicaCount
         value: "3"

--- a/pkg/install/v1alpha1/jiva_pool_0.7.0.go
+++ b/pkg/install/v1alpha1/jiva_pool_0.7.0.go
@@ -16,15 +16,15 @@ limitations under the License.
 
 package v1alpha1
 
-// JivaPoolArtifactsFor070 returns the jiva pool related artifacts
-// corresponding to version 0.7.0
+// JivaPoolArtifactsFor070 returns the default jiva pool and storage
+// class related artifacts corresponding to version 0.7.0
 func JivaPoolArtifactsFor070() (list ArtifactList) {
 	list.Items = append(list.Items, ParseArtifactListFromMultipleYamls(jivaPoolYamlsFor070)...)
 	return
 }
 
-// jivaPoolYamlsFor070 returns all the yamls related to jiva pool in a string
-// format
+// jivaPoolYamlsFor070 returns all the yamls related to jiva pool and 
+// storage class in a string format
 //
 // NOTE:
 //  This is an implementation of MultiYamlFetcher
@@ -38,6 +38,29 @@ metadata:
   type: hostdir
 spec:
   path: "/var/openebs"
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-standard
+  annotations:
+    cas.openebs.io/config: |
+      - name: ReplicaCount
+        value: "3"
+      - name: StoragePool
+        value: default
+      #- name: TargetResourceLimits
+      #  value: |-
+      #      memory: 1Gi
+      #      cpu: 100m
+      #- name: AuxResourceLimits
+      #  value: |-
+      #      memory: 0.5Gi
+      #      cpu: 50m
+      #- name: ReplicaResourceLimits
+      #  value: |-
+      #      memory: 2Gi
+provisioner: openebs.io/provisioner-iscsi
 ---
 `
 }

--- a/pkg/install/v1alpha1/openebs_crds_0.7.0.go
+++ b/pkg/install/v1alpha1/openebs_crds_0.7.0.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2018 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+// OpenEBSCRDArtifactsFor070 returns the CRDs required for version 0.7.0
+func OpenEBSCRDArtifactsFor070() (list ArtifactList) {
+	list.Items = append(list.Items, ParseArtifactListFromMultipleYamls(openEBSCRDYamlsFor070)...)
+	return
+}
+
+// openEBSCRDYamlsFor070 returns all the CRD yamls related to 0.7.0
+// in a string format
+//
+// NOTE:
+//  This is an implementation of MultiYamlFetcher
+func openEBSCRDYamlsFor070() string {
+	return `
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: castemplates.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: castemplates
+    # singular name to be used as an alias on the CLI and for display
+    singular: castemplate
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: CASTemplate
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - cast
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: runtasks.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: runtasks
+    # singular name to be used as an alias on the CLI and for display
+    singular: runtask
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: RunTask
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - rtask
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: storagepoolclaims.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: storagepoolclaims
+    # singular name to be used as an alias on the CLI and for display
+    singular: storagepoolclaim
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: StoragePoolClaim
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - spc
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: storagepools.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: storagepools
+    # singular name to be used as an alias on the CLI and for display
+    singular: storagepool
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: StoragePool
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - sp
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: cstorpools.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: cstorpools
+    # singular name to be used as an alias on the CLI and for display
+    singular: cstorpool
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: CStorPool
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - csp
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: cstorvolumes.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: CStorVolume
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: cstorvolumes
+    # singular name to be used as an alias on the CLI and for display
+    singular: cstorvolume
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - cstorvolume
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: cstorvolumereplicas.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: CStorVolumeReplica
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: cstorvolumereplicas
+    # singular name to be used as an alias on the CLI and for display
+    singular: cstorvolumereplica
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - cvr
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: disks.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: disks
+    # singular name to be used as an alias on the CLI and for display
+    singular: disk
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: Disk
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - disk
+---
+`
+}

--- a/pkg/install/v1alpha1/registrar.go
+++ b/pkg/install/v1alpha1/registrar.go
@@ -73,7 +73,7 @@ func RegisteredArtifactsFor070() (list ArtifactList) {
 
 	list.Items = append(list.Items, CstorPoolArtifactsFor070().Items...)
 	list.Items = append(list.Items, CstorVolumeArtifactsFor070().Items...)
-	list.Items = append(list.Items, CstorSparsePoolSpc070().Items...)
+	list.Items = append(list.Items, CstorSparsePoolSpcArtifactsFor070().Items...)
 
 	//Contains the SC to help with provisioning from clone. 
 	//This is generic for release till K8s supports native way of cloning.

--- a/pkg/install/v1alpha1/registrar.go
+++ b/pkg/install/v1alpha1/registrar.go
@@ -61,14 +61,23 @@ func ParseArtifactListFromMultipleYamls(multipleYamls MultiYamlFetcher) (artifac
 // installed
 func RegisteredArtifactsFor070() (list ArtifactList) {
 
+	//Note: CRDs have to be installed first. Keep this at top of the list.
+	list.Items = append(list.Items, OpenEBSCRDArtifactsFor070().Items...)
+
 	list.Items = append(list.Items, JivaVolumeArtifactsFor070().Items...)
 	//Contains the read/list/delete CAST for supporting older volumes
+	//The CAST defined here are provided as fallback options to corresponding
+	//0.7.0 CAST
 	list.Items = append(list.Items, JivaVolumeArtifactsFor060().Items...)
 	list.Items = append(list.Items, JivaPoolArtifactsFor070().Items...)
 
 	list.Items = append(list.Items, CstorPoolArtifactsFor070().Items...)
 	list.Items = append(list.Items, CstorVolumeArtifactsFor070().Items...)
 	list.Items = append(list.Items, CstorSparsePoolSpc070().Items...)
+
+	//Contains the SC to help with provisioning from clone. 
+	//This is generic for release till K8s supports native way of cloning.
+	list.Items = append(list.Items, SnapshotPromoterSCArtifacts().Items...)
 
 	return
 }

--- a/pkg/install/v1alpha1/snapshot_promoter_sc.go
+++ b/pkg/install/v1alpha1/snapshot_promoter_sc.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2018 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+// SnapshotPromoterSCArtifacts returns the snapshot(clone) provisioner related artifacts
+func SnapshotPromoterSCArtifacts() (list ArtifactList) {
+	list.Items = append(list.Items, ParseArtifactListFromMultipleYamls(snapshotPromoterSCYaml)...)
+	return
+}
+
+// snapshotPromoterSCYaml returns all the yamls related to 
+// snapshot promote (clone) provisioner SC in a string
+// format
+//
+// NOTE:
+//  This is an implementation of MultiYamlFetcher
+func snapshotPromoterSCYaml() string {
+	return `
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: openebs-snapshot-promoter
+provisioner: volumesnapshot.external-storage.k8s.io/snapshot-promoter
+---
+`
+}


### PR DESCRIPTION
This PR aims at reducing the manual operations when installing OpenEBS via helm charts and also to reduce some duplicated code across different helm charts.

- The CRDs don't change on every release and users don't need to customize/modify them. Hence it makes sense to install them via maya-installer and reduce the duplicated code between openebs-operator and various types of helm charts.

- Similarly, the default SP and SC for jiva have to be installed seperately by the user after installing via helm charts. This PR makes them available by default.

- Another additional step that user has to do when installing via helm charts is to create a StorageClass for snapshot promote(clone).

Signed-off-by: kmova <kiran.mova@openebs.io>

