### PR TITLE
run_pool_controller.go: Fix golint issue

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/pool-controller/run_pool_controller.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/run_pool_controller.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package poolcontroller
 
 import (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Adds a space before the package comment, which seems to fix the
warning given by golint.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes https://github.com/openebs/openebs/issues/2101

**Special notes for your reviewer**:
I am not sure *why* golint is giving this error, it seems like this format is followed in other files with no issue. But adding a space does fix the error and golint does not complain anymore.

