### PR TITLE
refactor(ci): disable the mayactl snapshot commands from ci temporarily

### DIFF
--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -39,50 +39,50 @@ if [[ $rc != 0 ]]; then
 	exit $rc;
 fi
 
-sleep 60
-echo "************** Running Jiva mayactl snapshot create **********************"
-${MAYACTL} snapshot create --volname $JIVAVOL --snapname snap1
-rc=$?;
-if [[ $rc != 0 ]]; then
-	kubectl logs --tail=10 $MAPIPOD -n openebs
-	exit $rc;
-fi
-
-printf "\n\n"
-sleep 30
-
-${MAYACTL} snapshot create --volname $JIVAVOL --snapname snap2
-if [[ $rc != 0 ]]; then
-	kubectl logs --tail=10 $MAPIPOD -n openebs
-	exit $rc;
-fi
-
-sleep 30
-
-echo "************** Running Jiva mayactl snapshot list ************************"
-${MAYACTL} snapshot list --volname $JIVAVOL
-if [[ $rc != 0 ]]; then
-	kubectl logs --tail=10 $MAPIPOD -n openebs
-	exit $rc;
-fi
-
-printf "\n\n"
-sleep 30
-echo "************** Running Jiva mayactl snapshot revert **********************"
-${MAYACTL} snapshot revert --volname $JIVAVOL --snapname snap1
-if [[ $rc != 0 ]]; then
-	kubectl logs --tail=10 $MAPIPOD -n openebs
-	exit $rc;
-fi
-printf "\n\n"
-sleep 10
-
-echo "************** Running Jiva mayactl snapshot list after revert ************"
-${MAYACTL} snapshot list --volname $JIVAVOL
-if [[ $rc != 0 ]]; then
-	kubectl logs --tail=10 $MAPIPOD -n openebs
-	exit $rc;
-fi
+#sleep 60
+#echo "************** Running Jiva mayactl snapshot create **********************"
+#${MAYACTL} snapshot create --volname $JIVAVOL --snapname snap1
+#rc=$?;
+#if [[ $rc != 0 ]]; then
+#	kubectl logs --tail=10 $MAPIPOD -n openebs
+#	exit $rc;
+#fi
+#
+#printf "\n\n"
+#sleep 30
+#
+#${MAYACTL} snapshot create --volname $JIVAVOL --snapname snap2
+#if [[ $rc != 0 ]]; then
+#	kubectl logs --tail=10 $MAPIPOD -n openebs
+#	exit $rc;
+#fi
+#
+#sleep 30
+#
+#echo "************** Running Jiva mayactl snapshot list ************************"
+#${MAYACTL} snapshot list --volname $JIVAVOL
+#if [[ $rc != 0 ]]; then
+#	kubectl logs --tail=10 $MAPIPOD -n openebs
+#	exit $rc;
+#fi
+#
+#printf "\n\n"
+#sleep 30
+#echo "************** Running Jiva mayactl snapshot revert **********************"
+#${MAYACTL} snapshot revert --volname $JIVAVOL --snapname snap1
+#if [[ $rc != 0 ]]; then
+#	kubectl logs --tail=10 $MAPIPOD -n openebs
+#	exit $rc;
+#fi
+#printf "\n\n"
+#sleep 10
+#
+#echo "************** Running Jiva mayactl snapshot list after revert ************"
+#${MAYACTL} snapshot list --volname $JIVAVOL
+#if [[ $rc != 0 ]]; then
+#	kubectl logs --tail=10 $MAPIPOD -n openebs
+#	exit $rc;
+#fi
 echo "************** Running Jiva mayactl volume delete ************************"
 ${MAYACTL} volume delete --volname $JIVAVOL
 if [[ $rc != 0 ]]; then


### PR DESCRIPTION
The snapshot workflow is being changed to use the CAS templates. (#527)

Until mayactl is updated to use the CAS templates way of creating the
snapshots, disabling them from CI.

Signed-off-by: kmova <kiran.mova@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
