### PR TITLE
feat(mayactl) Enhance run task to get controller host name and fix NS for cstor response

### DIFF
--- a/pkg/install/v1alpha1/cstor_pool_0.7.0.go
+++ b/pkg/install/v1alpha1/cstor_pool_0.7.0.go
@@ -16,20 +16,7 @@ limitations under the License.
 
 package v1alpha1
 
-// CstorPoolArtifactsFor070 returns the cstor pool related artifacts
-// corresponding to version 0.7.0
-func CstorPoolArtifactsFor070() (list ArtifactList) {
-	list.Items = append(list.Items, ParseArtifactListFromMultipleYamls(cstorPoolYamlsFor070)...)
-	return
-}
-
-// cstorPoolYamlsFor070 returns all the yamls related to cstor pool in a string
-// format
-//
-// NOTE:
-//  This is an implementation of MultiYamlFetcher
-func cstorPoolYamlsFor070() string {
-	return `
+const cstorPoolYamls070 = `
 ---
 apiVersion: openebs.io/v1alpha1
 kind: CASTemplate
@@ -484,4 +471,19 @@ spec:
     objectName: {{ keys .ListItems.splist.sps | join "," }}
 ---
 `
+
+// CstorPoolArtifactsFor070 returns the cstor pool related artifacts
+// corresponding to version 0.7.0
+func CstorPoolArtifactsFor070() (list ArtifactList) {
+	list.Items = append(list.Items, ParseArtifactListFromMultipleYamls(cstorPoolYamlsFor070)...)
+	return
+}
+
+// cstorPoolYamlsFor070 returns all the yamls related to cstor pool in a string
+// format
+//
+// NOTE:
+//  This is an implementation of MultiYamlFetcher
+func cstorPoolYamlsFor070() string {
+	return cstorPoolYamls070
 }

--- a/pkg/install/v1alpha1/cstor_sparse_pool_claim_0.7.0.go
+++ b/pkg/install/v1alpha1/cstor_sparse_pool_claim_0.7.0.go
@@ -17,32 +17,12 @@ limitations under the License.
 package v1alpha1
 
 import (
-	menv "github.com/openebs/maya/pkg/env/v1alpha1"
 	"strconv"
+
+	menv "github.com/openebs/maya/pkg/env/v1alpha1"
 )
 
-// IsCstorSparsePoolEnabled reads from env variable to check wether cstor sparse pool
-// should be created by default or not.
-func IsCstorSparsePoolEnabled() (enabled bool) {
-	enabled, _ = strconv.ParseBool(menv.Get(DefaultCstorSparsePool))
-	return
-}
-
-// CstorSparsePoolSpcArtifactsFor070 returns the default storagepoolclaim
-// and storageclass yaml corresponding to version 0.7.0 if cstor
-// sparse pool creation is enabled as a part of openebs installation
-func CstorSparsePoolSpcArtifactsFor070() (list ArtifactList) {
-	list.Items = append(list.Items, ParseArtifactListFromMultipleYamlConditional(cstorSparsePoolSpcArtifactsFor070, IsCstorSparsePoolEnabled)...)
-	return
-}
-
-// cstorPoolSpcForArtifacts070 returns all the yamls related to configuring
-// a stoaragepoolclaim and storageclass in string format
-//
-// NOTE:
-//  This is an implementation of MultiYamlFetcher
-func cstorSparsePoolSpcArtifactsFor070() string {
-	return `
+const cstorSparsePoolSpcArtifacts070 = `
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -96,4 +76,27 @@ spec:
     poolType: striped
 ---
 `
+
+// IsCstorSparsePoolEnabled reads from env variable to check wether cstor sparse pool
+// should be created by default or not.
+func IsCstorSparsePoolEnabled() (enabled bool) {
+	enabled, _ = strconv.ParseBool(menv.Get(DefaultCstorSparsePool))
+	return
+}
+
+// CstorSparsePoolSpcArtifactsFor070 returns the default storagepoolclaim
+// and storageclass yaml corresponding to version 0.7.0 if cstor
+// sparse pool creation is enabled as a part of openebs installation
+func CstorSparsePoolSpcArtifactsFor070() (list ArtifactList) {
+	list.Items = append(list.Items, ParseArtifactListFromMultipleYamlConditional(cstorSparsePoolSpcArtifactsFor070, IsCstorSparsePoolEnabled)...)
+	return
+}
+
+// cstorPoolSpcForArtifacts070 returns all the yamls related to configuring
+// a stoaragepoolclaim and storageclass in string format
+//
+// NOTE:
+//  This is an implementation of MultiYamlFetcher
+func cstorSparsePoolSpcArtifactsFor070() string {
+	return cstorSparsePoolSpcArtifacts070
 }

--- a/pkg/install/v1alpha1/cstor_volume_0.7.0.go
+++ b/pkg/install/v1alpha1/cstor_volume_0.7.0.go
@@ -16,14 +16,7 @@ limitations under the License.
 
 package v1alpha1
 
-// CstorVolumeArtifactsFor070 returns the cstor volume related artifacts
-// corresponding to version 0.7.0
-func CstorVolumeArtifactsFor070() (list ArtifactList) {
-	list.Items = append(list.Items, ParseArtifactListFromMultipleYamls(cstorVolumeYamlsFor070)...)
-	return
-}
-
-const cstorRunTask = `
+const cstorVolumeYamls070 = `
 ---
 apiVersion: openebs.io/v1alpha1
 kind: CASTemplate
@@ -666,7 +659,7 @@ spec:
     {{- jsonpath .JsonResult "{.items[*].metadata.name}" | trim | saveAs "readlistctrl.items" .TaskResult | noop -}}
     {{- .TaskResult.readlistctrl.items | notFoundErr "target pod not found" | saveIf "readlistctrl.notFoundErr" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.items[*].status.podIP}" | trim | saveAs "readlistctrl.podIP" .TaskResult | noop -}}
-    {{- jsonpath .JsonResult "{.items[*].spec.nodeName}" | trim | saveAs "readlistctrl.podNodeName" .TaskResult | noop -}}
+    {{- jsonpath .JsonResult "{.items[*].spec.nodeName}" | trim | saveAs "readlistctrl.targetNodeName" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.items[*].status.containerStatuses[*].ready}" | trim | saveAs "readlistctrl.status" .TaskResult | noop -}}
 ---
 # runTask to render output of read volume task as CAS Volume
@@ -694,7 +687,7 @@ spec:
         openebs.io/cvr-names: {{ .TaskResult.readlistrep.items | default "" | splitList " " | join "," }}
         openebs.io/node-names: {{ .TaskResult.readlistrep.hostname | default "" | splitList " " | join "," }}
         openebs.io/pool-names: {{ .TaskResult.readlistrep.poolname | default "" | splitList " " | join "," }}
-        openebs.io/controller-node-name: {{ .TaskResult.readlistctrl.podNodeName | default ""}}
+        openebs.io/controller-node-name: {{ .TaskResult.readlistctrl.targetNodeName | default ""}}
     spec:
       capacity: {{ $capacity }}
       iqn: iqn.2016-09.com.openebs.cstor:{{ .Volume.owner }}
@@ -866,11 +859,18 @@ spec:
 ---
 `
 
+// CstorVolumeArtifactsFor070 returns the cstor volume related artifacts
+// corresponding to version 0.7.0
+func CstorVolumeArtifactsFor070() (list ArtifactList) {
+	list.Items = append(list.Items, ParseArtifactListFromMultipleYamls(cstorVolumeYamlsFor070)...)
+	return
+}
+
 // cstorVolumeYamlsFor070 returns all the yamls related to cstor volume in a
 // string format
 //
 // NOTE:
 //  This is an implementation of MultiYamlFetcher
 func cstorVolumeYamlsFor070() string {
-	return cstorRunTask
+	return cstorVolumeYamls070
 }

--- a/pkg/install/v1alpha1/jiva_pool_0.7.0.go
+++ b/pkg/install/v1alpha1/jiva_pool_0.7.0.go
@@ -16,20 +16,7 @@ limitations under the License.
 
 package v1alpha1
 
-// JivaPoolArtifactsFor070 returns the default jiva pool and storage
-// class related artifacts corresponding to version 0.7.0
-func JivaPoolArtifactsFor070() (list ArtifactList) {
-	list.Items = append(list.Items, ParseArtifactListFromMultipleYamls(jivaPoolYamlsFor070)...)
-	return
-}
-
-// jivaPoolYamlsFor070 returns all the yamls related to jiva pool and
-// storage class in a string format
-//
-// NOTE:
-//  This is an implementation of MultiYamlFetcher
-func jivaPoolYamlsFor070() string {
-	return `
+const jivaPoolYamls070 = `
 ---
 apiVersion: openebs.io/v1alpha1
 kind: StoragePool
@@ -64,4 +51,19 @@ metadata:
 provisioner: openebs.io/provisioner-iscsi
 ---
 `
+
+// JivaPoolArtifactsFor070 returns the default jiva pool and storage
+// class related artifacts corresponding to version 0.7.0
+func JivaPoolArtifactsFor070() (list ArtifactList) {
+	list.Items = append(list.Items, ParseArtifactListFromMultipleYamls(jivaPoolYamlsFor070)...)
+	return
+}
+
+// jivaPoolYamlsFor070 returns all the yamls related to jiva pool and
+// storage class in a string format
+//
+// NOTE:
+//  This is an implementation of MultiYamlFetcher
+func jivaPoolYamlsFor070() string {
+	return jivaPoolYamls070
 }

--- a/pkg/install/v1alpha1/jiva_volume_0.6.0.go
+++ b/pkg/install/v1alpha1/jiva_volume_0.6.0.go
@@ -16,20 +16,7 @@ limitations under the License.
 
 package v1alpha1
 
-// JivaVolumeArtifactsFor060 returns the jiva volume related artifacts
-// corresponding to version 0.6.0
-func JivaVolumeArtifactsFor060() (list ArtifactList) {
-	list.Items = append(list.Items, ParseArtifactListFromMultipleYamls(jivaVolumeYamlsFor060)...)
-	return
-}
-
-// jivaVolumeYamlsFor060 returns all the yamls related to jiva volume in a
-// string format
-//
-// NOTE:
-//  This is an implementation of MultiYamlFetcher
-func jivaVolumeYamlsFor060() string {
-	return `
+const jivaVolumeYamls060 = `
 ---
 apiVersion: openebs.io/v1alpha1
 kind: CASTemplate
@@ -267,8 +254,20 @@ spec:
     {{- .TaskResult.deletelistrep.names | notFoundErr "replica deployment not found" | saveIf "deletelistrep.notFoundErr" .TaskResult | noop -}}
     {{- .TaskResult.deletelistrep.names | default "" | splitList " " | isLen 1 | not | verifyErr "total no. of replica deployments is not 1" | saveIf "deletelistrep.verifyErr" .TaskResult | noop -}}
 ---
-
-
-
 `
+
+// JivaVolumeArtifactsFor060 returns the jiva volume related artifacts
+// corresponding to version 0.6.0
+func JivaVolumeArtifactsFor060() (list ArtifactList) {
+	list.Items = append(list.Items, ParseArtifactListFromMultipleYamls(jivaVolumeYamlsFor060)...)
+	return
+}
+
+// jivaVolumeYamlsFor060 returns all the yamls related to jiva volume in a
+// string format
+//
+// NOTE:
+//  This is an implementation of MultiYamlFetcher
+func jivaVolumeYamlsFor060() string {
+	return jivaVolumeYamls060
 }

--- a/pkg/install/v1alpha1/jiva_volume_0.7.0.go
+++ b/pkg/install/v1alpha1/jiva_volume_0.7.0.go
@@ -23,13 +23,7 @@ func JivaVolumeArtifactsFor070() (list ArtifactList) {
 	return
 }
 
-// jivaVolumeYamlsFor070 returns all the yamls related to jiva volume in a
-// string format
-//
-// NOTE:
-//  This is an implementation of MultiYamlFetcher
-func jivaVolumeYamlsFor070() string {
-	return `
+const jivaRunTask = `
 ---
 apiVersion: openebs.io/v1alpha1
 kind: CASTemplate
@@ -409,6 +403,7 @@ spec:
   post: |
     {{- jsonpath .JsonResult "{.items[*].metadata.name}" | trim | saveAs "readlistctrl.items" .TaskResult | noop -}}
     {{- .TaskResult.readlistctrl.items | notFoundErr "controller pod not found" | saveIf "readlistctrl.notFoundErr" .TaskResult | noop -}}
+    {{- jsonpath .JsonResult "{.items[*].spec.nodeName}" | trim | saveAs "readlistctrl.nodeName" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.items[*].status.podIP}" | trim | saveAs "readlistctrl.podIP" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.items[*].status.containerStatuses[*].ready}" | trim | saveAs "readlistctrl.status" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.items[*].metadata.annotations.openebs\\.io/fs-type}" | trim | default "ext4" | saveAs "readlistctrl.fsType" .TaskResult | noop -}}
@@ -453,6 +448,7 @@ spec:
       annotations:
         vsm.openebs.io/controller-ips: {{ .TaskResult.readlistctrl.podIP | default "" | splitList " " | first }}
         vsm.openebs.io/cluster-ips: {{ .TaskResult.readlistsvc.clusterIP }}
+        vsm.openebs.io/controller-node-name: {{ .TaskResult.readlistctrl.nodeName | default "" }}
         vsm.openebs.io/iqn: iqn.2016-09.com.openebs.jiva:{{ .Volume.owner }}
         vsm.openebs.io/replica-count: {{ .TaskResult.readlistrep.podIP | default "" | splitList " " | len }}
         vsm.openebs.io/volume-size: {{ $capacity }}
@@ -462,6 +458,7 @@ spec:
         vsm.openebs.io/targetportals: {{ .TaskResult.readlistsvc.clusterIP }}:3260
         openebs.io/controller-ips: {{ .TaskResult.readlistctrl.podIP | default "" | splitList " " | first }}
         openebs.io/cluster-ips: {{ .TaskResult.readlistsvc.clusterIP }}
+        openebs.io/controller-node-name: {{ .TaskResult.readlistctrl.nodeName | default "" }}
         openebs.io/iqn: iqn.2016-09.com.openebs.jiva:{{ .Volume.owner }}
         openebs.io/replica-count: {{ .TaskResult.readlistrep.podIP | default "" | splitList " " | len }}
         openebs.io/volume-size: {{ $capacity }}
@@ -1055,4 +1052,12 @@ spec:
       name: {{ .Volume.owner }}
 ---
 `
+
+// jivaVolumeYamlsFor070 returns all the yamls related to jiva volume in a
+// string format
+//
+// NOTE:
+//  This is an implementation of MultiYamlFetcher
+func jivaVolumeYamlsFor070() string {
+	return jivaRunTask
 }

--- a/pkg/install/v1alpha1/jiva_volume_0.7.0.go
+++ b/pkg/install/v1alpha1/jiva_volume_0.7.0.go
@@ -23,7 +23,7 @@ func JivaVolumeArtifactsFor070() (list ArtifactList) {
 	return
 }
 
-const jivaRunTask = `
+const jivaVolumeYamls070 = `
 ---
 apiVersion: openebs.io/v1alpha1
 kind: CASTemplate
@@ -403,7 +403,7 @@ spec:
   post: |
     {{- jsonpath .JsonResult "{.items[*].metadata.name}" | trim | saveAs "readlistctrl.items" .TaskResult | noop -}}
     {{- .TaskResult.readlistctrl.items | notFoundErr "controller pod not found" | saveIf "readlistctrl.notFoundErr" .TaskResult | noop -}}
-    {{- jsonpath .JsonResult "{.items[*].spec.nodeName}" | trim | saveAs "readlistctrl.nodeName" .TaskResult | noop -}}
+    {{- jsonpath .JsonResult "{.items[*].spec.nodeName}" | trim | saveAs "readlistctrl.targetNodeName" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.items[*].status.podIP}" | trim | saveAs "readlistctrl.podIP" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.items[*].status.containerStatuses[*].ready}" | trim | saveAs "readlistctrl.status" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.items[*].metadata.annotations.openebs\\.io/fs-type}" | trim | default "ext4" | saveAs "readlistctrl.fsType" .TaskResult | noop -}}
@@ -448,7 +448,7 @@ spec:
       annotations:
         vsm.openebs.io/controller-ips: {{ .TaskResult.readlistctrl.podIP | default "" | splitList " " | first }}
         vsm.openebs.io/cluster-ips: {{ .TaskResult.readlistsvc.clusterIP }}
-        vsm.openebs.io/controller-node-name: {{ .TaskResult.readlistctrl.nodeName | default "" }}
+        vsm.openebs.io/controller-node-name: {{ .TaskResult.readlistctrl.targetNodeName | default "" }}
         vsm.openebs.io/iqn: iqn.2016-09.com.openebs.jiva:{{ .Volume.owner }}
         vsm.openebs.io/replica-count: {{ .TaskResult.readlistrep.podIP | default "" | splitList " " | len }}
         vsm.openebs.io/volume-size: {{ $capacity }}
@@ -458,7 +458,7 @@ spec:
         vsm.openebs.io/targetportals: {{ .TaskResult.readlistsvc.clusterIP }}:3260
         openebs.io/controller-ips: {{ .TaskResult.readlistctrl.podIP | default "" | splitList " " | first }}
         openebs.io/cluster-ips: {{ .TaskResult.readlistsvc.clusterIP }}
-        openebs.io/controller-node-name: {{ .TaskResult.readlistctrl.nodeName | default "" }}
+        openebs.io/controller-node-name: {{ .TaskResult.readlistctrl.targetNodeName | default "" }}
         openebs.io/iqn: iqn.2016-09.com.openebs.jiva:{{ .Volume.owner }}
         openebs.io/replica-count: {{ .TaskResult.readlistrep.podIP | default "" | splitList " " | len }}
         openebs.io/volume-size: {{ $capacity }}
@@ -1059,5 +1059,5 @@ spec:
 // NOTE:
 //  This is an implementation of MultiYamlFetcher
 func jivaVolumeYamlsFor070() string {
-	return jivaRunTask
+	return jivaVolumeYamls070
 }

--- a/pkg/install/v1alpha1/openebs_crds_0.7.0.go
+++ b/pkg/install/v1alpha1/openebs_crds_0.7.0.go
@@ -16,19 +16,7 @@ limitations under the License.
 
 package v1alpha1
 
-// OpenEBSCRDArtifactsFor070 returns the CRDs required for version 0.7.0
-func OpenEBSCRDArtifactsFor070() (list ArtifactList) {
-	list.Items = append(list.Items, ParseArtifactListFromMultipleYamls(openEBSCRDYamlsFor070)...)
-	return
-}
-
-// openEBSCRDYamlsFor070 returns all the CRD yamls related to 0.7.0
-// in a string format
-//
-// NOTE:
-//  This is an implementation of MultiYamlFetcher
-func openEBSCRDYamlsFor070() string {
-	return `
+const openEBSCRDYamls070 = `
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -215,4 +203,18 @@ spec:
     - disk
 ---
 `
+
+// OpenEBSCRDArtifactsFor070 returns the CRDs required for version 0.7.0
+func OpenEBSCRDArtifactsFor070() (list ArtifactList) {
+	list.Items = append(list.Items, ParseArtifactListFromMultipleYamls(openEBSCRDYamlsFor070)...)
+	return
+}
+
+// openEBSCRDYamlsFor070 returns all the CRD yamls related to 0.7.0
+// in a string format
+//
+// NOTE:
+//  This is an implementation of MultiYamlFetcher
+func openEBSCRDYamlsFor070() string {
+	return openEBSCRDYamls070
 }

--- a/pkg/install/v1alpha1/snapshot_promoter_sc.go
+++ b/pkg/install/v1alpha1/snapshot_promoter_sc.go
@@ -16,6 +16,16 @@ limitations under the License.
 
 package v1alpha1
 
+const snapshotPromoterSCYamls = `
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: openebs-snapshot-promoter
+provisioner: volumesnapshot.external-storage.k8s.io/snapshot-promoter
+---
+`
+
 // SnapshotPromoterSCArtifacts returns the snapshot(clone) provisioner related artifacts
 func SnapshotPromoterSCArtifacts() (list ArtifactList) {
 	list.Items = append(list.Items, ParseArtifactListFromMultipleYamls(snapshotPromoterSCYaml)...)
@@ -29,13 +39,5 @@ func SnapshotPromoterSCArtifacts() (list ArtifactList) {
 // NOTE:
 //  This is an implementation of MultiYamlFetcher
 func snapshotPromoterSCYaml() string {
-	return `
----
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: openebs-snapshot-promoter
-provisioner: volumesnapshot.external-storage.k8s.io/snapshot-promoter
----
-`
+	return snapshotPromoterSCYamls
 }

--- a/pkg/install/v1alpha1/version.go
+++ b/pkg/install/v1alpha1/version.go
@@ -27,10 +27,12 @@ const (
 	invalidVersion version = "invalid.version"
 )
 
+// CurrentVersion returns the version of the calling instance
 func CurrentVersion() version {
 	return version(mver.GetVersion())
 }
 
+// Version returns the version in version type if present
 func Version(version string) version {
 	switch version {
 	case "0.7.0":
@@ -38,5 +40,4 @@ func Version(version string) version {
 	default:
 		return invalidVersion
 	}
-	return invalidVersion
 }


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
-> Enhanced volume read runtask to give controller node name which can be consumed by mayactl .
-> Fixes empty namespace for cstor volumes in volume list.

**Special notes for your reviewer**:
-> volume list response: 
```
{
  "items": [
    {
      "apiVersion": "v1alpha1",
      "kind": "CASVolume",
      "metadata": {
        "annotations": {
          "openebs.io/replica-ips": "10.4.1.8, 10.4.0.10, 10.4.2.8",
          "openebs.io/replica-status": "running, running, running",
          "openebs.io/volume-size": "5G",
          "vsm.openebs.io/cluster-ips": "10.7.254.120",
          "vsm.openebs.io/replica-count": "3",
          "vsm.openebs.io/targetportals": "10.7.254.120:3260",
          "openebs.io/iqn": "iqn.2016-09.com.openebs.jiva:default-jiva-testvol-1-1931265930",
          "vsm.openebs.io/controller-status": "running,running",
          "vsm.openebs.io/volume-size": "5G",
          "openebs.io/cluster-ips": "10.7.254.120",
          "openebs.io/targetportals": "10.7.254.120:3260",
          "vsm.openebs.io/iqn": "iqn.2016-09.com.openebs.jiva:default-jiva-testvol-1-1931265930",
          "vsm.openebs.io/replica-ips": "10.4.1.8, 10.4.0.10, 10.4.2.8",
          "openebs.io/controller-ips": "10.4.0.9",
          "openebs.io/replica-count": "3",
          "vsm.openebs.io/controller-ips": "10.4.0.9",
          "vsm.openebs.io/replica-status": "running, running, running",
          "openebs.io/controller-status": "running,running"
        },
        "name": "default-jiva-testvol-1-1931265930",
        "namespace": "default"
      },
      "spec": {
        "capacity": "5G",
        "casType": "jiva",
        "fsType": "",
        "iqn": "iqn.2016-09.com.openebs.jiva:default-jiva-testvol-1-1931265930",
        "lun": 0,
        "replicas": "1",
        "targetIP": "10.7.254.120",
        "targetPort": "3260",
        "targetPortal": "10.7.254.120:3260"
      },
      "status": {
        "Message": "",
        "Phase": "",
        "Reason": ""
      }
    },
    {
      "apiVersion": "v1alpha1",
      "kind": "CASVolume",
      "metadata": {
        "annotations": {
          "openebs.io/cluster-ips": "10.7.248.146",
          "openebs.io/controller-status": "running running running",
          "openebs.io/volume-size": "5G"
        },
        "name": "default-cstor-testvol-1-678850436",
        "namespace": "openebs"
      },
      "spec": {
        "capacity": "5G",
        "casType": "cstor",
        "fsType": "",
        "iqn": "iqn.2016-09.com.openebs.cstor:default-cstor-testvol-1-678850436",
        "lun": 0,
        "replicas": "3",
        "targetIP": "10.7.248.146",
        "targetPort": "3260",
        "targetPortal": "10.7.248.146:3260"
      },
      "status": {
        "Message": "",
        "Phase": "",
        "Reason": ""
      }
    }
  ],
  "metadata": {},
  "metalist": {}
}
```
-> Volume read output for cstor:
```
{
  "apiVersion": "v1alpha1",
  "kind": "CASVolume",
  "metadata": {
    "annotations": {
      "openebs.io/pool-names": "cstor-sparse-pool-2bas,cstor-sparse-pool-5bvb,cstor-sparse-pool-tf4k",
      "openebs.io/controller-ips": "10.4.2.13",
      "openebs.io/controller-node-name": "gke-ashish-dev-default-pool-c5bc7514-j4gj",
      "openebs.io/controller-status": "running,running,running",
      "openebs.io/cvr-names": "default-cstor-testvol-1-678850436-cstor-sparse-pool-2bas,default-cstor-testvol-1-678850436-cstor-sparse-pool-5bvb,default-cstor-testvol-1-678850436-cstor-sparse-pool-tf4k",
      "openebs.io/node-names": "gke-ashish-dev-default-pool-c5bc7514-j4gj,gke-ashish-dev-default-pool-c5bc7514-rhqj,gke-ashish-dev-default-pool-c5bc7514-2j6w"
    },
    "name": "default-cstor-testvol-1-678850436"
  },
  "spec": {
    "capacity": "5G",
    "casType": "cstor",
    "fsType": "ext4",
    "iqn": "iqn.2016-09.com.openebs.cstor:default-cstor-testvol-1-678850436",
    "lun": 0,
    "replicas": "3",
    "targetIP": "10.7.248.146",
    "targetPort": "3260",
    "targetPortal": "10.7.248.146:3260"
  },
  "status": {
    "Message": "",
    "Phase": "",
    "Reason": ""
  }
}
```
-> volume read output for jiva:
```
{
  "apiVersion": "v1alpha1",
  "kind": "CASVolume",
  "metadata": {
    "annotations": {
      "vsm.openebs.io/controller-ips": "10.4.0.9",
      "openebs.io/controller-ips": "10.4.0.9",
      "openebs.io/replica-count": "3",
      "vsm.openebs.io/replica-count": "3",
      "vsm.openebs.io/replica-ips": "10.4.1.8,10.4.0.10,10.4.2.8",
      "openebs.io/replica-status": "running,running,running",
      "vsm.openebs.io/controller-node-name": "gke-ashish-dev-default-pool-c5bc7514-2j6w",
      "openebs.io/replica-ips": "10.4.1.8,10.4.0.10,10.4.2.8",
      "openebs.io/volume-size": "5G",
      "vsm.openebs.io/controller-status": "running,running",
      "vsm.openebs.io/iqn": "iqn.2016-09.com.openebs.jiva:default-jiva-testvol-1-1931265930",
      "vsm.openebs.io/replica-status": "running,running,running",
      "openebs.io/cluster-ips": "10.7.254.120",
      "openebs.io/controller-node-name": "gke-ashish-dev-default-pool-c5bc7514-2j6w",
      "openebs.io/targetportals": "10.7.254.120:3260",
      "vsm.openebs.io/cluster-ips": "10.7.254.120",
      "vsm.openebs.io/targetportals": "10.7.254.120:3260",
      "vsm.openebs.io/volume-size": "5G",
      "openebs.io/controller-status": "running,running",
      "openebs.io/iqn": "iqn.2016-09.com.openebs.jiva:default-jiva-testvol-1-1931265930"
    },
    "name": "default-jiva-testvol-1-1931265930"
  },
  "spec": {
    "capacity": "5G",
    "casType": "jiva",
    "fsType": "ext4",
    "iqn": "iqn.2016-09.com.openebs.jiva:default-jiva-testvol-1-1931265930",
    "lun": 0,
    "replicas": "3",
    "targetIP": "10.7.254.120",
    "targetPort": "3260",
    "targetPortal": "10.7.254.120:3260"
  },
  "status": {
    "Message": "",
    "Phase": "",
    "Reason": ""
  }
}
```