### PR TITLE
fix(exporter): make common structure for both jiva and cstor

### DIFF
--- a/cmd/maya-exporter/app/collector/cstorcollector_test.go
+++ b/cmd/maya-exporter/app/collector/cstorcollector_test.go
@@ -19,11 +19,11 @@ import (
 )
 
 var (
-	SplittedResponse             = "{ \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"Uptime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\" }"
+	SplittedResponse             = "{ \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"UpTime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\", \"RevisionCounter\":\"1000\", \"ReplicaCounter\":\"3\" }"
 	NilCstorResponse             = "OK IOSTATS\r\n"
-	CstorResponse                = "IOSTATS  { \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"Uptime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\" }\r\nOK IOSTATS\r\n"
-	JSONFormatedResponse         = "{ \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"Uptime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\" }"
-	ImproperJSONFormatedResponse = `IOSTATS  { \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"Uptime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\" }\r\nOK IOSTATS\r\n`
+	CstorResponse                = "IOSTATS  { \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"UpTime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\", \"RevisionCounter\":\"1000\", \"ReplicaCounter\":\"3\" }\r\nOK IOSTATS\r\n"
+	JSONFormatedResponse         = "{ \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"UpTime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\", \"RevisionCounter\":\"1000\", \"ReplicaCounter\":\"3\" }"
+	ImproperJSONFormatedResponse = `IOSTATS  { \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"UpTime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\", \"RevisionCounter\":\"1000\", \"ReplicaCounter\":\"3\" }\r\nOK IOSTATS\r\n`
 )
 
 func TestNewResponse(t *testing.T) {
@@ -46,7 +46,9 @@ func TestNewResponse(t *testing.T) {
 				TotalWriteBlockCount: "15",
 				TotalReadTime:        "13",
 				TotalWriteTime:       "132",
-				CstorUptime:          "20",
+				UpTime:               "20",
+				ReplicaCounter:       "3",
+				RevisionCounter:      "1000",
 			},
 		},
 		"[Failure]Unmarshal Response returns empty Metrics": {

--- a/cmd/maya-exporter/app/collector/jivacollector.go
+++ b/cmd/maya-exporter/app/collector/jivacollector.go
@@ -88,6 +88,8 @@ func (j *Jiva) set(m *Metrics) error {
 	m.totalReadTime.Set(volStats.totalReadTime)
 	m.writes.Set(volStats.writes)
 	m.totalWriteTime.Set(volStats.totalWriteTime)
+	m.totalReadBytes.Set(volStats.totalReadBytes)
+	m.totalWriteBytes.Set(volStats.totalWriteBytes)
 	m.totalReadBlockCount.Set(volStats.totalReadBlockCount)
 	m.totalWriteBlockCount.Set(volStats.totalWriteBlockCount)
 	m.sectorSize.Set(volStats.sectorSize)
@@ -97,7 +99,12 @@ func (j *Jiva) set(m *Metrics) error {
 	url := j.VolumeControllerURL
 	url = strings.TrimSuffix(url, ":9501/v1/stats")
 	url = strings.TrimPrefix(url, "http://")
-	m.volumeUpTime.WithLabelValues(volStatsJSON.Name, "iqn.2016-09.com.openebs.jiva:"+volStatsJSON.Name, url, "jiva").Set(volStatsJSON.UpTime)
+	m.volumeUpTime.WithLabelValues(
+		volStats.name,
+		"iqn.2016-09.com.openebs.jiva:"+volStatsJSON.Name,
+		url,
+		"jiva",
+	).Set(volStats.uptime)
 	return nil
 }
 
@@ -105,6 +112,8 @@ func (j *Jiva) parser(stats v1.VolumeStats) VolumeStats {
 	volStats := VolumeStats{}
 	volStats.reads, _ = stats.Reads.Float64()
 	volStats.writes, _ = stats.Writes.Float64()
+	volStats.totalReadBytes, _ = stats.TotalReadBytes.Float64()
+	volStats.totalWriteBytes, _ = stats.TotalWriteBytes.Float64()
 	volStats.totalReadTime, _ = stats.TotalReadTime.Float64()
 	volStats.totalWriteTime, _ = stats.TotalWriteTime.Float64()
 	volStats.totalReadBlockCount, _ = stats.TotalReadBlockCount.Float64()
@@ -120,5 +129,9 @@ func (j *Jiva) parser(stats v1.VolumeStats) VolumeStats {
 	volStats.actualSize, _ = v1.DivideFloat64(aUsed, v1.BytesToGB)
 	size, _ := stats.Size.Float64()
 	volStats.size, _ = v1.DivideFloat64(size, v1.BytesToGB)
+	volStats.replicaCount, _ = stats.ReplicaCounter.Float64()
+	volStats.revisionCount, _ = stats.RevisionCounter.Float64()
+	volStats.uptime, _ = stats.UpTime.Float64()
+	volStats.name = stats.Name
 	return volStats
 }

--- a/cmd/maya-exporter/app/collector/metrics.go
+++ b/cmd/maya-exporter/app/collector/metrics.go
@@ -134,6 +134,9 @@ type VolumeStats struct {
 	logicalSize          float64
 	actualSize           float64
 	uptime               float64
+	revisionCount        float64
+	replicaCount         float64
+	name                 string
 }
 
 // MetricsInitializer returns the Metrics instance used for registration

--- a/types/v1/metrics.go
+++ b/types/v1/metrics.go
@@ -45,8 +45,9 @@ type VolumeStats struct {
 	UsedBlocks        json.Number `json:"UsedBlocks"`
 	SectorSize        json.Number `json:"SectorSize"`
 	Size              json.Number `json:"Size"`
-	UpTime            float64     `json:"UpTime"`
-	CstorUptime       json.Number `json:"Uptime"`
+	RevisionCounter   json.Number `json:"RevisionCounter"`
+	ReplicaCounter    json.Number `json:"ReplicaCounter"`
+	UpTime            json.Number `json:"UpTime"`
 	Name              string      `json:"Name"`
 }
 


### PR DESCRIPTION
This commit fixes the following
- Fixes json tag of volume uptime to string
- Make common structure for jiva and cstore
- Add the missing fields in cstor
- Modularize the code

Depends on openebs/jiva#152 and openebs/istgt#175

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>