### PR TITLE
Fixed typo - line 554

### DIFF
--- a/pkg/install/v1alpha1/cstor_volume_0.7.0.go
+++ b/pkg/install/v1alpha1/cstor_volume_0.7.0.go
@@ -551,7 +551,7 @@ spec:
     {{/*
     We have a unique key for each volume in .ListItems.volumeList
     We iterate over it to extract various volume properties. These
-    properties were set in preceeding list tasks,
+    properties were set in preceding list tasks,
     */}}
     {{- range $pkey, $map := .ListItems.volumeList }}
     {{- $capacity := pluck "capacity" $map | first | default "" | splitList ", " | first }}


### PR DESCRIPTION
This PR aims at fixing typo ( "preceeding" to "preceding") in line 554 as mentioned in the issue #<1932>

Signed-off-by: gunjan01 gunjan.tank9@gmail.com