### PR TITLE
refactor(util.sh): removal of duplicate code in hack/cstor_volume/test/util.sh

### DIFF
--- a/hack/cstor_volume/test/util.sh
+++ b/hack/cstor_volume/test/util.sh
@@ -11,6 +11,8 @@ prefixedFileNames()
         shift
     done
 
+    # printing the following for N no of files passed as argument
+    # -f file1 -f file2 -f file3 ... -f fileN
     echo $filesToApply
 }
 

--- a/hack/cstor_volume/test/util.sh
+++ b/hack/cstor_volume/test/util.sh
@@ -1,28 +1,28 @@
 #!bin/bash
 # kubectl related generic functions
-kubectlApply()
+
+prefixedFileNames()
 {
     # append all the files together prefixed with -f
-    filesToApply=""
+    local filesToApply=""
     while [ "$1" != "" ]; do
         filesToApply="$filesToApply -f $1"
         sleep 1
         shift
     done
 
+    echo $filesToApply
+}
+
+kubectlApply()
+{
+    filesToApply=$(prefixedFileNames $@)
     kubectl apply $filesToApply
 }
 
 kubectlDelete()
 {
-    # append all the files together prefixed with -f
-    filesToDelete=""
-    while [ "$1" != "" ]; do
-        filesToDelete="$filesToDelete -f $1"
-        sleep 1
-        shift
-    done
-
+    filesToDelete=$(prefixedFileNames $@)
     kubectl delete $filesToDelete
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Duplicate code in kubectlApply() and kubectlDelete() functions.
Refactored code to create a function 'prefixedFileNames()' with common code in util.sh file to ensure code reusability at its best (with least complexity, of course)

**Which issue this PR fixes**: fixes #730 

**Special notes for your reviewer**: Please label it with hacktoberfest label.
