### PR TITLE
Fix modified env variable after tests

### DIFF
--- a/pkg/snapshot/v1alpha1/snapshot_test.go
+++ b/pkg/snapshot/v1alpha1/snapshot_test.go
@@ -48,6 +48,12 @@ func TestGetCreateCASTemplate(t *testing.T) {
 			"",
 		},
 	}
+
+	defer func() {
+		os.Unsetenv(string(menv.CASTemplateToCreateCStorSnapshotENVK))
+		os.Unsetenv(string(menv.CASTemplateToCreateJivaSnapshotENVK))
+	}()
+
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			sc.Annotations[string(v1alpha1.CASTemplateKeyForSnapshotCreate)] = test.scCreateCASAnnotation
@@ -103,6 +109,12 @@ func TestGetReadCASTemplate(t *testing.T) {
 			"",
 		},
 	}
+
+	defer func() {
+		os.Unsetenv(string(menv.CASTemplateToReadCStorSnapshotENVK))
+		os.Unsetenv(string(menv.CASTemplateToReadJivaSnapshotENVK))
+	}()
+
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			sc.Annotations[string(v1alpha1.CASTemplateKeyForSnapshotRead)] = test.scReadCASAnnotation
@@ -158,6 +170,12 @@ func TestGetDeleteCASTemplate(t *testing.T) {
 			"",
 		},
 	}
+
+	defer func() {
+		os.Unsetenv(string(menv.CASTemplateToDeleteCStorSnapshotENVK))
+		os.Unsetenv(string(menv.CASTemplateToDeleteJivaSnapshotENVK))
+	}()
+
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			sc.Annotations[string(v1alpha1.CASTemplateKeyForSnapshotDelete)] = test.scDeleteCASAnnotation


### PR DESCRIPTION
**What this PR does / why we need it**: Unset os' environment variables after each test that modifies it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes openebs/openebs#1999

Signed-off-by: Rudy rudolf_bast@live.com