### PR TITLE
feat(cast, job): introduce create, get & delete operation for job in castemplate

### DIFF
--- a/pkg/client/jiva/controller_client_test.go
+++ b/pkg/client/jiva/controller_client_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/openebs/maya/types/v1"
 	"github.com/openebs/maya/pkg/util"
+	"github.com/openebs/maya/types/v1"
 
 	utiltesting "k8s.io/client-go/util/testing"
 )

--- a/pkg/client/k8s/k8s.go
+++ b/pkg/client/k8s/k8s.go
@@ -19,7 +19,6 @@ package k8s
 import (
 	"encoding/json"
 
-	//openebs "github.com/openebs/maya/pkg/client/clientset/versioned"
 	openebs "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset"
 
 	"k8s.io/client-go/kubernetes"
@@ -27,7 +26,9 @@ import (
 
 	api_oe_v1alpha1 "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	api_oe_old "github.com/openebs/maya/types/v1"
+
 	api_apps_v1beta1 "k8s.io/api/apps/v1beta1"
+	api_batch_v1 "k8s.io/api/batch/v1"
 	api_core_v1 "k8s.io/api/core/v1"
 	api_extn_v1beta1 "k8s.io/api/extensions/v1beta1"
 	api_storage_v1 "k8s.io/api/storage/v1"
@@ -35,7 +36,6 @@ import (
 	mach_apis_meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	//typed_oe_v1alpha1 "github.com/openebs/maya/pkg/client/clientset/versioned/typed/openebs/v1alpha1"
 	typed_oe_v1alpha1 "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset/typed/openebs.io/v1alpha1"
 
 	typed_apps_v1beta1 "k8s.io/client-go/kubernetes/typed/apps/v1beta1"
@@ -51,37 +51,54 @@ import (
 type K8sKind string
 
 const (
+	// JobKK is a Kubernetes Job kind
+	JobKK K8sKind = "Job"
+
 	// StorageClassKK is a K8s StorageClass Kind
 	StorageClassKK K8sKind = "StorageClass"
+
 	// PodKK is a K8s Pod Kind
 	PodKK K8sKind = "Pod"
+
 	// DeploymentKK is a K8s Deployment Kind
 	DeploymentKK K8sKind = "Deployment"
+
 	// ConfigMapKK is a K8s ConfigMap Kind
 	ConfigMapKK K8sKind = "ConfigMap"
+
 	// ServiceKK is a K8s Service Kind
 	ServiceKK K8sKind = "Service"
+
 	// CRDKK is a K8s CustomResourceDefinition Kind
 	CRDKK K8sKind = "CustomResourceDefinition"
+
 	// StroagePoolCRKK is a K8s CR of kind StoragePool
 	StroagePoolCRKK K8sKind = "StoragePool"
+
 	// StroagePoolClaimCRKK is a K8s CR of kind StoragePool
 	StroagePoolClaimCRKK K8sKind = "StoragePoolClaim"
+
 	// PersistentVolumeKK is K8s PersistentVolume Kind
 	PersistentVolumeKK K8sKind = "PersistentVolume"
+
 	// PersistentVolumeClaimKK is a K8s PersistentVolumeClaim Kind
 	PersistentVolumeClaimKK K8sKind = "PersistentVolumeClaim"
+
 	// CstorPoolCRKK is a K8s CR of kind CStorPool
 	CStorPoolCRKK K8sKind = "CStorPool"
+
 	// DiskCRKK is a K8s CR of kind Disk
 	DiskCRKK K8sKind = "Disk"
+
 	// CstorVolumeCRKK is a K8s CR of kind CStorVolume
 	CStorVolumeCRKK K8sKind = "CStorVolume"
+
 	// CstorVolumeReplicaCRKK is a K8s CR of kind CStorVolumeReplica
 	CStorVolumeReplicaCRKK K8sKind = "CStorVolumeReplica"
 )
 
-//
+// K8sAPIVersion represents valid kubernetes api version of a native or custom
+// resource
 type K8sAPIVersion string
 
 const (
@@ -94,6 +111,8 @@ const (
 	OEV1alpha1KA K8sAPIVersion = "openebs.io/v1alpha1"
 
 	StorageV1KA K8sAPIVersion = "storage.k8s.io/v1"
+
+	BatchV1KA K8sAPIVersion = "batch/v1"
 )
 
 // K8sClient provides the necessary utility to operate over
@@ -235,6 +254,16 @@ func (k *K8sClient) GetStorageV1SCAsRaw(name string) (result []byte, err error) 
 		DoRaw()
 
 	return
+}
+
+// GetBatchV1JobAsRaw returns a Job instance
+func (k *K8sClient) GetBatchV1JobAsRaw(name string) (result []byte, err error) {
+	return k.cs.BatchV1().RESTClient().
+		Get().
+		Resource("jobs").
+		Name(name).
+		VersionedParams(&mach_apis_meta_v1.GetOptions{}, scheme.ParameterCodec).
+		DoRaw()
 }
 
 // oeV1alpha1SPCOps is a utility function that provides a instance capable of
@@ -786,6 +815,14 @@ func (k *K8sClient) DeleteCoreV1Service(name string) error {
 	})
 }
 
+// DeleteBatchV1Job deletes a K8s job
+func (k *K8sClient) DeleteBatchV1Job(name string) error {
+	deletePropagation := mach_apis_meta_v1.DeletePropagationForeground
+	return k.cs.BatchV1().Jobs(k.ns).Delete(
+		name,
+		&mach_apis_meta_v1.DeleteOptions{PropagationPolicy: &deletePropagation})
+}
+
 // TODO deprecate
 //
 // deploymentOps is a utility function that provides a instance capable of
@@ -920,6 +957,15 @@ func (k *K8sClient) DeleteExtnV1B1Deployment(name string) error {
 	return dops.Delete(name, &mach_apis_meta_v1.DeleteOptions{
 		PropagationPolicy: &deletePropagation,
 	})
+}
+
+// CreateBatchV1JobAsRaw creates a kubernetes Job
+func (k *K8sClient) CreateBatchV1JobAsRaw(j *api_batch_v1.Job) ([]byte, error) {
+	job, err := k.cs.BatchV1().Jobs(k.ns).Create(j)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(job)
 }
 
 // appsV1B1DeploymentOps is a utility function that provides a instance capable of

--- a/pkg/install/v1alpha1/cstor_sparse_pool_claim_0.7.0.go
+++ b/pkg/install/v1alpha1/cstor_sparse_pool_claim_0.7.0.go
@@ -28,15 +28,15 @@ func IsCstorSparsePoolEnabled() (enabled bool) {
 	return
 }
 
-// CstorSparsePoolSpcArtifactsFor070 returns the default storagepoolclaim 
-// and storageclass yaml corresponding to version 0.7.0 if cstor 
+// CstorSparsePoolSpcArtifactsFor070 returns the default storagepoolclaim
+// and storageclass yaml corresponding to version 0.7.0 if cstor
 // sparse pool creation is enabled as a part of openebs installation
 func CstorSparsePoolSpcArtifactsFor070() (list ArtifactList) {
 	list.Items = append(list.Items, ParseArtifactListFromMultipleYamlConditional(cstorSparsePoolSpcArtifactsFor070, IsCstorSparsePoolEnabled)...)
 	return
 }
 
-// cstorPoolSpcForArtifacts070 returns all the yamls related to configuring 
+// cstorPoolSpcForArtifacts070 returns all the yamls related to configuring
 // a stoaragepoolclaim and storageclass in string format
 //
 // NOTE:

--- a/pkg/install/v1alpha1/jiva_pool_0.7.0.go
+++ b/pkg/install/v1alpha1/jiva_pool_0.7.0.go
@@ -23,7 +23,7 @@ func JivaPoolArtifactsFor070() (list ArtifactList) {
 	return
 }
 
-// jivaPoolYamlsFor070 returns all the yamls related to jiva pool and 
+// jivaPoolYamlsFor070 returns all the yamls related to jiva pool and
 // storage class in a string format
 //
 // NOTE:

--- a/pkg/install/v1alpha1/registrar.go
+++ b/pkg/install/v1alpha1/registrar.go
@@ -75,7 +75,7 @@ func RegisteredArtifactsFor070() (list ArtifactList) {
 	list.Items = append(list.Items, CstorVolumeArtifactsFor070().Items...)
 	list.Items = append(list.Items, CstorSparsePoolSpcArtifactsFor070().Items...)
 
-	//Contains the SC to help with provisioning from clone. 
+	//Contains the SC to help with provisioning from clone.
 	//This is generic for release till K8s supports native way of cloning.
 	list.Items = append(list.Items, SnapshotPromoterSCArtifacts().Items...)
 

--- a/pkg/install/v1alpha1/snapshot_promoter_sc.go
+++ b/pkg/install/v1alpha1/snapshot_promoter_sc.go
@@ -22,7 +22,7 @@ func SnapshotPromoterSCArtifacts() (list ArtifactList) {
 	return
 }
 
-// snapshotPromoterSCYaml returns all the yamls related to 
+// snapshotPromoterSCYaml returns all the yamls related to
 // snapshot promote (clone) provisioner SC in a string
 // format
 //

--- a/pkg/k8s/from_yaml.go
+++ b/pkg/k8s/from_yaml.go
@@ -24,9 +24,39 @@ import (
 	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	"github.com/openebs/maya/pkg/template"
 	api_apps_v1beta1 "k8s.io/api/apps/v1beta1"
+	api_batch_v1 "k8s.io/api/batch/v1"
 	api_core_v1 "k8s.io/api/core/v1"
 	api_extn_v1beta1 "k8s.io/api/extensions/v1beta1"
 )
+
+// JobYml helps generating kubernetes Job object
+type JobYml struct {
+	YmlInBytes []byte // YmlInBytes represents a K8s Job in yaml format
+}
+
+// NewJobYml returns a new instance of JobYml
+func NewJobYml(context, yml string, values map[string]interface{}) (*JobYml, error) {
+	b, err := template.AsTemplatedBytes(context, yml, values)
+	if err != nil {
+		return nil, err
+	}
+	return &JobYml{
+		YmlInBytes: b,
+	}, nil
+}
+
+// AsBatchV1Job returns a batch/v1 Job instance
+func (m *JobYml) AsBatchV1Job() (*api_batch_v1.Job, error) {
+	if m.YmlInBytes == nil {
+		return nil, fmt.Errorf("Missing yaml")
+	}
+	job := &api_batch_v1.Job{}
+	err := yaml.Unmarshal(m.YmlInBytes, job)
+	if err != nil {
+		return nil, err
+	}
+	return job, nil
+}
 
 // DeploymentYml provides utility methods to generate K8s Deployment objects
 type DeploymentYml struct {

--- a/pkg/task/identity.go
+++ b/pkg/task/identity.go
@@ -69,6 +69,10 @@ func (i taskIdentifier) isDeployment() bool {
 	return i.identity.Kind == string(m_k8s_client.DeploymentKK)
 }
 
+func (i taskIdentifier) isJob() bool {
+	return i.identity.Kind == string(m_k8s_client.JobKK)
+}
+
 func (i taskIdentifier) isService() bool {
 	return i.identity.Kind == string(m_k8s_client.ServiceKK)
 }
@@ -95,6 +99,10 @@ func (i taskIdentifier) isPV() bool {
 
 func (i taskIdentifier) isExtnV1B1() bool {
 	return i.identity.APIVersion == string(m_k8s_client.ExtensionsV1Beta1KA)
+}
+
+func (i taskIdentifier) isBatchV1() bool {
+	return i.identity.APIVersion == string(m_k8s_client.BatchV1KA)
 }
 
 func (i taskIdentifier) isAppsV1B1() bool {
@@ -147,6 +155,10 @@ func (i taskIdentifier) isOEV1alpha1CSP() bool {
 
 func (i taskIdentifier) isExtnV1B1Deploy() bool {
 	return i.isExtnV1B1() && i.isDeployment()
+}
+
+func (i taskIdentifier) isBatchV1Job() bool {
+	return i.isBatchV1() && i.isJob()
 }
 
 func (i taskIdentifier) isAppsV1B1Deploy() bool {

--- a/pkg/task/meta.go
+++ b/pkg/task/meta.go
@@ -298,6 +298,10 @@ func (m *metaTaskExecutor) isPutExtnV1B1Deploy() bool {
 	return m.identifier.isExtnV1B1Deploy() && m.isPut()
 }
 
+func (m *metaTaskExecutor) isPutBatchV1Job() bool {
+	return m.identifier.isBatchV1Job() && m.isPut()
+}
+
 func (m *metaTaskExecutor) isPatchExtnV1B1Deploy() bool {
 	return m.identifier.isExtnV1B1Deploy() && m.isPatch()
 }
@@ -352,6 +356,14 @@ func (m *metaTaskExecutor) isListAppsV1B1Deploy() bool {
 
 func (m *metaTaskExecutor) isGetStorageV1SC() bool {
 	return m.identifier.isStorageV1SC() && m.isGet()
+}
+
+func (m *metaTaskExecutor) isGetBatchV1Job() bool {
+	return m.identifier.isBatchV1Job() && m.isGet()
+}
+
+func (m *metaTaskExecutor) isDeleteBatchV1Job() bool {
+	return m.identifier.isBatchV1Job() && m.isDelete()
 }
 
 func (m *metaTaskExecutor) isGetOEV1alpha1Disk() bool {


### PR DESCRIPTION
This commit enables CASTemplate/RunTask to understand Kubernetes Job yaml. It
enables Create, Get & Delete operations w.r.t a Kubernetes Job via CASTemplate.

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
