### PR TITLE
Fix spelling errors

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -21,7 +21,7 @@
 
 # Adding the generators here allows us to vendor the code-generator package
 # This is required since code-generator is not directly or transitively
-# dependant
+# dependent
 required = [
   "k8s.io/code-generator/cmd/deepcopy-gen",
   "k8s.io/code-generator/cmd/client-gen",

--- a/buildscripts/push
+++ b/buildscripts/push
@@ -15,7 +15,7 @@ then
   exit 1
 fi
 
-# Generate a uniqe tag based on the commit and tag
+# Generate a unique tag based on the commit and tag
 BUILD_ID=$(git describe --tags --always)
 
 # Determine the current branch

--- a/cmd/maya-apiserver/app/config/config.go
+++ b/cmd/maya-apiserver/app/config/config.go
@@ -80,7 +80,7 @@ type MayaConfig struct {
 	Files []string `mapstructure:"-"`
 
 	// HTTPAPIResponseHeaders allows users to configure the Nomad http agent to
-	// set arbritrary headers on API responses
+	// set arbitrary headers on API responses
 	HTTPAPIResponseHeaders map[string]string `mapstructure:"http_api_response_headers"`
 }
 

--- a/cmd/maya-apiserver/app/server/http.go
+++ b/cmd/maya-apiserver/app/server/http.go
@@ -151,9 +151,9 @@ type HTTPServer struct {
 	addr     string
 }
 
-// init registers Prometheus metrics.It's good to register these varibles here
+// init registers Prometheus metrics.It's good to register these variables here
 // otherwise you need to register it before you are going to use it. So you will
-// have to register it everytime unnecessarily, instead initialize it once and
+// have to register it every time unnecessarily, instead initialize it once and
 // use anywhere at anytime through the code.
 func init() {
 	prometheus.MustRegister(latestOpenEBSVolumeRequestDuration)
@@ -464,13 +464,13 @@ func setHeaders(resp http.ResponseWriter, headers map[string]string) {
 //func parseWait(resp http.ResponseWriter, req *http.Request, qo *structs.QueryOptions) bool {
 //	query := req.URL.Query()
 //	if wait := query.Get("wait"); wait != "" {
-//		dur, err := time.ParseDuration(wait)
+//		duration, err := time.ParseDuration(wait)
 //		if err != nil {
 //			resp.WriteHeader(400)
 //			resp.Write([]byte("Invalid wait time"))
 //			return true
 //		}
-//		qo.MaxQueryTime = dur
+//		qo.MaxQueryTime = duration
 //	}
 //	if idx := query.Get("index"); idx != "" {
 //		index, err := strconv.ParseUint(idx, 10, 64)

--- a/cmd/maya-apiserver/app/server/http_test.go
+++ b/cmd/maya-apiserver/app/server/http_test.go
@@ -92,7 +92,7 @@ func BenchmarkHTTPRequests(b *testing.B) {
 	defer s.Cleanup()
 
 	handler := func(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-		// TODO we are returing a num;
+		// TODO we are returning a num;
 		// instead return some big payload i.e. big array of any structure
 		return 1000, nil
 	}

--- a/cmd/maya-apiserver/spc-watcher/controller.go
+++ b/cmd/maya-apiserver/spc-watcher/controller.go
@@ -58,7 +58,7 @@ type Controller struct {
 	// spcSynced is used for caches sync to get populated
 	spcSynced cache.InformerSynced
 
-	// deletedIndexer holds deleted resource to be retreived after workqueue
+	// deletedIndexer holds deleted resource to be retrieved after workqueue
 	deletedIndexer cache.Indexer
 
 	// workqueue is a rate limited work queue. This is used to queue work to be

--- a/cmd/maya-apiserver/spc-watcher/handler.go
+++ b/cmd/maya-apiserver/spc-watcher/handler.go
@@ -99,7 +99,7 @@ func (c *Controller) spcEventHandler(operation string, spcGot *apis.StoragePoolC
 
 		return deleteEvent, err
 	default:
-		// opeartion with tag other than add,update and delete are ignored.
+		// operation with tag other than add,update and delete are ignored.
 		return ignoreEvent, nil
 	}
 }

--- a/cmd/maya-apiserver/spc-watcher/handler_test.go
+++ b/cmd/maya-apiserver/spc-watcher/handler_test.go
@@ -30,7 +30,7 @@ import (
 	"time"
 )
 
-// TestEnqueueSpc function test enqueueSpc function to check wether the queueload is
+// TestEnqueueSpc function test enqueueSpc function to check whether the queueload is
 // properly formed for enqueue into the workqueue
 
 func TestEnqueueSpc(t *testing.T) {

--- a/cmd/maya-apiserver/spc-watcher/select_disk.go
+++ b/cmd/maya-apiserver/spc-watcher/select_disk.go
@@ -49,7 +49,7 @@ type nodeDisk struct {
 // maxPool field of the storagepoolclaim and return a list of selected disks from
 // those selected nodes.
 
-// For exapmle, if maxPool=5 and minPool=3, it will try to search for 5 nodes that will qualify for
+// For example, if maxPool=5 and minPool=3, it will try to search for 5 nodes that will qualify for
 // pool provisioning. At least 3 node should qualify else pool will not be provisioned and pool creation
 // will be aborted gracefully with proper log messages.
 
@@ -87,9 +87,9 @@ func (k *clientSet) nodeDiskAlloter(cp *v1alpha1.CasPool) ([]string, error) {
 	// gotAllotment is the count of nodes where storagepool can be provisioned
 	gotAllotment := cp.MaxPools - pendingAllotment
 	if gotAllotment < cp.MinPools {
-		return nil, fmt.Errorf("not enough nodes qualified for pool:only %d node could be alloted but required is %d", gotAllotment, cp.MinPools)
+		return nil, fmt.Errorf("not enough nodes qualified for pool:only %d node could be allotted but required is %d", gotAllotment, cp.MinPools)
 	}
-	// if alloted node was less than the maxPool that means partial allotment is done and
+	// if allotted node was less than the maxPool that means partial allotment is done and
 	// some allotment is still pending.
 	if gotAllotment < cp.MaxPools {
 		glog.Warning("partial node allotment done:pending node allotment:", pendingAllotment)
@@ -176,7 +176,7 @@ func diskSelector(nodeDiskMap map[string]*nodeDisk, poolType string) []string {
 	// minimum number of node qualifies
 	var selectedDisk []string
 
-	// requiredDiskCount will hold the required number of disk that should be selcted from a qualified
+	// requiredDiskCount will hold the required number of disk that should be selected from a qualified
 	// node for specific pool type
 	var requiredDiskCount int
 	// If pool type is striped, 1 disk should be selected

--- a/cmd/maya-apiserver/spc-watcher/spc_lease.go
+++ b/cmd/maya-apiserver/spc-watcher/spc_lease.go
@@ -82,7 +82,7 @@ func (sl *Lease) Hold() error {
 	}
 	// If leaseValue is empty acquire lease.
 	// If leaseValue is empty check whether it is expired.
-	// If leaseValue is not emtpy and not expired check wether the holder is live.
+	// If leaseValue is not empty and not expired check whether the holder is live.
 	if strings.TrimSpace(leaseValue) == "" || isLeaseExpired(leaseValueObj) || !sl.isLeaderLive(leaseValueObj) {
 		err := sl.Update(sl.getPodName())
 		if err != nil {

--- a/cmd/maya-apiserver/spc-watcher/start.go
+++ b/cmd/maya-apiserver/spc-watcher/start.go
@@ -74,7 +74,7 @@ func Start() error {
 	go kubeInformerFactory.Start(stopCh)
 	go spcInformerFactory.Start(stopCh)
 
-	// Threadiness defines the nubmer of workers to be launched in Run function
+	// Threadiness defines the number of workers to be launched in Run function
 	return controller.Run(2, stopCh)
 }
 

--- a/cmd/maya-apiserver/spc-watcher/storagepool_create.go
+++ b/cmd/maya-apiserver/spc-watcher/storagepool_create.go
@@ -45,7 +45,7 @@ func (c *Controller) CreateStoragePool(spcGot *apis.StoragePoolClaim, reSync boo
 	} else {
 		glog.Infof("Storagepool create event received for storagepoolclaim %s", spcGot.ObjectMeta.Name)
 	}
-	// Check wether the spc object has been processed for storagepool creation
+	// Check whether the spc object has been processed for storagepool creation
 	if spcGot.Status.Phase == onlineStatus && !reSync {
 		glog.Infof("Storagepool already exists since the status on storagepoolclaim object %s is Online", spcGot.Name)
 		return nil

--- a/cmd/maya-exporter/app/collector/cstorcollector.go
+++ b/cmd/maya-exporter/app/collector/cstorcollector.go
@@ -131,7 +131,7 @@ func (c *Cstor) set(m *Metrics) error {
 		newResp v1.VolumeStats
 		// parse JSON response (string) into appropriate type
 		// (float64, int64 etc).JSON can only handle the data
-		// upto 53 bits precision, so this needs to be converted
+		// up to 53 bits precision, so this needs to be converted
 		// into string.
 		volStats VolumeStats
 		err      error

--- a/cmd/maya-exporter/app/command/command.go
+++ b/cmd/maya-exporter/app/command/command.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Constants defined here are the dafault value of the flags. Which can be
+// Constants defined here are the default value of the flags. Which can be
 // changed while running the binary.
 const (
 	// listenAddress is the address where exporter listens for the rest api

--- a/cmd/mayactl/app/command/snapshot/snapshot.go
+++ b/cmd/mayactl/app/command/snapshot/snapshot.go
@@ -26,7 +26,7 @@ var (
 	}
 )
 
-// CmdSnaphotOptions holds informations of snapshots being operated
+// CmdSnaphotOptions holds information of snapshots being operated
 type CmdSnaphotOptions struct {
 	volName   string
 	snapName  string

--- a/cmd/mayactl/app/command/volume_info.go
+++ b/cmd/mayactl/app/command/volume_info.go
@@ -233,7 +233,7 @@ Replica Count     :   {{.ReplicaCount}}
 		// making a map of replica ip and their respective status,index and mode
 		replicaIPStatus := make(map[string]*Value)
 
-		// Creating a map of address and mode. The IP is chosed as key so that the status of that corresponding replica can be merged in linear time complexity
+		// Creating a map of address and mode. The IP is chosen as key so that the status of that corresponding replica can be merged in linear time complexity
 		for index, IP := range addressIPStrings {
 			if strings.Contains(IP, "nil") {
 				// appending address with index to avoid same key conflict as the IP is returned as `nil` in case of error

--- a/hack/cstor_volume/test/openebs-operator.yaml
+++ b/hack/cstor_volume/test/openebs-operator.yaml
@@ -114,7 +114,7 @@ spec:
         #- name: OPENEBS_IO_K8S_MASTER
         #  value: "http://172.28.128.3:8080"
         # OPENEBS_IO_INSTALL_CONFIG_NAME specifies the config map containing the install configuration. 
-        # Currently, the configuration can be used to specifiy the default version for the CAS Templates 
+        # Currently, the configuration can be used to specify the default version for the CAS Templates 
         - name: OPENEBS_IO_INSTALL_CONFIG_NAME
           value: "maya-install-config"
         # OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL decides whether default cstor sparse pool should be
@@ -269,7 +269,7 @@ metadata:
   namespace: openebs
 data:
   # udev-probe is default or primary probe which should be enabled to run ndm
-  # filterconfigs contails configs of filters - in ther form fo include
+  # filterconfigs contails configs of filters - in their form fo include
   # and exclude comma separated strings
   node-disk-manager.config: |
     {

--- a/hack/cstor_volume/test/test_1/test-script.sh
+++ b/hack/cstor_volume/test/test_1/test-script.sh
@@ -8,7 +8,7 @@ cleanUp()
 {
     kubectlDelete app.yaml
     kubectlDelete pvc.yaml
-    # sleep as pvc deleteion is dependent on sc
+    # sleep as pvc deletion is dependent on sc
     sleep 5
     kubectlDelete sc.yaml
     sleep 5

--- a/hack/cstor_volume/test/test_3/test-script.sh
+++ b/hack/cstor_volume/test/test_3/test-script.sh
@@ -86,9 +86,9 @@ export appName=`kubectl get po -l name=nginx -o jsonpath='{.items[0].metadata.na
 printf "%s" "Trying to write file to openebs vol in the app"
 until [ "$writeStatus" == "0"  ] || [ $try == 20 ]; do
     printf " %s" $try
-    # run a seperate process and kill it after some time
+    # run a separate process and kill it after some time
     # the script would write its exit status into a file
-    # write-status.txt. 0 value indicates sucess any other
+    # write-status.txt. 0 value indicates success any other
     # value is failure
     bash sanity-script.sh &
     pid=$!

--- a/hack/cstor_volume/test/test_4/test-script.sh
+++ b/hack/cstor_volume/test/test_4/test-script.sh
@@ -84,9 +84,9 @@ export appName=`kubectl get po -l name=nginx -o jsonpath='{.items[0].metadata.na
 printf "%s" "Trying to write file to openebs vol in the app"
 until [ "$writeStatus" == "0"  ] || [ $try == 20 ]; do
     printf " %s" $try
-    # run a seperate process and kill it after some time
+    # run a separate process and kill it after some time
     # the script would write its exit status into a file
-    # write-status.txt. 0 value indicates sucess any other
+    # write-status.txt. 0 value indicates success any other
     # value is failure
     bash sanity-script.sh &
     pid=$!

--- a/orchprovider/k8s/v1/k8s.go
+++ b/orchprovider/k8s/v1/k8s.go
@@ -324,7 +324,7 @@ func (k *k8sOrchestrator) AddStorage(volProProfile volProfile.VolumeProvisionerP
 //    This also handles the cases where creation failed mid-flight, and bail
 // out requires calling delete function.
 func (k *k8sOrchestrator) DeleteStorage(volProProfile volProfile.VolumeProvisionerProfile) (bool, error) {
-	// Assume the presence of atleast one VSM object
+	// Assume the presence of at least one VSM object
 	// Set this flag to false initially
 	var hasAtleastOneVSMObj bool
 
@@ -645,7 +645,7 @@ func (k *k8sOrchestrator) listStorageByNS(vol *v1.Volume) (*v1.VolumeList, error
 	// for K8s list operation
 	//
 	// Note: Here volume acts as a placeholder for namespace &
-	// doesnot necessarily represent a volume
+	// doesn't necessarily represent a volume
 	dl, err := k.getVSMDeployments(&k8sUtil{
 		volume: vol,
 	})
@@ -880,7 +880,7 @@ func (k *k8sOrchestrator) createControllerDeployment(volProProfile volProfile.Vo
 	//  to determine if quorum is available for making volume as read-write.
 	//  For example,
 	//   - if replication factor is 1, volume will be marked as RW when one replica connects
-	//   - if replication factor is 3, volume will be marked as RW when when atleast 2 replica connect
+	//   - if replication factor is 3, volume will be marked as RW when when at least 2 replica connect
 	//  Similar logic will be applied to turn the volume into RO, when qorum is lost.
 	//Note: When kubectl scale up/down is done for replica deployment,
 	// this ENV on controller deployment needs to be patched.
@@ -1131,7 +1131,7 @@ func (k *k8sOrchestrator) createReplicaDeployment(volProProfile volProfile.Volum
 		//(a) Deploy the application using a statefulset where application has single replica
 		//    In this case, an application label to use as key is specified.
 		//(b) Deploy the replicas of a single application need to be spread out.
-		//    In this case, there is no need to specify a seperate the application label.
+		//    In this case, there is no need to specify a separate the application label.
 		//    Use the auto generated id.
 		if appLV != "" {
 			repAntiAffinityLabelSpec[string(v1.ApplicationSelectorKey)] = appLV

--- a/orchprovider/k8s/v1/k8s_test.go
+++ b/orchprovider/k8s/v1/k8s_test.go
@@ -445,7 +445,7 @@ func (m *mockSvcOps) ProxyGet(scheme, name, port, path string, params map[string
 	return nil
 }
 
-// okVsmNameVolumeProfile focusses on NOT returning any error during invocation
+// okVsmNameVolumeProfile focuses on NOT returning any error during invocation
 // of VSMName() method
 type okVsmNameVolumeProfile struct {
 	volProfile.VolumeProvisionerProfile
@@ -476,7 +476,7 @@ func (e *okVsmNameVolumeProfile) IsReplicaNodeSelectors() ([]string, bool, error
 	return []string{"k=v"}, true, nil
 }
 
-// okCtrlImgVolumeProfile focusses on not returning any error during invocation
+// okCtrlImgVolumeProfile focuses on not returning any error during invocation
 // of ControllerImage() method
 type okCtrlImgVolumeProfile struct {
 	okVsmNameVolumeProfile
@@ -502,7 +502,7 @@ func (e *okCtrlImgVolumeProfile) IsReplicaNodeSelectors() ([]string, bool, error
 	return []string{"k=v"}, true, nil
 }
 
-// errVsmNameVolumeProfile focusses on returning error during invocation of
+// errVsmNameVolumeProfile focuses on returning error during invocation of
 // VSMName() method
 type errVsmNameVolumeProfile struct {
 	volProfile.VolumeProvisionerProfile
@@ -531,7 +531,7 @@ func TestCreateControllerDeploymentReturnsErrVsmName(t *testing.T) {
 	}
 }
 
-// errCtrlImgVolumeProfile focusses on returning error during invocation of
+// errCtrlImgVolumeProfile focuses on returning error during invocation of
 // ControllerImage() method
 type errCtrlImgVolumeProfile struct {
 	volProfile.VolumeProvisionerProfile
@@ -564,7 +564,7 @@ func TestCreateControllerDeploymentReturnsErrCtrlImg(t *testing.T) {
 	}
 }
 
-// noSupportCtrlImgVolumeProfile focusses on returning not supported during
+// noSupportCtrlImgVolumeProfile focuses on returning not supported during
 // invocation of ControllerImage() method
 type noSupportCtrlImgVolumeProfile struct {
 	volProfile.VolumeProvisionerProfile

--- a/orchprovider/nomad/v1/nomad_plug.go
+++ b/orchprovider/nomad/v1/nomad_plug.go
@@ -28,7 +28,7 @@ type NomadOrchestrator struct {
 	name string
 
 	// The region where this orchestrator is deployed
-	// This is set during the initilization time.
+	// This is set during the initialization time.
 	region string
 
 	// nStorApis represents an instance capable of invoking

--- a/pkg/apis/openebs.io/v1alpha1/disk.go
+++ b/pkg/apis/openebs.io/v1alpha1/disk.go
@@ -45,7 +45,7 @@ type DiskSpec struct {
 
 // DiskStatus provides current state of the disk (Active/Inactive)
 type DiskStatus struct {
-	State string `json:"state"` 
+	State string `json:"state"`
 }
 
 // DiskCapacity provides disk size in byte
@@ -60,7 +60,7 @@ type DiskDetails struct {
 	Vendor string `json:"vendor"` // Vendor is vendor of disk
 }
 
-// DiskDevLink holds the maping between type and links like by-id type or by-path type link
+// DiskDevlink holds the mapping between type and links like by-id type or by-path type link
 type DiskDevLink struct {
 	Kind  string   `json:"kind,omitempty"`  // Kind is the type of link like by-id or by-path.
 	Links []string `json:"links,omitempty"` // Links are the soft links of Type type

--- a/pkg/apis/openebs.io/v1alpha1/register.go
+++ b/pkg/apis/openebs.io/v1alpha1/register.go
@@ -17,8 +17,8 @@ func Resource(resource string) schema.GroupResource {
 }
 
 var (
+	SchemeBuilder runtime.SchemeBuilder
 	// localSchemeBuilder and AddToScheme will stay in k8s.io/kubernetes.
-	SchemeBuilder      runtime.SchemeBuilder
 	localSchemeBuilder = &SchemeBuilder
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )

--- a/pkg/client/mapiserver/utils_test.go
+++ b/pkg/client/mapiserver/utils_test.go
@@ -37,7 +37,7 @@ func TestGetURL(t *testing.T) {
 			envaddr:        "192.168.0.2",
 			expectedoutput: "192.168.0.2",
 		},
-		"Environment vaiable not set": {
+		"Environment variable not set": {
 			addr:           "192.168.0.1",
 			port:           "5656",
 			expectedoutput: "http://192.168.0.1:5656",

--- a/pkg/engine/cas_template_engine.go
+++ b/pkg/engine/cas_template_engine.go
@@ -245,7 +245,7 @@ func (c *CASEngine) prepareOutputTask() (err error) {
 }
 
 // prepareFallback prepares the taskGroupRunner instance with the
-// fallback template which is used incase of specific errors e.g. version
+// fallback template which is used in case of specific errors e.g. version
 // mismatch error
 func (c *CASEngine) prepareFallback() {
 	f := c.casTemplate.Spec.Fallback

--- a/pkg/install/v1alpha1/cstor_sparse_pool_claim_0.7.0.go
+++ b/pkg/install/v1alpha1/cstor_sparse_pool_claim_0.7.0.go
@@ -77,7 +77,7 @@ spec:
 ---
 `
 
-// IsCstorSparsePoolEnabled reads from env variable to check wether cstor sparse pool
+// IsCstorSparsePoolEnabled reads from env variable to check whether cstor sparse pool
 // should be created by default or not.
 func IsCstorSparsePoolEnabled() (enabled bool) {
 	enabled, _ = strconv.ParseBool(menv.Get(DefaultCstorSparsePool))

--- a/pkg/install/v1alpha1/jiva_volume_0.6.0.go
+++ b/pkg/install/v1alpha1/jiva_volume_0.6.0.go
@@ -124,7 +124,7 @@ spec:
     options: |-
       labelSelector: openebs/replica=jiva-replica
   post: |
-    {{- $replicaPairs := jsonpath .JsonResult "{range .items[*]}pkey={@.metadata.namespace}/{@.metadata.labels.vsm},replicaIP={@.status.podIP},replicaStatus={@.status.containerStatuses[*].ready},capacity=Uknown;{end}" | trim | default "" | splitList ";" -}}
+    {{- $replicaPairs := jsonpath .JsonResult "{range .items[*]}pkey={@.metadata.namespace}/{@.metadata.labels.vsm},replicaIP={@.status.podIP},replicaStatus={@.status.containerStatuses[*].ready},capacity=Unknown;{end}" | trim | default "" | splitList ";" -}}
     {{- $replicaPairs | keyMap "volumeList" .ListItems | noop -}}
 ---
 apiVersion: openebs.io/v1alpha1

--- a/pkg/nethelper/ipcalc.go
+++ b/pkg/nethelper/ipcalc.go
@@ -73,7 +73,7 @@ type Pong struct {
 	Alive bool
 }
 
-// ping does a network ping of the ip that it recives in its channel
+// ping does a network ping of the ip that it receives in its channel
 // i.e. pingChannel. The result of this ping is built as a Pong structure &
 // pushed into another channel i.e. pongChannel
 //

--- a/pkg/task/v1alpha1/jiva_volume_delete.go
+++ b/pkg/task/v1alpha1/jiva_volume_delete.go
@@ -75,7 +75,7 @@ func (j *jivaVolumeDelete) fetchDeleteVolumeLink(b []byte) (url string) {
 	// execute json query
 	s := jsp.Query(jp.Selection("dellink", path))
 
-	// collect the messages occured during jsonpath querying
+	// collect the messages occurred during jsonpath querying
 	j.Msgs.Merge(jsp.Msgs)
 	return s.Value()
 }

--- a/pkg/task/v1alpha1/runtask_command.go
+++ b/pkg/task/v1alpha1/runtask_command.go
@@ -54,7 +54,7 @@ const (
 )
 
 // RunCommandCategory represents the category of the run command. It helps
-// in determing the exact entity or feature this run command is targeting.
+// in determining the exact entity or feature this run command is targeting.
 //
 // NOTE:
 //  A run command can have more than one categories to determine an entity
@@ -344,7 +344,7 @@ type RunCommand struct {
 	Category  RunCommandCategoryList // classification of run command
 	Data      RunCommandDataMap      // input data required to execute run command
 	Selects   SelectPaths            // paths whose values will be retrieved after run command execution
-	*msg.Msgs                        // store and retrieve info, warns, errors, etc occured during execution
+	*msg.Msgs                        // store and retrieve info, warns, errors, etc occurred during execution
 }
 
 // SelfInfo returns this instance of RunCommand as a string format

--- a/pkg/task/v1alpha1/store_command.go
+++ b/pkg/task/v1alpha1/store_command.go
@@ -160,7 +160,7 @@ type storeCommand struct {
 	cond      RunCondition  // flag that determines if run command will execute or not
 	id        string        // unique identification of run command
 	cmd       *RunCommand   // current command to execute
-	*msg.Msgs               // store and retrieve info, warns, errors, etc occured during execution
+	*msg.Msgs               // store and retrieve info, warns, errors, etc occurred during execution
 }
 
 // StoreCommand returns a new instance of storeCommand

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -432,7 +432,7 @@ func keyMap(destinationFields string, destination map[string]interface{}, given 
 // nestedKeyMap builds a nested map from the given string(s). Each string item is
 // split as per the provided set of delimiters and is transformed into a
 // hierarchical path that is used to set the value. Value here implies the last
-// resulting split item once all the splits are perfomed. The resulting map is
+// resulting split item once all the splits are performed. The resulting map is
 // then set into the provided destination object.
 //
 // NOTE:

--- a/types/v1/amount.go
+++ b/types/v1/amount.go
@@ -203,8 +203,9 @@ func (a *int64Amount) Sub(b int64Amount) bool {
 	return a.Add(int64Amount{value: -b.value, scale: b.scale})
 }
 
-// AsScale adjusts this amount to set a minimum scale, rounding up, and returns true iff no precision
-// was lost. (1.1e5).AsScale(5) would return 1.1e5, but (1.1e5).AsScale(6) would return 1e6.
+// AsScale adjusts this amount to set a minimum scale, rounding up, and returns
+// true if and only if no precision was lost. (1.1e5).AsScale(5) would return
+// 1.1e5, but (1.1e5).AsScale(6) would return 1e6.
 func (a int64Amount) AsScale(scale Scale) (int64Amount, bool) {
 	if a.scale >= scale {
 		return a, true
@@ -260,8 +261,9 @@ type infDecAmount struct {
 	*inf.Dec
 }
 
-// AsScale adjusts this amount to set a minimum scale, rounding up, and returns true iff no precision
-// was lost. (1.1e5).AsScale(5) would return 1.1e5, but (1.1e5).AsScale(6) would return 1e6.
+// AsScale adjusts this amount to set a minimum scale, rounding up, and returns
+// true if and only if no precision was lost. (1.1e5).AsScale(5) would return
+// 1.1e5, but (1.1e5).AsScale(6) would return 1e6.
 func (a infDecAmount) AsScale(scale Scale) (infDecAmount, bool) {
 	tmp := &inf.Dec{}
 	tmp.Round(a.Dec, scale.infScale(), inf.RoundUp)

--- a/types/v1/profile/orchestrator/profile.go
+++ b/types/v1/profile/orchestrator/profile.go
@@ -130,7 +130,7 @@ func (op *pvcOrchProviderProfile) Name() v1.OrchProviderProfileRegistry {
 // PVC provides the persistent volume claim associated with this profile.
 //
 // NOTE:
-//    This method provides a convinient way to access pvc. In other words
+//    This method provides a convenient way to access pvc. In other words
 // orchestration provider profile acts as a wrapper over pvc.
 func (op *pvcOrchProviderProfile) PVC() (*v1.Volume, error) {
 	return op.vol, nil

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -369,7 +369,7 @@ type VolumeSnapshotStatus struct {
 	// +optional
 	CreationTimestamp Time `json:"creationTimestamp" protobuf:"bytes,1,opt,name=creationTimestamp"`
 
-	// Represents the lates available observations about the volume snapshot
+	// Represents the latest available observations about the volume snapshot
 	Conditions []VolumeSnapshotCondition `json:"conditions" protobuf:"bytes,2,rep,name=conditions"`
 }
 

--- a/volume/policies/v1/policy_jiva.go
+++ b/volume/policies/v1/policy_jiva.go
@@ -82,7 +82,7 @@ func (p *JivaPolicies) Enforce(volume *v1.Volume) (*v1.Volume, error) {
 	return p.volume, nil
 }
 
-// init intializes volume structure w.r.t jiva volume type
+// init initializes volume structure w.r.t jiva volume type
 func (p *JivaPolicies) init() {
 	if len(p.volume.Specs) == 0 {
 		p.isNoSpecs = true

--- a/volume/policies/v1/policy_k8s.go
+++ b/volume/policies/v1/policy_k8s.go
@@ -83,7 +83,7 @@ func (p *K8sPolicies) Enforce(volume *v1.Volume) (*v1.Volume, error) {
 	return p.volume, nil
 }
 
-// initSC intializes the storage class
+// initSC initializes the storage class
 func (p *K8sPolicies) initSC() {
 	// There is no volume specific property for
 	// storage class. Hence, Labels' based property
@@ -112,7 +112,7 @@ func (p *K8sPolicies) initSC() {
 	}
 }
 
-// initSC intializes the storage class
+// initSC initializes the storage class
 func (p *K8sPolicies) initNS() {
 	// The volume property will prevail over others
 	p.ns = p.volume.Namespace
@@ -133,7 +133,7 @@ func (p *K8sPolicies) initNS() {
 	}
 }
 
-// initSC intializes the storage class
+// initSC initializes the storage class
 func (p *K8sPolicies) initOutCluster() {
 	// There is no volume specific property for
 	// out cluster. Hence, Labels' based property

--- a/volume/profiles/profiles.go
+++ b/volume/profiles/profiles.go
@@ -152,7 +152,7 @@ func (pp *defVolProProfile) Name() v1.VolumeProvisionerProfileRegistry {
 // Volume provides the volume associated with this profile.
 //
 // NOTE:
-//    This method provides a convinient way to access volume. In other words
+//    This method provides a convenient way to access volume. In other words
 // volume provisioner profile acts as a wrapper over volume.
 func (pp *defVolProProfile) Volume() (*v1.Volume, error) {
 	return pp.vol, nil

--- a/volume/provisioners/jiva/snapshot_create.go
+++ b/volume/provisioners/jiva/snapshot_create.go
@@ -17,8 +17,8 @@ import (
 )*/
 
 // Snapshot will create the snapshot of a given volume name 'volname' with name of
-// snapshot 'snapname'. If there is no name provided for snapshot, an auto genrated
-// string will be genrated for this.
+// snapshot 'snapname'. If there is no name provided for snapshot, an auto generated
+// string will be generated for this.
 func Snapshot(snapname string, controllerIP string, labels map[string]string) (client.SnapshotOutput, error) {
 	output := client.SnapshotOutput{}
 	var c ControllerClient

--- a/volume/provisioners/jiva/snapshot_list.go
+++ b/volume/provisioners/jiva/snapshot_list.go
@@ -201,7 +201,7 @@ func CheckSnapshotExist(snapshot string, controllerIP string) error {
 
 // getNameAndIndex get the name and index value based on the existence of
 // snapshot. If snapshot is already exists the index value will be -1
-// if not then any possitive number
+// if not then any positive number
 func getNameAndIndex(chain []string, snapshot string) (string, int) {
 	index := find(chain, snapshot)
 

--- a/volume/provisioners/jiva/snapshot_revert.go
+++ b/volume/provisioners/jiva/snapshot_revert.go
@@ -5,7 +5,7 @@ import client "github.com/openebs/maya/pkg/client/jiva"
 // SnapshotRevert will be responsible for reverting to a
 // particular snapshot. If there is more then one snapshot has been
 // created for a volume, then user can revert to any specific created
-// snaphot for that particular volume.
+// snapshot for that particular volume.
 func SnapshotRevert(snapshot string, controllerIP string) error {
 
 	controller, err := client.NewControllerClient(controllerIP + ":9501")


### PR DESCRIPTION
Spelling errors were detected by running

    codespell -L 'uint,cas,te,slect' --skip='./vendor,./.git'

Also see openebs/openebs#671