### PR TITLE
fix(cast): Fix cstor clone cast.

### DIFF
--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -134,6 +134,10 @@ spec:
   output: cstor-volume-list-output-default
 ---
 # runTask to list cvrs if this is a clone volume
+# this run task will list all the cvrs that belong to
+# the source volume. If this is not a cloned volume
+# then we ignore the cvrs using non existent label
+# openebs.io/ignore
 apiVersion: openebs.io/v1alpha1
 kind: RunTask
 metadata:
@@ -149,6 +153,8 @@ spec:
     options: |-
     {{- if ne $isClone "false" }}
       labelSelector: openebs.io/persistent-volume={{ .Volume.sourceVolume }}
+    {{- else }}
+      labelSelector: openebs.io/ignore=false
     {{- end }}
   post: |
     {{- $poolsList := jsonpath .JsonResult "{range .items[*]}pkey=pools,{@.metadata.labels.cstorpool\\.openebs\\.io/uid}={@.metadata.labels.cstorpool\\.openebs\\.io/name};{end}" | trim | default "" | splitListTrim ";" -}}

--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -133,11 +133,10 @@ spec:
     - cstor-volume-list-listcstorvolumereplicacr-default
   output: cstor-volume-list-output-default
 ---
-# runTask to list cvrs if this is a clone volume
-# this run task will list all the cvrs that belong to
-# the source volume. If this is not a cloned volume
-# then we ignore the cvrs using non existent label
-# openebs.io/ignore
+# This RunTask is meant to be run only during clone create requests.
+# However, clone & volume creation follow the same CASTemplate specifications.
+# As of today, RunTask can not be run based on conditions. Hence, it contains
+# a logic which will list empty pools
 apiVersion: openebs.io/v1alpha1
 kind: RunTask
 metadata:


### PR DESCRIPTION
If the volume to be created is not clone volume then the runtask
cstor-volume-create-listclonecstorvolumecr-default-0.7.0 will list
all the present cvrs.

This is not required and will lead to unseen consequences like having
different pools than the source volume pools.

Fixed this by using a non existent label selector.

Signed-off-by: princerachit <prince.rachit@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
