### PR TITLE
fix(cast): remove /tmp/cstor dummyfile mount from cstor target pod

### DIFF
--- a/pkg/install/v1alpha1/cstor_volume_0.7.0.go
+++ b/pkg/install/v1alpha1/cstor_volume_0.7.0.go
@@ -335,8 +335,6 @@ spec:
             - name: tmp
               mountPath: /tmp
               mountPropagation: Bidirectional
-            - name: dummyfile
-              mountPath: /tmp/cstor
           {{- if eq $isMonitor "true" }}
           - image: {{ .Config.VolumeMonitorImage.value }}
             name: maya-volume-exporter
@@ -384,14 +382,10 @@ spec:
             - name: tmp
               mountPath: /tmp
               mountPropagation: Bidirectional              
-            - name: dummyfile
-              mountPath: /tmp/cstor
           volumes:
           - name: sockfile
             emptyDir: {}
           - name: conf
-            emptyDir: {}
-          - name: dummyfile
             emptyDir: {}
           - name: tmp
             hostPath:


### PR DESCRIPTION
The dummyfile mount to target deployment's mgmt and istgt container is
at /tmp/cstor is not required.
This commit removes the mounting.

Signed-off-by: Prince Rachit Sinha <prince.rachit@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
