### PR TITLE
Mayactl volume list should show the bound state of volumes #1988

### DIFF
--- a/cmd/mayactl/app/command/volumes_list.go
+++ b/cmd/mayactl/app/command/volumes_list.go
@@ -63,15 +63,17 @@ func (c *CmdVolumeOptions) RunVolumesList(cmd *cobra.Command) error {
 	}
 
 	out := make([]string, len(cvols.Items)+2)
-	out[0] = "Namespace|Name|Status|Type"
-	out[1] = "---------|----|------|----"
+	out[0] = "Namespace|Name|Status|Type|Bound State"
+	out[1] = "---------|----|------|----|-----------"
 	for i, items := range cvols.Items {
 		if len(items.Status.Reason) == 0 {
 			items.Status.Reason = volumeStatusOK
 		}
-		out[i+2] = fmt.Sprintf("%s|%s|%s|%s", items.ObjectMeta.Namespace,
+		out[i+2] = fmt.Sprintf("%s|%s|%s|%s|%s", items.ObjectMeta.Namespace,
 			items.ObjectMeta.Name,
-			items.Status.Reason, items.Spec.CasType)
+			items.Status.Reason, 
+		        items.Spec.CasType,
+		        items.Status.Phase)
 	}
 	if len(out) == 2 {
 		fmt.Println("No Volumes are running")


### PR DESCRIPTION
Signed-off-by: Manjiri Tapaswi <mptapasw@ncsu.edu>
Fixes https://github.com/openebs/openebs/issues/1988

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**: Adds one more field of bound state to `mayactl volume list` command which can provide details of the volume bound state.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/openebs/openebs/issues/1988

**Special notes for your reviewer**:
Thanks for considering my PR.

