### PR TITLE
feat(csp status): enhance pool-mgmt to update status on csp

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/common/common.go
+++ b/cmd/cstor-pool-mgmt/controller/common/common.go
@@ -44,7 +44,8 @@ const (
 	MessageModifySynced EventReason = "Received Resource modify event"
 	// MessageDestroySynced holds message for corresponding destroy request sync.
 	MessageDestroySynced EventReason = "Received Resource destroy event"
-
+	// StatusSynced holds message for corresponding status request sync.
+	StatusSynced EventReason = "Resource status sync event"
 	// SuccessCreated holds status for corresponding created resource.
 	SuccessCreated EventReason = "Created"
 	// MessageResourceCreated holds message for corresponding created resource.
@@ -64,7 +65,10 @@ const (
 	FailureImport EventReason = "FailImport"
 	// MessageResourceFailImport holds message for corresponding failed import resource.
 	MessageResourceFailImport EventReason = "Resource import failed"
-
+	// FailureStatusSync holds status for corresponding failed status sync of resource.
+	FailureStatusSync EventReason = "FailStatusSync"
+	// MessageResourceFailStatusSync holds message for corresponding failed status sync of resource.
+	MessageResourceFailStatusSync EventReason = "Resource status sync failed"
 	// FailureDestroy holds status for corresponding failed destroy resource.
 	FailureDestroy EventReason = "FailDestroy"
 	// MessageResourceFailDestroy holds message for corresponding failed destroy resource.
@@ -129,6 +133,8 @@ const (
 	QOpAdd     QueueOperation = "add"
 	QOpDestroy QueueOperation = "destroy"
 	QOpModify  QueueOperation = "modify"
+	// QOpStatusSync is the operation for updating the status on cstor pool object.
+	QOpStatusSync QueueOperation = "statusSync"
 )
 
 // namespace defines kubernetes namespace specified for cvr.

--- a/pkg/apis/openebs.io/v1alpha1/cstor_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_pool.go
@@ -60,10 +60,20 @@ type CStorPoolPhase string
 const (
 	// CStorPoolStatusEmpty ensures the create operation is to be done, if import fails.
 	CStorPoolStatusEmpty CStorPoolPhase = ""
-	// CStorPoolStatusOnline ensures the resource is available.
+	// CStorPoolStatusOnline signifies that the pool is online.
 	CStorPoolStatusOnline CStorPoolPhase = "Online"
-	// CStorPoolStatusOffline ensures the resource is not available.
+	// CStorPoolStatusOffline signifies that the pool is offline.
 	CStorPoolStatusOffline CStorPoolPhase = "Offline"
+	// CStorPoolStatusDegraded signifies that the pool is degraded.
+	CStorPoolStatusDegraded CStorPoolPhase = "Degraded"
+	// CStorPoolStatusFaulted signifies that the pool is faulted.
+	CStorPoolStatusFaulted CStorPoolPhase = "Faulted"
+	// CStorPoolStatusRemoved signifies that the pool is removed.
+	CStorPoolStatusRemoved CStorPoolPhase = "Removed"
+	// CStorPoolStatusUnavail signifies that the pool is not available.
+	CStorPoolStatusUnavail CStorPoolPhase = "Unavail"
+	// CStorPoolStatusDeletionFailed signifies that the pool status could not be fetched.
+	CStorPoolStatusUnknown CStorPoolPhase = "Unknown"
 	// CStorPoolStatusDeletionFailed ensures the resource deletion has failed.
 	CStorPoolStatusDeletionFailed CStorPoolPhase = "DeletionFailed"
 	// CStorPoolStatusInvalid ensures invalid resource.

--- a/pkg/client/jiva/controller_client_test.go
+++ b/pkg/client/jiva/controller_client_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/openebs/maya/types/v1"
 	"github.com/openebs/maya/pkg/util"
+	"github.com/openebs/maya/types/v1"
 
 	utiltesting "k8s.io/client-go/util/testing"
 )

--- a/types/v1/meta.go
+++ b/types/v1/meta.go
@@ -276,11 +276,11 @@ type LabelSelectorOperator string
 
 const (
 	// LabelSelectorOpIn : LabelSelectorOperator for In
-	LabelSelectorOpIn           LabelSelectorOperator = "In"
+	LabelSelectorOpIn LabelSelectorOperator = "In"
 	// LabelSelectorOpNotIn : LabelSelectorOperator for NotIn
-	LabelSelectorOpNotIn        LabelSelectorOperator = "NotIn"
+	LabelSelectorOpNotIn LabelSelectorOperator = "NotIn"
 	// LabelSelectorOpExists : LabelSelectorOperator for Exists
-	LabelSelectorOpExists       LabelSelectorOperator = "Exists"
+	LabelSelectorOpExists LabelSelectorOperator = "Exists"
 	// LabelSelectorOpDoesNotExist : LabelSelectorOperator for DoesNotExist
 	LabelSelectorOpDoesNotExist LabelSelectorOperator = "DoesNotExist"
 )


### PR DESCRIPTION
Following possible statuses can exist for cstor pool object:
1. Degraded
2. Faulted
3.Offline
4.Online
5. Unavail
6.Removed
7. Unknown
The pool-mgmt watcher is going to synchronise the status after every resync period by getting the output from `zpool status <pool-name>` command. 
Signed-off-by: sonasingh46 <sonasingh46@gmail.com>