### PR TITLE
feat(snapshot-delete): Add support to delete cstor-snapshot.

### DIFF
--- a/pkg/snapshot/v1alpha1/snapshot.go
+++ b/pkg/snapshot/v1alpha1/snapshot.go
@@ -218,7 +218,7 @@ func (s *snapshot) Delete() (*v1alpha1.CASSnapshot, error) {
 		return nil, err
 	}
 
-	castName := getReadCASTemplate(sc)
+	castName := getDeleteCASTemplate(sc)
 	if len(castName) == 0 {
 		return nil, errors.Errorf("unable to delete snapshot %s: missing cas template for delete snapshot", s.snapOptions.Name)
 	}


### PR DESCRIPTION
Add cas template and runtasks to support cstor snapshot delete.  

Fixed bug function call from `getReadCASTemplate` to `getDeleteCASTemplate`
in snapshot `Delete` function.
    
Signed-off-by: princerachit <prince.rachit@mayadata.io>

