### PR TITLE
chore(cas engine): Use storage class from pv labels.

### DIFF
--- a/pkg/install/v1alpha1/snapshot_promoter_sc.go
+++ b/pkg/install/v1alpha1/snapshot_promoter_sc.go
@@ -24,14 +24,6 @@ metadata:
   name: openebs-snapshot-promoter
 provisioner: volumesnapshot.external-storage.k8s.io/snapshot-promoter
 ---
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: openebs-snapshot-promoter-cstor
-  annotations:
-    openebs.io/cas-type: cstor
-provisioner: volumesnapshot.external-storage.k8s.io/snapshot-promoter
----
 `
 
 // SnapshotPromoterSCArtifacts returns the snapshot(clone) provisioner related artifacts

--- a/pkg/snapshot/v1alpha1/snapshot.go
+++ b/pkg/snapshot/v1alpha1/snapshot.go
@@ -77,7 +77,7 @@ func (s *snapshot) Create() (*v1alpha1.CASSnapshot, error) {
 		return nil, err
 	}
 
-	storageEngine := pv.Labels[string(v1alpha1.CASConfigKey)]
+	storageEngine := pv.Labels[string(v1alpha1.CASTypeKey)]
 	scName := pv.Labels[string(v1alpha1.StorageClassKey)]
 	if len(scName) == 0 {
 		scName = pv.Spec.StorageClassName
@@ -148,7 +148,7 @@ func (s *snapshot) Read() (*v1alpha1.CASSnapshot, error) {
 		return nil, err
 	}
 
-	storageEngine := pv.Labels[string(v1alpha1.CASConfigKey)]
+	storageEngine := pv.Labels[string(v1alpha1.CASTypeKey)]
 	scName := pv.Labels[string(v1alpha1.StorageClassKey)]
 	if len(scName) == 0 {
 		scName = pv.Spec.StorageClassName
@@ -217,7 +217,7 @@ func (s *snapshot) Delete() (*v1alpha1.CASSnapshot, error) {
 		return nil, err
 	}
 
-	storageEngine := pv.Labels[string(v1alpha1.CASConfigKey)]
+	storageEngine := pv.Labels[string(v1alpha1.CASTypeKey)]
 	scName := pv.Labels[string(v1alpha1.StorageClassKey)]
 	if len(scName) == 0 {
 		scName = pv.Spec.StorageClassName
@@ -284,7 +284,7 @@ func (s *snapshot) List() (*v1alpha1.CASSnapshotList, error) {
 		return nil, err
 	}
 
-	storageEngine := pv.Labels[string(v1alpha1.CASConfigKey)]
+	storageEngine := pv.Labels[string(v1alpha1.CASTypeKey)]
 	scName := pv.Labels[string(v1alpha1.StorageClassKey)]
 	if len(scName) == 0 {
 		scName = pv.Spec.StorageClassName

--- a/pkg/snapshot/v1alpha1/snapshot_test.go
+++ b/pkg/snapshot/v1alpha1/snapshot_test.go
@@ -15,6 +15,7 @@ func TestGetCreateCASTemplate(t *testing.T) {
 	tests := map[string]struct {
 		scCreateCASAnnotation string
 		scCASTypeAnnotation   string
+		defaultCasType        string
 		envJivaCAST           string
 		envCStorCAST          string
 		expectedCAST          string
@@ -24,11 +25,13 @@ func TestGetCreateCASTemplate(t *testing.T) {
 			"",
 			"",
 			"",
+			"",
 			"cast-create-from-annotation",
 		},
-		"CAST annotation is absent/empty and cas type is cstor": {
+		"CAST annotation is absent/empty and cas type is cstor, defaultCasType is jiva": {
 			"",
 			"cstor",
+			"jiva",
 			"",
 			"cast-cstor-create-from-env",
 			"cast-cstor-create-from-env",
@@ -36,13 +39,23 @@ func TestGetCreateCASTemplate(t *testing.T) {
 		"CAST annotation is absent/empty and cas type is jiva": {
 			"",
 			"jiva",
+			"",
 			"cast-jiva-create-from-env",
 			"",
 			"cast-jiva-create-from-env",
 		},
+		"CAST annotation is absent/empty and cas type is missing, defaultCasType is cstor": {
+			"",
+			"",
+			"cstor",
+			"",
+			"cast-cstor-create-from-env",
+			"cast-cstor-create-from-env",
+		},
 		"CAST annotation is absent/empty and cas type unknown": {
 			"",
 			"unknown",
+			"",
 			"cast-jiva-create-from-env",
 			"cast-cstor-create-from-env",
 			"",
@@ -61,7 +74,7 @@ func TestGetCreateCASTemplate(t *testing.T) {
 			os.Setenv(string(menv.CASTemplateToCreateCStorSnapshotENVK), test.envCStorCAST)
 			os.Setenv(string(menv.CASTemplateToCreateJivaSnapshotENVK), test.envJivaCAST)
 
-			castName := getCreateCASTemplate(sc)
+			castName := getCreateCASTemplate(test.defaultCasType, sc)
 
 			if castName != test.expectedCAST {
 				t.Fatalf("unexpected cast name, wanted %q got %q", test.expectedCAST, castName)
@@ -76,6 +89,7 @@ func TestGetReadCASTemplate(t *testing.T) {
 	tests := map[string]struct {
 		scReadCASAnnotation string
 		scCASTypeAnnotation string
+		defaultCasType      string
 		envJivaCAST         string
 		envCStorCAST        string
 		expectedCAST        string
@@ -85,11 +99,13 @@ func TestGetReadCASTemplate(t *testing.T) {
 			"",
 			"",
 			"",
+			"",
 			"cast-read-from-annotation",
 		},
-		"CAST annotation is absent/empty and cas type is cstor": {
+		"CAST annotation is absent/empty and cas type is cstor, defaultCasType is jiva": {
 			"",
 			"cstor",
+			"jiva",
 			"",
 			"cast-cstor-read-from-env",
 			"cast-cstor-read-from-env",
@@ -97,13 +113,23 @@ func TestGetReadCASTemplate(t *testing.T) {
 		"CAST annotation is absent/empty and cas type is jiva": {
 			"",
 			"jiva",
+			"",
 			"cast-jiva-read-from-env",
 			"",
 			"cast-jiva-read-from-env",
 		},
+		"CAST annotation is absent/empty and cas type is missing, defaultCasType is cstor": {
+			"",
+			"",
+			"cstor",
+			"",
+			"cast-cstor-read-from-env",
+			"cast-cstor-read-from-env",
+		},
 		"CAST annotation is absent/empty and cas type unknown": {
 			"",
 			"unknown",
+			"",
 			"cast-jiva-read-from-env",
 			"cast-cstor-read-from-env",
 			"",
@@ -122,7 +148,7 @@ func TestGetReadCASTemplate(t *testing.T) {
 			os.Setenv(string(menv.CASTemplateToReadCStorSnapshotENVK), test.envCStorCAST)
 			os.Setenv(string(menv.CASTemplateToReadJivaSnapshotENVK), test.envJivaCAST)
 
-			castName := getReadCASTemplate(sc)
+			castName := getReadCASTemplate(test.defaultCasType, sc)
 
 			if castName != test.expectedCAST {
 				t.Fatalf("unexpected cast name, wanted %q got %q", test.expectedCAST, castName)
@@ -137,36 +163,49 @@ func TestGetDeleteCASTemplate(t *testing.T) {
 	tests := map[string]struct {
 		scDeleteCASAnnotation string
 		scCASTypeAnnotation   string
+		defaultCasType        string
 		envJivaCAST           string
 		envCStorCAST          string
 		expectedCAST          string
 	}{
 		"CAST annotation is present": {
-			"cast-read-from-annotation",
+			"cast-delete-from-annotation",
 			"",
 			"",
 			"",
-			"cast-read-from-annotation",
+			"",
+			"cast-delete-from-annotation",
 		},
-		"CAST annotation is absent/empty and cas type is cstor": {
+		"CAST annotation is absent/empty and cas type is cstor, defaultCasType is jiva": {
 			"",
 			"cstor",
+			"jiva",
 			"",
-			"cast-cstor-read-from-env",
-			"cast-cstor-read-from-env",
+			"cast-cstor-delete-from-env",
+			"cast-cstor-delete-from-env",
 		},
 		"CAST annotation is absent/empty and cas type is jiva": {
 			"",
 			"jiva",
+			"",
 			"cast-jiva-read-from-env",
 			"",
 			"cast-jiva-read-from-env",
 		},
+		"CAST annotation is absent/empty and cas type is missing, defaultCasType is cstor": {
+			"",
+			"",
+			"cstor",
+			"",
+			"cast-cstor-delete-from-env",
+			"cast-cstor-delete-from-env",
+		},
 		"CAST annotation is absent/empty and cas type unknown": {
 			"",
 			"unknown",
-			"cast-jiva-read-from-env",
-			"cast-cstor-read-from-env",
+			"",
+			"cast-jiva-delete-from-env",
+			"cast-cstor-delete-from-env",
 			"",
 		},
 	}
@@ -183,7 +222,7 @@ func TestGetDeleteCASTemplate(t *testing.T) {
 			os.Setenv(string(menv.CASTemplateToDeleteCStorSnapshotENVK), test.envCStorCAST)
 			os.Setenv(string(menv.CASTemplateToDeleteJivaSnapshotENVK), test.envJivaCAST)
 
-			castName := getDeleteCASTemplate(sc)
+			castName := getDeleteCASTemplate(test.defaultCasType, sc)
 
 			if castName != test.expectedCAST {
 				t.Fatalf("unexpected cast name, wanted %q got %q", test.expectedCAST, castName)

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -135,13 +135,13 @@ func (v *Operation) Create() (*v1alpha1.CASVolume, error) {
 	}
 	scName := v.volume.Labels[string(v1alpha1.StorageClassKey)]
 
-	// if cloneLabels[string(v1alpha1.StorageClassVTP)] != "" {
-	// 	// get the storage class name corresponding to this volume
-	// 	scName = cloneLabels[string(v1alpha1.StorageClassVTP)].(string)
-	// }
 	if len(scName) == 0 {
 		return nil, fmt.Errorf("unable to create volume: missing storage class")
 	}
+
+	// scName might not be initialized in getCloneLabels
+	// assign the latest available scName
+	cloneLabels[string(v1alpha1.StorageClassVTP)] = scName
 
 	// fetch the storage class specifications
 	sc, err := v.k8sClient.GetStorageV1SC(scName, mach_apis_meta_v1.GetOptions{})

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -214,7 +214,7 @@ func (v *Operation) Delete() (*v1alpha1.CASVolume, error) {
 	// get the storage class name corresponding to this volume
 	scName := pv.Labels[string(v1alpha1.StorageClassKey)]
 	// get the storage engine type
-	storageEngine := pv.Labels[string(v1alpha1.CASConfigKey)]
+	storageEngine := pv.Labels[string(v1alpha1.CASTypeKey)]
 
 	if len(scName) == 0 {
 		scName = pv.Spec.StorageClassName
@@ -291,7 +291,7 @@ func (v *Operation) Read() (*v1alpha1.CASVolume, error) {
 		scName = strings.TrimSpace(pv.Spec.StorageClassName)
 
 		// extract the storage engine
-		storageEngine = pv.Labels[string(v1alpha1.CASConfigKey)]
+		storageEngine = pv.Labels[string(v1alpha1.CASTypeKey)]
 	}
 
 	if len(scName) == 0 {

--- a/pkg/volume/volume_test.go
+++ b/pkg/volume/volume_test.go
@@ -1,11 +1,12 @@
 package volume
 
 import (
+	"os"
+	"testing"
+
 	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	menv "github.com/openebs/maya/pkg/env/v1alpha1"
 	v1_storage "k8s.io/api/storage/v1"
-	"os"
-	"testing"
 )
 
 func TestGetCreateCASTemplate(t *testing.T) {
@@ -14,6 +15,7 @@ func TestGetCreateCASTemplate(t *testing.T) {
 	tests := map[string]struct {
 		scCreateCASAnnotation string
 		scCASTypeAnnotation   string
+		defaultCasType        string
 		envJivaCAST           string
 		envCStorCAST          string
 		expectedCAST          string
@@ -23,11 +25,13 @@ func TestGetCreateCASTemplate(t *testing.T) {
 			"",
 			"",
 			"",
+			"",
 			"cast-create-from-annotation",
 		},
-		"CAST annotation is absent/empty and cas type is cstor": {
+		"CAST annotation is absent/empty and cas type is cstor, defaultCasType is jiva": {
 			"",
 			"cstor",
+			"jiva",
 			"",
 			"cast-cstor-create-from-env",
 			"cast-cstor-create-from-env",
@@ -35,18 +39,34 @@ func TestGetCreateCASTemplate(t *testing.T) {
 		"CAST annotation is absent/empty and cas type is jiva": {
 			"",
 			"jiva",
+			"",
 			"cast-jiva-create-from-env",
 			"",
 			"cast-jiva-create-from-env",
 		},
+		"CAST annotation is absent/empty and cas type is missing, defaultCasType is cstor": {
+			"",
+			"",
+			"cstor",
+			"",
+			"cast-cstor-create-from-env",
+			"cast-cstor-create-from-env",
+		},
 		"CAST annotation is absent/empty and cas type unknown": {
 			"",
 			"unknown",
+			"",
 			"cast-jiva-create-from-env",
 			"cast-cstor-create-from-env",
 			"",
 		},
 	}
+
+	defer func() {
+		os.Unsetenv(string(menv.CASTemplateToCreateCStorVolumeENVK))
+		os.Unsetenv(string(menv.CASTemplateToCreateJivaVolumeENVK))
+	}()
+
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			sc.Annotations[string(v1alpha1.CASTemplateKeyForVolumeCreate)] = test.scCreateCASAnnotation
@@ -54,7 +74,7 @@ func TestGetCreateCASTemplate(t *testing.T) {
 			os.Setenv(string(menv.CASTemplateToCreateCStorVolumeENVK), test.envCStorCAST)
 			os.Setenv(string(menv.CASTemplateToCreateJivaVolumeENVK), test.envJivaCAST)
 
-			castName := getCreateCASTemplate(sc)
+			castName := getCreateCASTemplate(test.defaultCasType, sc)
 
 			if castName != test.expectedCAST {
 				t.Fatalf("unexpected cast name, wanted %q got %q", test.expectedCAST, castName)
@@ -69,6 +89,7 @@ func TestGetReadCASTemplate(t *testing.T) {
 	tests := map[string]struct {
 		scReadCASAnnotation string
 		scCASTypeAnnotation string
+		defaultCasType      string
 		envJivaCAST         string
 		envCStorCAST        string
 		expectedCAST        string
@@ -78,11 +99,13 @@ func TestGetReadCASTemplate(t *testing.T) {
 			"",
 			"",
 			"",
+			"",
 			"cast-read-from-annotation",
 		},
-		"CAST annotation is absent/empty and cas type is cstor": {
+		"CAST annotation is absent/empty and cas type is cstor, defaultCasType is jiva": {
 			"",
 			"cstor",
+			"jiva",
 			"",
 			"cast-cstor-read-from-env",
 			"cast-cstor-read-from-env",
@@ -90,18 +113,34 @@ func TestGetReadCASTemplate(t *testing.T) {
 		"CAST annotation is absent/empty and cas type is jiva": {
 			"",
 			"jiva",
+			"",
 			"cast-jiva-read-from-env",
 			"",
 			"cast-jiva-read-from-env",
 		},
+		"CAST annotation is absent/empty and cas type is missing, defaultCasType is cstor": {
+			"",
+			"",
+			"cstor",
+			"",
+			"cast-cstor-read-from-env",
+			"cast-cstor-read-from-env",
+		},
 		"CAST annotation is absent/empty and cas type unknown": {
 			"",
 			"unknown",
+			"",
 			"cast-jiva-read-from-env",
 			"cast-cstor-read-from-env",
 			"",
 		},
 	}
+
+	defer func() {
+		os.Unsetenv(string(menv.CASTemplateToCreateCStorVolumeENVK))
+		os.Unsetenv(string(menv.CASTemplateToCreateJivaVolumeENVK))
+	}()
+
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			sc.Annotations[string(v1alpha1.CASTemplateKeyForVolumeRead)] = test.scReadCASAnnotation
@@ -109,7 +148,7 @@ func TestGetReadCASTemplate(t *testing.T) {
 			os.Setenv(string(menv.CASTemplateToReadCStorVolumeENVK), test.envCStorCAST)
 			os.Setenv(string(menv.CASTemplateToReadJivaVolumeENVK), test.envJivaCAST)
 
-			castName := getReadCASTemplate(sc)
+			castName := getReadCASTemplate(test.defaultCasType, sc)
 
 			if castName != test.expectedCAST {
 				t.Fatalf("unexpected cast name, wanted %q got %q", test.expectedCAST, castName)
@@ -124,39 +163,58 @@ func TestGetDeleteCASTemplate(t *testing.T) {
 	tests := map[string]struct {
 		scDeleteCASAnnotation string
 		scCASTypeAnnotation   string
+		defaultCasType        string
 		envJivaCAST           string
 		envCStorCAST          string
 		expectedCAST          string
 	}{
 		"CAST annotation is present": {
-			"cast-read-from-annotation",
+			"cast-delete-from-annotation",
 			"",
 			"",
 			"",
-			"cast-read-from-annotation",
+			"",
+			"cast-delete-from-annotation",
 		},
-		"CAST annotation is absent/empty and cas type is cstor": {
+		"CAST annotation is absent/empty and cas type is cstor, defaultCasType is jiva": {
 			"",
 			"cstor",
+			"jiva",
 			"",
-			"cast-cstor-read-from-env",
-			"cast-cstor-read-from-env",
+			"cast-cstor-delete-from-env",
+			"cast-cstor-delete-from-env",
 		},
 		"CAST annotation is absent/empty and cas type is jiva": {
 			"",
 			"jiva",
+			"",
 			"cast-jiva-read-from-env",
 			"",
 			"cast-jiva-read-from-env",
+		},
+		"CAST annotation is absent/empty and cas type is missing, defaultCasType is cstor": {
+			"",
+			"",
+			"cstor",
+			"",
+			"cast-cstor-delete-from-env",
+			"cast-cstor-delete-from-env",
 		},
 		"CAST annotation is absent/empty and cas type unknown": {
 			"",
 			"unknown",
-			"cast-jiva-read-from-env",
-			"cast-cstor-read-from-env",
+			"",
+			"cast-jiva-delete-from-env",
+			"cast-cstor-delete-from-env",
 			"",
 		},
 	}
+
+	defer func() {
+		os.Unsetenv(string(menv.CASTemplateToCreateCStorVolumeENVK))
+		os.Unsetenv(string(menv.CASTemplateToCreateJivaVolumeENVK))
+	}()
+
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			sc.Annotations[string(v1alpha1.CASTemplateKeyForVolumeDelete)] = test.scDeleteCASAnnotation
@@ -164,7 +222,7 @@ func TestGetDeleteCASTemplate(t *testing.T) {
 			os.Setenv(string(menv.CASTemplateToDeleteCStorVolumeENVK), test.envCStorCAST)
 			os.Setenv(string(menv.CASTemplateToDeleteJivaVolumeENVK), test.envJivaCAST)
 
-			castName := getDeleteCASTemplate(sc)
+			castName := getDeleteCASTemplate(test.defaultCasType, sc)
 
 			if castName != test.expectedCAST {
 				t.Fatalf("unexpected cast name, wanted %q got %q", test.expectedCAST, castName)


### PR DESCRIPTION
A clone volume would always have promoter as default storage class.

This storage class is no distiguishable, it is common for jiva and
the cstor volume. The clone volume therefore should make use of the
the same sc as that of the source pv.

Modified the logic accordingly in both snapshot and volume engine.

Use sc from label > Use sc from pvref(if cast annotation is present) >
Use default annotation for given storage engine.

Signed-off-by: princerachit <prince.rachit@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
