### PR TITLE
feat(provisioning): add pod affinity expr to target pod

### DIFF
--- a/pkg/install/v1alpha1/jiva_volume_0.7.0.go
+++ b/pkg/install/v1alpha1/jiva_volume_0.7.0.go
@@ -569,8 +569,10 @@ spec:
     objectName: {{ .Volume.pvc }}
     action: get
   post: |
-    {{- $replicaAntiAffinity := jsonpath .JsonResult "{.metadata.labels.openebs\\.io/replica-anti-affinity}" | default "none" -}}
-    {{- trim $replicaAntiAffinity | saveAs "creategetpvc.replicaAntiAffinity" .TaskResult | noop -}}
+    {{- $replicaAntiAffinity := jsonpath .JsonResult "{.metadata.labels.openebs\\.io/replica-anti-affinity}" | trim | default "none" -}}
+    {{- $replicaAntiAffinity | saveAs "creategetpvc.replicaAntiAffinity" .TaskResult | noop -}}
+    {{- $targetAffinity := jsonpath .JsonResult "{.metadata.labels.openebs\\.io/target-affinity}" | trim | default "none" -}}
+    {{- $targetAffinity | saveAs "creategetpvc.targetAffinity" .TaskResult | noop -}}
 ---
 apiVersion: openebs.io/v1alpha1
 kind: RunTask
@@ -673,6 +675,7 @@ spec:
     {{- $auxResourceLimitsVal := fromYaml .Config.AuxResourceLimits.value -}}
     {{- $hasNodeSelector := .Config.TargetNodeSelector.value | default "none" -}}
     {{- $nodeSelectorVal := fromYaml .Config.TargetNodeSelector.value -}}
+    {{- $targetAffinityVal := .TaskResult.creategetpvc.targetAffinity -}}
     apiVersion: extensions/v1beta1
     Kind: Deployment
     metadata:
@@ -718,6 +721,18 @@ spec:
               {{ $sK }}: {{ $sV }}
             {{- end }}
           {{- end}}
+          {{- if ne $targetAffinityVal "none" }}
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: openebs.io/target-affinity
+                    operator: In
+                    values:
+                    - {{ $targetAffinityVal }}
+                topologyKey: kubernetes.io/hostname
+          {{- end }}
           containers:
           - args:
             - controller


### PR DESCRIPTION
When application and volume target pod are located in different nodes, a node down event on node containing target pod will cause the IO to break for the application.

It is sometimes desirable to **co-locate** the target pod on the same node as the application pod.

This commit uses the application pod label to create the affinity. The user will have to specify the following label on both application and PVC:
```yaml
  openebs.io/target-affinity: <unique application name>
```
The volume target pod will have the following pod affinity rule:
```
  affinity:
    podAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector:
          matchExpressions:
          - key: openebs.io/target-affinity
            operator: In
            values:
            - <unique application name>
        topologyKey: kubernetes.io/hostname
```

The following cases have been tested:
- Create without target-affinity label. The target pod is independent of the application. 
- With target-affinity:
  * The target pod will be scheduled on the same node as the application. The node should have enough resources to schedule the target pod. 
  * When target pod is killed, it is re-scheduled back on to the same node as application. 
  * When application node is brought down, the target pod waits for the application pod to be scheduled and will get scheduled onto that node. 
  
**Note** If the application pod is evicted due to resource constraints, target still remains on the source node. The target will move to the application pod, if the node it is running is shutdown or drained or target pod is restarted as part of upgrade.


Some **alternate solutions** for achieving in future k8s versions:
- enhance volume topology
- make target as a side car to application pod

**Note:** This feature works only for cases where there is a 1-1 mapping between a application and PVC. _Not recommended for STS where PVC is specified as a template_.

Signed-off-by: kmova <kiran.mova@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
