### PR TITLE
fix(ci): Use jsonpath to get the volume name for integration test

### DIFF
--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -7,9 +7,10 @@ export MAYACTL="$GOPATH/src/github.com/openebs/maya/bin/maya/mayactl"
 export KUBECONFIG=$HOME/.kube/config
 
 MAPIPOD=$(kubectl get pods -o jsonpath='{.items[?(@.spec.containers[0].name=="maya-apiserver")].metadata.name}' -n openebs)
-CSTORVOL=$(kubectl get pv -o jsonpath='{range.items[0]}{.metadata.name}{"\n"}{end}')
-JIVAVOL=$(kubectl get pv -o jsonpath='{range.items[1]}{.metadata.name}{"\n"}{end}')
+CSTORVOL=$(kubectl get pv -o jsonpath='{.items[?(@.metadata.annotations.openebs\.io/cas-type=="cstor")].metadata.name}')
+JIVAVOL=$(kubectl get pv -o jsonpath='{.items[?(@.metadata.annotations.openebs\.io/cas-type=="jiva")].metadata.name}')
 
+	
 echo "*************** Running mayactl volume list *******************************"
 ${MAYACTL} volume list
 rc=$?;


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**: Due to change in PV name, needs to read the volume name using CASType.