### PR TITLE
fix(cast): put the volume annotations on the pod

### DIFF
--- a/pkg/install/v1alpha1/jiva_volume_0.7.0.go
+++ b/pkg/install/v1alpha1/jiva_volume_0.7.0.go
@@ -701,6 +701,9 @@ spec:
             openebs.io/controller: jiva-controller
             openebs.io/persistent-volume: {{ .Volume.owner }}
             openebs.io/persistent-volume-claim: {{ .Volume.pvc }}
+          annotations:
+            openebs.io/fs-type: {{ .Config.FSType.value }}
+            openebs.io/lun: {{ .Config.Lun.value }}
         spec:
           {{- if ne $hasNodeSelector "none" }}
           nodeSelector:


### PR DESCRIPTION
Refer: https://github.com/openebs/openebs/issues/1907

FSType details were being placed on the deployment annotations
but the read CAST was looking for them from the pod annotations.
This was causing the FSType to be empty in CASVolume spec
returned to provisioner - resulting in ext4 only being used.

Made the change to volume controller deployment CAST to place
the annotations on the pod.

Signed-off-by: kmova <kiran.mova@openebs.io>
