### PR TITLE
fix(spc, install, startup): move spc start logic post API service start

### DIFF
--- a/cmd/maya-apiserver/app/command/start.go
+++ b/cmd/maya-apiserver/app/command/start.go
@@ -128,12 +128,7 @@ func Run(cmd *cobra.Command, c *CmdStartOptions) error {
 	if mconfig == nil {
 		return errors.New("Unable to load the configuration.")
 	}
-	go func() {
-		err := spc.Start()
-		if err != nil {
-			glog.Errorf("Could not start controller: %s", err.Error())
-		}
-	}()
+
 	//TODO Setup Log Level
 
 	// Setup Maya server
@@ -176,6 +171,14 @@ func Run(cmd *cobra.Command, c *CmdStartOptions) error {
 
 	// Output the header that the server has started
 	glog.Info("Maya api server started! Log data will stream in below:\n")
+
+	// start storage pool controller
+	go func() {
+		err := spc.Start()
+		if err != nil {
+			glog.Errorf("Failed to start storage pool controller: %s", err.Error())
+		}
+	}()
 
 	// Wait for exit
 	if c.handleSignals(mconfig) > 0 {


### PR DESCRIPTION
This commit moves the start logic of storage pool controller post the API service is started successfully.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
