### PR TITLE
[WIP]feat(mayactl): Adds Pool Details to mayactl volume info command

### DIFF
--- a/cmd/mayactl/app/command/volume.go
+++ b/cmd/mayactl/app/command/volume.go
@@ -59,6 +59,7 @@ const (
 	// CstorStorageEngine is constant for cstor engine
 	CstorStorageEngine CASType = "cstor"
 	timeout                    = 5 * time.Second
+	poolPath                   = "openebs.io/hostPath"
 )
 
 // # Create a Volume:

--- a/cmd/mayactl/app/command/volume_test.go
+++ b/cmd/mayactl/app/command/volume_test.go
@@ -690,3 +690,41 @@ func TestGetNodeName(t *testing.T) {
 		})
 	}
 }
+
+func TestGetControllerNode(t *testing.T) {
+	tests := map[string]struct {
+		expectedOutput string
+		Volume         VolumeInfo
+	}{
+		"Fetching Node Name from openebs.io/controller-node-name": {
+			Volume: VolumeInfo{
+				Volume: v1alpha1.CASVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"openebs.io/controller-node-name": "127.1.1.1",
+						},
+					},
+				},
+			},
+			expectedOutput: "127.1.1.1",
+		},
+		"Fetching Node Name when no key is present": {
+			Volume: VolumeInfo{
+				Volume: v1alpha1.CASVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			expectedOutput: "",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tt.Volume.GetControllerNode()
+			if got != tt.expectedOutput {
+				t.Fatalf("Test: %v Expected: %v but got: %v", name, tt.expectedOutput, got)
+			}
+		})
+	}
+}

--- a/pkg/install/v1alpha1/jiva_volume_0.7.0.go
+++ b/pkg/install/v1alpha1/jiva_volume_0.7.0.go
@@ -428,6 +428,7 @@ spec:
     {{- jsonpath .JsonResult "{.items[*].status.podIP}" | trim | saveAs "readlistrep.podIP" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.items[*].status.containerStatuses[*].ready}" | trim | saveAs "readlistrep.status" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.items[*].metadata.annotations.openebs\\.io/capacity}" | trim | saveAs "readlistrep.capacity" .TaskResult | noop -}}
+    {{- jsonpath .JsonResult "{.items[*].spec.volumes[0].hostPath.path}" | trim | saveAs "readlistrep.hostPath" .TaskResult | noop -}}
 ---
 apiVersion: openebs.io/v1alpha1
 kind: RunTask
@@ -441,6 +442,7 @@ spec:
     apiVersion: v1alpha1
   task: |
     {{- $capacity := .TaskResult.readlistrep.capacity | default "" | splitList " " | first -}}
+    {{- $hostPath := .TaskResult.readlistrep.hostPath | default "" | splitList " " | first -}}
     kind: CASVolume
     apiVersion: v1alpha1
     metadata:
@@ -466,6 +468,7 @@ spec:
         openebs.io/replica-status: {{ .TaskResult.readlistrep.status | default "" | splitList " " | join "," | replace "true" "running" | replace "false" "notready" }}
         openebs.io/controller-status: {{ .TaskResult.readlistctrl.status | default "" | splitList " " | join "," | replace "true" "running" | replace "false" "notready" }}
         openebs.io/targetportals: {{ .TaskResult.readlistsvc.clusterIP }}:3260
+        openebs.io/hostPath: {{ $hostPath }}
     spec:
       capacity: {{ $capacity }}
       targetPortal: {{ .TaskResult.readlistsvc.clusterIP }}:3260


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
-> Modifies run task to provide underlying pool path details.
-> Add Pool Details info in mayactl volume info.

**Special notes for your reviewer**:
-> new volume read response after this:
```
{
  "apiVersion": "v1alpha1",
  "kind": "CASVolume",
  "metadata": {
    "annotations": {
      "openebs.io/replica-status": "running,running,running",
      "openebs.io/volume-size": "5G",
      "vsm.openebs.io/controller-ips": "10.4.2.18",
      "vsm.openebs.io/controller-status": "running,running",
      "vsm.openebs.io/iqn": "iqn.2016-09.com.openebs.jiva:default-jiva-testvol-1-2800663365",
      "vsm.openebs.io/replica-count": "3",
      "vsm.openebs.io/replica-status": "running,running,running",
      "openebs.io/iqn": "iqn.2016-09.com.openebs.jiva:default-jiva-testvol-1-2800663365",
      "openebs.io/replica-count": "3",
      "vsm.openebs.io/cluster-ips": "10.7.248.46",
      "vsm.openebs.io/targetportals": "10.7.248.46:3260",
      "openebs.io/cluster-ips": "10.7.248.46",
      "openebs.io/targetportals": "10.7.248.46:3260",
      "vsm.openebs.io/volume-size": "5G",
      "openebs.io/hostPath": "/var/openebs/default-jiva-testvol-1-2800663365",
      "openebs.io/controller-status": "running,running",
      "openebs.io/replica-ips": "10.4.0.25,10.4.1.15,10.4.2.17",
      "vsm.openebs.io/replica-ips": "10.4.0.25,10.4.1.15,10.4.2.17",
      "openebs.io/controller-ips": "10.4.2.18"
    },
    "name": "default-jiva-testvol-1-2800663365"
  },
  "spec": {
    "capacity": "5G",
    "casType": "jiva",
    "fsType": "ext4",
    "iqn": "iqn.2016-09.com.openebs.jiva:default-jiva-testvol-1-2800663365",
    "lun": 0,
    "replicas": "3",
    "targetIP": "10.7.248.46",
    "targetPort": "3260",
    "targetPortal": "10.7.248.46:3260"
  },
  "status": {
    "Message": "",
    "Phase": "",
    "Reason": ""
  }
}
```
-> New Mayactl volume info output:
```
Portal Details :
----------------
IQN           :   iqn.2016-09.com.openebs.jiva:default-jiva-testvol-1-2800663365
Volume        :   default-jiva-testvol-1-2800663365
Portal        :   10.7.248.46:3260
Size          :   5G
Status        :   running,running
Replica Count :   3

Pool Details :
--------------
Pool Path : /var/openebs/default-jiva-testvol-1-2800663365    

Replica Details :
-----------------
NAME                                                      ACCESSMODE      STATUS      IP            NODE
-----                                                     -----------     -------     ---           ----- 
default-jiva-testvol-1-2800663365-rep-785796994-d727n     RW              running     10.4.0.25     gke-ashish-dev-default-pool-5713d7cc-gj1k 
default-jiva-testvol-1-2800663365-rep-785796994-l89b2     RW              running     10.4.1.15     gke-ashish-dev-default-pool-5713d7cc-zdvp 
default-jiva-testvol-1-2800663365-rep-785796994-lzftd     RW              running     10.4.2.17     gke-ashish-dev-default-pool-5713d7cc-bxg9 

```