### PR TITLE
fix(cast): do not perform rollback on disabled run tasks

### DIFF
--- a/pkg/task/meta.go
+++ b/pkg/task/meta.go
@@ -480,8 +480,9 @@ func getRollbackMetaInstances(given MetaTaskSpec, objectName string) (m MetaTask
 //  The bool return with value as `false` implies there is no
 // need for a rollback
 func (m *metaTaskExecutor) asRollbackInstance(objectName string) (*metaTaskExecutor, bool, error) {
+	// there is no rollback when task is disabled
 	// there is no rollback when original action is not put
-	if !m.isPut() {
+	if m.isDisabled() || !m.isPut() {
 		return nil, false, nil
 	}
 


### PR DESCRIPTION
With the introduction of disabled tasks, the CAST
engine should skip forming rollback tasks for runtasks
that evaluate to disabled.

Signed-off-by: kmova <kiran.mova@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
