### PR TITLE
feat(cstor-operator):handle node disruption for pools

### DIFF
--- a/cmd/maya-apiserver/spc-watcher/select_disk_test.go
+++ b/cmd/maya-apiserver/spc-watcher/select_disk_test.go
@@ -18,19 +18,25 @@ package spc
 
 import (
 	"testing"
-	//openebsFakeClientset "github.com/openebs/maya/pkg/client/clientset/versioned/fake"
+
 	"github.com/golang/glog"
 	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	openebsFakeClientset "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset/fake"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 	"strconv"
 )
 
-func (focs *clientSet) FakeDiskCreator() {
+const (
+	UnschedulableNode = "unschedulable"
+	UnreachableNode   = "unreachable"
+)
+
+func (focs *clientSet) FakeDiskCreator(badNodeCount int, createNodeResource bool, badNodeKind string) bool {
 	// Create some fake disk objects over nodes.
 	// For example, create 6 disk (out of 6 disks 2 disks are sparse disks)for each of 5 nodes.
 	// That meant 6*5 i.e. 30 disk objects should be created
-
 	// diskObjectList will hold the list of disk objects
 	var diskObjectList [30]*v1alpha1.Disk
 
@@ -43,6 +49,12 @@ func (focs *clientSet) FakeDiskCreator() {
 		diskIdentifier := strconv.Itoa(diskListIndex)
 		if diskListIndex%6 == 0 {
 			nodeIdentifer++
+			if badNodeCount > 0 {
+				focs.FakeNodeCreator("gke-ashu-cstor-default-pool-a4065fd6-vxsh"+strconv.Itoa(nodeIdentifer), true, badNodeKind)
+				badNodeCount--
+			} else {
+				focs.FakeNodeCreator("gke-ashu-cstor-default-pool-a4065fd6-vxsh"+strconv.Itoa(nodeIdentifer), false, badNodeKind)
+			}
 			sparseDiskCount = 0
 		}
 		if sparseDiskCount != 2 {
@@ -66,22 +78,84 @@ func (focs *clientSet) FakeDiskCreator() {
 			glog.Error(err)
 		}
 	}
+	return true
+}
 
+func (focs *clientSet) FakeNodeCreator(hostName string, badNode bool, badNodeKind string) {
+	var condition v1.ConditionStatus
+	var unschedulable bool
+	condition = v1.ConditionTrue
+	unschedulable = false
+	if badNode {
+		if badNodeKind == UnschedulableNode {
+			unschedulable = true
+			condition = v1.ConditionTrue
+		} else {
+			condition = v1.ConditionFalse
+			unschedulable = false
+		}
+	}
+	nodeObject := &v1.Node{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: hostName,
+		},
+		Spec: v1.NodeSpec{
+			Unschedulable: unschedulable,
+		},
+		Status: v1.NodeStatus{
+			Conditions: []v1.NodeCondition{
+				v1.NodeCondition{
+					Type:   v1.NodeReady,
+					Status: condition,
+				},
+			},
+		},
+	}
+	_, err := focs.kubeclientset.CoreV1().Nodes().Create(nodeObject)
+	if err != nil {
+		glog.Error(err)
+	}
+
+}
+func (focs *clientSet) FakeDiskDeleter() {
+	for diskListIndex := 0; diskListIndex < 30; diskListIndex++ {
+		diskIdentifier := strconv.Itoa(diskListIndex)
+		diskName := "disk" + diskIdentifier
+		err := focs.oecs.OpenebsV1alpha1().Disks().Delete(diskName, &metav1.DeleteOptions{})
+		if err != nil {
+			glog.Error("Cannot delete fake disks:", err)
+		}
+	}
+}
+func (focs *clientSet) FakeNodeDeleter() {
+	for nodeListIndex := 1; nodeListIndex < 6; nodeListIndex++ {
+		nodeIdentifier := strconv.Itoa(nodeListIndex)
+		nodeName := "gke-ashu-cstor-default-pool-a4065fd6-vxsh" + nodeIdentifier
+		err := focs.kubeclientset.CoreV1().Nodes().Delete(nodeName, &metav1.DeleteOptions{})
+		if err != nil {
+			glog.Error("Cannot delete fake nodes:", err)
+		}
+	}
 }
 func TestNodeDiskAlloter(t *testing.T) {
 
 	// Get a fake openebs client set
 	focs := &clientSet{
-		oecs: openebsFakeClientset.NewSimpleClientset(),
+		oecs:          openebsFakeClientset.NewSimpleClientset(),
+		kubeclientset: fake.NewSimpleClientset(),
 	}
-	focs.FakeDiskCreator()
+	//focs.FakeDiskCreator()
 	tests := map[string]struct {
 		// fakeCasPool holds the fake fakeCasPool object in test cases.
 		fakeCasPool *v1alpha1.CasPool
 		// expectedDiskListLength holds the length of disk list
 		expectedDiskListLength int
 		// err is a bool , true signifies presence of error and vice-versa
-		err bool
+		err                bool
+		badNodeCount       int
+		createNodeResource bool
+		nodeDisruptionType string
 	}{
 		// Test Case #1
 		"CasPool1": {&v1alpha1.CasPool{
@@ -92,6 +166,9 @@ func TestNodeDiskAlloter(t *testing.T) {
 		},
 			3,
 			false,
+			0,
+			true,
+			"",
 		},
 		// Test Case #2
 		"CasPool2": {&v1alpha1.CasPool{
@@ -101,6 +178,9 @@ func TestNodeDiskAlloter(t *testing.T) {
 		},
 			3,
 			false,
+			0,
+			true,
+			"",
 		},
 		// Test Case #3
 		"CasPool3": {&v1alpha1.CasPool{
@@ -111,6 +191,9 @@ func TestNodeDiskAlloter(t *testing.T) {
 		},
 			6,
 			false,
+			0,
+			true,
+			"",
 		},
 		// Test Case #4
 		"CasPool4": {&v1alpha1.CasPool{
@@ -121,6 +204,9 @@ func TestNodeDiskAlloter(t *testing.T) {
 		},
 			0,
 			true,
+			0,
+			true,
+			"",
 		},
 		// Test Case #5
 		"CasPool5": {&v1alpha1.CasPool{
@@ -131,6 +217,9 @@ func TestNodeDiskAlloter(t *testing.T) {
 		},
 			0,
 			true,
+			0,
+			true,
+			"",
 		},
 		// Test Case #6
 		"CasPool6": {&v1alpha1.CasPool{
@@ -141,6 +230,9 @@ func TestNodeDiskAlloter(t *testing.T) {
 		},
 			5,
 			false,
+			0,
+			true,
+			"",
 		},
 		// Test Case #7
 		"CasPool7 of sparse type": {&v1alpha1.CasPool{
@@ -151,8 +243,11 @@ func TestNodeDiskAlloter(t *testing.T) {
 		},
 			5,
 			false,
+			0,
+			true,
+			"",
 		},
-		// Test Case #7
+		// Test Case #8
 		"CasPool8 of sparse type": {&v1alpha1.CasPool{
 			PoolType: "mirrored",
 			MaxPools: 6,
@@ -161,21 +256,94 @@ func TestNodeDiskAlloter(t *testing.T) {
 		},
 			10,
 			false,
+			0,
+			true,
+			"",
+		},
+		//Test Case #9
+		"CasPool9": {&v1alpha1.CasPool{
+			PoolType: "striped",
+			MaxPools: 3,
+			MinPools: 3,
+			Type:     "disk",
+		},
+			3,
+			false,
+			2,
+			true,
+			UnschedulableNode,
+		},
+		// Test Case #10
+		"CasPool10": {&v1alpha1.CasPool{
+			PoolType: "striped",
+			MaxPools: 3,
+			MinPools: 3,
+			Type:     "disk",
+		},
+			0,
+			true,
+			3,
+			true,
+			UnschedulableNode,
+		},
+		// Test Case #11
+		"CasPool11": {&v1alpha1.CasPool{
+			PoolType: "striped",
+			MaxPools: 3,
+			MinPools: 1,
+			Type:     "disk",
+		},
+			2,
+			false,
+			3,
+			true,
+			UnschedulableNode,
+		},
+		// Test Case #12
+		"CasPool12": {&v1alpha1.CasPool{
+			PoolType: "striped",
+			MaxPools: 3,
+			MinPools: 3,
+			Type:     "disk",
+		},
+			0,
+			true,
+			3,
+			true,
+			UnreachableNode,
+		},
+		// Test Case #13
+		"CasPool13": {&v1alpha1.CasPool{
+			PoolType: "striped",
+			MaxPools: 3,
+			MinPools: 1,
+			Type:     "disk",
+		},
+			2,
+			false,
+			3,
+			true,
+			UnreachableNode,
 		},
 	}
 	for name, test := range tests {
+		focs.FakeDiskCreator(test.badNodeCount, test.createNodeResource, test.nodeDisruptionType)
 		t.Run(name, func(t *testing.T) {
 			diskList, err := focs.nodeDiskAlloter(test.fakeCasPool)
 			gotErr := false
 			if err != nil {
+				glog.Error(err)
 				gotErr = true
 			}
 			if gotErr != test.err {
-				t.Fatalf("Test case failed as the expected error %v but got %v", test.err, gotErr)
+				t.Errorf("Test case failed as the expected error %v but got %v", test.err, gotErr)
 			}
 			if len(diskList) != test.expectedDiskListLength {
 				t.Errorf("Test case failed as the expected disk list length is %d but got %d", test.expectedDiskListLength, len(diskList))
 			}
 		})
+		// Delete all the created node and disk resources
+		focs.FakeDiskDeleter()
+		focs.FakeNodeDeleter()
 	}
 }

--- a/cmd/maya-apiserver/spc-watcher/storagepool_create.go
+++ b/cmd/maya-apiserver/spc-watcher/storagepool_create.go
@@ -65,11 +65,13 @@ func CreateStoragePool(spcGot *apis.StoragePoolClaim, reSync bool, pendingPoolCo
 	// Get openebs clientset using a getter method (i.e. GetOECS() ) as
 	// the openebs clientset is not exported.
 	newOecsClient := newK8sClient.GetOECS()
+	newKubeClient := newK8sClient.GetKCS()
 
 	// Create instance of clientset struct defined above which binds
 	// ListDisk method and fill it with openebs clienset (i.e.newOecsClient ).
 	newClientSet := clientSet{
-		oecs: newOecsClient,
+		oecs:          newOecsClient,
+		kubeclientset: newKubeClient,
 	}
 	// Get a CasPool object
 	err, pool := newClientSet.newCasPool(spcGot, reSync, pendingPoolCount)

--- a/cmd/maya-apiserver/spc-watcher/storagepool_create_test.go
+++ b/cmd/maya-apiserver/spc-watcher/storagepool_create_test.go
@@ -19,12 +19,14 @@ import (
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	openebsFakeClientset "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 	"testing"
 )
 
 func TestNewCasPool(t *testing.T) {
 	focs := &clientSet{
-		oecs: openebsFakeClientset.NewSimpleClientset(),
+		oecs:          openebsFakeClientset.NewSimpleClientset(),
+		kubeclientset: fake.NewSimpleClientset(),
 	}
 	// Make a map of string(key) to struct(value).
 	// Key of map describes test case behaviour.
@@ -175,8 +177,7 @@ func TestNewCasPool(t *testing.T) {
 			// newCasPool is the function under test.
 			if test.autoProvisioning {
 				// Get a fake openebs client set
-
-				focs.FakeDiskCreator()
+				focs.FakeDiskCreator(0, false, "")
 			}
 			err, CasPool := focs.newCasPool(test.fakestoragepoolclaim, test.reSync, test.pendingPoolCount)
 			if test.invalidDataInjection {

--- a/pkg/client/k8s/k8s.go
+++ b/pkg/client/k8s/k8s.go
@@ -208,6 +208,12 @@ func (k *K8sClient) GetOECS() *openebs.Clientset {
 	return k.oecs
 }
 
+// GetKCS() is a getter method for fetching kube clientset as
+// the kube clientset is not exported.
+func (k *K8sClient) GetKCS() *kubernetes.Clientset {
+	return k.cs
+}
+
 // scOps is a utility function that provides a instance capable of
 // executing various K8s StorageClass related operations
 func (k *K8sClient) storageV1SCOps() typed_storage_v1.StorageClassInterface {


### PR DESCRIPTION
For creation of cstor-pool the cstor operator will
reject nodes that are unreachable or unschedulable.

Hence, even if stale disk CRs are present with host
name which is out of cluster or destroyed or unreachable,
such disks will not be selected for pool creation.

This way if any disruption happens for a node, deleting all
the pool resources for that node will create pool on another
healthy node whenever it is available.
See following design doc ( Page No:25) for more details:
https://docs.google.com/document/d/1dcm7wvdpUHfSOMoFTPJBUeesMej46eAIN_06-1h_lvw/edit#

Signed-off-by: sonasingh46 <sonasingh46@gmail.com>

