### PR TITLE
refactor(cstor-integration)restart pool mgmt container when unable to find zrepl pool.

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
@@ -79,7 +79,7 @@ func (c *CStorPoolController) cStorPoolEventHandler(operation common.QueueOperat
 		common.SyncResources.Mux.Lock()
 		status, err := c.cStorPoolAddEventHandler(cStorPoolGot)
 		common.SyncResources.Mux.Unlock()
-
+		pool.PoolAddEventHandled = true
 		return status, err
 
 	case common.QOpDestroy:

--- a/cmd/cstor-pool-mgmt/controller/start-controller/controller.go
+++ b/cmd/cstor-pool-mgmt/controller/start-controller/controller.go
@@ -78,7 +78,7 @@ func StartControllers(kubeconfig string) {
 		// for zrepl container such that the period(x) of the goroutine thread will
 		// be half that of this initialTimeDelay y. (x = 1/2 y).
 		pool.CheckForZreplContinuous(common.ContinuousZreplRetryInterval)
-		glog.Errorf("Zrepl is not available, Shutting down")
+		glog.Errorf("Zrepl/Pool is not available, Shutting down")
 		os.Exit(1)
 	}()
 	// Blocking call for checking status of CStorPool CRD.

--- a/cmd/cstor-pool-mgmt/pool/pool.go
+++ b/cmd/cstor-pool-mgmt/pool/pool.go
@@ -28,8 +28,12 @@ import (
 
 // PoolOperator is the name of the tool that makes pool-related operations.
 const (
-	PoolOperator = "zpool"
+	PoolOperator           = "zpool"
+	StatusNoPoolsAvailable = "no pools available"
 )
+
+//PoolAddEventHandled is a flag representing if the pool has been initially imported or created
+var PoolAddEventHandled = false
 
 type PoolNamePrefix string
 
@@ -179,12 +183,17 @@ func CheckForZreplInitial(ZreplRetryInterval time.Duration) {
 // CheckForZreplContinuous is continuous health checker for status of zrepl in cstor-pool container.
 func CheckForZreplContinuous(ZreplRetryInterval time.Duration) {
 	for {
-		_, err := RunnerVar.RunCombinedOutput(PoolOperator, "status")
+		out, err := RunnerVar.RunCombinedOutput(PoolOperator, "status")
 		if err == nil {
+			//even though we imported pool, it disappeared (may be due to zrepl container crashing).
+			// so we need to reimport.
+			if PoolAddEventHandled && strings.Contains(string(out), StatusNoPoolsAvailable) {
+				break
+			}
 			time.Sleep(ZreplRetryInterval)
 			continue
 		}
-		glog.Errorf("zpool status returned error in zrepl healthcheck : %v", err)
+		glog.Errorf("zpool status returned error in zrepl healthcheck : %v, out: %s", err, out)
 		break
 	}
 }


### PR DESCRIPTION
- this change is to make pool mgmt container to restart itself there by re-importing a pool upon zrepl crash.
- this change also makes the pool-mgmt container to restart when pool creation or import fails. this is achieved by checking for the "zpool status" command output and finding out if there is no pool available  after handling the cstorpool add event.

Signed-off-by: moteesh <moteesh@gmail.com>
