### PR TITLE
Fixes typo line 554 in cstor_volume_0.7.0.go

### DIFF
--- a/pkg/install/v1alpha1/cstor_volume_0.7.0.go
+++ b/pkg/install/v1alpha1/cstor_volume_0.7.0.go
@@ -368,7 +368,7 @@ spec:
               mountPath: /usr/local/etc/istgt
             - name: tmp
               mountPath: /tmp
-              mountPropagation: Bidirectional              
+              mountPropagation: Bidirectional
           volumes:
           - name: sockfile
             emptyDir: {}
@@ -551,7 +551,7 @@ spec:
     {{/*
     We have a unique key for each volume in .ListItems.volumeList
     We iterate over it to extract various volume properties. These
-    properties were set in preceeding list tasks,
+    properties were set in preceding list tasks,
     */}}
     {{- range $pkey, $map := .ListItems.volumeList }}
     {{- $capacity := pluck "capacity" $map | first | default "" | splitList ", " | first }}


### PR DESCRIPTION
This PR fixes a typo in line 554 of the cstor_volume_0.7.0.go. It fixes "https://github.com/openebs/openebs/issues/1932"

Signed-off-by: gunjan01 <gunjan.tank9@gmail.com>

