### PR TITLE
fix(analytics) Add node information to GA hit

### DIFF
--- a/pkg/client/k8s/v1alpha1/node.go
+++ b/pkg/client/k8s/v1alpha1/node.go
@@ -67,3 +67,15 @@ func NumberOfNodes() (int, error) {
 		return len(nodes.Items), nil
 	}
 }
+
+// GetOSAndKernelVersion gets us the OS,Kernel version
+func GetOSAndKernelVersion() (string, error) {
+	nodes := Node()
+	// get a single node
+	firstNode, err := nodes.List(metav1.ListOptions{Limit: 1})
+	if err != nil {
+		return "unknown, unknown", errors.Wrapf(err, "failed to get the os kernel/arch")
+	}
+	nodedetails := firstNode.Items[0].Status.NodeInfo
+	return nodedetails.OSImage + ", " + nodedetails.KernelVersion, nil
+}

--- a/pkg/usage/googleanalytics.go
+++ b/pkg/usage/googleanalytics.go
@@ -53,7 +53,12 @@ func (e *Event) Send() error {
 	if err != nil {
 		return err
 	}
+	nodeInfo, err := k8sapi.GetOSAndKernelVersion()
+	if err != nil {
+		return err
+	}
 	glog.Infof("Kubernetes version: %s", k8sversion.GitVersion)
+	glog.Infof("Node type: %s", nodeInfo)
 	// anonymous user identifying
 	// client-id - uid of default namespace
 	gaClient.ClientID(uuid).
@@ -63,7 +68,7 @@ func (e *Event) Send() error {
 		// K8s version
 
 		// TODO: Find k8s Environment type
-		// DataSource().
+		DataSource(nodeInfo).
 		ApplicationName(k8sversion.Platform).
 		ApplicationInstallerID(k8sversion.GitVersion).
 		DocumentTitle(uuid)


### PR DESCRIPTION
**What this PR does / why we need it**:
- This will add `OS name, Kernel version` to the event hit.

**Which issue this PR fixes** 
improvement: https://github.com/openebs/openebs/issues/2257

Signed-off-by: Harsh Vardhan <harsh.vardhan@mayadata.io>