### PR TITLE
enhancement(usage) Unblock sending usage events

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -326,11 +326,12 @@
   version = "v1.0"
 
 [[projects]]
-  digest = "1:289a0aeeff2a467506d6faacb71c783a8610e53639e8f065e1997a569e622d6b"
+  digest = "1:36e1fc7eedfc97063f29db638bacded76e34d4ef32f8ec2ee789a1c912eb97ab"
   name = "github.com/jpillora/go-ogle-analytics"
   packages = ["."]
   pruneopts = "UT"
-  revision = "14b04e0594ef6a9fd943363b135656f0ec8c9d0e"
+  revision = "694492144d734d1500dfb877b47fb2f32a4ec53f"
+  source = "github.com/openebs/go-ogle-analytics"
 
 [[projects]]
   digest = "1:3e551bbb3a7c0ab2a2bf4660e7fcad16db089fdcfbb44b0199e62838038623ea"
@@ -1113,6 +1114,7 @@
     "k8s.io/apimachinery/pkg/util/json",
     "k8s.io/apimachinery/pkg/util/runtime",
     "k8s.io/apimachinery/pkg/util/wait",
+    "k8s.io/apimachinery/pkg/version",
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/discovery/fake",
@@ -1125,7 +1127,6 @@
     "k8s.io/client-go/kubernetes/typed/core/v1",
     "k8s.io/client-go/kubernetes/typed/extensions/v1beta1",
     "k8s.io/client-go/kubernetes/typed/storage/v1",
