### PR TITLE
feat(jiva): add scrub job on deleted jiva replicas

### DIFF
--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -20,7 +20,6 @@ if [[ $rc != 0 ]]; then
 fi
 
 printf "\n\n"
-
 echo "************** Running Jiva mayactl volume info **************************"
 ${MAYACTL} volume info --volname $JIVAVOL
 rc=$?;
@@ -28,10 +27,9 @@ if [[ $rc != 0 ]]; then
 	kubectl logs --tail=10 $MAPIPOD -n openebs
 	exit $rc;
 fi
-
-printf "\n\n"
 sleep 5
 
+printf "\n\n"
 echo "************** Running Jiva mayactl volume stats *************************"
 ${MAYACTL} volume stats --volname  $JIVAVOL
 rc=$?;
@@ -39,8 +37,8 @@ if [[ $rc != 0 ]]; then
 	kubectl logs --tail=10 $MAPIPOD -n openebs
 	exit $rc;
 fi
-
 sleep 60
+
 echo "************** Running Jiva mayactl snapshot create **********************"
 ${MAYACTL} snapshot create --volname $JIVAVOL --snapname snap1
 rc=$?;
@@ -48,48 +46,55 @@ if [[ $rc != 0 ]]; then
 	kubectl logs --tail=10 $MAPIPOD -n openebs
 	exit $rc;
 fi
-
-printf "\n\n"
 sleep 30
 
 ${MAYACTL} snapshot create --volname $JIVAVOL --snapname snap2
+rc=$?;
 if [[ $rc != 0 ]]; then
 	kubectl logs --tail=10 $MAPIPOD -n openebs
 	exit $rc;
 fi
-
 sleep 30
 
+printf "\n\n"
 echo "************** Running Jiva mayactl snapshot list ************************"
 ${MAYACTL} snapshot list --volname $JIVAVOL
+rc=$?;
 if [[ $rc != 0 ]]; then
 	kubectl logs --tail=10 $MAPIPOD -n openebs
 	exit $rc;
 fi
+sleep 30
 
 printf "\n\n"
-sleep 30
 echo "************** Running Jiva mayactl snapshot revert **********************"
 ${MAYACTL} snapshot revert --volname $JIVAVOL --snapname snap1
+rc=$?;
 if [[ $rc != 0 ]]; then
 	kubectl logs --tail=10 $MAPIPOD -n openebs
 	exit $rc;
 fi
-printf "\n\n"
 sleep 10
 
+printf "\n\n"
 echo "************** Running Jiva mayactl snapshot list after revert ************"
 ${MAYACTL} snapshot list --volname $JIVAVOL
+rc=$?;
 if [[ $rc != 0 ]]; then
 	kubectl logs --tail=10 $MAPIPOD -n openebs
 	exit $rc;
 fi
+
+printf "\n\n"
 echo "************** Running Jiva mayactl volume delete ************************"
 ${MAYACTL} volume delete --volname $JIVAVOL
+rc=$?;
 if [[ $rc != 0 ]]; then
-	kubectl logs --tail=10 $MAPIPOD -n openebs
+	kubectl logs --tail=100 $MAPIPOD -n openebs
 	exit $rc;
 fi
+sleep 30
+
 
 printf "\n\n"
 echo "************** Running Cstor mayactl volume info *************************"
@@ -100,3 +105,15 @@ if [[ $rc != 0 ]]; then
 	exit $rc;
 fi
 
+printf "\n\n"
+echo "************** Check if jiva replica data is cleared *************************"
+if [ -f /var/openebs/$JIVAVOL/volume.meta ]; then
+	#Check if the job is in progress. 
+	printf "\n"
+	ls -lR /var/openebs
+	printf "\n"
+	kubectl get jobs
+	printf "\n"
+	kubectl get pods
+	printf "\n"
+fi


### PR DESCRIPTION
Refer: 
https://github.com/openebs/openebs/issues/1246

After the jiva volumes are delete, the data stored
in the corresponding jiva pool directory is not
deleted. This can cause the space outage issues
when many jiva volumes are created and deleted.

This PR updates the delete jiva volume CAS templates
to launch a K8s job that clears the contents. A job
is scheduled with the node selector where replica
exists, so in case the node is offline during delete,
the job will still get executed after the nodes
comes back online.

Few things for future:
- When volume replica are migrated to a different node,
  the data from older nodes needs to be cleared
- For volumes in earlier version, the contents
  have to be manually deleted.

Signed-off-by: kmova <kiran.mova@openebs.io>

