### PR TITLE
feat(cast, jiva, snapshot): add castemplate to take jiva snapshot

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -70,6 +70,7 @@ deps:
 	dep ensure
 
 clean:
+	go clean -testcache
 	rm -rf bin
 	rm -rf ${GOPATH}/bin/${MAYACTL}
 	rm -rf ${GOPATH}/bin/${APISERVER}

--- a/cmd/maya-agent/types/v1/storagebackend.go
+++ b/cmd/maya-agent/types/v1/storagebackend.go
@@ -7,7 +7,7 @@ type StorageBackendAdaptor struct {
 	MaxAllocationSize string `json:"maxAllocationSize"`
 }
 
-// HostDirSBA contains the generic options that apply to all the 
+// HostDirSBA contains the generic options that apply to all the
 // HostDirStorageBackendAdaptors (K8s CRD yaml)
 type HostDirSBA struct {
 	StorageBackendAdaptor

--- a/pkg/client/http/v1alpha1/http_client.go
+++ b/pkg/client/http/v1alpha1/http_client.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
@@ -25,8 +26,27 @@ import (
 	. "k8s.io/client-go/rest"
 )
 
-type rest struct {
+// HttpVerb is a typed constant that represents various http action
+type HttpVerb string
+
+const (
+	DeleteAction HttpVerb = "DELETE"
+	PostAction   HttpVerb = "POST"
+	GetAction    HttpVerb = "GET"
+	PutAction    HttpVerb = "PUT"
+	PatchAction  HttpVerb = "PATCH"
+)
+
+// TODO
+// expose REST via interface
+
+// rest is a wrapper over restclient library
+type Rest struct {
 	client *RESTClient // rest client that does the actual API invocation
+	base   string
+	name   string
+	verb   HttpVerb
+	body   interface{}
 }
 
 // REST provides a new instance of rest client capable of invoking REST API
@@ -34,7 +54,7 @@ type rest struct {
 //
 // NOTE:
 // base url can be of form http://ipaddr:port with no trailing slash
-func REST(base string) (r *rest, err error) {
+func REST(base string) (r *Rest, err error) {
 	c, err := RESTClientFor(&Config{
 		Host: base,
 		ContentConfig: ContentConfig{
@@ -45,11 +65,48 @@ func REST(base string) (r *rest, err error) {
 	if err != nil {
 		return
 	}
-	r = &rest{client: c}
+	r = &Rest{base: base, client: c}
 	return
 }
 
-func API(verb, baseurl, name string) (b []byte, err error) {
+func (r *Rest) WithName(n string) (u *Rest) {
+	r.name = n
+	return r
+}
+
+func (r *Rest) WithVerb(v HttpVerb) (u *Rest) {
+	r.verb = v
+	return r
+}
+
+func (r *Rest) WithBody(o interface{}) (u *Rest) {
+	r.body = o
+	return r
+}
+
+func (r *Rest) Do() (res interface{}, err error) {
+	req := r.client.Verb(string(r.verb))
+	if len(r.name) != 0 {
+		req.Name(r.name)
+	} else {
+		req.RequestURI(r.base)
+	}
+	if r.body != nil {
+		req.Body(r.body)
+	}
+	b, err := req.DoRaw()
+	if err != nil {
+		err = errors.Wrapf(err, "failed to invoke REST call %s %s %s", r.verb, r.base, r.name)
+		return
+	}
+	err = json.Unmarshal(b, &res)
+	if err != nil {
+		err = errors.Wrapf(err, "failed to invoke REST call %s %s %s", r.verb, r.base, r.name)
+	}
+	return
+}
+
+func API(verb HttpVerb, baseurl, name string) (b []byte, err error) {
 	if len(name) == 0 {
 		err = fmt.Errorf("empty resource name: failed to invoke REST API %s %s", verb, baseurl)
 		return
@@ -59,26 +116,26 @@ func API(verb, baseurl, name string) (b []byte, err error) {
 		err = errors.Wrapf(err, "failed to invoke REST API %s %s %s", verb, baseurl, name)
 		return
 	}
-	req := r.client.Verb(verb).Name(name)
+	req := r.client.Verb(string(verb)).Name(name)
 	return doRaw(verb, req)
 }
 
-func URL(verb, url string) (b []byte, err error) {
+func URL(verb HttpVerb, url string) (b []byte, err error) {
 	if len(url) == 0 {
 		err = fmt.Errorf("empty URL: failed to invoke REST API %s", verb)
 		return
 	}
 	r, err := REST(url)
 	if err != nil {
-		err = errors.Wrapf(err, "failed to invoke REST API %s %s %s", verb, url)
+		err = errors.Wrapf(err, "failed to invoke REST API %s %s", verb, url)
 		return
 	}
 	// override the formed URL with the one provided
-	req := r.client.Verb(verb).RequestURI(url)
+	req := r.client.Verb(string(verb)).RequestURI(url)
 	return doRaw(verb, req)
 }
 
-func doRaw(verb string, req *Request) (b []byte, err error) {
+func doRaw(verb HttpVerb, req *Request) (b []byte, err error) {
 	b, err = req.DoRaw()
 	if err != nil {
 		err = errors.Wrapf(err, "error invoking REST API %s %s", verb, req.URL())

--- a/pkg/client/http/v1alpha1/http_client_test.go
+++ b/pkg/client/http/v1alpha1/http_client_test.go
@@ -22,19 +22,19 @@ import (
 
 func TestAPI(t *testing.T) {
 	tests := map[string]struct {
-		verb    string
+		verb    HttpVerb
 		baseurl string
 		name    string
 		iserr   bool
 	}{
-		"101": {"GET", "", "", true},
-		"102": {"GET", "http", "abc", true},
-		"103": {"GET", "http://", "abc", true},
-		"104": {"GET", "http://127.0.0.1", "abc", true},
-		"105": {"GET", "http://127.0.0.1:8080", "abc", true},
-		"106": {"DELETE", "http://127.0.0.1:2123", "abc", true},
-		"107": {"POST", "http://127.0.0.1:2123", "abc", true},
-		"108": {"PUT", "http://127.0.0.1:2123", "abc", true},
+		"101": {GetAction, "", "", true},
+		"102": {GetAction, "http", "abc", true},
+		"103": {GetAction, "http://", "abc", true},
+		"104": {GetAction, "http://127.0.0.1", "abc", true},
+		"105": {GetAction, "http://127.0.0.1:8080", "abc", true},
+		"106": {DeleteAction, "http://127.0.0.1:2123", "abc", true},
+		"107": {PostAction, "http://127.0.0.1:2123", "abc", true},
+		"108": {PutAction, "http://127.0.0.1:2123", "abc", true},
 	}
 
 	for name, mock := range tests {
@@ -50,33 +50,33 @@ func TestAPI(t *testing.T) {
 
 func TestURL(t *testing.T) {
 	tests := map[string]struct {
-		verb  string
+		verb  HttpVerb
 		url   string
 		iserr bool
 	}{
-		"101": {"GET", "", true},
-		"102": {"GET", "http", true},
-		"103": {"GET", "http://", true},
-		"104": {"GET", "http://127.0.0.1", true},
-		"105": {"GET", "http://127.0.0.1:8080", true},
-		"106": {"DELETE", "http://127.0.0.1:2123", true},
-		"107": {"POST", "http://127.0.0.1:2123", true},
-		"108": {"PUT", "http://127.0.0.1:2123", true},
+		"101": {GetAction, "", true},
+		"102": {GetAction, "http", true},
+		"103": {GetAction, "http://", true},
+		"104": {GetAction, "http://127.0.0.1", true},
+		"105": {GetAction, "http://127.0.0.1:8080", true},
+		"106": {DeleteAction, "http://127.0.0.1:2123", true},
+		"107": {PostAction, "http://127.0.0.1:2123", true},
+		"108": {PutAction, "http://127.0.0.1:2123", true},
 		// with version
-		"201": {"GET", "http://127.0.0.1:8080/v2", true},
-		"202": {"DELETE", "http://127.0.0.1:2123/v2", true},
-		"203": {"POST", "http://127.0.0.1:2123/v2", true},
-		"204": {"PUT", "http://127.0.0.1:2123/v2", true},
+		"201": {GetAction, "http://127.0.0.1:8080/v2", true},
+		"202": {DeleteAction, "http://127.0.0.1:2123/v2", true},
+		"203": {PostAction, "http://127.0.0.1:2123/v2", true},
+		"204": {PutAction, "http://127.0.0.1:2123/v2", true},
 		// with version; with resource name
-		"301": {"GET", "http://127.0.0.1:8080/v2/vol", true},
-		"302": {"DELETE", "http://127.0.0.1:2123/v2/vol", true},
-		"303": {"POST", "http://127.0.0.1:2123/v2/vol", true},
-		"304": {"PUT", "http://127.0.0.1:2123/v2/vol", true},
+		"301": {GetAction, "http://127.0.0.1:8080/v2/vol", true},
+		"302": {DeleteAction, "http://127.0.0.1:2123/v2/vol", true},
+		"303": {PostAction, "http://127.0.0.1:2123/v2/vol", true},
+		"304": {PutAction, "http://127.0.0.1:2123/v2/vol", true},
 		// with server != localhost
-		"401": {"GET", "http://10.0.0.1:8080/v2/vol", true},
-		"402": {"DELETE", "http://10.0.0.1:2123/v2/vol", true},
-		"403": {"POST", "http://10.0.0.1:2123/v2/vol", true},
-		"404": {"PUT", "http://10.0.0.1:2123/v2/vol", true},
+		"401": {GetAction, "http://10.0.0.1:8080/v2/vol", true},
+		"402": {DeleteAction, "http://10.0.0.1:2123/v2/vol", true},
+		"403": {PostAction, "http://10.0.0.1:2123/v2/vol", true},
+		"404": {PutAction, "http://10.0.0.1:2123/v2/vol", true},
 	}
 
 	for name, mock := range tests {

--- a/pkg/client/jiva/controller_client.go
+++ b/pkg/client/jiva/controller_client.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/openebs/maya/pkg/util"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
-	"github.com/openebs/maya/pkg/util"
 )
 
 // NewControllerClient create the new controller client

--- a/pkg/install/v1alpha1/jiva_snapshot_0.7.0.go
+++ b/pkg/install/v1alpha1/jiva_snapshot_0.7.0.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2018 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+// JivaSnapshotArtifactsFor070 returns the jiva snapshot related artifacts
+// corresponding to version 0.7.0
+func JivaSnapshotArtifactsFor070() (list ArtifactList) {
+	list.Items = append(list.Items, ParseArtifactListFromMultipleYamls(jivaSnapshotYamlsFor070)...)
+	return
+}
+
+// jivaSnapshotYamlsFor070 returns all the yamls related to jiva snapshot in a
+// string format
+//
+// NOTE:
+//  This is an implementation of MultiYamlFetcher
+func jivaSnapshotYamlsFor070() string {
+	return jivaSnapshotYamls070
+}
+
+const jivaSnapshotYamls070 = `
+---
+apiVersion: openebs.io/v1alpha1
+kind: CASTemplate
+metadata:
+  name: jiva-snapshot-create-default-0.7.0
+spec:
+  taskNamespace: {{env "OPENEBS_NAMESPACE"}}
+  run:
+    tasks:
+    - jiva-snapshot-create-listsourcetargetservice-default-0.7.0
+    - jiva-snapshot-create-invokehttp-default-0.7.0
+---
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: jiva-snapshot-create-listsourcetargetservice-default-0.7.0
+spec:
+  meta: |
+    id: readSourceSvc
+    runNamespace: {{ .Snapshot.runNamespace }}
+    apiVersion: v1
+    kind: Service
+    action: list
+    options: |-
+      labelSelector: openebs.io/controller-service=jiva-controller-svc,openebs.io/persistent-volume={{ .Snapshot.volumeName }}
+  post: |
+    {{- jsonpath .JsonResult "{.items[*].metadata.name}" | trim | saveAs "readSourceSvc.name" .TaskResult | noop -}}
+    {{- .TaskResult.readSourceSvc.name | notFoundErr "source volume target service not found" | saveIf "readSourceSvc.notFoundErr" .TaskResult | noop -}}
+    {{- jsonpath .JsonResult "{.items[*].spec.clusterIP}" | trim | saveAs "readSourceSvc.clusterIP" .TaskResult | noop -}}
+---
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: jiva-snapshot-create-invokehttp-default-0.7.0
+spec:
+  meta: |
+    id: createJivaSnap
+    kind: Command
+  post: |
+    {{- $store :=  storeAt .TaskResult -}}
+    {{- $runner := storeRunner $store -}}
+    {{- $volsUrl := print "http://" .TaskResult.readSourceSvc.clusterIP ":9501/v1/volumes" -}}
+    {{- $volID := print "{.data[?(@.name=='" .Snapshot.volumeName "')].id} as id" -}}
+    {{- select $volID | get http | withoption "url" $volsUrl | runas "getVol" $runner -}}
+    {{- $snapUrl := print $volsUrl "/" .TaskResult.getVol.result.id "?action=snapshot" -}}
+    {{- $body := dict "name" .Snapshot.name -}}
+    {{- post http | withoption "url" $snapUrl | withoption "body" $body | runas "createSnap" $runner -}}
+    {{- $err := .TaskResult.createSnap.error | default "" | toString -}}
+    {{- $err | empty | not | verifyErr $err | saveIf "createJivaSnap.verifyErr" .TaskResult | noop -}}
+---
+`

--- a/pkg/install/v1alpha1/registrar.go
+++ b/pkg/install/v1alpha1/registrar.go
@@ -79,5 +79,8 @@ func RegisteredArtifactsFor070() (list ArtifactList) {
 	//This is generic for release till K8s supports native way of cloning.
 	list.Items = append(list.Items, SnapshotPromoterSCArtifacts().Items...)
 
+	// snapshots
+	list.Items = append(list.Items, JivaSnapshotArtifactsFor070().Items...)
+
 	return
 }

--- a/pkg/jsonpath/v1alpha1/json_path.go
+++ b/pkg/jsonpath/v1alpha1/json_path.go
@@ -26,24 +26,29 @@ import (
 	"reflect"
 )
 
+// selection is a utility struct that wraps over json path and values obtained
+// after querying this path
 type selection struct {
-	Name   string   `json:"name"`   // name of selection
-	Path   string   `json:"path"`   // selection path used to build jsonpath query
-	Values []string `json:"values"` // resulting values due to selection path
+	Alias  string   `json:"alias"`  // alias name tagged against the json path
+	Path   string   `json:"path"`   // json path against which jsonpath query will get executed
+	Values []string `json:"values"` // resulting values due to after querying
 	*Msgs
 }
 
-func Selection(name, path string) *selection {
+// Selection returns a new instance of selection
+func Selection(alias, path string) *selection {
 	return &selection{
-		Name: name,
-		Path: path,
-		Msgs: &Msgs{},
+		Alias: alias,
+		Path:  path,
+		Msgs:  &Msgs{},
 	}
 }
 
+// SetValues populates the selection instance with values; typically obtained
+// after querying the select path
 func (s *selection) SetValues(rvals [][]reflect.Value) {
 	if len(rvals) == 0 {
-		s.AddWarn(fmt.Sprintf("no value(s) found for %s %s", s.Name, s.Path))
+		s.AddWarn(fmt.Sprintf("no value(s) found for %s %s", s.Alias, s.Path))
 		s.Values = append(s.Values, "<no value>")
 		return
 	}
@@ -51,7 +56,7 @@ func (s *selection) SetValues(rvals [][]reflect.Value) {
 		for _, rv := range rvs {
 			pv, ok := ft.PrintableValue(rv)
 			if !ok {
-				s.AddWarn(fmt.Sprintf("can not print type %s: failed to query %s %s", rv.Type(), s.Name, s.Path))
+				s.AddWarn(fmt.Sprintf("can not print type %s: failed to query %s %s", rv.Type(), s.Alias, s.Path))
 				pv = "<not printable>"
 			}
 			var buffer bytes.Buffer
@@ -62,30 +67,77 @@ func (s *selection) SetValues(rvals [][]reflect.Value) {
 	return
 }
 
-type SelectionList []*selection
+// Value returns the first value that was obtained after querying the select
+// path
+func (s *selection) Value() (val string) {
+	if len(s.Values) == 0 {
+		return
+	}
+	val = s.Values[0]
+	return
+}
 
-func (l SelectionList) String() string {
+// selectionList represents a list of selection instances
+type selectionList []*selection
+
+// SelectionList returns a new list of selection instances based on given
+// select aliases & paths
+func SelectionList(aliasPaths map[string]string) (sl selectionList) {
+	for alias, path := range aliasPaths {
+		sl = append(sl, Selection(alias, path))
+	}
+	return
+}
+
+// String is an implementation of Stringer interface
+func (l selectionList) String() string {
 	return YamlString("selectionlist", l)
 }
 
-func (l SelectionList) ValuesByName(name string) (vals []string) {
+// Values maps the values (obtained after querying the path) against the path's
+// alias
+func (l selectionList) Values() (vals map[string]interface{}) {
+	if len(l) == 0 {
+		return
+	}
+	vals = map[string]interface{}{}
+	var v interface{}
 	for _, s := range l {
-		if s.Name == name {
+		v = nil
+		if len(s.Values) > 1 {
+			v = s.Values
+		} else if len(s.Values) == 1 {
+			v = s.Values[0]
+		}
+		vals[s.Alias] = v
+	}
+	return
+}
+
+// ValuesByAlias returns the values (obtained after querying the path) of
+// corresponding path's alias
+func (l selectionList) ValuesByAlias(alias string) (vals []string) {
+	for _, s := range l {
+		if s.Alias == alias {
 			return s.Values
 		}
 	}
 	return
 }
 
-func (l SelectionList) ValueByName(name string) (value string) {
-	vals := l.ValuesByName(name)
+// ValueByAlias returns the first value / only value (obtained after querying
+// the path) of corresponding path's alias
+func (l selectionList) ValueByAlias(alias string) (value string) {
+	vals := l.ValuesByAlias(alias)
 	if len(vals) == 0 {
 		return
 	}
 	return vals[0]
 }
 
-func (l SelectionList) ValuesByPath(path string) (vals []string) {
+// ValuesByPath returns the values (obtained after querying the path) of
+// corresponding path
+func (l selectionList) ValuesByPath(path string) (vals []string) {
 	for _, s := range l {
 		if s.Path == path {
 			return s.Values
@@ -94,7 +146,9 @@ func (l SelectionList) ValuesByPath(path string) (vals []string) {
 	return
 }
 
-func (l SelectionList) ValueByPath(path string) (value string) {
+// ValueByPath returns the first value / only value (obtained after querying
+// the path) of corresponding path
+func (l selectionList) ValueByPath(path string) (value string) {
 	vals := l.ValuesByPath(path)
 	if len(vals) == 0 {
 		return
@@ -102,14 +156,16 @@ func (l SelectionList) ValueByPath(path string) (value string) {
 	return vals[0]
 }
 
+// jsonpath is a wrapper over jsonpath library
 type jsonpath struct {
 	name    string        // name given to the json querying
 	target  interface{}   // target to be queried against
 	jpath   *jp.JSONPath  // instance that understands querying json doc
-	selects SelectionList // selective queries to be done against json doc
+	selects selectionList // selective queries to be done against json doc
 	*Msgs
 }
 
+// JSONPath returns a new jsonpath instance
 func JSONPath(name string) (j *jsonpath) {
 	return &jsonpath{
 		name:  name,
@@ -118,11 +174,13 @@ func JSONPath(name string) (j *jsonpath) {
 	}
 }
 
+// WithTarget sets the target to be queried against
 func (j *jsonpath) WithTarget(target interface{}) (u *jsonpath) {
 	j.target = target
 	return j
 }
 
+// WithTarget sets the raw target to be queried against
 func (j *jsonpath) WithTargetAsRaw(target []byte) (u *jsonpath) {
 	var t interface{}
 	err := json.Unmarshal(target, &t)
@@ -134,6 +192,8 @@ func (j *jsonpath) WithTargetAsRaw(target []byte) (u *jsonpath) {
 	return j
 }
 
+// Values executes jsonpath query by parsing the target against the provided
+// path
 func (j *jsonpath) Values(path string) (vals [][]reflect.Value, err error) {
 	err = j.jpath.Parse(path)
 	if err != nil {
@@ -142,15 +202,21 @@ func (j *jsonpath) Values(path string) (vals [][]reflect.Value, err error) {
 	return j.jpath.FindResults(j.target)
 }
 
-func (j *jsonpath) Query(selects SelectionList) (l SelectionList) {
+// Query executes jsonpath query for given select path against the target
+func (j *jsonpath) Query(s *selection) (u *selection) {
+	vals, err := j.Values(s.Path)
+	if err != nil {
+		j.AddError(fmt.Errorf("failed to query %s %s: error - %s", s.Alias, s.Path, err.Error()))
+	}
+	s.SetValues(vals)
+	j.Msgs.Merge(s.Msgs)
+	return s
+}
+
+// Query executes jsonpath query for each given select path against the target
+func (j *jsonpath) QueryAll(selects selectionList) (l selectionList) {
 	for _, s := range selects {
-		vals, err := j.Values(s.Path)
-		if err != nil {
-			j.AddError(fmt.Errorf("failed to query %s %s: error - %s", s.Name, s.Path, err.Error()))
-		}
-		s.SetValues(vals)
-		l = append(l, s)
-		j.Msgs.Merge(s.Msgs)
+		l = append(l, j.Query(s))
 	}
 	return
 }

--- a/pkg/storagepool/storagepool_template_engine.go
+++ b/pkg/storagepool/storagepool_template_engine.go
@@ -19,11 +19,11 @@ package storagepool
 
 import (
 	"fmt"
-	"strings"
 	"github.com/ghodss/yaml"
 	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	"github.com/openebs/maya/pkg/engine"
 	"github.com/openebs/maya/pkg/util"
+	"strings"
 )
 
 // casStoragePoolEngine is capable of creating a storagepool via CAS template

--- a/pkg/task/v1alpha1/http_command.go
+++ b/pkg/task/v1alpha1/http_command.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2018 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	rest "github.com/openebs/maya/pkg/client/http/v1alpha1"
+	"github.com/pkg/errors"
+)
+
+// TODO
+// Make use of interfaces exposed from pkg/client/http/v1alpha1 than using the
+// direct structures
+
+// httpCommand represents a http API invocation command
+//
+// NOTE:
+//  This is an implementation of Runner
+type httpCommand struct {
+	*RunCommand
+	url  string
+	rest *rest.Rest
+	name string
+	verb rest.HttpVerb
+	body interface{}
+}
+
+// HttpCommand returns a new instance of httpCommand
+func HttpCommand(c *RunCommand) *httpCommand {
+	return &httpCommand{RunCommand: c}
+}
+
+// withURL sets either the base url or url with full path
+func (c *httpCommand) withURL(u string) *httpCommand {
+	c.url = u
+	return c
+}
+
+// withREST sets the rest instance capable to perform REST invocation
+func (c *httpCommand) withREST(r *rest.Rest) *httpCommand {
+	c.rest = r
+	return c
+}
+
+// withName sets the resource name to be used during REST invocation
+func (c *httpCommand) withName() *httpCommand {
+	n, _ := c.Data["name"].(string)
+	c.name = n
+	return c
+}
+
+// withVerb sets the resource name to be used during REST invocation
+func (c *httpCommand) withVerb(v rest.HttpVerb) *httpCommand {
+	c.verb = v
+	return c
+}
+
+// withBody sets the body of the REST request
+func (c *httpCommand) withBody() *httpCommand {
+	b, _ := c.Data["body"]
+	c.body = b
+	return c
+}
+
+// do invokes the REST call
+func (c *httpCommand) do() (r RunCommandResult) {
+	res, err := c.rest.WithName(c.name).WithVerb(c.verb).WithBody(c.body).Do()
+	if err != nil {
+		return c.AddError(err).Result(nil)
+	}
+	return c.Result(res)
+}
+
+// instance returns specific http api command implementation based on the
+// command's action
+func (c *httpCommand) instance() (r Runner) {
+	switch c.Action {
+	case DeleteCommandAction:
+		r = &httpDelete{c}
+	case GetCommandAction:
+		r = &httpGet{c}
+	case PostCommandAction:
+		r = &httpPost{c}
+	case PutCommandAction:
+		r = &httpPut{c}
+	case PatchCommandAction:
+		r = &httpPatch{c}
+	default:
+		r = &notSupportedActionCommand{c.RunCommand}
+	}
+	return
+}
+
+// invokeURL invokes http call using the provided verb
+func (c *httpCommand) invokeURL(verb rest.HttpVerb) (b []byte, err error) {
+	return rest.URL(verb, c.url)
+}
+
+// invokeAPI invokes http call using the provided verb and resource name
+func (c *httpCommand) invokeAPI(verb rest.HttpVerb, name string) (b []byte, err error) {
+	return rest.API(verb, c.url, name)
+}
+
+// invoke invokes http call using the provided http verb
+func (c *httpCommand) invoke(verb rest.HttpVerb) (r RunCommandResult) {
+	var (
+		b   []byte
+		err error
+		res interface{}
+	)
+	name, _ := c.Data["name"].(string)
+	if len(name) != 0 {
+		b, err = c.invokeAPI(verb, name)
+	} else {
+		b, err = c.invokeURL(verb)
+	}
+	if err != nil {
+		return c.AddError(err).Result(nil)
+	}
+	err = json.Unmarshal(b, &res)
+	if err != nil {
+		return c.AddError(errors.Wrap(err, "failed to invoke http command")).Result(nil)
+	}
+	return c.Result(res)
+}
+
+// Run executes various jiva volume related operations
+func (c *httpCommand) Run() (r RunCommandResult) {
+	url, _ := c.Data["url"].(string)
+	if len(url) == 0 {
+		return c.AddError(errors.New("missing url: failed to invoke http command")).Result(nil)
+	}
+	return c.withURL(url).instance().Run()
+}
+
+// httpDelete represents a delete http invocation command
+//
+// NOTE:
+//  This is an implementation of Runner
+type httpDelete struct {
+	*httpCommand
+}
+
+// Run invokes delete http call
+func (d *httpDelete) Run() (r RunCommandResult) {
+	return d.invoke(rest.DeleteAction)
+}
+
+// httpGet represents a GET http invocation command
+//
+// NOTE:
+//  This is an implementation of CommandRunner
+type httpGet struct {
+	*httpCommand
+}
+
+// Run invokes GET http call
+func (g *httpGet) Run() (r RunCommandResult) {
+	return g.invoke(rest.GetAction)
+}
+
+// httpPost represents a POST http invocation command
+//
+// NOTE:
+//  This is an implementation of CommandRunner
+type httpPost struct {
+	*httpCommand
+}
+
+// Run invokes POST http call
+func (p *httpPost) Run() (r RunCommandResult) {
+	robj, err := rest.REST(p.url)
+	if err != nil {
+		return p.AddError(errors.Wrap(err, "failed to invoke http post command")).Result(nil)
+	}
+	return p.withREST(robj).withName().withVerb(rest.PostAction).withBody().do()
+}
+
+// httpPut represents a PUT http invocation command
+//
+// NOTE:
+//  This is an implementation of CommandRunner
+type httpPut struct {
+	*httpCommand
+}
+
+// Run invokes PUT http call
+func (g *httpPut) Run() (r RunCommandResult) {
+	return g.invoke(rest.PutAction)
+}
+
+// httpPatch represents a PATCH http invocation command
+//
+// NOTE:
+//  This is an implementation of CommandRunner
+type httpPatch struct {
+	*httpCommand
+}
+
+// Run invokes PATCH http call
+func (g *httpPatch) Run() (r RunCommandResult) {
+	return g.invoke(rest.PatchAction)
+}

--- a/pkg/task/v1alpha1/http_command_test.go
+++ b/pkg/task/v1alpha1/http_command_test.go
@@ -1,0 +1,423 @@
+/*
+Copyright 2018 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	. "github.com/openebs/maya/pkg/client/http/v1alpha1"
+	"testing"
+)
+
+var _ Runner = &httpCommand{}
+var _ Runner = &httpGet{}
+var _ Runner = &httpPost{}
+var _ Runner = &httpPut{}
+var _ Runner = &httpDelete{}
+var _ Runner = &httpPatch{}
+
+func TestHttpCommandInstance(t *testing.T) {
+	tests := map[string]struct {
+		action      RunCommandAction
+		isSupported bool
+	}{
+		"101": {DeleteCommandAction, true},
+		"102": {CreateCommandAction, false},
+		"103": {GetCommandAction, true},
+		"104": {ListCommandAction, false},
+		"105": {PatchCommandAction, true},
+		"106": {UpdateCommandAction, false},
+		"107": {PostCommandAction, true},
+		"108": {PutCommandAction, true},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmd := WithAction(Command(), mock.action)
+			j := &httpCommand{RunCommand: cmd}
+			r := j.instance()
+			if r == nil {
+				t.Fatalf("Test '%s' failed: expected not nil runner: actual nil runner", name)
+			}
+
+			if mock.isSupported {
+				if _, nosupport := r.(*notSupportedActionCommand); nosupport {
+					t.Fatalf("Test '%s' failed: expected supported command instance: actual '%#v'", name, r)
+				}
+			}
+
+			if !mock.isSupported {
+				if _, nosupport := r.(*notSupportedActionCommand); !nosupport {
+					t.Fatalf("Test '%s' failed: expected not supported command instance: actual '%#v'", name, r)
+				}
+			}
+		})
+	}
+}
+
+func TestHttpCommandSetURL(t *testing.T) {
+	tests := map[string]struct {
+		origURL     string
+		newURL      string
+		expectedURL string
+	}{
+		"101": {"", "http://1.1.1.1:1010", "http://1.1.1.1:1010"},
+		"102": {"http://", "http://1.1.1.1", "http://1.1.1.1"},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmd := Command()
+			j := &httpCommand{RunCommand: cmd, url: mock.origURL}
+			j.withURL(mock.newURL)
+
+			if mock.expectedURL != j.url {
+				t.Fatalf("Test '%s' failed: expected url '%s': actual url '%s'", name, mock.expectedURL, j.url)
+			}
+		})
+	}
+}
+
+func TestHttpCommandInvokeURL(t *testing.T) {
+	tests := map[string]struct {
+		url  string
+		verb HttpVerb
+	}{
+		"101": {"", DeleteAction},
+		"102": {"http://", DeleteAction},
+		"201": {"", GetAction},
+		"202": {"http://", GetAction},
+		"301": {"", PutAction},
+		"302": {"http://", PutAction},
+		"401": {"", PostAction},
+		"402": {"http://", PostAction},
+		"501": {"", PatchAction},
+		"502": {"http://", PatchAction},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmd := Command()
+			j := &httpCommand{RunCommand: cmd, url: mock.url}
+			_, err := j.invokeURL(mock.verb)
+
+			if err == nil {
+				t.Fatalf("Test '%s' failed: expected error: actual no error", name)
+			}
+		})
+	}
+}
+
+func TestHttpCommandInvokeAPI(t *testing.T) {
+	tests := map[string]struct {
+		url      string
+		verb     HttpVerb
+		resource string
+	}{
+		"101": {"", DeleteAction, ""},
+		"102": {"http://", DeleteAction, "volume"},
+		"103": {"http://", DeleteAction, "pool"},
+		"201": {"", GetAction, ""},
+		"202": {"http://", GetAction, "volume"},
+		"203": {"http://", GetAction, "pool"},
+		"301": {"", PutAction, ""},
+		"302": {"http://", PutAction, "volume"},
+		"303": {"http://", PutAction, "pool"},
+		"401": {"", PostAction, ""},
+		"402": {"http://", PostAction, "volume"},
+		"403": {"http://", PostAction, "pool"},
+		"501": {"", PatchAction, ""},
+		"502": {"http://", PatchAction, "volume"},
+		"503": {"http://", PatchAction, "pool"},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmd := Command()
+			j := &httpCommand{RunCommand: cmd, url: mock.url}
+			_, err := j.invokeAPI(mock.verb, mock.resource)
+
+			if err == nil {
+				t.Fatalf("Test '%s' failed: expected error: actual no error", name)
+			}
+		})
+	}
+}
+
+func TestHttpCommandInvoke(t *testing.T) {
+	tests := map[string]struct {
+		url      string
+		verb     HttpVerb
+		resource string
+	}{
+		"101": {"", DeleteAction, ""},
+		"102": {"http://", DeleteAction, "volume"},
+		"103": {"http://", DeleteAction, "pool"},
+		"201": {"", GetAction, ""},
+		"202": {"http://", GetAction, "volume"},
+		"203": {"http://", GetAction, "pool"},
+		"301": {"", PutAction, ""},
+		"302": {"http://", PutAction, "volume"},
+		"303": {"http://", PutAction, "pool"},
+		"401": {"", PostAction, ""},
+		"402": {"http://", PostAction, "volume"},
+		"403": {"http://", PostAction, "pool"},
+		"501": {"", PutAction, ""},
+		"502": {"http://", PutAction, "volume"},
+		"503": {"http://", PutAction, "pool"},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmd := WithData(Command(), "name", mock.resource)
+			j := &httpCommand{RunCommand: cmd, url: mock.url}
+			result := j.invoke(mock.verb)
+
+			if result.Error() == nil {
+				t.Fatalf("Test '%s' failed: expected error: actual no error", name)
+			}
+
+			if result.Result() != nil {
+				t.Fatalf("Test '%s' failed: expected nil result: actual '%#v'", name, result.Result())
+			}
+		})
+	}
+}
+
+func TestHttpCommandRun(t *testing.T) {
+	tests := map[string]struct {
+		action   RunCommandAction
+		url      string
+		resource string
+	}{
+		"101": {DeleteCommandAction, "", ""},
+		"102": {DeleteCommandAction, "http://", "volume"},
+		"103": {DeleteCommandAction, "http://", "pool"},
+		"201": {GetCommandAction, "", ""},
+		"202": {GetCommandAction, "http://", "volume"},
+		"203": {GetCommandAction, "http://", "pool"},
+		"301": {PutCommandAction, "", ""},
+		"302": {PutCommandAction, "http://", "volume"},
+		"303": {PutCommandAction, "http://", "pool"},
+		"401": {PostCommandAction, "", ""},
+		"402": {PostCommandAction, "http://", "volume"},
+		"403": {PostCommandAction, "http://", "pool"},
+		"501": {PatchCommandAction, "", ""},
+		"502": {PatchCommandAction, "http://", "volume"},
+		"503": {PatchCommandAction, "http://", "pool"},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmd := WithData(Command(), "name", mock.resource)
+			cmd = WithAction(cmd, mock.action)
+			j := &httpCommand{RunCommand: cmd, url: mock.url}
+			result := j.Run()
+
+			if result.Error() == nil {
+				t.Fatalf("Test '%s' failed: expected error: actual no error", name)
+			}
+
+			if result.Result() != nil {
+				t.Fatalf("Test '%s' failed: expected nil result: actual '%#v'", name, result.Result())
+			}
+		})
+	}
+}
+
+func TestHttpDeleteRun(t *testing.T) {
+	tests := map[string]struct {
+		url      string
+		resource string
+	}{
+		"101": {"", ""},
+		"102": {"http://", "volume"},
+		"103": {"http://", "pool"},
+		"201": {"", ""},
+		"202": {"http://", "volume"},
+		"203": {"http://", "pool"},
+		"301": {"", ""},
+		"302": {"http://", "volume"},
+		"303": {"http://", "pool"},
+		"401": {"", ""},
+		"402": {"http://", "volume"},
+		"403": {"http://", "pool"},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmd := WithData(Command(), "name", mock.resource)
+			h := &httpCommand{RunCommand: cmd, url: mock.url}
+			d := &httpDelete{h}
+			result := d.Run()
+
+			if result.Error() == nil {
+				t.Fatalf("Test '%s' failed: expected error: actual no error", name)
+			}
+
+			if result.Result() != nil {
+				t.Fatalf("Test '%s' failed: expected nil result: actual '%#v'", name, result.Result())
+			}
+		})
+	}
+}
+
+func TestHttpGetRun(t *testing.T) {
+	tests := map[string]struct {
+		url      string
+		resource string
+	}{
+		"101": {"", ""},
+		"102": {"http://", "volume"},
+		"103": {"http://", "pool"},
+		"201": {"", ""},
+		"202": {"http://", "volume"},
+		"203": {"http://", "pool"},
+		"301": {"", ""},
+		"302": {"http://", "volume"},
+		"303": {"http://", "pool"},
+		"401": {"", ""},
+		"402": {"http://", "volume"},
+		"403": {"http://", "pool"},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmd := WithData(Command(), "name", mock.resource)
+			h := &httpCommand{RunCommand: cmd, url: mock.url}
+			g := &httpGet{h}
+			result := g.Run()
+
+			if result.Error() == nil {
+				t.Fatalf("Test '%s' failed: expected error: actual no error", name)
+			}
+
+			if result.Result() != nil {
+				t.Fatalf("Test '%s' failed: expected nil result: actual '%#v'", name, result.Result())
+			}
+		})
+	}
+}
+
+func TestHttpPostRun(t *testing.T) {
+	tests := map[string]struct {
+		url      string
+		resource string
+	}{
+		"101": {"", ""},
+		"102": {"http://", "volume"},
+		"103": {"http://", "pool"},
+		"201": {"", ""},
+		"202": {"http://", "volume"},
+		"203": {"http://", "pool"},
+		"301": {"", ""},
+		"302": {"http://", "volume"},
+		"303": {"http://", "pool"},
+		"401": {"", ""},
+		"402": {"http://", "volume"},
+		"403": {"http://", "pool"},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmd := WithData(Command(), "name", mock.resource)
+			h := &httpCommand{RunCommand: cmd, url: mock.url}
+			p := &httpPost{h}
+			result := p.Run()
+
+			if result.Error() == nil {
+				t.Fatalf("Test '%s' failed: expected error: actual no error", name)
+			}
+
+			if result.Result() != nil {
+				t.Fatalf("Test '%s' failed: expected nil result: actual '%#v'", name, result.Result())
+			}
+		})
+	}
+}
+
+func TestHttpPutRun(t *testing.T) {
+	tests := map[string]struct {
+		url      string
+		resource string
+	}{
+		"101": {"", ""},
+		"102": {"http://", "volume"},
+		"103": {"http://", "pool"},
+		"201": {"", ""},
+		"202": {"http://", "volume"},
+		"203": {"http://", "pool"},
+		"301": {"", ""},
+		"302": {"http://", "volume"},
+		"303": {"http://", "pool"},
+		"401": {"", ""},
+		"402": {"http://", "volume"},
+		"403": {"http://", "pool"},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmd := WithData(Command(), "name", mock.resource)
+			h := &httpCommand{RunCommand: cmd, url: mock.url}
+			p := &httpPut{h}
+			result := p.Run()
+
+			if result.Error() == nil {
+				t.Fatalf("Test '%s' failed: expected error: actual no error", name)
+			}
+
+			if result.Result() != nil {
+				t.Fatalf("Test '%s' failed: expected nil result: actual '%#v'", name, result.Result())
+			}
+		})
+	}
+}
+
+func TestHttpPatchRun(t *testing.T) {
+	tests := map[string]struct {
+		url      string
+		resource string
+	}{
+		"101": {"", ""},
+		"102": {"http://", "volume"},
+		"103": {"http://", "pool"},
+		"201": {"", ""},
+		"202": {"http://", "volume"},
+		"203": {"http://", "pool"},
+		"301": {"", ""},
+		"302": {"http://", "volume"},
+		"303": {"http://", "pool"},
+		"401": {"", ""},
+		"402": {"http://", "volume"},
+		"403": {"http://", "pool"},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmd := WithData(Command(), "name", mock.resource)
+			h := &httpCommand{RunCommand: cmd, url: mock.url}
+			p := &httpPatch{h}
+			result := p.Run()
+
+			if result.Error() == nil {
+				t.Fatalf("Test '%s' failed: expected error: actual no error", name)
+			}
+
+			if result.Result() != nil {
+				t.Fatalf("Test '%s' failed: expected nil result: actual '%#v'", name, result.Result())
+			}
+		})
+	}
+}

--- a/pkg/task/v1alpha1/jiva_volume_command.go
+++ b/pkg/task/v1alpha1/jiva_volume_command.go
@@ -16,22 +16,22 @@ limitations under the License.
 
 package v1alpha1
 
-// jivaVolumeCommand represents a jiva volume runtask command
+// jivaVolumeCommand represents a jiva volume command
 //
 // NOTE:
-//  This is an implementation of CommandRunner
+//  This is an implementation of Runner
 type jivaVolumeCommand struct {
-	cmd *RunCommand
+	*RunCommand
 }
 
-// instance returns specific jiva volume runtask command implementation based
+// instance returns specific jiva volume command implementation based
 // on the command's action
-func (c *jivaVolumeCommand) instance() (r CommandRunner) {
-	switch c.cmd.Action {
+func (c *jivaVolumeCommand) instance() (r Runner) {
+	switch c.Action {
 	case DeleteCommandAction:
-		r = &jivaVolumeDelete{cmd: c.cmd}
+		r = &jivaVolumeDelete{c}
 	default:
-		r = &notSupportedActionCommand{cmd: c.cmd}
+		r = &notSupportedActionCommand{c.RunCommand}
 	}
 	return
 }

--- a/pkg/task/v1alpha1/jiva_volume_command_test.go
+++ b/pkg/task/v1alpha1/jiva_volume_command_test.go
@@ -35,19 +35,16 @@ func TestJivaVolumeCommand(t *testing.T) {
 
 	for name, mock := range tests {
 		t.Run(name, func(t *testing.T) {
-			j := &jivaVolumeCommand{
-				cmd: Command(),
-			}
-			j.cmd = WithAction(j.cmd, mock.action)
-
+			cmd := WithAction(Command(), mock.action)
+			j := &jivaVolumeCommand{cmd}
 			result := j.Run()
 
-			if !mock.isSupportedAction && result.Error() != NotSupportedActionError {
-				t.Fatalf("Test '%s' failed: expected 'NotSupportedActionError': actual '%s': result '%s'", name, result.Error(), result)
+			if !mock.isSupportedAction && result.Error() != ErrorNotSupportedAction {
+				t.Fatalf("Test '%s' failed: expected 'ErrorNotSupportedAction': actual '%s': result '%s'", name, result.Error(), result)
 			}
 
-			if mock.isSupportedAction && result.Error() == NotSupportedActionError {
-				t.Fatalf("Test '%s' failed: expected 'supported action': actual 'NotSupportedActionError': result '%s'", name, result)
+			if mock.isSupportedAction && result.Error() == ErrorNotSupportedAction {
+				t.Fatalf("Test '%s' failed: expected 'supported action': actual 'ErrorNotSupportedAction': result '%s'", name, result)
 			}
 		})
 	}

--- a/pkg/task/v1alpha1/jiva_volume_delete_test.go
+++ b/pkg/task/v1alpha1/jiva_volume_delete_test.go
@@ -33,10 +33,8 @@ func TestJivaVolumeDelete(t *testing.T) {
 
 	for name, mock := range tests {
 		t.Run(name, func(t *testing.T) {
-			j := &jivaVolumeDelete{
-				cmd: Command(),
-			}
-			j.cmd = WithData(j.cmd, "url", mock.url)
+			cmd := &jivaVolumeCommand{WithData(Command(), "url", mock.url)}
+			j := &jivaVolumeDelete{cmd}
 			result := j.Run()
 
 			if mock.iserr && result.Error() == nil {

--- a/pkg/task/v1alpha1/runtask_command.go
+++ b/pkg/task/v1alpha1/runtask_command.go
@@ -19,8 +19,13 @@ package v1alpha1
 import (
 	"errors"
 	"fmt"
-	. "github.com/openebs/maya/pkg/msg/v1alpha1"
-	"time"
+	jp "github.com/openebs/maya/pkg/jsonpath/v1alpha1"
+	msg "github.com/openebs/maya/pkg/msg/v1alpha1"
+	"strings"
+)
+
+const (
+	SkipExecutionMessage string = "will skip run command execution"
 )
 
 // RunCommandAction determines the kind of action that gets executed by run task
@@ -30,16 +35,19 @@ type RunCommandAction string
 const (
 	DeleteCommandAction RunCommandAction = "delete"
 	CreateCommandAction RunCommandAction = "create"
+	PostCommandAction   RunCommandAction = "post"
 	GetCommandAction    RunCommandAction = "get"
 	ListCommandAction   RunCommandAction = "list"
 	PatchCommandAction  RunCommandAction = "patch"
 	UpdateCommandAction RunCommandAction = "update"
+	PutCommandAction    RunCommandAction = "put"
 )
 
-// RunCommandCategory represents the category of the runtask command
+// RunCommandCategory represents the category of the run command. It helps
+// in determing the exact entity or feature this run command is targeting.
 //
 // NOTE:
-//  A runtask command can belong to more than one categories
+//  A run command can have more than one categories to determine an entity
 type RunCommandCategory string
 
 const (
@@ -47,13 +55,15 @@ const (
 	CstorCommandCategory  RunCommandCategory = "cstor"
 	VolumeCommandCategory RunCommandCategory = "volume"
 	PoolCommandCategory   RunCommandCategory = "pool"
+	HttpCommandCategory   RunCommandCategory = "http"
 )
 
 // RunCommandCategoryList represents a list of RunCommandCategory
 type RunCommandCategoryList []RunCommandCategory
 
+// String implements Stringer interface
 func (l RunCommandCategoryList) String() string {
-	return YamlString("runcommandcategories", l)
+	return msg.YamlString("runcommandcategories", l)
 }
 
 // Contains returns true if this list has the given category
@@ -81,6 +91,17 @@ func (l RunCommandCategoryList) IsJivaVolume() (no bool) {
 	return
 }
 
+// IsHttpReq returns true if this list points to a http based request
+func (l RunCommandCategoryList) IsHttpReq() (no bool) {
+	if len(l) == 0 {
+		return
+	}
+	if l.Contains(HttpCommandCategory) {
+		return !no
+	}
+	return
+}
+
 // IsCstorVolume returns true if this list has both cstor and volume as its
 // category items
 func (l RunCommandCategoryList) IsCstorVolume() (no bool) {
@@ -94,10 +115,10 @@ func (l RunCommandCategoryList) IsCstorVolume() (no bool) {
 }
 
 // IsValid returns true if category list is valid
+//
+// TODO
+// Move volume specific validations to volume command file
 func (l RunCommandCategoryList) IsValid() (no bool) {
-	if len(l) == 0 {
-		return
-	}
 	if l.Contains(JivaCommandCategory) && l.Contains(CstorCommandCategory) {
 		// a volume can be either cstor or jiva based; not both
 		return
@@ -105,26 +126,36 @@ func (l RunCommandCategoryList) IsValid() (no bool) {
 	return !no
 }
 
-// RunCommandData represents data provided to the runtask command before
+// IsEmpty returns true if no category is set
+func (l RunCommandCategoryList) IsEmpty() (empty bool) {
+	if len(l) == 0 {
+		return true
+	}
+	return
+}
+
+// RunCommandData represents data provided to the run command before
 // its execution i.e. input data
 type RunCommandData interface{}
 
 // RunCommandDataMap represents a map of input data required to execute
-// runtask command
+// run command
 type RunCommandDataMap map[string]RunCommandData
 
+// String implements Stringer interface
 func (m RunCommandDataMap) String() string {
-	return YamlString("runcommanddatamap", m)
+	return msg.YamlString("runcommanddatamap", m)
 }
 
-// RunCommandResult holds the result of executing runtask command
+// RunCommandResult holds the result and execution info of a run command
 type RunCommandResult struct {
-	Res    interface{} `json:"result"`          // result of runtask command execution
-	Err    error       `json:"error"`           // root cause of issue; error if any during runtask command execution
-	Extras AllMsgs     `json:"debug,omitempty"` // debug details i.e. errors, warnings, information, etc during execution
+	Res    interface{} `json:"result"`          // result of run command execution
+	Err    error       `json:"error"`           // root cause of issue; error if any during run command execution
+	Extras msg.AllMsgs `json:"debug,omitempty"` // debug details i.e. errors, warnings, information, etc during execution
 }
 
-func NewRunCommandResult(result interface{}, extras AllMsgs) (r RunCommandResult) {
+// NewRunCommandResult returns a new RunCommandResult struct
+func NewRunCommandResult(result interface{}, extras msg.AllMsgs) (r RunCommandResult) {
 	return RunCommandResult{
 		Res:    result,
 		Err:    extras.Error(),
@@ -132,48 +163,172 @@ func NewRunCommandResult(result interface{}, extras AllMsgs) (r RunCommandResult
 	}
 }
 
+// String implements Stringer interface
 func (r RunCommandResult) String() string {
-	return YamlString("runcommandresult", r)
+	return msg.YamlString("runcommandresult", r)
 }
 
+// GoString implements GoStringer interface
+func (r RunCommandResult) GoString() string {
+	return msg.YamlString("runcommandresult", r)
+}
+
+// Error returns the error if any from the run command's result
 func (r RunCommandResult) Error() error {
 	return r.Err
 }
 
+// Result returns the expected output if any from the run command's result
 func (r RunCommandResult) Result() interface{} {
 	return r.Res
 }
 
-func (r RunCommandResult) Debug() AllMsgs {
+// Debug returns the debug info gathered during execution of run command's
+// result
+func (r RunCommandResult) Debug() msg.AllMsgs {
 	return r.Extras
 }
 
-var (
-	NotSupportedCategoryError          = errors.New("not supported category: invalid runtask command")
-	NotSupportedActionError            = errors.New("not supported action: invalid runtask command")
-	InvalidCategoryError               = errors.New("invalid categories: invalid runtask command")
-	CanNotRunDueToFailedConditionError = errors.New("can not execute runtask command: run condition failed")
+// SelectPathAliasDelimiter is used to delimit a select path from its alias
+//
+// e.g.
+//
+// ".metadata.namespace as namespace" implies
+// - '.metadata.namespace' is the path
+// - ' as ' is the delimiter
+// - 'namespace' is the alias
+type SelectPathAliasDelimiter string
+
+const (
+	// AsSelectDelimiter represents " as " as the delimiter
+	AsSelectDelimiter SelectPathAliasDelimiter = " as "
 )
 
-// CommandRunner abstracts execution of runtask command
-type CommandRunner interface {
+// SelectPaths holds all the select paths specified in a run command
+type SelectPaths []string
+
+// String implements Stringer interface
+func (s SelectPaths) String() (str string) {
+	if len(s) > 0 {
+		str = "select '" + strings.Join(s, "' '") + "'"
+	}
+	return
+}
+
+// aliasPaths transforms the select paths into a map of alias & corresponding
+// path
+func (s SelectPaths) aliasPaths() (ap map[string]string) {
+	if len(s) == 0 {
+		return
+	}
+	ap = map[string]string{}
+	for idx, slt := range s {
+		splits := strings.Split(slt, string(AsSelectDelimiter))
+		if len(splits) == 2 {
+			ap[splits[1]] = splits[0]
+		} else {
+			ap[fmt.Sprintf("s%d", idx)] = slt
+		}
+	}
+	return
+}
+
+// QueryCommandResult queries the run command's result based on the select paths
+func (s SelectPaths) QueryCommandResult(r RunCommandResult) (u RunCommandResult) {
+	result := r.Result()
+	if result == nil {
+		msgs := r.Debug().ToMsgs().AddWarn(fmt.Sprintf("nil command result: can not query %s", s))
+		return NewRunCommandResult(nil, msgs.AllMsgs())
+	}
+	// execute jsonpath query against the result
+	j := jp.JSONPath(s.String()).WithTarget(result)
+	sl := j.QueryAll(jp.SelectionList(s.aliasPaths()))
+	// return a new result with selected path values and add additional debug info
+	// due to jsonpath query
+	u = NewRunCommandResult(sl.Values(), r.Debug().ToMsgs().Merge(j.Msgs).AllMsgs())
+	return
+}
+
+var (
+	ErrorNotSupportedCategory = errors.New("not supported category: invalid run command")
+	ErrorNotSupportedAction   = errors.New("not supported action: invalid run command")
+	ErrorInvalidCategory      = errors.New("invalid categories: invalid run command")
+	ErrorEmptyCategory        = errors.New("missing categories: invalid run command")
+)
+
+// Interface abstracts execution run command
+type Interface interface {
+	IDMapper
+	Runner
+	RunCondition
+}
+
+// IDMapper abstracts mapping of a RunCommand instance against an id
+type IDMapper interface {
+	ID() string
+	Map(id string, r *RunCommand)
+}
+
+// RunCondition abstracts evaluating the condition to run or skip executing a
+// run command
+type RunCondition interface {
+	WillRun() (condition string, willrun bool)
+}
+
+// runAlways is an implementation of RunCondition that evaluates the condition
+// to execute a run command to true. In other words, any run command will get
+// executed if this instance is set as former's run condition.
+type runAlways struct{}
+
+// RunAlways returns a new instance of runAlways
+func RunAlways() *runAlways {
+	return &runAlways{}
+}
+
+// WillRun returns true always
+func (r *runAlways) WillRun() (condition string, willrun bool) {
+	return "execute the run command always", true
+}
+
+// Runner abstracts execution of command
+type Runner interface {
 	Run() (r RunCommandResult)
 }
 
-// RunCommand represent a runtask command
+// RunPredicate abstracts evaluation of executing or skipping execution
+// of a runner instance
+type RunPredicate func() bool
+
+// On enables a runner instance
+func On() bool {
+	return true
+}
+
+// Off disables a runner instance
+func Off() bool {
+	return false
+}
+
+// RunCommand represent a run command
 type RunCommand struct {
-	ID          string                 // uniquely identifies a runtask command
-	WillRun     bool                   // flags if this runtask command should get executed or not
-	Action      RunCommandAction       // represents the runtask command's action
-	Category    RunCommandCategoryList // classification of runtask command
-	Data        RunCommandDataMap      // input data required to execute runtask command
-	SelectPaths []string               // paths whose values will be retrieved after runtask command execution
-	*Msgs                              // store and retrieve info, warns, errors, etc occurred during execution
+	ID        string                 // uniquely identifies a run command
+	WillRun   bool                   // flags if this run command should get executed or not
+	Action    RunCommandAction       // represents the run command's action
+	Category  RunCommandCategoryList // classification of run command
+	Data      RunCommandDataMap      // input data required to execute run command
+	Selects   SelectPaths            // paths whose values will be retrieved after run command execution
+	*msg.Msgs                        // store and retrieve info, warns, errors, etc occured during execution
 }
 
 // SelfInfo returns this instance of RunCommand as a string format
-func (c *RunCommand) SelfInfo() string {
-	var categories, data string
+func (c *RunCommand) SelfInfo() (me string) {
+	if c == nil {
+		return
+	}
+	var selects, categories, data string
+	if len(c.Selects) > 0 {
+		selects = c.Selects.String() + " "
+	}
 	for _, c := range c.Category {
 		categories = categories + " " + string(c)
 	}
@@ -181,21 +336,23 @@ func (c *RunCommand) SelfInfo() string {
 		data = data + fmt.Sprintf(" --%s=%s", n, d)
 	}
 	willrun := fmt.Sprintf(" --willrun=%t", c.WillRun)
-	return fmt.Sprintf("%s%s%s%s", c.Action, categories, data, willrun)
+	me = fmt.Sprintf("%s%s%s%s%s", selects, c.Action, categories, data, willrun)
+	return
 }
 
 // Command returns a new instance of RunCommand
 func Command() *RunCommand {
-	return &RunCommand{Msgs: &Msgs{}, WillRun: true}
+	return &RunCommand{Msgs: &msg.Msgs{}, WillRun: true}
 }
 
-// SetRun updates RunCommand instance with run flag
-func (c *RunCommand) SetRun(willrun bool) (u *RunCommand) {
-	c.WillRun = willrun
+// Enables enables or disables execution of RunCommand instance based on the
+// outcome of given predicate
+func (c *RunCommand) Enable(p RunPredicate) (u *RunCommand) {
+	c.WillRun = p()
 	return c
 }
 
-// IsRun flags if this runtask command will get executed or not
+// IsRun flags if this run command will get executed or not
 func (c *RunCommand) IsRun() bool {
 	return c.WillRun
 }
@@ -209,6 +366,18 @@ func (c *RunCommand) AddError(err error) (u *RunCommand) {
 // CreateAction updates RunCommand instance with create action
 func (c *RunCommand) CreateAction() (u *RunCommand) {
 	c.Action = CreateCommandAction
+	return c
+}
+
+// PostAction updates RunCommand instance with post action
+func (c *RunCommand) PostAction() (u *RunCommand) {
+	c.Action = PostCommandAction
+	return c
+}
+
+// PutAction updates RunCommand instance with put action
+func (c *RunCommand) PutAction() (u *RunCommand) {
+	c.Action = PutCommandAction
 	return c
 }
 
@@ -260,7 +429,7 @@ func WithData(given *RunCommand, name string, d RunCommandData) (updated *RunCom
 		given.Data = map[string]RunCommandData{}
 	}
 	if d == nil {
-		given.AddWarn(fmt.Sprintf("nil value provided for '%s': runtask command may fail", name))
+		given.AddWarn(fmt.Sprintf("nil value provided for '%s': run command may fail", name))
 	}
 	given.Data[name] = d
 	return given
@@ -271,51 +440,76 @@ func WithSelect(given *RunCommand, paths []string) (updated *RunCommand) {
 	if len(paths) == 0 {
 		return given
 	}
-	given.SelectPaths = append(given.SelectPaths, paths...)
+	given.Selects = append(given.Selects, paths...)
 	return given
 }
 
 func (c *RunCommand) String() string {
-	return YamlString("runcommand", c)
+	return msg.YamlString("runcommand", c)
 }
 
 func (c *RunCommand) Result(result interface{}) (r RunCommandResult) {
 	return NewRunCommandResult(result, c.AllMsgs())
 }
 
-// instance fetches the specific runtask command implementation instance based
+// instance fetches the specific run command implementation instance based
 // on command categories
-func (c *RunCommand) instance() (r CommandRunner) {
+func (c *RunCommand) instance() (r Runner) {
 	if c.Category.IsJivaVolume() {
-		r = &jivaVolumeCommand{cmd: c}
+		r = &jivaVolumeCommand{c}
+	} else if c.Category.IsHttpReq() {
+		r = HttpCommand(c)
 	} else {
-		r = &notSupportedCategoryCommand{cmd: c}
+		r = &notSupportedCategoryCommand{c}
 	}
 	return
 }
 
-// preRun evaluates conditions and sets options prior to execution of runtask
+// preRun evaluates conditions and sets options prior to execution of run
 // command
 func (c *RunCommand) preRun() {
-	if !c.Category.IsValid() {
-		c.SetRun(false).AddError(InvalidCategoryError)
+	if c.Category.IsEmpty() {
+		c.Enable(Off).AddError(ErrorEmptyCategory)
 	}
-	c.AddInfo(c.SelfInfo())
+	if !c.Category.IsValid() {
+		c.Enable(Off).AddError(ErrorInvalidCategory)
+	}
+	if !c.IsRun() {
+		c.AddSkip(SkipExecutionMessage)
+	}
 }
 
-// Run finds the specific runtask command implementation and executes the same
+// postRun invokes operations after executing the run command
+func (c *RunCommand) postRun(r RunCommandResult) (u RunCommandResult) {
+	if len(c.Selects) == 0 {
+		return r
+	}
+	u = c.Selects.QueryCommandResult(r)
+	return
+}
+
+// Run finds the specific run command implementation and executes the same
 func (c *RunCommand) Run() (r RunCommandResult) {
+	// prior to run
 	c.preRun()
+
+	// run
+	c.AddInfo(c.SelfInfo())
 	if !c.IsRun() {
+		// no need of post run
 		return c.Result(nil)
 	}
-	return c.instance().Run()
+	r = c.instance().Run()
+
+	// post run
+	r = c.postRun(r)
+	return
 }
 
 // RunCommandMiddleware abstracts updating the given RunCommand instance
 type RunCommandMiddleware func(given *RunCommand) (updated *RunCommand)
 
-// JivaCategory updates RunCommand instance with jiva as the runtask command's
+// JivaCategory updates RunCommand instance with jiva as the run command's
 // category
 func JivaCategory() RunCommandMiddleware {
 	return func(given *RunCommand) (updated *RunCommand) {
@@ -323,7 +517,15 @@ func JivaCategory() RunCommandMiddleware {
 	}
 }
 
-// CstorCategory updates RunCommand instance with cstor as the runtask command's
+// HttpCategory updates RunCommand instance with http as the run command's
+// category
+func HttpCategory() RunCommandMiddleware {
+	return func(given *RunCommand) (updated *RunCommand) {
+		return WithCategory(given, HttpCommandCategory)
+	}
+}
+
+// CstorCategory updates RunCommand instance with cstor as the run command's
 // category
 func CstorCategory() RunCommandMiddleware {
 	return func(given *RunCommand) (updated *RunCommand) {
@@ -331,7 +533,7 @@ func CstorCategory() RunCommandMiddleware {
 	}
 }
 
-// VolumeCategory updates RunCommand instance with volume as the runtask
+// VolumeCategory updates RunCommand instance with volume as the run
 // command's category
 func VolumeCategory() RunCommandMiddleware {
 	return func(given *RunCommand) (updated *RunCommand) {
@@ -340,7 +542,7 @@ func VolumeCategory() RunCommandMiddleware {
 }
 
 // Select updates the RunCommand instance with paths whose values will be
-// extracted after execution of runtask command
+// extracted after execution of run command
 func Select(paths []string) RunCommandMiddleware {
 	return func(given *RunCommand) (updated *RunCommand) {
 		return WithSelect(given, paths)
@@ -362,124 +564,23 @@ func (l RunCommandMiddlewareList) Update(given *RunCommand) (updated *RunCommand
 }
 
 // notSupportedCategoryCommand is a CommandRunner implementation for
-// un-supported runtask command category
+// un-supported run command category
 type notSupportedCategoryCommand struct {
-	cmd *RunCommand
+	*RunCommand
 }
 
 func (c *notSupportedCategoryCommand) Run() (r RunCommandResult) {
-	c.cmd.AddError(NotSupportedCategoryError)
-	return NewRunCommandResult(nil, c.cmd.AllMsgs())
+	c.AddError(ErrorNotSupportedCategory)
+	return NewRunCommandResult(nil, c.AllMsgs())
 }
 
 // notSupportedActionCommand is a CommandRunner implementation for
-// un-supported runtask command action
+// un-supported run command action
 type notSupportedActionCommand struct {
-	cmd *RunCommand
+	*RunCommand
 }
 
 func (c *notSupportedActionCommand) Run() (r RunCommandResult) {
-	c.cmd.AddError(NotSupportedActionError)
-	return NewRunCommandResult(nil, c.cmd.AllMsgs())
-}
-
-// ResultStoreFn abstracts storing a key value pair against the provided id
-type ResultStoreFn func(id string, key string, value interface{})
-
-// WillRunFn abstracts evaluation of condition to execute or skip a runtask
-// command
-type WillRunFn func() bool
-
-// defaultCommandRunner manages execution of RunCommand instance based on
-// provided hooks
-//
-// Hooks set in this runner are defined externally to this runner
-//
-// 1/ 'willrun' hook can be used to determine if the given runtask command
-// should get executed or can be skipped
-//
-// 2/ 'store' hook can be used to save runtask command's execution response
-type defaultCommandRunner struct {
-	store   ResultStoreFn // mechanism to store runtask command's response
-	willrun WillRunFn     // flag that determines if runtask command will execute or not
-	id      string        // unique identification of the runtask command
-	cmd     *RunCommand   // manages execution of runtask command
-	*Msgs                 // store and retrieve info, warns, errors, etc occurred during execution
-}
-
-// DefaultCommandRunner returns a new instance of defaultCommandRunner
-func DefaultCommandRunner(s ResultStoreFn, w WillRunFn) *defaultCommandRunner {
-	return &defaultCommandRunner{store: s, willrun: w, Msgs: &Msgs{}}
-}
-
-// GetID returns unique id of this runner / runtask command
-func (r *defaultCommandRunner) GetID() string {
-	return r.id
-}
-
-// Result sets the result due to execution of runtask command
-func (r *defaultCommandRunner) Result(id string, v interface{}) *defaultCommandRunner {
-	r.store(id, "result", v)
-	return r
-}
-
-// Debug sets the debug information due to execution of runtask command
-func (r *defaultCommandRunner) Debug(id string, d AllMsgs) *defaultCommandRunner {
-	r.store(id, "debug", d)
-	return r
-}
-
-// Error sets the error due to execution of runtask command
-func (r *defaultCommandRunner) Error(id string, e error) *defaultCommandRunner {
-	r.store(id, "error", e)
-	return r
-}
-
-// Stores sets various responses due to execution of runtask command
-func (r *defaultCommandRunner) Stores(res RunCommandResult) {
-	if len(r.id) == 0 {
-		r.id = time.Now().Format("15040500000")
-	}
-	r.Result(r.id, res.Result()).Debug(r.id, res.Debug()).Error(r.id, res.Error())
-}
-
-// Command sets the runtask command to be executed via this runner
-func (r *defaultCommandRunner) Command(id string, c *RunCommand) (u *defaultCommandRunner) {
-	if len(id) == 0 {
-		r.AddError(fmt.Errorf("missing runtask id: can not execute runtask command"))
-		return r
-	}
-	r.id = id
-
-	if c == nil {
-		r.AddError(fmt.Errorf("nil runtask command: can not execute runtask command with id '%s'", id))
-		return r
-	}
-	r.cmd = c
-	return r
-}
-
-// preRun sets options conditionally prior to execution of runtask command
-func (r *defaultCommandRunner) preRun() {
-	if !r.willrun() && r.cmd != nil {
-		r.cmd.SetRun(false).AddError(CanNotRunDueToFailedConditionError)
-	}
-}
-
-// postRun executes the post activities associated after the execution of
-// runtask command
-func (r *defaultCommandRunner) postRun(res RunCommandResult) {
-	r.Stores(res)
-}
-
-// Run executes the runtask command
-func (r *defaultCommandRunner) Run() (res RunCommandResult) {
-	r.preRun()
-	if r.cmd == nil {
-		res = NewRunCommandResult(nil, r.AllMsgs())
-	} else {
-		res = r.cmd.Run()
-	}
-	r.postRun(res)
-	return
+	c.AddError(ErrorNotSupportedAction)
+	return NewRunCommandResult(nil, c.AllMsgs())
 }

--- a/pkg/task/v1alpha1/runtask_command_test.go
+++ b/pkg/task/v1alpha1/runtask_command_test.go
@@ -17,28 +17,12 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/ghodss/yaml"
+	cas "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	. "github.com/openebs/maya/pkg/msg/v1alpha1"
-	"github.com/openebs/maya/pkg/util"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
 	"testing"
 )
-
-// mockNoopStore is an implementation of ResultStoreFn
-func mockNoopStore(id string, key string, value interface{}) {}
-
-// mockMapStore stores the provided key value pair against the provided id
-// inside the provided storage map
-func mockMapStore(storage map[string]interface{}) ResultStoreFn {
-	return func(id string, key string, value interface{}) {
-		util.SetNestedField(storage, value, id, key)
-	}
-}
-
-// mockAlwaysRun is an implementation of WillRunFn
-func mockAlwaysRun() bool { return true }
-
-// mockNeverRun is an implementation of WillRunFn
-func mockNeverRun() bool { return false }
 
 func mockRunCommandFromCategory(l []RunCommandCategory) (r *RunCommand) {
 	r = Command()
@@ -46,8 +30,236 @@ func mockRunCommandFromCategory(l []RunCommandCategory) (r *RunCommand) {
 	return
 }
 
-// check if RunCommand implements CommandRunner interface
-var _ CommandRunner = &RunCommand{}
+// check if RunCommand implements Runner interface
+var _ Runner = &RunCommand{}
+
+func TestSelectPathsString(t *testing.T) {
+	tests := map[string]struct {
+		paths    []string
+		expected string
+	}{
+		"101": {[]string{".metadata.name"}, "select '.metadata.name'"},
+		"102": {[]string{".metadata.name", ".metadata.namespace"}, "select '.metadata.name' '.metadata.namespace'"},
+		"103": {[]string{".metadata.name as name"}, "select '.metadata.name as name'"},
+		"104": {[]string{".metadata.name as name", ".spec.replicas as replicas"}, "select '.metadata.name as name' '.spec.replicas as replicas'"},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			s := SelectPaths{}
+			s = append(s, mock.paths...)
+			if s.String() != mock.expected {
+				t.Fatalf("Test '%s' failed: expected '%s': actual '%s'", name, mock.expected, s.String())
+			}
+		})
+	}
+}
+
+func TestSelectsAliasPaths(t *testing.T) {
+	tests := map[string]struct {
+		paths    []string
+		expected map[string]string
+	}{
+		"101": {nil, nil},
+		"102": {[]string{}, nil},
+		"103": {[]string{".metadata.name"}, map[string]string{"s0": ".metadata.name"}},
+		"104": {[]string{".metadata.name", ".metadata.namespace"}, map[string]string{"s0": ".metadata.name", "s1": ".metadata.namespace"}},
+		"105": {[]string{".metadata.name as name"}, map[string]string{"name": ".metadata.name"}},
+		"106": {[]string{".metadata.name as name", ".spec.replicas as replicas"}, map[string]string{"name": ".metadata.name", "replicas": ".spec.replicas"}},
+		// invalid aliases
+		"201": {[]string{".metadata.name name"}, map[string]string{"s0": ".metadata.name name"}},
+		"202": {[]string{".metadata.name is name"}, map[string]string{"s0": ".metadata.name is name"}},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			s := SelectPaths{}
+			s = append(s, mock.paths...)
+			m := s.aliasPaths()
+
+			if len(s) == 0 && mock.expected != nil {
+				t.Fatalf("Test '%s' failed: expected nil: actual '%#v'", name, mock.expected)
+			}
+
+			for a, p := range m {
+				if mock.expected[a] != p {
+					t.Fatalf("Test '%s' failed: with alias '%s': expected '%s': actual '%s'", name, a, mock.expected[a], p)
+				}
+			}
+		})
+	}
+}
+
+func TestSelectsQueryCommandResult(t *testing.T) {
+	var result interface{}
+	result = &cas.CStorVolumeReplica{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "my-cstor-rep",
+		},
+		Spec: cas.CStorVolumeReplicaSpec{
+			TargetIP: "20.10.10.10",
+			Capacity: "40Gi",
+		},
+		Status: cas.CStorVolumeReplicaStatus{
+			Phase: "Online",
+		},
+	}
+	r := NewRunCommandResult(result, AllMsgs{})
+
+	tests := map[string]struct {
+		paths    []string
+		expected map[string]interface{}
+	}{
+		"101": {nil, nil},
+		"102": {[]string{}, nil},
+		"103": {[]string{"{.Name}"}, map[string]interface{}{"s0": "my-cstor-rep"}},
+		"104": {[]string{"{.Spec.TargetIP}", "{.Spec.Capacity}"}, map[string]interface{}{"s0": "20.10.10.10", "s1": "40Gi"}},
+		"105": {[]string{"{..TargetIP}", "{..Capacity}"}, map[string]interface{}{"s0": "20.10.10.10", "s1": "40Gi"}},
+		"106": {[]string{"{.Status.Phase}", "{..Phase}"}, map[string]interface{}{"s0": "Online", "s1": "Online"}},
+		"107": {[]string{"{.Status.Phase} as phase", "{..Phase} as ph"}, map[string]interface{}{"phase": "Online", "ph": "Online"}},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			s := SelectPaths{}
+			s = append(s, mock.paths...)
+			u := s.QueryCommandResult(r)
+
+			if len(mock.paths) == 0 {
+				// there were no runtime errors! good !!!
+				return
+			}
+			result := u.Result()
+			m, ok := result.(map[string]interface{})
+			if !ok {
+				t.Fatalf("Test '%s' failed: expected map[string]interface{}: actual '%#v'", name, u)
+			}
+			for alias, value := range m {
+				if !reflect.DeepEqual(mock.expected[alias], value) {
+					t.Fatalf("Test '%s' failed for alias '%s': expected '%#v': actual '%#v'", name, alias, mock.expected[alias], value)
+				}
+			}
+		})
+	}
+}
+
+func TestSelectsQueryCommandResultV2(t *testing.T) {
+	var result interface{}
+	result = struct {
+		Items []*cas.CStorVolumeReplica
+	}{
+		Items: []*cas.CStorVolumeReplica{
+			&cas.CStorVolumeReplica{
+				ObjectMeta: v1.ObjectMeta{Name: "my-cstor-rep"},
+				Spec:       cas.CStorVolumeReplicaSpec{TargetIP: "20.10.10.10", Capacity: "40Gi"},
+				Status:     cas.CStorVolumeReplicaStatus{Phase: "Online"},
+			},
+			&cas.CStorVolumeReplica{
+				ObjectMeta: v1.ObjectMeta{Name: "my-cstor-rep-2"},
+				Spec:       cas.CStorVolumeReplicaSpec{TargetIP: "20.1.1.1", Capacity: "20Gi"},
+				Status:     cas.CStorVolumeReplicaStatus{Phase: "Offline"},
+			},
+		},
+	}
+	r := NewRunCommandResult(result, AllMsgs{})
+
+	tests := map[string]struct {
+		paths    []string
+		expected map[string]interface{}
+	}{
+		"101": {nil, nil},
+		"102": {[]string{}, nil},
+		"103": {[]string{"{.Items[*].Name}"}, map[string]interface{}{"s0": []string{"my-cstor-rep", "my-cstor-rep-2"}}},
+		"104": {[]string{"{.Items[*].Spec.TargetIP}"}, map[string]interface{}{"s0": []string{"20.10.10.10", "20.1.1.1"}}},
+		"105": {[]string{"{.Items[*]..TargetIP}"}, map[string]interface{}{"s0": []string{"20.10.10.10", "20.1.1.1"}}},
+		"106": {[]string{"{.Items[*].Status.Phase}"}, map[string]interface{}{"s0": []string{"Online", "Offline"}}},
+		"107": {[]string{"{.Items[*]..Phase}"}, map[string]interface{}{"s0": []string{"Online", "Offline"}}},
+		"108": {[]string{"{.Items[*].Status.Phase} as phase"}, map[string]interface{}{"phase": []string{"Online", "Offline"}}},
+		"109": {[]string{"{range .Items[*]..Phase}{@}{end}"}, map[string]interface{}{"s0": []string{"Online", "Offline"}}},
+		"110": {[]string{"{range .Items[*].Spec}{@.TargetIP}{@.Capacity}{end}"}, map[string]interface{}{"s0": []string{"20.10.10.10", "40Gi", "20.1.1.1", "20Gi"}}},
+		"111": {[]string{"{range .Items[*].Spec}{.TargetIP}{.Capacity}{end}"}, map[string]interface{}{"s0": []string{"20.10.10.10", "40Gi", "20.1.1.1", "20Gi"}}},
+		"112": {[]string{"{.Items[*].Spec['.TargetIP','.Capacity']}"}, map[string]interface{}{"s0": []string{"20.10.10.10", "20.1.1.1", "40Gi", "20Gi"}}},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			s := SelectPaths{}
+			s = append(s, mock.paths...)
+			u := s.QueryCommandResult(r)
+
+			if len(mock.paths) == 0 {
+				// there were no runtime errors! good !!!
+				return
+			}
+			result := u.Result()
+			m, ok := result.(map[string]interface{})
+			if !ok {
+				t.Fatalf("Test '%s' failed: expected map[string]interface{}: actual '%#v'", name, u)
+			}
+			for alias, value := range m {
+				if !reflect.DeepEqual(mock.expected[alias], value) {
+					t.Fatalf("Test '%s' failed for alias '%s': expected '%#v': actual '%#v'", name, alias, mock.expected[alias], value)
+				}
+			}
+		})
+	}
+}
+
+func TestRunCommandEnable(t *testing.T) {
+	tests := map[string]struct {
+		predicate RunPredicate
+		willrun   bool
+	}{
+		"101": {On, true},
+		"102": {Off, false},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := Command()
+			isRun := c.Enable(mock.predicate).IsRun()
+			if isRun != mock.willrun {
+				t.Fatalf("Test '%s' failed: expected willrun '%t': actual willrun '%t'", name, mock.willrun, isRun)
+			}
+		})
+	}
+}
+
+func TestRunCommandPostRun(t *testing.T) {
+	tests := map[string]struct {
+		result   RunCommandResult
+		selects  SelectPaths
+		expected map[string]interface{}
+	}{
+		"101": {RunCommandResult{}, nil, nil},
+		"102": {RunCommandResult{}, []string{"{.}"}, nil},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := WithSelect(Command(), mock.selects)
+			u := c.postRun(mock.result)
+			result := u.Result()
+			if mock.expected == nil && result != nil {
+				t.Fatalf("Test '%s' failed: expected nil result: actual '%#v'", name, result)
+			}
+			if mock.expected == nil {
+				return
+			}
+			// this test is designed to have result as a map
+			m, ok := result.(map[string]interface{})
+			if !ok {
+				t.Fatalf("Test '%s' failed: expected map[string]interface{}: actual '%#v'", name, result)
+			}
+			// test each value within the map
+			for alias, value := range m {
+				if !reflect.DeepEqual(mock.expected[alias], value) {
+					t.Fatalf("Test '%s' failed for alias '%s': expected '%#v': actual '%#v'", name, alias, mock.expected[alias], value)
+				}
+			}
+		})
+	}
+}
 
 func TestRunCommandWithData(t *testing.T) {
 	tests := map[string]struct {
@@ -99,12 +311,12 @@ func TestNotSupportedCategoryCommand(t *testing.T) {
 				return
 			}
 
-			if !mock.isSupportedCategory && result.Error() != NotSupportedCategoryError {
-				t.Fatalf("Test '%s' failed: expected 'NotSupportedCategoryError': actual '%s': result '%s'", name, result.Error(), result)
+			if !mock.isSupportedCategory && result.Error() != ErrorNotSupportedCategory {
+				t.Fatalf("Test '%s' failed: expected 'ErrorNotSupportedCategory': actual '%s': result '%s'", name, result.Error(), result)
 			}
 
-			if mock.isSupportedCategory && result.Error() == NotSupportedCategoryError {
-				t.Fatalf("Test '%s' failed: expected 'supported category': actual 'NotSupportedCategoryError': result '%s'", name, result)
+			if mock.isSupportedCategory && result.Error() == ErrorNotSupportedCategory {
+				t.Fatalf("Test '%s' failed: expected 'supported category': actual 'ErrorNotSupportedCategory': result '%s'", name, result)
 			}
 		})
 	}
@@ -191,7 +403,7 @@ func TestRunCommandIsValid(t *testing.T) {
 		"101": {[]RunCommandCategory{JivaCommandCategory}, true},
 		"102": {[]RunCommandCategory{CstorCommandCategory, JivaCommandCategory}, false},
 		"103": {[]RunCommandCategory{CstorCommandCategory, VolumeCommandCategory}, true},
-		"104": {[]RunCommandCategory{}, false},
+		"104": {[]RunCommandCategory{}, true},
 		"105": {[]RunCommandCategory{JivaCommandCategory, VolumeCommandCategory}, true},
 		"106": {[]RunCommandCategory{JivaCommandCategory, VolumeCommandCategory, CstorCommandCategory}, false},
 	}
@@ -207,116 +419,25 @@ func TestRunCommandIsValid(t *testing.T) {
 	}
 }
 
-// check if defaultCommandRunner implements CommandRunner interface
-var _ CommandRunner = &defaultCommandRunner{}
-
-func TestDefaultCommandRunnerRun(t *testing.T) {
+func TestRunCommandIsEmpty(t *testing.T) {
 	tests := map[string]struct {
-		willrun      WillRunFn
-		id           string
-		cmd          *RunCommand
-		expectResult bool
-		expectError  bool
-		expectDebug  bool
-		expectWarn   bool
+		given    []RunCommandCategory
+		expected bool
 	}{
-		// always run
-		"101": {mockAlwaysRun, "", Command(), false, true, true, true},
-		"102": {mockAlwaysRun, "t102", nil, false, true, true, true},
-		"103": {mockAlwaysRun, "t103", Command(), false, true, true, false},
-		"104": {mockAlwaysRun, "t104", VolumeCategory()(Command()), false, true, true, false},
-		"105": {mockAlwaysRun, "t105", JivaCategory()(Command()), false, true, true, false},
-		"106": {mockAlwaysRun, "t106", CstorCategory()(Command()), false, true, true, false},
-		// never run
-		"201": {mockNeverRun, "", Command(), false, true, true, true},
-		"202": {mockNeverRun, "t202", nil, false, true, true, true},
-		"203": {mockNeverRun, "t203", Command(), false, true, true, false},
-		"204": {mockNeverRun, "t204", VolumeCategory()(Command()), false, true, true, false},
-		"205": {mockNeverRun, "t205", JivaCategory()(Command()), false, true, true, false},
-		"206": {mockNeverRun, "t206", CstorCategory()(Command()), false, true, true, false},
+		"101": {[]RunCommandCategory{JivaCommandCategory}, false},
+		"102": {[]RunCommandCategory{CstorCommandCategory, JivaCommandCategory}, false},
+		"103": {[]RunCommandCategory{CstorCommandCategory, VolumeCommandCategory}, false},
+		"104": {[]RunCommandCategory{}, true},
+		"105": {[]RunCommandCategory{JivaCommandCategory, VolumeCommandCategory}, false},
+		"106": {[]RunCommandCategory{JivaCommandCategory, VolumeCommandCategory, CstorCommandCategory}, false},
 	}
 
 	for name, mock := range tests {
 		t.Run(name, func(t *testing.T) {
-			r := DefaultCommandRunner(mockNoopStore, mock.willrun)
-			res := r.Command(mock.id, mock.cmd).Run()
-			if !mock.expectResult && res.Result() != nil {
-				t.Fatalf("Test '%s' failed: expected nil result: actual '%#v'", name, res.Result())
-			}
-			if !mock.expectError && res.Error() != nil {
-				t.Fatalf("Test '%s' failed: expected nil error: actual '%+v'", name, res.Error())
-			}
-			if !mock.expectDebug && !res.Debug().IsEmpty() {
-				t.Fatalf("Test '%s' failed: expected no debug: actual '%#v'", name, res.Debug())
-			}
-			if !mock.expectWarn && res.Debug().HasWarn() {
-				t.Fatalf("Test '%s' failed: expected no warn: actual '%#v'", name, res.Debug())
-			}
-		})
-	}
-}
-
-func TestDefaultCommandRunnerStore(t *testing.T) {
-	tests := map[string]struct {
-		willrun      WillRunFn
-		id           string
-		cmd          *RunCommand
-		expectResult bool
-		expectError  bool
-		expectDebug  bool
-		expectWarn   bool
-	}{
-		// always run
-		"101": {mockAlwaysRun, "", Command(), false, true, true, false},
-		"102": {mockAlwaysRun, "t102", nil, false, true, true, false},
-		"103": {mockAlwaysRun, "t103", Command(), false, true, true, false},
-		"104": {mockAlwaysRun, "t104", VolumeCategory()(Command()), false, true, true, false},
-		"105": {mockAlwaysRun, "t105", JivaCategory()(Command()), false, true, true, false},
-		"106": {mockAlwaysRun, "t106", CstorCategory()(Command()), false, true, true, false},
-		// never run
-		"201": {mockNeverRun, "", Command(), false, true, true, false},
-		"202": {mockNeverRun, "t202", nil, false, true, true, false},
-		"203": {mockNeverRun, "t203", Command(), false, true, true, false},
-		"204": {mockNeverRun, "t204", VolumeCategory()(Command()), false, true, true, false},
-		"205": {mockNeverRun, "t205", JivaCategory()(Command()), false, true, true, false},
-		"206": {mockNeverRun, "t206", CstorCategory()(Command()), false, true, true, false},
-	}
-
-	for name, mock := range tests {
-		t.Run(name, func(t *testing.T) {
-			stor := map[string]interface{}{}
-			runner := DefaultCommandRunner(mockMapStore(stor), mock.willrun)
-			runner.Command(mock.id, mock.cmd).Run()
-			runid := runner.GetID()
-
-			story, _ := yaml.Marshal(stor)
-			s := string(story)
-
-			resp := util.GetNestedField(stor, runid)
-			if resp == nil {
-				t.Fatalf("Test '%s' failed: expected response at id '%s': actual \n%s", name, runid, s)
-			}
-
-			if mock.expectResult && util.GetNestedField(stor, runid, "result") == nil {
-				t.Fatalf("Test '%s' failed: expected result at id '%s': actual \n%s", name, runid, s)
-			}
-
-			if mock.expectDebug {
-				d := util.GetNestedField(stor, runid, "debug").(AllMsgs)
-				if d.IsEmpty() {
-					t.Fatalf("Test '%s' failed: expected debug at id '%s': actual \n%s", name, runid, s)
-				}
-			}
-
-			if mock.expectWarn {
-				d := util.GetNestedField(stor, runid, "debug").(AllMsgs)
-				if !d.HasWarn() {
-					t.Fatalf("Test '%s' failed: expected warn at id '%s.debug': actual \n%s", name, runid, s)
-				}
-			}
-
-			if mock.expectError && util.GetNestedField(stor, runid, "error") == nil {
-				t.Fatalf("Test '%s' failed: expected error at id '%s': actual \n%s", name, runid, s)
+			c := mockRunCommandFromCategory(mock.given)
+			actual := c.Category.IsEmpty()
+			if mock.expected != actual {
+				t.Fatalf("Test '%s' failed: expected '%t' actual '%t'", name, mock.expected, actual)
 			}
 		})
 	}

--- a/pkg/task/v1alpha1/store_command.go
+++ b/pkg/task/v1alpha1/store_command.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2018 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	msg "github.com/openebs/maya/pkg/msg/v1alpha1"
+	"github.com/openebs/maya/pkg/util"
+	"github.com/pkg/errors"
+	"time"
+)
+
+var (
+	ErrorCanNotRunDueToFailedCondition = errors.New("run condition failed: can not execute run command")
+)
+
+// StoreKey represents supported keys to store run command's execution results
+type StoreKey string
+
+const (
+	ResultStoreKey    StoreKey = "result"
+	DebugStoreKey     StoreKey = "debug"
+	ErrorStoreKey     StoreKey = "error"
+	RootCauseStoreKey StoreKey = "rootCause"
+)
+
+// BucketStorageCondition abstracts saving of run command results and also
+// abstracts the evaluation of whether the run command should get executed or
+// skipped in the first place
+type BucketStorageCondition interface {
+	BucketStorage
+	RunCondition
+}
+
+// BucketStorage abstracts storing one or more run command results into
+// buckets
+type BucketStorage interface {
+	Bucket
+	Storage
+}
+
+// Bucket abstracts categorising run command results into specific bucket
+type Bucket interface {
+	SetBucket(b string)
+	IsBucketTaken(b string) bool
+}
+
+// Storage abstracts saving run command results
+type Storage interface {
+	Store(key StoreKey, data interface{})
+}
+
+// kvStore is used to store one or more run commands' execution results
+type kvStore struct {
+	bucket string                 // identifies one run command
+	MStore map[string]interface{} `json:"mstore"` // database of all run commands' results categorized by buckets
+}
+
+// KVStore returns a new instance of kvStore
+func KVStore(store map[string]interface{}) *kvStore {
+	return &kvStore{MStore: store}
+}
+
+// String implements Stringer interface
+func (kv kvStore) String() string {
+	return msg.YamlString("kvstore", kv)
+}
+
+// GoString implements GoStringer interface
+func (kv kvStore) GoString() string {
+	return msg.YamlString("kvstore", kv)
+}
+
+// SetBucket sets the bucket to be considered while saving data into the store
+func (kv *kvStore) SetBucket(b string) {
+	kv.bucket = b
+}
+
+// IsBucketTaken flags if the given bucket is already in use
+func (kv *kvStore) IsBucketTaken(bucket string) bool {
+	for b, _ := range kv.MStore {
+		if b == bucket {
+			return true
+		}
+	}
+	return false
+}
+
+// storeRootCause saves the first ever error saved into this store as root cause
+func (kv *kvStore) storeRootCause(data interface{}) {
+	if data == nil {
+		return
+	}
+	c := util.GetNestedField(kv.MStore, string(RootCauseStoreKey))
+	if c != nil {
+		return
+	}
+	util.SetNestedField(kv.MStore, data, string(RootCauseStoreKey))
+}
+
+// Store saves the given data along with the given key in this kv store
+func (kv *kvStore) Store(key StoreKey, data interface{}) {
+	if kv.MStore == nil {
+		return
+	}
+	util.SetNestedField(kv.MStore, data, kv.bucket, string(key))
+	if key == ErrorStoreKey {
+		kv.storeRootCause(data)
+	}
+}
+
+// WillRun evaluates if run command execution should proceed or be skipped based
+// on the results of earlier run commands
+//
+// NOTE:
+// This is an implementation of RunCondition
+func (kv *kvStore) WillRun() (condition string, willrun bool) {
+	condition = "errors with previous commands' execution(s)"
+	for _, data := range kv.MStore {
+		kv, ok := data.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if kv[string(ErrorStoreKey)] != nil {
+			return
+		}
+	}
+	willrun = true
+	return
+}
+
+// storeCommand is a wrapper over RunCommand instance and provides extra
+// features e.g. storing the run command results & evaluating if run command
+// should be executed or skipped.
+//
+// NOTE:
+// A storeCommand will mostly be preferred over a RunCommand instance
+type storeCommand struct {
+	storage   BucketStorage // store a run command's result, error, debug messages
+	cond      RunCondition  // flag that determines if run command will execute or not
+	id        string        // unique identification of run command
+	cmd       *RunCommand   // current command to execute
+	*msg.Msgs               // store and retrieve info, warns, errors, etc occured during execution
+}
+
+// StoreCommand returns a new instance of storeCommand
+func StoreCommand(s BucketStorageCondition) *storeCommand {
+	return StoreCommandCondition(s, s)
+}
+
+// StoreCommandCondition returns a new instance of storeCommand
+func StoreCommandCondition(s BucketStorage, c RunCondition) *storeCommand {
+	return &storeCommand{storage: s, cond: c, Msgs: &msg.Msgs{}}
+}
+
+// reset will reset this instance to manage a new run command instance for
+// later's execution
+func (r *storeCommand) reset() {
+	r.id = ""
+	r.cmd = nil
+	r.Msgs.Reset()
+}
+
+// setID sets the run command's identity
+func (r *storeCommand) setID(id string) {
+	r.storage.SetBucket(id)
+	r.id = id
+}
+
+// setGenID sets the run command's identity based on a generated number
+func (r *storeCommand) setGenID() {
+	id := time.Now().Format("15040500000")
+	r.setID(id)
+}
+
+// ID returns the id corresponding to the run command
+func (r *storeCommand) ID() string {
+	return r.id
+}
+
+// WillRun evaluates if the run command will get executed or skipped
+func (r *storeCommand) WillRun() (condition string, willrun bool) {
+	return r.cond.WillRun()
+}
+
+// Map sets the given run command against the given id
+func (r *storeCommand) Map(id string, c *RunCommand) {
+	// reset earlier settings if any
+	r.reset()
+
+	if len(id) == 0 {
+		r.AddError(errors.Errorf("missing run command id: can not execute run command: '%s'", c.SelfInfo()))
+		r.setGenID()
+		return
+	}
+	if r.storage.IsBucketTaken(id) {
+		r.AddError(errors.Errorf("duplicate id '%s': can not execute run command: '%s'", id, c.SelfInfo()))
+		r.setGenID()
+		return
+	}
+	r.setID(id)
+	if c == nil {
+		r.AddError(errors.Errorf("nil run command: can not execute run command with id '%s'", id))
+		return
+	}
+	r.cmd = c
+	return
+}
+
+// WithResult sets the result due to execution of run command
+func (r *storeCommand) WithResult(v interface{}) *storeCommand {
+	r.storage.Store(ResultStoreKey, v)
+	return r
+}
+
+// WithDebug sets the debug information due to execution of run command
+func (r *storeCommand) WithDebug(d msg.AllMsgs) *storeCommand {
+	r.storage.Store(DebugStoreKey, d)
+	return r
+}
+
+// WithError sets the error due to execution of run command
+func (r *storeCommand) WithError(e error) *storeCommand {
+	r.storage.Store(ErrorStoreKey, e)
+	return r
+}
+
+// Stores sets various responses due to execution of run command
+func (r *storeCommand) Store(res RunCommandResult) {
+	r.WithResult(res.Result()).WithDebug(res.Debug()).WithError(res.Error())
+}
+
+// preRun sets options conditionally prior to execution of run command
+func (r *storeCommand) preRun() {
+	if r.cmd == nil {
+		return
+	}
+	c, willrun := r.WillRun()
+	if !willrun {
+		r.cmd.Enable(Off).AddWarn(c).AddError(ErrorCanNotRunDueToFailedCondition)
+	}
+}
+
+// postRun executes the post activities associated after the execution of
+// run command
+func (r *storeCommand) postRun(res RunCommandResult) {
+	r.Store(res)
+}
+
+// Run executes the run command
+func (r *storeCommand) Run() (res RunCommandResult) {
+	if r.cmd == nil {
+		res = NewRunCommandResult(nil, r.AllMsgs())
+	} else {
+		r.preRun()
+		res = r.cmd.Run()
+	}
+	r.postRun(res)
+	return
+}

--- a/pkg/task/v1alpha1/store_command_test.go
+++ b/pkg/task/v1alpha1/store_command_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2018 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	. "github.com/openebs/maya/pkg/msg/v1alpha1"
+	"github.com/openebs/maya/pkg/util"
+	"testing"
+)
+
+// check if storeCommand implements Interface interface
+var _ Interface = &storeCommand{}
+
+// check if kvStore implements BucketStorageCondition interface
+var _ BucketStorageCondition = &kvStore{}
+
+// mockNoopStore is an implementation of StoreRunResultFn
+//func mockNoopStore(id string, key StoreKey, value interface{}) {}
+
+// mockMapStore stores the provided key value pair against the provided id
+// inside the provided storage map
+//func mockMapStore(store map[string]interface{}) StorageInterface {
+//	return KVStore(store)
+//}
+
+type mockRunAlwaysStore struct {
+	*storeCommand
+}
+
+func (m *mockRunAlwaysStore) WillRun() (cond string, willrun bool) {
+	return "runalways", true
+}
+
+type mockRunNeverStore struct {
+	*storeCommand
+}
+
+func (m *mockRunNeverStore) WillRun() (cond string, willrun bool) {
+	return "runnever", false
+}
+
+// mockAlwaysRun is an implementation of WillRunConditionFn
+func mockAlwaysRun() bool { return true }
+
+// mockNeverRun is an implementation of WillRunConditionFn
+func mockNeverRun() bool { return false }
+
+func TestStoreCommandRun(t *testing.T) {
+	tests := map[string]struct {
+		store        Interface
+		id           string
+		cmd          *RunCommand
+		expectResult bool
+		expectError  bool
+		expectDebug  bool
+		expectWarn   bool
+	}{
+		// always run
+		"101": {&mockRunAlwaysStore{StoreCommand(KVStore(map[string]interface{}{}))}, "", Command(), false, true, true, true},
+		"102": {&mockRunAlwaysStore{StoreCommand(KVStore(map[string]interface{}{}))}, "t102", nil, false, true, true, true},
+		"103": {&mockRunAlwaysStore{StoreCommand(KVStore(map[string]interface{}{}))}, "t103", Command(), false, true, true, false},
+		"104": {&mockRunAlwaysStore{StoreCommand(KVStore(map[string]interface{}{}))}, "t104", VolumeCategory()(Command()), false, true, true, false},
+		"105": {&mockRunAlwaysStore{StoreCommand(KVStore(map[string]interface{}{}))}, "t105", JivaCategory()(Command()), false, true, true, false},
+		"106": {&mockRunAlwaysStore{StoreCommand(KVStore(map[string]interface{}{}))}, "t106", CstorCategory()(Command()), false, true, true, false},
+		// never run
+		"201": {&mockRunNeverStore{StoreCommand(KVStore(map[string]interface{}{}))}, "", Command(), false, true, true, true},
+		"202": {&mockRunNeverStore{StoreCommand(KVStore(map[string]interface{}{}))}, "t202", nil, false, true, true, true},
+		"203": {&mockRunNeverStore{StoreCommand(KVStore(map[string]interface{}{}))}, "t203", Command(), false, true, true, false},
+		"204": {&mockRunNeverStore{StoreCommand(KVStore(map[string]interface{}{}))}, "t204", VolumeCategory()(Command()), false, true, true, false},
+		"205": {&mockRunNeverStore{StoreCommand(KVStore(map[string]interface{}{}))}, "t205", JivaCategory()(Command()), false, true, true, false},
+		"206": {&mockRunNeverStore{StoreCommand(KVStore(map[string]interface{}{}))}, "t206", CstorCategory()(Command()), false, true, true, false},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			sc := mock.store
+			sc.Map(mock.id, mock.cmd)
+			res := sc.Run()
+			if !mock.expectResult && res.Result() != nil {
+				t.Fatalf("Test '%s' failed: expected nil result: actual '%#v'", name, res.Result())
+			}
+			if !mock.expectError && res.Error() != nil {
+				t.Fatalf("Test '%s' failed: expected nil error: actual '%+v'", name, res.Error())
+			}
+			if !mock.expectDebug && !res.Debug().IsEmpty() {
+				t.Fatalf("Test '%s' failed: expected no debug: actual '%#v'", name, res.Debug())
+			}
+			if !mock.expectWarn && res.Debug().HasWarn() {
+				t.Fatalf("Test '%s' failed: expected no warn: actual '%#v'", name, res.Debug())
+			}
+		})
+	}
+}
+
+func TestStoreCommandStorage(t *testing.T) {
+	mstore := map[string]interface{}{}
+	kv := KVStore(mstore)
+	sc := StoreCommand(kv)
+	runalways := &mockRunAlwaysStore{sc}
+	runnever := &mockRunNeverStore{sc}
+
+	// init runs
+	sc.Map("sc000", Command())
+	sc.Run()
+
+	tests := map[string]struct {
+		store        Interface
+		id           string
+		cmd          *RunCommand
+		expectResult bool
+		expectError  bool
+		expectDebug  bool
+		expectWarn   bool
+		expectSkip   bool
+		expectInfo   bool
+	}{
+		// always run
+		"101": {runalways, "", Command(), false, true, true, false, false, false},
+		"102": {runalways, "t102", nil, false, true, true, false, false, false},
+		"103": {runalways, "t103", Command(), false, true, true, true, true, true},
+		"104": {runalways, "t104", VolumeCategory()(Command()), false, true, true, true, true, true},
+		"105": {runalways, "t105", JivaCategory()(Command()), false, true, true, true, true, true},
+		"106": {runalways, "t106", CstorCategory()(Command()), false, true, true, true, true, true},
+		// never run
+		"201": {runnever, "", Command(), false, true, true, false, false, false},
+		"202": {runnever, "t202", nil, false, true, true, false, false, false},
+		"203": {runnever, "t203", Command(), false, true, true, true, true, true},
+		"204": {runnever, "t204", VolumeCategory()(Command()), false, true, true, true, true, true},
+		"205": {runnever, "t205", JivaCategory()(Command()), false, true, true, true, true, true},
+		"206": {runnever, "t206", CstorCategory()(Command()), false, true, true, true, true, true},
+		// default storage command
+		"301": {sc, "", Command(), false, true, true, false, false, false},
+		"302": {sc, "t302", nil, false, true, true, false, false, false},
+		"303": {sc, "t303", Command(), false, true, true, true, true, true},
+		"304": {sc, "t304", VolumeCategory()(Command()), false, true, true, true, true, true},
+		"305": {sc, "t305", JivaCategory()(Command()), false, true, true, true, true, true},
+		"306": {sc, "t306", CstorCategory()(Command()), false, true, true, true, true, true},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			runner := mock.store
+			runner.Map(mock.id, mock.cmd)
+			runner.Run()
+			runid := runner.ID()
+
+			resp := util.GetNestedField(mstore, runid)
+			if resp == nil {
+				t.Fatalf("Test '%s' failed: expected response for run id '%s': actual no response: %s", name, runid, kv)
+			}
+
+			if mock.expectResult && util.GetNestedField(mstore, runid, "result") == nil {
+				t.Fatalf("Test '%s' failed: expected result for run id '%s': actual no result: %s", name, runid, kv)
+			}
+
+			if mock.expectError && util.GetNestedField(mstore, runid, "error") == nil {
+				t.Fatalf("Test '%s' failed: expected error for run id '%s': actual no error: %s", name, runid, kv)
+			}
+
+			d := util.GetNestedField(mstore, runid, "debug").(AllMsgs)
+
+			if mock.expectDebug && d.IsEmpty() {
+				t.Fatalf("Test '%s' failed: expected debug for run id '%s': actual no debug: %s", name, runid, kv)
+			}
+			if !mock.expectDebug && !d.IsEmpty() {
+				t.Fatalf("Test '%s' failed: expected no debug for run id '%s': actual debug: %s", name, runid, kv)
+			}
+
+			if mock.expectError && !d.HasError() {
+				t.Fatalf("Test '%s' failed: expected error for run id '%s': actual no error: %s", name, runid, kv)
+			}
+			if !mock.expectError && d.HasError() {
+				t.Fatalf("Test '%s' failed: expected no error for run id '%s': actual error: %s", name, runid, kv)
+			}
+
+			if mock.expectWarn && !d.HasWarn() {
+				t.Fatalf("Test '%s' failed: expected warn for run id '%s': actual no warn: %s", name, runid, kv)
+			}
+			if !mock.expectWarn && d.HasWarn() {
+				t.Fatalf("Test '%s' failed: expected no warn for run id '%s': actual warn: %s", name, runid, kv)
+			}
+
+			if mock.expectSkip && !d.HasSkip() {
+				t.Fatalf("Test '%s' failed: expected skip for run id '%s': actual no skip: %s", name, runid, kv)
+			}
+			if !mock.expectSkip && d.HasSkip() {
+				t.Fatalf("Test '%s' failed: expected no skip for run id '%s': actual skip: %s", name, runid, kv)
+			}
+
+			if mock.expectInfo && !d.HasInfo() {
+				t.Fatalf("Test '%s' failed: expected info for run id '%s': actual no info: %s", name, runid, kv)
+			}
+			if !mock.expectInfo && d.HasInfo() {
+				t.Fatalf("Test '%s' failed: expected no info for run id '%s': actual info: %s", name, runid, kv)
+			}
+		})
+	}
+}

--- a/pkg/template/runtask_functions.go
+++ b/pkg/template/runtask_functions.go
@@ -17,11 +17,10 @@ limitations under the License.
 package template
 
 import (
+	cmd "github.com/openebs/maya/pkg/task/v1alpha1"
+	"github.com/openebs/maya/pkg/util"
 	"strings"
 	"text/template"
-
-	. "github.com/openebs/maya/pkg/task/v1alpha1"
-	"github.com/openebs/maya/pkg/util"
 )
 
 // delete returns a new instance of delete based runtask command
@@ -30,8 +29,8 @@ import (
 // ---------
 // {{- delete jiva volume | run -}}
 // {{- delete cstor volume | run -}}
-func delete(ml ...RunCommandMiddleware) *RunCommand {
-	return RunCommandMiddlewareList(ml).Update(Command().DeleteAction())
+func delete(ml ...cmd.RunCommandMiddleware) *cmd.RunCommand {
+	return cmd.RunCommandMiddlewareList(ml).Update(cmd.Command().DeleteAction())
 }
 
 // get returns a new instance of get based runtask command
@@ -40,8 +39,9 @@ func delete(ml ...RunCommandMiddleware) *RunCommand {
 // ---------
 // {{- get jiva volume | run -}}
 // {{- get cstor volume | run -}}
-func get(ml ...RunCommandMiddleware) *RunCommand {
-	return RunCommandMiddlewareList(ml).Update(Command().GetAction())
+// {{- get http | url $url | run -}}
+func get(ml ...cmd.RunCommandMiddleware) *cmd.RunCommand {
+	return cmd.RunCommandMiddlewareList(ml).Update(cmd.Command().GetAction())
 }
 
 // list returns a new instance of list based runtask command
@@ -50,8 +50,8 @@ func get(ml ...RunCommandMiddleware) *RunCommand {
 // ---------
 // {{- list jiva volume | run -}}
 // {{- list cstor volume | run -}}
-func list(ml ...RunCommandMiddleware) *RunCommand {
-	return RunCommandMiddlewareList(ml).Update(Command().ListAction())
+func list(ml ...cmd.RunCommandMiddleware) *cmd.RunCommand {
+	return cmd.RunCommandMiddlewareList(ml).Update(cmd.Command().ListAction())
 }
 
 // create returns a new instance of create based runtask command
@@ -60,8 +60,26 @@ func list(ml ...RunCommandMiddleware) *RunCommand {
 // ---------
 // {{- create jiva volume | run -}}
 // {{- create cstor volume | run -}}
-func create(ml ...RunCommandMiddleware) *RunCommand {
-	return RunCommandMiddlewareList(ml).Update(Command().CreateAction())
+func create(ml ...cmd.RunCommandMiddleware) *cmd.RunCommand {
+	return cmd.RunCommandMiddlewareList(ml).Update(cmd.Command().CreateAction())
+}
+
+// post returns a new instance of post based runtask command
+//
+// Examples:
+// ---------
+// {{- post http | url $url -}}
+func post(ml ...cmd.RunCommandMiddleware) *cmd.RunCommand {
+	return cmd.RunCommandMiddlewareList(ml).Update(cmd.Command().PostAction())
+}
+
+// put returns a new instance of put based runtask command
+//
+// Examples:
+// ---------
+// {{- put http | url $url -}}
+func put(ml ...cmd.RunCommandMiddleware) *cmd.RunCommand {
+	return cmd.RunCommandMiddlewareList(ml).Update(cmd.Command().PutAction())
 }
 
 // patch returns a new instance of patch based runtask command
@@ -70,8 +88,8 @@ func create(ml ...RunCommandMiddleware) *RunCommand {
 // ---------
 // {{- patch jiva volume | run -}}
 // {{- patch cstor volume | run -}}
-func patch(ml ...RunCommandMiddleware) *RunCommand {
-	return RunCommandMiddlewareList(ml).Update(Command().PatchAction())
+func patch(ml ...cmd.RunCommandMiddleware) *cmd.RunCommand {
+	return cmd.RunCommandMiddlewareList(ml).Update(cmd.Command().PatchAction())
 }
 
 // update returns a new instance of update based runtask command
@@ -80,8 +98,18 @@ func patch(ml ...RunCommandMiddleware) *RunCommand {
 // ---------
 // {{- update jiva volume | run -}}
 // {{- update cstor volume | run -}}
-func update(ml ...RunCommandMiddleware) *RunCommand {
-	return RunCommandMiddlewareList(ml).Update(Command().UpdateAction())
+func update(ml ...cmd.RunCommandMiddleware) *cmd.RunCommand {
+	return cmd.RunCommandMiddlewareList(ml).Update(cmd.Command().UpdateAction())
+}
+
+// http returns a new instance of http based runtask command
+//
+// Examples:
+// ---------
+// {{- post http | url $url | run -}}
+// {{- get http | url $url | run -}}
+func http() cmd.RunCommandMiddleware {
+	return cmd.HttpCategory()
 }
 
 // jiva returns a new instance of jiva based runtask command
@@ -90,8 +118,8 @@ func update(ml ...RunCommandMiddleware) *RunCommand {
 // ---------
 // {{- get jiva volume | run -}}
 // {{- list jiva volume | run -}}
-func jiva() RunCommandMiddleware {
-	return JivaCategory()
+func jiva() cmd.RunCommandMiddleware {
+	return cmd.JivaCategory()
 }
 
 // cstor returns a new instance of cstor based runtask command
@@ -100,8 +128,8 @@ func jiva() RunCommandMiddleware {
 // ---------
 // {{- get cstor volume | run -}}
 // {{- list cstor volume | run -}}
-func cstor() RunCommandMiddleware {
-	return CstorCategory()
+func cstor() cmd.RunCommandMiddleware {
+	return cmd.CstorCategory()
 }
 
 // volume returns a new instance of volume based runtask command
@@ -112,8 +140,8 @@ func cstor() RunCommandMiddleware {
 // {{- list cstor volume | run -}}
 // {{- update jiva volume | run -}}
 // {{- create jiva volume | run -}}
-func volume() RunCommandMiddleware {
-	return VolumeCategory()
+func volume() cmd.RunCommandMiddleware {
+	return cmd.VolumeCategory()
 }
 
 // slect returns the values of the specified paths post runtask command
@@ -125,21 +153,18 @@ func volume() RunCommandMiddleware {
 // {{- select "name" | list cstor volume | run -}}
 // {{- select "name" "namespace" | update jiva volume | run -}}
 // {{- select ".metadata.name" | create jiva volume | run -}}
-func slect(paths ...string) RunCommandMiddleware {
+func slect(paths ...string) cmd.RunCommandMiddleware {
 	if len(paths) == 0 {
 		paths = append(paths, "all")
 	}
-	return Select(paths)
+	return cmd.Select(paths)
 }
 
-// withoption sets the provided <key,value> pair as an input data to runtask command
+// withOption sets the provided <key,value> pair as an input data to run command
 //
-// Examples:
-// ---------
-// {{- $url := "http://10.10.10.10:9501" -}}
-// {{- delete jiva volume | withoption "url" $url | withoption "name" "myvol" | run -}}
-func withoption(key, value string, given *RunCommand) (updated *RunCommand) {
-	return WithData(given, key, value)
+// {{- delete jiva volume | withOption "url" $url | withOption "name" "myvol" | run -}}
+func withOption(key string, value interface{}, given *cmd.RunCommand) (updated *cmd.RunCommand) {
+	return cmd.WithData(given, key, value)
 }
 
 // run executes the runtask command
@@ -147,8 +172,65 @@ func withoption(key, value string, given *RunCommand) (updated *RunCommand) {
 // Examples:
 // ---------
 // {{- get jiva volume | run -}}
-func run(given *RunCommand) RunCommandResult {
+func run(given *cmd.RunCommand) cmd.RunCommandResult {
 	return given.Run()
+}
+
+// runAlways will always execute the provided command
+//
+// Examples:
+// ---------
+// {{- $cond := runAlways .TaskResult -}}
+// {{- $store :=  storeAt .TaskResult -}}
+// {{- $runner := storeRunnerCond $store $cond -}}
+func runAlways() cmd.RunCondition {
+	return cmd.RunAlways()
+}
+
+// storeAt sets the storage to save the command's execution result(s)
+//
+// Examples:
+// ---------
+// {{- $store :=  storeAt .TaskResult -}}
+// {{- $runner := storeRunner $store -}}
+func storeAt(kv map[string]interface{}) cmd.BucketStorageCondition {
+	return cmd.KVStore(kv)
+}
+
+// storeRunner provides a utility that helps executing a run command as well as
+// saving the execution result(s)
+//
+// Examples:
+// ---------
+// {{- $store :=  storeAt .TaskResult -}}
+// {{- $runner := storeRunner $store -}}
+func storeRunner(store cmd.BucketStorageCondition) cmd.Interface {
+	return cmd.StoreCommand(store)
+}
+
+// storeRunnerCond provides a utility that helps executing a run command as well
+// as saving the execution result(s)
+//
+// Examples:
+// ---------
+// {{- $cond := runAlways .TaskResult -}}
+// {{- $store :=  storeAt .TaskResult -}}
+// {{- $runner := storeRunnerCond $store $cond -}}
+func storeRunnerCond(store cmd.BucketStorage, cond cmd.RunCondition) cmd.Interface {
+	return cmd.StoreCommandCondition(store, cond)
+}
+
+// runas executes the runtask command by mapping it against a provided id
+//
+// Examples:
+// ---------
+// {{- $store :=  storeAt .TaskResult -}}
+// {{- $runner := storeRunner $store -}}
+// {{- get jiva volume | runas "getJivaVol" $runner -}}
+// {{- get cstor volume | runas "getCstorVol" $runner -}}
+func runas(id string, runner cmd.Interface, given *cmd.RunCommand) cmd.RunCommandResult {
+	runner.Map(id, given)
+	return runner.Run()
 }
 
 // runlog executes the runtask command and stores the result as well as other
@@ -166,7 +248,7 @@ func run(given *RunCommand) RunCommandResult {
 // Once above template gets executed '.Values' will have .Values.getj.result
 // and .Values.getj.extras set with result and extras due to runtask command
 // execution
-func runlog(resultpath, debugpath string, store map[string]interface{}, given *RunCommand) (res RunCommandResult) {
+func runlog(resultpath, debugpath string, store map[string]interface{}, given *cmd.RunCommand) (res cmd.RunCommandResult) {
 	res = run(given)
 
 	resultpath = strings.TrimPrefix(resultpath, ".")
@@ -185,18 +267,27 @@ func runlog(resultpath, debugpath string, store map[string]interface{}, given *R
 // runCommandFuncs returns the set of runtask command based template functions
 func runCommandFuncs() template.FuncMap {
 	return template.FuncMap{
-		"delete":     delete,
-		"get":        get,
-		"lst":        list,
-		"create":     create,
-		"patch":      patch,
-		"update":     update,
-		"jiva":       jiva,
-		"cstor":      cstor,
-		"volume":     volume,
-		"withoption": withoption,
-		"run":        run,
-		"runlog":     runlog,
-		"select":     slect,
+		"delete":          delete,
+		"get":             get,
+		"lst":             list,
+		"create":          create,
+		"post":            post,
+		"patch":           patch,
+		"update":          update,
+		"put":             put,
+		"jiva":            jiva,
+		"cstor":           cstor,
+		"volume":          volume,
+		"http":            http,
+		"withOption":      withOption,
+		"withoption":      withOption,
+		"run":             run,
+		"runlog":          runlog,
+		"select":          slect,
+		"storeAt":         storeAt,
+		"storeRunner":     storeRunner,
+		"storeRunnerCond": storeRunnerCond,
+		"runas":           runas,
+		"runAlways":       runAlways,
 	}
 }

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -203,7 +203,7 @@ func (v *VolumeOperation) Create() (*v1alpha1.CASVolume, error) {
 	return vol, nil
 }
 
-// Delete removes a CASVolume 
+// Delete removes a CASVolume
 func (v *VolumeOperation) Delete() (*v1alpha1.CASVolume, error) {
 	if len(v.volume.Name) == 0 {
 		return nil, fmt.Errorf("unable to delete volume: volume name not provided")


### PR DESCRIPTION
This commit makes use of generic http APIs exposed via CAS Template to take jiva snapshot.

This commit has below change:
- `pkg/task/v1alpha1`
  - updates run command to understand select via json path query
  - introduces store command which is a wrapper over run command & provides features like storing the run command execution result and conditional execution of run commands.
  - introduces http based post, get, delete, put, patch operations as run commands
- `pkg/template/runtask_functions.go`
  - introduces following template functions:
    - storeAt, storeRunner, storeRunnerCond, runas, runAlways
- `pkg/install`
  - introduces cas templates based artifacts w.r.t jiva snapshot operation

Dependencies:
- PR https://github.com/openebs/maya/pull/527

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