-    "k8s.io/client-go/pkg/version",
     "k8s.io/client-go/rest",
     "k8s.io/client-go/testing",
     "k8s.io/client-go/third_party/forked/golang/template",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -80,4 +80,5 @@ required = [
 
 [[constraint]]
   name = "github.com/jpillora/go-ogle-analytics"
-  revision = "14b04e0594ef6a9fd943363b135656f0ec8c9d0e"
+  source = "github.com/openebs/go-ogle-analytics"
+  revision = "694492144d734d1500dfb877b47fb2f32a4ec53f"

--- a/cmd/maya-apiserver/app/command/start.go
+++ b/cmd/maya-apiserver/app/command/start.go
@@ -184,9 +184,7 @@ func Run(cmd *cobra.Command, c *CmdStartOptions) error {
 	}()
 
 	if env.Truthy(env.OpenEBSEnableAnalytics) {
-		usageCfg := usage.New().Build()
-		gClinet := usageCfg.InstallBuilder()
-		usageCfg.Send(gClinet)
+		usage.New().Build().InstallBuilder().Send()
 	}
 
 	// Wait for exit

--- a/cmd/maya-apiserver/app/command/start.go
+++ b/cmd/maya-apiserver/app/command/start.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/openebs/maya/cmd/maya-apiserver/app/config"
 	"github.com/openebs/maya/cmd/maya-apiserver/app/server"
-	k8sapi "github.com/openebs/maya/pkg/client/k8s/v1alpha1"
 	env "github.com/openebs/maya/pkg/env/v1alpha1"
 	install "github.com/openebs/maya/pkg/install/v1alpha1"
 	"github.com/openebs/maya/pkg/usage"
@@ -130,7 +129,7 @@ func Run(cmd *cobra.Command, c *CmdStartOptions) error {
 	// Read and merge with default configuration
 	mconfig := c.readMayaConfig()
 	if mconfig == nil {
-		return errors.New("Unable to load the configuration.")
+		return errors.New("Unable to load the configuration")
 	}
 
 	//TODO Setup Log Level
@@ -185,14 +184,14 @@ func Run(cmd *cobra.Command, c *CmdStartOptions) error {
 	}()
 
 	if env.Truthy(env.OpenEBSEnableAnalytics) {
-		clusterSize, _ := k8sapi.NumberOfNodes()
-		event := usage.NewEvent("install", "running", "nodes", int64(clusterSize))
-		event.Send()
+		usageCfg := usage.New().Build()
+		gClinet := usageCfg.InstallBuilder()
+		usageCfg.Send(gClinet)
 	}
 
 	// Wait for exit
 	if c.handleSignals(mconfig) > 0 {
-		return errors.New("Ungraceful exit ...")
+		return errors.New("Ungraceful exit")
 	}
 
 	return nil

--- a/pkg/usage/googleanalytics.go
+++ b/pkg/usage/googleanalytics.go
@@ -3,84 +3,17 @@ package usage
 import (
 	"github.com/golang/glog"
 	analytics "github.com/jpillora/go-ogle-analytics"
-	k8sapi "github.com/openebs/maya/pkg/client/k8s/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	// GAclientID is the unique code of OpenEBS project in Google Analytics
-	GAclientID = "UA-127388617-1"
-)
-
-// Event is a represents usage of OpenEBS
-// Event contains all the query param fields when hits is of type='event'
-// Ref: https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#ec
-type Event struct {
-	// (Required) Event Category, ec
-	category string
-	// (Required) Event Action, ea
-	action string
-	// (Optional) Event Label, el
-	label string
-	// (Optional) Event vallue, ev
-	// Non negative
-	value int64
-}
-
-// NewEvent returns an Event struct with eventCategory, eventAction,
-// eventLabel, eventValue fields
-func NewEvent(c, a, l string, v int64) *Event {
-	return &Event{
-		category: c,
-		action:   a,
-		label:    l,
-		value:    v,
-	}
-}
-
-// Send starts a goroutine to send a single event to Google Analytics
-func (e *Event) Send() {
+// Send sends a single usage metric to Google Analytics
+func (u *Usage) Send(gaClient *analytics.Client) {
 	go func() {
-		v := &versionSet{}
-		if err := v.getVersion(); err != nil {
-			glog.Error(err)
+		event := analytics.NewEvent(u.category, u.action)
+		event.Label(u.label)
+		event.Value(u.value)
+		if err := gaClient.Send(event); err != nil {
+			glog.Errorf(err.Error())
 			return
 		}
-		// anonymous user identifying
-		// client-id - uid of default namespace
-		gaClient, _ := analytics.NewClient(GAclientID)
-		gaClient.ClientID(v.id).
-			// OpenEBS version details
-			ApplicationID("OpenEBS").
-			ApplicationVersion(v.openebsVersion).
-			// K8s version
-
-			// TODO: Find k8s Environment type
-			DataSource(v.nodeType).
-			ApplicationName(v.k8sArch).
-			ApplicationInstallerID(v.k8sVersion).
-			DocumentTitle(v.id)
-
-		event := analytics.NewEvent(e.category, e.action)
-		event.Label(e.label)
-		event.Value(e.value)
-		if err := gaClient.Send(event); err != nil {
-			glog.Error(err)
-		}
-		glog.V(4).Infof("Event %s:%s sent", e.category, e.action)
 	}()
-}
-
-// getUUIDbyNS returns the metadata.object.uid of a namespace in Kubernetes
-func getUUIDbyNS(namespace string) (string, error) {
-	ns := k8sapi.Namespace()
-	NSstruct, err := ns.Get(namespace, metav1.GetOptions{})
-	if err != nil {
-		return "", err
-	}
-	if NSstruct != nil {
-		return string(NSstruct.GetObjectMeta().GetUID()), nil
-	}
-	return "", nil
-
 }

--- a/pkg/usage/googleanalytics.go
+++ b/pkg/usage/googleanalytics.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2018 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package usage
 
 import (

--- a/pkg/usage/googleanalytics.go
+++ b/pkg/usage/googleanalytics.go
@@ -20,9 +20,25 @@ import (
 	analytics "github.com/jpillora/go-ogle-analytics"
 )
 
-// Send sends a single usage metric to Google Analytics
-func (u *Usage) Send(gaClient *analytics.Client) {
+// Send sends a single usage metric to Google Analytics with some
+// compulsory fields defined in Google Analytics API
+// bindings(jpillora/go-ogle-analytics)
+func (u *Usage) Send() {
+	// Instantiate a Gclient with the tracking ID
 	go func() {
+		// Un-wrap the gaClient struct back here
+		gaClient, err := analytics.NewClient(u.Gclient.trackID)
+		if err != nil {
+			return
+		}
+		gaClient.ClientID(u.clientID).
+			ApplicationID(u.appID).
+			ApplicationVersion(u.appVersion).
+			DataSource(u.dataSource).
+			ApplicationName(u.appName).
+			ApplicationInstallerID(u.appInstallerID).
+			DocumentTitle(u.documentTitle)
+		// Un-wrap the Event struct back here
 		event := analytics.NewEvent(u.category, u.action)
 		event.Label(u.label)
 		event.Value(u.value)

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2018 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package usage
 
 import (

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -1,0 +1,192 @@
+package usage
+
+import (
+	analytics "github.com/jpillora/go-ogle-analytics"
+	k8sapi "github.com/openebs/maya/pkg/client/k8s/v1alpha1"
+)
+
+const (
+	// GAclientID is the unique code of OpenEBS project in Google Analytics
+	GAclientID = "UA-127388617-1"
+)
+
+// Usage struct represents all information about a usage metric sent to
+// Google Analytics with respect to the application
+type Usage struct {
+	// Embedded Event struct as we are currently only sending hits of type
+	// 'event'
+	Event
+
+	// https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#an
+	// use-case: cstor or jiva volume, or m-apiserver application
+	// Embedded field for application
+	Application
+
+	// Embedded Gclient struct
+	Gclient
+}
+
+// Event is a represents usage of OpenEBS
+// Event contains all the query param fields when hits is of type='event'
+// Ref: https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#ec
+type Event struct {
+	// (Required) Event Category, ec
+	category string
+	// (Required) Event Action, ea
+	action string
+	// (Optional) Event Label, el
+	label string
+	// (Optional) Event vallue, ev
+	// Non negative
+	value int64
+}
+
+// NewEvent returns an Event struct with eventCategory, eventAction,
+// eventLabel, eventValue fields
+func (u *Usage) NewEvent(c, a, l string, v int64) *Usage {
+	u.category = c
+	u.action = a
+	u.label = l
+	u.value = v
+	return u
+}
+
+// Application struct holds details about the Application
+type Application struct {
+	// eg. project version
+	appVersion string
+
+	// eg. kubernetes version
+	appInstallerID string
+
+	// Name of the application, usage(OpenEBS/NDM)
+	appID string
+
+	// eg. usage(os-type/architecture) of system or volume's CASType
+	appName string
+}
+
+// Gclient struct represents a Google Analytics hit
+type Gclient struct {
+	// constant tracking-id used to send a hit
+	trackID string
+	// anonymous client-id
+	clientID string
+
+	// https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#ds
+	// (usecase) node-detail
+	dataSource string
+
+	// Document-title property in Google Analytics
+	// https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#dt
+	// use-case: uuid of the volume objects or a uuid to anonymously tell objects apart
+	documentTitle string
+}
+
+// New returns an instance of Usage
+func New() *Usage {
+	return &Usage{}
+}
+
+// SetDataSource : usage(os-type, kernel)
+func (u *Usage) SetDataSource(dataSource string) *Usage {
+	u.dataSource = dataSource
+	return u
+}
+
+// SetTrackingID Sets the GA-code for the project
+func (u *Usage) SetTrackingID(track string) *Usage {
+	u.trackID = track
+	return u
+}
+
+// SetDocumentTitle : usecase(anonymous-id)
+func (u *Usage) SetDocumentTitle(documentTitle string) *Usage {
+	u.documentTitle = documentTitle
+	return u
+}
+
+// SetApplicationName : usecase(os-type/arch, volume CASType)
+func (u *Usage) SetApplicationName(appName string) *Usage {
+	u.appName = appName
+	return u
+}
+
+// SetApplicationID : usecase(OpenEBS/NDM)
+func (u *Usage) SetApplicationID(appID string) *Usage {
+	u.appID = appID
+	return u
+}
+
+// SetApplicationVersion : usecase(project-version)
+func (u *Usage) SetApplicationVersion(appVersion string) *Usage {
+	u.appVersion = appVersion
+	return u
+}
+
+// SetApplicationInstallerID : usecase(k8s-version)
+func (u *Usage) SetApplicationInstallerID(appInstallerID string) *Usage {
+	u.appInstallerID = appInstallerID
+	return u
+}
+
+// SetClientID sets the anonymous user id
+func (u *Usage) SetClientID(userID string) *Usage {
+	u.clientID = userID
+	return u
+}
+
+// Build is a builder method for Usage struct
+func (u *Usage) Build() *Usage {
+	// Default ApplicationID for openebs project is OpenEBS
+	v := NewVersion()
+	v.getVersion()
+	u.SetApplicationID("OpenEBS").
+		SetTrackingID(GAclientID).
+		SetClientID(v.id)
+	// TODO: Add condition for version over-ride
+	// Case: CAS/Jiva version, etc
+	return u
+}
+
+// InstallBuilder is a concrete builder for install events
+func (u *Usage) InstallBuilder() *analytics.Client {
+	v := NewVersion()
+	clusterSize, _ := k8sapi.NumberOfNodes()
+	v.getVersion()
+	u.SetApplicationVersion(v.openebsVersion).
+		SetApplicationName(v.k8sArch).
+		SetApplicationInstallerID(v.k8sVersion).
+		SetDataSource(v.nodeType).
+		SetDocumentTitle(v.id).
+		SetApplicationID("OpenEBS").
+		NewEvent("install", "running", "nodes", int64(clusterSize))
+
+	gaClient, _ := analytics.NewClient(GAclientID)
+	// anonymous user identifying
+	// client-id - uid of default namespace
+	gaClient.ClientID(u.clientID).
+		// OpenEBS version details
+		ApplicationID(u.appID).
+		ApplicationVersion(u.appVersion).
+		// K8s version
+
+		// TODO: Find k8s Environment type
+		DataSource(u.dataSource).
+		ApplicationName(u.appName).
+		// ^ This needs to be cstor or jiva later
+		ApplicationInstallerID(u.appInstallerID).
+		DocumentTitle(u.documentTitle)
+	// Update it to volume uuid if this is a volume-event
+	// (optional) Application ID
+	if u.appID != "" {
+		gaClient.ApplicationID(u.appID)
+	}
+
+	//event := New()
+	//event.SetCategory(u.category).
+	//	SetAction(u.action).
+	//	SetLabel(u.label).
+	// SetValue(u.value)
+	return gaClient
+}

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -16,7 +16,6 @@ limitations under the License.
 package usage
 
 import (
-	analytics "github.com/jpillora/go-ogle-analytics"
 	k8sapi "github.com/openebs/maya/pkg/client/k8s/v1alpha1"
 )
 
@@ -151,6 +150,30 @@ func (u *Usage) SetClientID(userID string) *Usage {
 	return u
 }
 
+// SetCategory sets the category of an event
+func (u *Usage) SetCategory(c string) *Usage {
+	u.category = c
+	return u
+}
+
+// SetAction sets the action of an event
+func (u *Usage) SetAction(a string) *Usage {
+	u.action = a
+	return u
+}
+
+// SetLabel sets the label for an event
+func (u *Usage) SetLabel(l string) *Usage {
+	u.label = l
+	return u
+}
+
+// SetValue sets the value for an event's label
+func (u *Usage) SetValue(v int64) *Usage {
+	u.value = v
+	return u
+}
+
 // Build is a builder method for Usage struct
 func (u *Usage) Build() *Usage {
 	// Default ApplicationID for openebs project is OpenEBS
@@ -165,7 +188,7 @@ func (u *Usage) Build() *Usage {
 }
 
 // InstallBuilder is a concrete builder for install events
-func (u *Usage) InstallBuilder() *analytics.Client {
+func (u *Usage) InstallBuilder() *Usage {
 	v := NewVersion()
 	clusterSize, _ := k8sapi.NumberOfNodes()
 	v.getVersion()
@@ -176,32 +199,5 @@ func (u *Usage) InstallBuilder() *analytics.Client {
 		SetDocumentTitle(v.id).
 		SetApplicationID("OpenEBS").
 		NewEvent("install", "running", "nodes", int64(clusterSize))
-
-	gaClient, _ := analytics.NewClient(GAclientID)
-	// anonymous user identifying
-	// client-id - uid of default namespace
-	gaClient.ClientID(u.clientID).
-		// OpenEBS version details
-		ApplicationID(u.appID).
-		ApplicationVersion(u.appVersion).
-		// K8s version
-
-		// TODO: Find k8s Environment type
-		DataSource(u.dataSource).
-		ApplicationName(u.appName).
-		// ^ This needs to be cstor or jiva later
-		ApplicationInstallerID(u.appInstallerID).
-		DocumentTitle(u.documentTitle)
-	// Update it to volume uuid if this is a volume-event
-	// (optional) Application ID
-	if u.appID != "" {
-		gaClient.ApplicationID(u.appID)
-	}
-
-	//event := New()
-	//event.SetCategory(u.category).
-	//	SetAction(u.action).
-	//	SetLabel(u.label).
-	// SetValue(u.value)
-	return gaClient
+	return u
 }

--- a/pkg/usage/versionset.go
+++ b/pkg/usage/versionset.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2018 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package usage
 
 import (

--- a/vendor/github.com/jpillora/go-ogle-analytics/client.go
+++ b/vendor/github.com/jpillora/go-ogle-analytics/client.go
@@ -4,7 +4,9 @@ package ga
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -16,9 +18,22 @@ func NewClient(trackingID string) (*Client, error) {
 	if !trackingIDMatcher.MatchString(trackingID) {
 		return nil, fmt.Errorf("Invalid Tracking ID: %s", trackingID)
 	}
+	dialer := &net.Dialer{
+		Resolver: &net.Resolver{
+			PreferGo: true,
+			Dial: func(ctx context.Context, network, address string) (net.Conn, error){
+				dialer := net.Dialer{}
+				return dialer.DialContext(ctx, network, "8.8.8.8:53")
+			},
+		},
+	}
 	return &Client{
 		UseTLS:             true,
-		HttpClient:         http.DefaultClient,
+		HttpClient:         &http.Client{
+			Transport: &http.Transport{
+				DialContext: dialer.DialContext,
+			},
+		},
 		protocolVersion:    "1",
 		protocolVersionSet: true,
 		trackingID:         trackingID,
@@ -49,17 +64,17 @@ func (c *Client) Send(h hitType) error {
 		return err
 	}
 
-	url := ""
+	gaUrl := ""
 	if cpy.UseTLS {
-		url = "https://www.google-analytics.com/collect"
+		gaUrl = "https://www.google-analytics.com/collect"
 	} else {
-		url = "http://ssl.google-analytics.com/collect"
+		gaUrl = "http://ssl.google-analytics.com/collect"
 	}
 
 	str := v.Encode()
 	buf := bytes.NewBufferString(str)
 
-	resp, err := c.HttpClient.Post(url, "application/x-www-form-urlencoded", buf)
+	resp, err := c.HttpClient.Post(gaUrl, "application/x-www-form-urlencoded", buf)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Harsh Vardhan <harsh.vardhan@mayadata.io>

**What this PR does / why we need it**:
- Earlier, sending events to `GoogleAnalytics` was a blocking call now it runs in a different `goroutine`
- This updates the `go-ogle-analytics` package to pickup from `openebs` organization, this has updated [vendor packages](https://github.com/openebs/go-ogle-analytics/pull/1/) which helps with [this limitation](https://blog.yaakov.online/kubernetes-getting-pods-to-talk-to-the-internet/) 

**Which issue this PR fixes** 
issue: https://github.com/openebs/openebs/issues/2257