### PR TITLE
fix(volume, cast): fix error due to use of PVC cas config during volume delete

### DIFF
--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -223,16 +223,6 @@ func (v *VolumeOperation) Delete() (*v1alpha1.CASVolume, error) {
 	}
 	casConfigSC := sc.Annotations[string(v1alpha1.CASConfigKey)]
 
-	// pvc details
-	var casConfigPVC string
-	if pv.Spec.ClaimRef != nil {
-		pvc, err := v.k8sClient.GetPVC(pv.Spec.ClaimRef.Name, mach_apis_meta_v1.GetOptions{})
-		if err != nil {
-			return nil, err
-		}
-		casConfigPVC = pvc.Annotations[string(v1alpha1.CASConfigKey)]
-	}
-
 	// cas template details
 	castName := getDeleteCASTemplate(sc)
 	if len(castName) == 0 {
@@ -245,7 +235,7 @@ func (v *VolumeOperation) Delete() (*v1alpha1.CASVolume, error) {
 
 	// delete cas volume via cas template engine
 	engine, err := NewCASVolumeEngine(
-		casConfigPVC,
+		"",
 		casConfigSC,
 		cast,
 		string(v1alpha1.VolumeTLP),


### PR DESCRIPTION
This commit removes kubernetes API query against PVC resource during volume delete operation. It was seen that the volume's corresponding PVC object gets deleted by the time volume delete operation takes place.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
