### PR TITLE
[WIP]feat(csp): put node status on csp cr

### DIFF
--- a/pkg/apis/openebs.io/v1alpha1/cstor_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_pool.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/api/core/v1"
 )
 
 // +genclient
@@ -86,7 +87,25 @@ const (
 
 // CStorPoolStatus is for handling status of pool.
 type CStorPoolStatus struct {
-	Phase CStorPoolPhase `json:"phase"`
+	Phase         CStorPoolPhase  `json:"phase"`
+	DisksStatuses []DisksStatuses `json:"diskStatuses"`
+	NodeStatus    NodeStatus    `json:"nodeStatus"`
+}
+
+// DisksStatuses contains details for the current status of disks associated to this CSP.
+type DisksStatuses struct {
+	// Name of the disk.
+	Name string `json:"name"`
+	// Details about the disk's current status.
+	Status DiskStatus `json:"state"`
+}
+
+// NodeStatus contains details for the current status of the node to which the CSP is associated.
+type NodeStatus struct {
+	// Name of the node
+	Name string `json:"name"`
+	// Details about the node's current phase.
+	Phase v1.NodePhase `json:"phase"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2018 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	clientset "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+type ClientSet struct {
+	// kubeclientset is a standard kubernetes clientset
+	Kubeclientset kubernetes.Interface
+	// clientset is a openebs custom resource package generated for custom API group.
+	OpenebsClientset clientset.Interface
+}
+
+// Patch is the struct based on standards of JSON patch.
+type Patch struct {
+	// Op defines the operation
+	Op string `json:"op"`
+	// Path defines the key path
+	// eg. for
+	// {
+	//  	"Name": "openebs"
+	//	    Category: {
+	//		  "Inclusive": "v1",
+	//		  "Rank": "A"
+	//	     }
+	// }
+	// The path of 'Inclusive' would be
+	// "/Name/Category/Inclusive"
+	Path  string      `json:"path"`
+	Value interface{} `json:"value"`
+}
+
+// Patcher interface has Patch functions which can be implemented for several objects that needs to be patched.
+type Patcher interface {
+	Patch(string, types.PatchType) (interface{}, error)
+}
+
+// NewPatchPayload constructs the patch payload fo any type of object.
+func NewPatchPayload(operation string, path string, value interface{}) (payload []Patch) {
+	PatchPayload := make([]Patch, 1)
+	PatchPayload[0].Op = operation
+	PatchPayload[0].Path = path
+	PatchPayload[0].Value = value
+	return PatchPayload
+}
+
+func (c *ClientSet) PatchCsp(cspName string, patchType types.PatchType, patches []byte) (*apis.CStorPool, error) {
+	csp, err := c.OpenebsClientset.OpenebsV1alpha1().CStorPools().Patch(cspName, patchType, patches)
+	return csp, err
+}

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// ClientSet struct holds kubernetes and openebs clientsets.
 type ClientSet struct {
 	// kubeclientset is a standard kubernetes clientset
 	Kubeclientset kubernetes.Interface
@@ -49,7 +50,7 @@ type Patch struct {
 	Value interface{} `json:"value"`
 }
 
-// Patcher interface has Patch functions which can be implemented for several objects that needs to be patched.
+// Patcher interface has Patch function which can be implemented for several objects that needs to be patched.
 type Patcher interface {
 	Patch(string, types.PatchType) (interface{}, error)
 }
@@ -63,6 +64,7 @@ func NewPatchPayload(operation string, path string, value interface{}) (payload 
 	return PatchPayload
 }
 
+// PatchCsp will patch the CSP object
 func (c *ClientSet) PatchCsp(cspName string, patchType types.PatchType, patches []byte) (*apis.CStorPool, error) {
 	csp, err := c.OpenebsClientset.OpenebsV1alpha1().CStorPools().Patch(cspName, patchType, patches)
 	return csp, err


### PR DESCRIPTION
This PR will do following :
Patch CSP object associated to the SPC resync activity to update the node status.
```json
{
            "apiVersion": "openebs.io/v1alpha1",
            "kind": "CStorPool",
            "metadata": {
                "creationTimestamp": "2018-11-20T11:08:13Z",
                "generation": 1,
                "labels": {
                    "kubernetes.io/hostname": "gke-cstor-it-default-pool-e84f5225-7zph",
                    "openebs.io/cas-template-name": "cstor-pool-create-default-0.8.0",
                    "openebs.io/storage-pool-claim": "cstor-sparse-pool",
                    "openebs.io/version": "0.8.0"
                },
                "name": "cstor-sparse-pool-n1rc",
                "namespace": "",
                "resourceVersion": "7820148",
                "selfLink": "/apis/openebs.io/v1alpha1/cstorpools/cstor-sparse-pool-n1rc",
                "uid": "92822e21-ecb4-11e8-87fd-42010a800087"
            },
            "spec": {
                "disks": {
                    "diskList": [
                        "/var/openebs/sparse/0-ndm-sparse.img"
                    ]
                },
                "poolSpec": {
                    "cacheFile": "/tmp/cstor-sparse-pool.cache",
                    "overProvisioning": false,
                    "poolType": "striped"
                }
            },
            "status": {
                "nodeStatus": {
                    "name": "gke-cstor-it-default-pool-e84f5225-7zph",
                    "phase": "Online"
                },
                "phase": "Online"
            }
        }
```
Above is an example CSP object with `nodeStatus` field. 
Currently the following phases(`nodeStatus.phase` value) are defined based on Node Conditions:
1.  `Online`  ( If `NetworkUnavailable` node condition is `false`)
2. `Offline`  ( If `NetworkUnavailable` node condition is `true`)
In subsequent PRs, the status mapping will be enhanced.

**For a general info, following node conditions are defined( as of k8s version 1.11):** 
1.  KernelDeadlock
2. FrequentUnregisterNetDevice
3. NetworkUnavailable
4. OutOfDisk 
5. MemoryPressure
6. DiskPressure
7. PIDPressure
8. Ready

**List of modified file(s):**
1. cmd/maya-apiserver/spc-watcher/handler.go
2. pkg/apis/openebs.io/v1alpha1/cstor_pool.go

**List of newly added file(s):**

1.pkg/patch/patch.go

**List of CRs that got changed:**
1. CstorPool (CSP) 
Signed-off-by: sonasingh46 <sonasingh46@gmail.com>