### PR TITLE
fix(cast): Fix jiva snapshot cast.

### DIFF
--- a/pkg/install/v1alpha1/jiva_snapshot_0.7.0.go
+++ b/pkg/install/v1alpha1/jiva_snapshot_0.7.0.go
@@ -79,7 +79,7 @@ spec:
     {{- $volID := print "{.data[?(@.name=='" .Snapshot.volumeName "')].id} as id" -}}
     {{- select $volID | get http | withoption "url" $volsUrl | runas "getVol" $runner -}}
     {{- $snapUrl := print $volsUrl "/" .TaskResult.getVol.result.id "?action=snapshot" -}}
-    {{- $body := dict "name" .Snapshot.owner | toJson -}}
+    {{- $body := dict "name" .Snapshot.owner | toJsonObj -}}
     {{- post http | withoption "url" $snapUrl | withoption "body" $body | runas "createSnap" $runner -}}
     {{- $err := .TaskResult.createSnap.error | default "" | toString -}}
     {{- $err | empty | not | verifyErr $err | saveIf "createJivaSnap.verifyErr" .TaskResult | noop -}}

--- a/pkg/install/v1alpha1/jiva_snapshot_0.7.0.go
+++ b/pkg/install/v1alpha1/jiva_snapshot_0.7.0.go
@@ -44,7 +44,7 @@ spec:
     tasks:
     - jiva-snapshot-create-listsourcetargetservice-default-0.7.0
     - jiva-snapshot-create-invokehttp-default-0.7.0
-    - jiva-snapshot-create-output-default-0.7.0
+  output: jiva-snapshot-create-output-default-0.7.0
 ---
 apiVersion: openebs.io/v1alpha1
 kind: RunTask

--- a/pkg/template/runtask_functions.go
+++ b/pkg/template/runtask_functions.go
@@ -17,6 +17,7 @@ limitations under the License.
 package template
 
 import (
+	"encoding/json"
 	"strings"
 	"text/template"
 
@@ -169,6 +170,14 @@ func slect(paths ...string) cmd.RunCommandMiddleware {
 	return cmd.Select(paths)
 }
 
+// toJsonObj marshals and returns the json representation of value interface
+//
+// {{- "{'name':'openebs'}" | toJsonObj -}}
+func toJsonObj(value interface{}) (b []byte) {
+	b, _ = json.Marshal(value)
+	return
+}
+
 // withOption sets the provided <key,value> pair as an input data to run command
 //
 // {{- delete jiva volume | withOption "url" $url | withOption "name" "myvol" | run -}}
@@ -299,5 +308,6 @@ func runCommandFuncs() template.FuncMap {
 		"storeRunnerCond": storeRunnerCond,
 		"runas":           runas,
 		"runAlways":       runAlways,
+		"toJsonObj":       toJsonObj,
 	}
 }


### PR DESCRIPTION
Introduce function `toJsonObj` which converts given interface to json bytes.
Update runtask `openebs jiva-snapshot-create-invokehttp-default-0.7.0` to use above method.
Add output run task to jiva snapshot create cast.

Signed-off-by: princerachit <prince.rachit@mayadata.io>