### PR TITLE
refactor(ci): support both docker and quay images for ci

### DIFF
--- a/ci/install_openebs.sh
+++ b/ci/install_openebs.sh
@@ -18,6 +18,13 @@ if [ ${CI_TAG} != "ci" ]; then
   sudo docker tag openebs/cstor-volume-mgmt:ci openebs/cstor-volume-mgmt:${CI_TAG}
 fi
 
+#Tag the images with quay.io, since the operator can either have quay or docker images
+sudo docker tag openebs/m-apiserver:ci quay.io/openebs/m-apiserver:${CI_TAG}
+sudo docker tag openebs/m-exporter:ci quay.io/openebs/m-exporter:${CI_TAG}
+sudo docker tag openebs/cstor-pool-mgmt:ci quay.io/openebs/cstor-pool-mgmt:${CI_TAG}
+sudo docker tag openebs/cstor-volume-mgmt:ci quay.io/openebs/cstor-volume-mgmt:${CI_TAG}
+
+
 kubectl apply -f https://raw.githubusercontent.com/openebs/openebs/${CI_BRANCH}/k8s/openebs-operator.yaml
 
 function waitForDeployment() {


### PR DESCRIPTION
integration (or ci) tests are done by applying the openebs-operator
fetched from openebs/openebs repo. This file can either have images
specified as quay or docker.

Before applying the operator yaml, retag the local docker ci images
with quay tags.

Signed-off-by: kmova <kiran.mova@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
