### PR TITLE
fixed typo in json tag in maya/types/v1/metrics.go

### DIFF
--- a/types/v1/metrics.go
+++ b/types/v1/metrics.go
@@ -16,7 +16,7 @@ type VolumeMetrics struct {
 
 	WriteIOPS            string `json:"WriteIOPS"`
 	TotalWriteTime       string `json:"TotalWriteTime"`
-	TotalWriteBlockCount string `json:"TotatWriteBlockCount"`
+	TotalWriteBlockCount string `json:"TotalWriteBlockCount"`
 
 	UsedLogicalBlocks string  `json:"UsedLogicalBlocks"`
 	UsedBlocks        string  `json:"UsedBlocks"`
@@ -38,7 +38,7 @@ type VolumeStats struct {
 
 	Writes               json.Number `json:"WriteIOPS"`
 	TotalWriteTime       json.Number `json:"TotalWriteTime"`
-	TotalWriteBlockCount json.Number `json:"TotatWriteBlockCount"`
+	TotalWriteBlockCount json.Number `json:"TotalWriteBlockCount"`
 	TotalWriteBytes      json.Number `json:"TotalWriteBytes"`
 
 	UsedLogicalBlocks json.Number `json:"UsedLogicalBlocks"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**: fixes typos in maya/types/v1/metrics.go `TotatWriteBlockCount`
to `TotalWriteBlockCount`

**Which issue this PR fixes** : fixes openebs issue [#2214](https://github.com/openebs/openebs/issues/2214)

**Special notes for your reviewer**:
something like [gomodifytags](https://github.com/fatih/gomodifytags) can prevent typos.