### PR TITLE
fix(install): remove hardcoded ns from cstor pool cast

### DIFF
--- a/pkg/install/v1alpha1/cstor_pool_0.7.0.go
+++ b/pkg/install/v1alpha1/cstor_pool_0.7.0.go
@@ -208,7 +208,7 @@ metadata:
   name: cstor-pool-create-putcstorpooldeployment-default-0.7.0
 spec:
   meta: |
-    runNamespace: openebs
+    runNamespace: {{.Config.RunNamespace.value}}
     apiVersion: extensions/v1beta1
     kind: Deployment
     action: put
@@ -428,7 +428,7 @@ spec:
   meta: |
     id: listcstorpooldeployment
     apiVersion: extensions/v1beta1
-    runNamespace: openebs
+    runNamespace: {{.Config.RunNamespace.value}}
     kind: Deployment
     action: list
     options: |-
@@ -446,7 +446,7 @@ metadata:
 spec:
   meta: |
     id: deletecstorpooldeployment
-    runNamespace: openebs
+    runNamespace: {{.Config.RunNamespace.value}}
     apiVersion: extensions/v1beta1
     kind: Deployment
     action: delete


### PR DESCRIPTION
Use the namespace passed from the configuration instead
of hardcoded value of openebs.

Signed-off-by: kmova <kiran.mova@openebs.io>

