### PR TITLE
chore(merge): cherry-fix jiva delete fixes from 0.7.x to master

### DIFF
--- a/ci/install_openebs.sh
+++ b/ci/install_openebs.sh
@@ -18,6 +18,13 @@ if [ ${CI_TAG} != "ci" ]; then
   sudo docker tag openebs/cstor-volume-mgmt:ci openebs/cstor-volume-mgmt:${CI_TAG}
 fi
 
+#Tag the images with quay.io, since the operator can either have quay or docker images
+sudo docker tag openebs/m-apiserver:ci quay.io/openebs/m-apiserver:${CI_TAG}
+sudo docker tag openebs/m-exporter:ci quay.io/openebs/m-exporter:${CI_TAG}
+sudo docker tag openebs/cstor-pool-mgmt:ci quay.io/openebs/cstor-pool-mgmt:${CI_TAG}
+sudo docker tag openebs/cstor-volume-mgmt:ci quay.io/openebs/cstor-volume-mgmt:${CI_TAG}
+
+
 kubectl apply -f https://raw.githubusercontent.com/openebs/openebs/${CI_BRANCH}/k8s/openebs-operator.yaml
 
 function waitForDeployment() {

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -85,10 +85,12 @@ fi
 #fi
 echo "************** Running Jiva mayactl volume delete ************************"
 ${MAYACTL} volume delete --volname $JIVAVOL
+rc=$?;
 if [[ $rc != 0 ]]; then
-	kubectl logs --tail=10 $MAPIPOD -n openebs
+	kubectl logs --tail=100 $MAPIPOD -n openebs
 	exit $rc;
 fi
+sleep 30
 
 printf "\n\n"
 echo "************** Running Cstor mayactl volume describe *************************"
@@ -97,5 +99,18 @@ rc=$?;
 if [[ $rc != 0 ]]; then
 	kubectl logs --tail=10 $MAPIPOD -n openebs
 	exit $rc;
+fi
+
+printf "\n\n"
+echo "************** Check if jiva replica data is cleared *************************"
+if [ -f /var/openebs/$JIVAVOL/volume.meta ]; then
+	#Check if the job is in progress. 
+	printf "\n"
+	ls -lR /var/openebs
+	printf "\n"
+	kubectl get jobs
+	printf "\n"
+	kubectl get pods
+	printf "\n"
 fi
 

--- a/pkg/k8s/from_yaml.go
+++ b/pkg/k8s/from_yaml.go
@@ -24,9 +24,39 @@ import (
 	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	"github.com/openebs/maya/pkg/template"
 	api_apps_v1beta1 "k8s.io/api/apps/v1beta1"
+	api_batch_v1 "k8s.io/api/batch/v1"
 	api_core_v1 "k8s.io/api/core/v1"
 	api_extn_v1beta1 "k8s.io/api/extensions/v1beta1"
 )
+
+// JobYml helps generating kubernetes Job object
+type JobYml struct {
+	YmlInBytes []byte // YmlInBytes represents a K8s Job in yaml format
+}
+
+// NewJobYml returns a new instance of JobYml
+func NewJobYml(context, yml string, values map[string]interface{}) (*JobYml, error) {
+	b, err := template.AsTemplatedBytes(context, yml, values)
+	if err != nil {
+		return nil, err
+	}
+	return &JobYml{
+		YmlInBytes: b,
+	}, nil
+}
+
+// AsBatchV1Job returns a batch/v1 Job instance
+func (m *JobYml) AsBatchV1Job() (*api_batch_v1.Job, error) {
+	if m.YmlInBytes == nil {
+		return nil, fmt.Errorf("Missing yaml")
+	}
+	job := &api_batch_v1.Job{}
+	err := yaml.Unmarshal(m.YmlInBytes, job)
+	if err != nil {
+		return nil, err
+	}
+	return job, nil
+}
 
 // DeploymentYml provides utility methods to generate K8s Deployment objects
 type DeploymentYml struct {

--- a/pkg/task/identity.go
+++ b/pkg/task/identity.go
@@ -82,6 +82,10 @@ func (i taskIdentifier) isDeployment() bool {
 	return i.identity.Kind == string(m_k8s_client.DeploymentKK)
 }
 
+func (i taskIdentifier) isJob() bool {
+	return i.identity.Kind == string(m_k8s_client.JobKK)
+}
+
 func (i taskIdentifier) isService() bool {
 	return i.identity.Kind == string(m_k8s_client.ServiceKK)
 }
@@ -108,6 +112,10 @@ func (i taskIdentifier) isPV() bool {
 
 func (i taskIdentifier) isExtnV1B1() bool {
 	return i.identity.APIVersion == string(m_k8s_client.ExtensionsV1Beta1KA)
+}
+
+func (i taskIdentifier) isBatchV1() bool {
+	return i.identity.APIVersion == string(m_k8s_client.BatchV1KA)
 }
 
 func (i taskIdentifier) isAppsV1B1() bool {
@@ -160,6 +168,10 @@ func (i taskIdentifier) isOEV1alpha1CSP() bool {
 
 func (i taskIdentifier) isExtnV1B1Deploy() bool {
 	return i.isExtnV1B1() && i.isDeployment()
+}
+
+func (i taskIdentifier) isBatchV1Job() bool {
+	return i.isBatchV1() && i.isJob()
 }
 
 func (i taskIdentifier) isAppsV1B1Deploy() bool {

--- a/pkg/task/meta.go
+++ b/pkg/task/meta.go
@@ -77,14 +77,18 @@ type MetaTaskProps struct {
 	// RunNamespace is the namespace where task will get
 	// executed
 	RunNamespace string `json:"runNamespace"`
+
 	// Owner represents the owner of this task
 	Owner string `json:"owner"`
+
 	// ObjectName is the name of the resource that gets
 	// created or will get operated by this task
 	ObjectName string `json:"objectName"`
+
 	// Options is a set of selectors that can be used for
 	// tasks that are get or list based actions
 	Options string `json:"options"`
+
 	// Retry specifies the no. of times this particular task (i.e. all properties
 	// remains same) can be re-tried. This is typically used along with task
 	// result verify options for get or list related actions.
@@ -94,6 +98,9 @@ type MetaTaskProps struct {
 	// # max of 10 attempts in 20 seconds interval
 	// retry: "10,20s"
 	Retry string `json:"retry"`
+
+	// Disable will disable execution of this task
+	Disable bool `json:"disable"`
 }
 
 // toString returns a string representation of MetaTaskProps structure. In this
@@ -103,12 +110,13 @@ type MetaTaskProps struct {
 // Example:
 //  runNamespace=default::objectName=MySvc::retry=3,20s
 func (m MetaTaskProps) toString() string {
-	return fmt.Sprintf("runNamespace=%s::owner=%s::objectName=%s::options=%s::retry=%s",
+	return fmt.Sprintf("runNamespace=%s::owner=%s::objectName=%s::options=%s::retry=%s::disable=%t",
 		m.RunNamespace,
 		m.Owner,
 		m.ObjectName,
 		m.Options,
-		m.Retry)
+		m.Retry,
+		m.Disable)
 }
 
 // selectOverride will override the current meta task properties from the given
@@ -134,6 +142,7 @@ func (m MetaTaskProps) selectOverride(given MetaTaskProps) MetaTaskProps {
 	if len(retry) != 0 {
 		m.Retry = retry
 	}
+	m.Disable = given.Disable
 
 	return m
 }
@@ -222,6 +231,10 @@ func (m *metaTaskExecutor) getMetaInfo() MetaTaskSpec {
 
 func (m *metaTaskExecutor) getRepeatExecutor() repeatExecutor {
 	return m.repeater
+}
+
+func (m *metaTaskExecutor) isDisabled() bool {
+	return m.metaTask.Disable
 }
 
 func (m *metaTaskExecutor) getIdentity() string {

--- a/pkg/task/meta.go
+++ b/pkg/task/meta.go
@@ -484,8 +484,9 @@ func getRollbackMetaInstances(given MetaTaskSpec, objectName string) (m MetaTask
 //  The bool return with value as `false` implies there is no
 // need for a rollback
 func (m *metaTaskExecutor) asRollbackInstance(objectName string) (*metaTaskExecutor, bool, error) {
+	// there is no rollback when task is disabled
 	// there is no rollback when original action is not put
-	if !m.isPut() {
+	if m.isDisabled() || !m.isPut() {
 		return nil, false, nil
 	}
 

--- a/pkg/task/meta.go
+++ b/pkg/task/meta.go
@@ -302,6 +302,10 @@ func (m *metaTaskExecutor) isPutExtnV1B1Deploy() bool {
 	return m.identifier.isExtnV1B1Deploy() && m.isPut()
 }
 
+func (m *metaTaskExecutor) isPutBatchV1Job() bool {
+	return m.identifier.isBatchV1Job() && m.isPut()
+}
+
 func (m *metaTaskExecutor) isPatchExtnV1B1Deploy() bool {
 	return m.identifier.isExtnV1B1Deploy() && m.isPatch()
 }
@@ -356,6 +360,14 @@ func (m *metaTaskExecutor) isListAppsV1B1Deploy() bool {
 
 func (m *metaTaskExecutor) isGetStorageV1SC() bool {
 	return m.identifier.isStorageV1SC() && m.isGet()
+}
+
+func (m *metaTaskExecutor) isGetBatchV1Job() bool {
+	return m.identifier.isBatchV1Job() && m.isGet()
+}
+
+func (m *metaTaskExecutor) isDeleteBatchV1Job() bool {
+	return m.identifier.isBatchV1Job() && m.isDelete()
 }
 
 func (m *metaTaskExecutor) isGetOEV1alpha1Disk() bool {

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -271,6 +271,9 @@ func (m *taskExecutor) retryOnVerificationError() (err error) {
 // Execute executes a runtask by following the directives specified in the
 // runtask's meta specifications and other conditions like presence of VerifyErr
 func (m *taskExecutor) Execute() (err error) {
+	if m.metaTaskExec.isDisabled() {
+		return
+	}
 	return m.repeatWith()
 }
 

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openebs/maya/pkg/template"
 	"github.com/openebs/maya/pkg/util"
 	api_apps_v1beta1 "k8s.io/api/apps/v1beta1"
+	api_batch_v1 "k8s.io/api/batch/v1"
 	api_core_v1 "k8s.io/api/core/v1"
 	api_extn_v1beta1 "k8s.io/api/extensions/v1beta1"
 )
@@ -380,6 +381,12 @@ func (m *taskExecutor) ExecuteIt() (err error) {
 		err = m.getStorageV1SC()
 	} else if m.metaTaskExec.isGetCoreV1PV() {
 		err = m.getCoreV1PV()
+	} else if m.metaTaskExec.isDeleteBatchV1Job() {
+		err = m.deleteBatchV1Job()
+	} else if m.metaTaskExec.isGetBatchV1Job() {
+		err = m.getBatchV1Job()
+	} else if m.metaTaskExec.isPutBatchV1Job() {
+		err = m.putBatchV1Job()
 	} else {
 		err = fmt.Errorf("un-supported task operation: failed to execute task: '%+v'", m.metaTaskExec.getMetaInfo())
 	}
@@ -409,6 +416,15 @@ func (m *taskExecutor) asRollbackInstance(objectName string) (*taskExecutor, err
 	return &taskExecutor{
 		metaTaskExec: mte,
 	}, nil
+}
+
+// asBatchV1Job generates a K8s Job object out of the embedded yaml
+func (m *taskExecutor) asBatchV1Job() (*api_batch_v1.Job, error) {
+	j, err := m_k8s.NewJobYml("BatchV1Job", m.runtask.Spec.Task, m.templateValues)
+	if err != nil {
+		return nil, err
+	}
+	return j.AsBatchV1Job()
 }
 
 // asAppsV1B1Deploy generates a K8s Deployment object
@@ -486,6 +502,20 @@ func (m *taskExecutor) asCoreV1Svc() (*api_core_v1.Service, error) {
 	}
 
 	return s.AsCoreV1Service()
+}
+
+// putBatchV1Job will put a Job object
+func (m *taskExecutor) putBatchV1Job() (err error) {
+	j, err := m.asBatchV1Job()
+	if err != nil {
+		return
+	}
+	job, err := m.getK8sClient().CreateBatchV1JobAsRaw(j)
+	if err != nil {
+		return
+	}
+	util.SetNestedField(m.templateValues, job, string(v1alpha1.CurrentJSONResultTLP))
+	return
 }
 
 // putAppsV1B1Deploy will put (i.e. apply to a kubernetes cluster) a Deployment
@@ -735,6 +765,28 @@ func (m *taskExecutor) getCoreV1PV() (err error) {
 	}
 
 	util.SetNestedField(m.templateValues, pv, string(v1alpha1.CurrentJSONResultTLP))
+	return
+}
+
+// getBatchV1Job will get the Job as specified in the RunTask
+func (m *taskExecutor) getBatchV1Job() (err error) {
+	job, err := m.getK8sClient().GetBatchV1JobAsRaw(m.getTaskObjectName())
+	if err != nil {
+		return
+	}
+	util.SetNestedField(m.templateValues, job, string(v1alpha1.CurrentJSONResultTLP))
+	return
+}
+
+// deleteBatchV1Job will delete one or more Jobs specified in the RunTask
+func (m *taskExecutor) deleteBatchV1Job() (err error) {
+	jobs := strings.Split(strings.TrimSpace(m.getTaskObjectName()), ",")
+	for _, name := range jobs {
+		err = m.getK8sClient().DeleteBatchV1Job(strings.TrimSpace(name))
+		if err != nil {
+			return
+		}
+	}
 	return
 }
 

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -223,16 +223,6 @@ func (v *Operation) Delete() (*v1alpha1.CASVolume, error) {
 	}
 	casConfigSC := sc.Annotations[string(v1alpha1.CASConfigKey)]
 
-	// pvc details
-	var casConfigPVC string
-	if pv.Spec.ClaimRef != nil {
-		pvc, err := v.k8sClient.GetPVC(pv.Spec.ClaimRef.Name, mach_apis_meta_v1.GetOptions{})
-		if err != nil {
-			return nil, err
-		}
-		casConfigPVC = pvc.Annotations[string(v1alpha1.CASConfigKey)]
-	}
-
 	// cas template corresponding to this volume
 	casType := pv.Labels[string(v1alpha1.CASTypeKey)]
 	castName := getDeleteCASTemplate(casType, sc)
@@ -244,9 +234,9 @@ func (v *Operation) Delete() (*v1alpha1.CASVolume, error) {
 		return nil, err
 	}
 
-	// cas template engine
+	// delete cas volume via cas template engine
 	engine, err := NewVolumeEngine(
-		casConfigPVC,
+		"",
 		casConfigSC,
 		cast,
 		string(v1alpha1.VolumeTLP),


### PR DESCRIPTION
Cherry Pick the following commits:

- c8e7a7469caf6280e02e68af6ce6ee1a729c1584 ( feat(jiva): add scrub job on deleted jiva replicas (#786) )
- 3b1cda24832d197b5ef3ad9c8c3c41fda5d06441 ( fix(spc, install, startup): move spc start logic after API service starts)
- e173c3f117cc3eb404963b930591e31bc7dc600c ( feat(cast): add disable option to RunTask)
- 7fd61ebde133b8a847865f136a7c625a406d3b45 ( feat(cast, job): add Create, Get & Delete operation for job in CASTemplate)
- 250fd947f368462cb802ed2e16ede770c56fdcd1 ( refactor(ci): support both docker and quay images for ci (#785))
- ecb712039755a2f55b46ba4560767d1ad9fdd4e9 ( fix(volume, cast): fix error due to use of PVC cas config during volume delete )
- 5055eefd7005d35f94d38393c756f7cebdc2b1f9 ( feat(provisioning): add pod affinity expr to jiva target pod (#802))
