### PR TITLE
feat(cast): Introduce withoption function in cas template.

### DIFF
--- a/pkg/template/runtask_functions.go
+++ b/pkg/template/runtask_functions.go
@@ -17,10 +17,11 @@ limitations under the License.
 package template
 
 import (
-	. "github.com/openebs/maya/pkg/task/v1alpha1"
-	"github.com/openebs/maya/pkg/util"
 	"strings"
 	"text/template"
+
+	. "github.com/openebs/maya/pkg/task/v1alpha1"
+	"github.com/openebs/maya/pkg/util"
 )
 
 // delete returns a new instance of delete based runtask command
@@ -131,24 +132,14 @@ func slect(paths ...string) RunCommandMiddleware {
 	return Select(paths)
 }
 
-// url sets the provided url as a input data to runtask command
+// withoption sets the provided <key,value> pair as an input data to runtask command
 //
 // Examples:
 // ---------
 // {{- $url := "http://10.10.10.10:9501" -}}
-// {{- delete jiva volume | url $url | run -}}
-func url(u string, given *RunCommand) (updated *RunCommand) {
-	return WithData(given, "url", u)
-}
-
-// name sets the provided name as a input data to runtask command
-//
-// Examples:
-// ---------
-// {{- $url := "http://10.10.10.10:9501" -}}
-// {{- delete jiva volume | url $url | name "myvol" | run -}}
-func name(n string, given *RunCommand) (updated *RunCommand) {
-	return WithData(given, "name", n)
+// {{- delete jiva volume | withoption "url" $url | withoption "name" "myvol" | run -}}
+func withoption(key, value string, given *RunCommand) (updated *RunCommand) {
+	return WithData(given, key, value)
 }
 
 // run executes the runtask command
@@ -194,19 +185,18 @@ func runlog(resultpath, debugpath string, store map[string]interface{}, given *R
 // runCommandFuncs returns the set of runtask command based template functions
 func runCommandFuncs() template.FuncMap {
 	return template.FuncMap{
-		"delete": delete,
-		"get":    get,
-		"lst":    list,
-		"create": create,
-		"patch":  patch,
-		"update": update,
-		"jiva":   jiva,
-		"cstor":  cstor,
-		"volume": volume,
-		"url":    url,
-		"name":   name,
-		"run":    run,
-		"runlog": runlog,
-		"select": slect,
+		"delete":     delete,
+		"get":        get,
+		"lst":        list,
+		"create":     create,
+		"patch":      patch,
+		"update":     update,
+		"jiva":       jiva,
+		"cstor":      cstor,
+		"volume":     volume,
+		"withoption": withoption,
+		"run":        run,
+		"runlog":     runlog,
+		"select":     slect,
 	}
 }

--- a/pkg/template/runtask_functions_test.go
+++ b/pkg/template/runtask_functions_test.go
@@ -19,10 +19,11 @@ package template
 import (
 	"bytes"
 	"fmt"
-	. "github.com/openebs/maya/pkg/task/v1alpha1"
 	"strings"
 	"testing"
 	"text/template"
+
+	. "github.com/openebs/maya/pkg/task/v1alpha1"
 )
 
 // TestIsValidTemplateFunctionName verifies if suggested template function names
@@ -49,7 +50,7 @@ func TestIsValidTemplateFunctionName(t *testing.T) {
 		"'cstor' as function name":     {"cstor"},
 		"'volume' as function name":    {"volume"},
 		"'pool' as function name":      {"pool"},
-		"'url' as function name":       {"url"},
+		"'withoption' as function name":  {"withoption"},
 		"'namespace' as function name": {"namespace"},
 		// possible selector based template functions
 		"'select' as function name": {"select"},
@@ -104,11 +105,11 @@ func TestRunCommandTemplatingCombinations(t *testing.T) {
 		"test 206": {"get volume cstor | run"},
 		"test 207": {"lst cstor volume | run"},
 		"test 208": {"lst volume cstor | run"},
-		// with url as input data combinations
-		"test 301": {`delete jiva volume | url "http://10.10.10.10:9501/v1" | run`},
-		"test 302": {`delete volume jiva | url "http://10.10.10.10:9501/v1" | run`},
-		"test 303": {`delete cstor volume | url "http://10.10.10.10:9501/v1" | run`},
-		"test 304": {`delete volume cstor | url "http://10.10.10.10:9501/v1" | run`},
+		// with withoption as input data combinations
+		"test 301": {`delete jiva volume | withoption "url" "http://10.10.10.10:9501/v1" | run`},
+		"test 302": {`delete volume jiva | withoption "url" "http://10.10.10.10:9501/v1" | run`},
+		"test 303": {`delete cstor volume | withoption "url" "http://10.10.10.10:9501/v1" | run`},
+		"test 304": {`delete volume cstor | withoption "url" "http://10.10.10.10:9501/v1" | run`},
 		// with select path combinations
 		"test 401": {`select "name" "namespace" | get jiva volume | run`},
 		"test 402": {`select "all" | lst jiva volume | run`},
@@ -252,11 +253,11 @@ func TestDeleteJivaVolumeCommand(t *testing.T) {
 		tvalues  map[string]interface{}
 	}{
 		"test 101": {`{{- delete jiva volume | run -}}`, mockval},
-		"test 102": {`{{- delete jiva volume | url "" | run -}}`, mockval},
-		"test 103": {`{{- delete jiva volume | url "http://1.1.1.1" | run -}}`, mockval},
-		"test 104": {`{{- delete jiva volume | url "http://1.1.1.1:1010/v1" | run -}}`, mockval},
+		"test 102": {`{{- delete jiva volume | withoption "url" "" | run -}}`, mockval},
+		"test 103": {`{{- delete jiva volume | withoption "url" "http://1.1.1.1" | run -}}`, mockval},
+		"test 104": {`{{- delete jiva volume | withoption "url" "http://1.1.1.1:1010/v1" | run -}}`, mockval},
 		"test 105": {`{{- $url := "http://1.1.1.1:1010/v1" -}}
-		              {{- delete jiva volume | url $url | run -}}`, mockval},
+		              {{- delete jiva volume | withoption "url" $url | run -}}`, mockval},
 	}
 
 	for name, mock := range tests {
@@ -294,13 +295,13 @@ func TestDeleteJivaVolumeSaveAs(t *testing.T) {
 		// NOTE:
 		//  Name of the test case and saveas key needs to be same
 		"101": {`{{- delete jiva volume | run | saveas "101" .Values -}}`},
-		"102": {`{{- delete jiva volume | url "" | name "" | run | saveas "102" .Values -}}`},
-		"103": {`{{- delete jiva volume | url "http://1.1.1.1" | name "ab" | run | saveas "103" .Values -}}`},
-		"104": {`{{- delete jiva volume | url "http://1.1.1.1:1010" | name "abc" | run | saveas "104" .Values -}}`},
+		"102": {`{{- delete jiva volume | withoption "url" "" | withoption "name" "" | run | saveas "102" .Values -}}`},
+		"103": {`{{- delete jiva volume | withoption "url" "http://1.1.1.1" | withoption "name" "ab" | run | saveas "103" .Values -}}`},
+		"104": {`{{- delete jiva volume | withoption "url" "http://1.1.1.1:1010" | withoption "name" "abc" | run | saveas "104" .Values -}}`},
 		"105": {`{{- $url := "http://1.1.1.1:1010/v1" -}}
-		         {{- delete jiva volume | url $url | name "abcd" | run | saveas "105" .Values -}}`},
+		         {{- delete jiva volume | withoption "url" $url | withoption "name" "abcd" | run | saveas "105" .Values -}}`},
 		"106": {`{{- $url := "http://1.1.1.1:1010/v1/volumes" -}}
-		         {{- delete jiva volume | url $url | name "abcde" | run | saveas "106" .Values -}}`},
+		         {{- delete jiva volume | withoption "url" $url | withoption "name" "abcde" | run | saveas "106" .Values -}}`},
 	}
 
 	for name, mock := range tests {
@@ -365,7 +366,7 @@ func TestDeleteJivaVolumeSaveAsVerifyError(t *testing.T) {
 		//  Name of the test case should equal to the key used by saveas & saveif
 		// functions
 		"t101": {`{{- $url := "http://1.1.1.1:1010" -}}
-		         {{- delete jiva volume | url $url | name "myvol" | run | saveas "t101" .Values -}}
+		         {{- delete jiva volume | withoption "url" $url | withoption "name" "myvol" | run | saveas "t101" .Values -}}
 		         {{- $err := toString .Values.t101.error -}}
 		         {{- $err | empty | not | verifyErr $err | saveif "t101.verifyerr" .Values | noop -}}`},
 	}

--- a/pkg/template/runtask_functions_test.go
+++ b/pkg/template/runtask_functions_test.go
@@ -46,12 +46,12 @@ func TestIsValidTemplateFunctionName(t *testing.T) {
 		"'patch' as function name":  {"patch"},
 		"'update' as function name": {"update"},
 		// possible domain based template functions
-		"'jiva' as function name":      {"jiva"},
-		"'cstor' as function name":     {"cstor"},
-		"'volume' as function name":    {"volume"},
-		"'pool' as function name":      {"pool"},
-		"'withoption' as function name":  {"withoption"},
-		"'namespace' as function name": {"namespace"},
+		"'jiva' as function name":       {"jiva"},
+		"'cstor' as function name":      {"cstor"},
+		"'volume' as function name":     {"volume"},
+		"'pool' as function name":       {"pool"},
+		"'withoption' as function name": {"withoption"},
+		"'namespace' as function name":  {"namespace"},
 		// possible selector based template functions
 		"'select' as function name": {"select"},
 		"'where' as function name":  {"where"},


### PR DESCRIPTION
Remove older `url` and `name` functions which were specific for keys
'url' and 'name' respectively and introduce a generic function
`withoption` which will accept both the key and value.

Signed-off-by: Prince Rachit Sinha <prince.rachit@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
