### PR TITLE
fix(runtask): Fix available pool count check.

### DIFF
--- a/pkg/install/v1alpha1/cstor_volume_0.7.0.go
+++ b/pkg/install/v1alpha1/cstor_volume_0.7.0.go
@@ -164,7 +164,7 @@ spec:
     Save the cstorpool's uid:name into .ListItems.cvolPoolList otherwise
     */}}
     {{- $replicaCount := int64 .Config.ReplicaCount.value | saveAs "rc" .ListItems -}}
-    {{- $poolsList := jsonpath .JsonResult "{range .items[?(@.status.phase=='Online')]}pkey=pools,{@.metadata.uid}={@.metadata.name};{end}" | trim | default "" | splitList ";" -}}
+    {{- $poolsList := jsonpath .JsonResult "{range .items[?(@.status.phase=='Online')]}pkey=pools,{@.metadata.uid}={@.metadata.name};{end}" | trim | default "" | splitListTrim ";" -}}
     {{- $poolsList | saveAs "pl" .ListItems -}}
     {{- len $poolsList | gt $replicaCount | verifyErr "not enough pools available to create replicas" | saveAs "cvolcreatelistpool.verifyErr" .TaskResult | noop -}}
     {{- $poolsList | keyMap "cvolPoolList" .ListItems | noop -}}

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -853,6 +853,6 @@ func AsMapOfStrings(context string, yml string, values map[string]interface{}) (
 // Above operation would assign an array of strings containing
 // 'pool1' and 'pool2' to pools
 func splitListTrim(sep, orig string) []string {
-	processedStr := strings.TrimSuffix(strings.TrimPrefix(orig, sep), sep)
+	processedStr := strings.TrimRight(strings.TrimLeft(orig, sep), sep)
 	return strings.Split(processedStr, sep)
 }

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -768,6 +768,7 @@ func funcMap() template.FuncMap {
 		"nestedKeyMap":       nestedKeyMap,
 		"keyMap":             keyMap,
 		"splitKeyMap":        splitKeyMap,
+		"splitListTrim":      splitListTrim,
 	}
 
 	for k, v := range extra {
@@ -838,4 +839,20 @@ func AsMapOfStrings(context string, yml string, values map[string]interface{}) (
 	}
 
 	return obj, nil
+}
+
+// splitListTrim trims the separator from prefix and suffix, then
+// returns an array of strings split on separator
+//
+// NOTE:
+//  This is intended to be used as a template function
+//
+// Example:
+//  {{- $pools =: "pool1;pool2;" | splitListTrim ";" | -}}
+//
+// Above operation would assign an array of strings containing
+// 'pool1' and 'pool2' to pools
+func splitListTrim(sep, orig string) []string {
+	processedStr := strings.TrimSuffix(strings.TrimPrefix(orig, sep), sep)
+	return strings.Split(processedStr, sep)
 }

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -2237,11 +2237,16 @@ func TestSplitListTrim(t *testing.T) {
 		"Multiple seperators only": {
 			";",
 			";;;;",
-			[]string{"", "", ""},
+			[]string{""},
+		},
+		"Multiple seperators in between": {
+			";",
+			"p1;;;p2",
+			[]string{"p1", "", "", "p2"},
 		},
 		"Prefix-Suffix seperators in string": {
 			";",
-			";p1;p2;p3;",
+			";;p1;p2;p3;;;",
 			[]string{"p1", "p2", "p3"},
 		},
 		"Single seperator in string": {

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -31,12 +31,11 @@ package template
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
 	"text/template"
-
-	"encoding/json"
 
 	"github.com/ghodss/yaml"
 )
@@ -2209,6 +2208,55 @@ all:
 			ok := reflect.DeepEqual(objExpected, objActual)
 			if !ok {
 				t.Fatalf("failed to test dynamic templating:\n\nexpected: '%s' \n\nactual: '%s'", mock.ymlExpected, buf.Bytes())
+			}
+		})
+	}
+}
+
+func TestSplitListTrim(t *testing.T) {
+	tests := map[string]struct {
+		sep  string
+		orig string
+		want []string
+	}{
+		"No separator in string": {
+			";",
+			"pool1pool2",
+			[]string{"pool1pool2"},
+		},
+		"Prefixed seperator in string": {
+			";",
+			";pool1;pool2",
+			[]string{"pool1", "pool2"},
+		},
+		"Suffixed seperator in string": {
+			";",
+			"pool1;pool2;",
+			[]string{"pool1", "pool2"},
+		},
+		"Multiple seperators only": {
+			";",
+			";;;;",
+			[]string{"", "", ""},
+		},
+		"Prefix-Suffix seperators in string": {
+			";",
+			";p1;p2;p3;",
+			[]string{"p1", "p2", "p3"},
+		},
+		"Single seperator in string": {
+			";",
+			";",
+			[]string{""},
+		},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			list := splitListTrim(mock.sep, mock.orig)
+			ok := reflect.DeepEqual(list, mock.want)
+			if !ok {
+				t.Fatalf("failed to test splitListTrim: expected '%v': actual '%v'", mock.want, list)
 			}
 		})
 	}


### PR DESCRIPTION
The cstor-volume-create-listcstorpoolcr-default-0.7.0 task was getting
the size of pool as actual count + 1. This is because when the list is
split there is an extra entry with content "" appended to the array.
e.g. 'a;b;' when split will give 3 values instead of two.

This was causing the pool size to appear as one size extra.
Fixed this by adding a function splitListTrim in template.go which would
first remove prefix and suffix seperator and then internally use the
same logic as that of splitList.

Signed-off-by: Prince Rachit Sinha <prince.rachit@mayadata.io>