### PR TITLE
refactor(cstor-volume-mgmt): Use status being supplied by istgt command.

### DIFF
--- a/cmd/cstor-volume-mgmt/controller/common/common.go
+++ b/cmd/cstor-volume-mgmt/controller/common/common.go
@@ -95,13 +95,13 @@ type CStorVolumeStatus string
 const (
 	// volume is getting initialized
 	CVStatusInit CStorVolumeStatus = "Init"
-	// volume is up and running
-	CVStatusRunning CStorVolumeStatus = "Running"
+	// volume allows IOs and snapshot
+	CVStatusHealthy CStorVolumeStatus = "Healthy"
 	// volume only satisfies consistency factor
 	CVStatusDegraded CStorVolumeStatus = "Degraded"
-	// volume does not satisfies consistency factor but has atleast one replica
-	CVStatusRO CStorVolumeStatus = "ReadOnly"
 	// Volume is offline
+	CVStatusOffline CStorVolumeStatus = "Offline"
+	// Error in retrieving volume details
 	CVStatusError CStorVolumeStatus = "Error"
 	// volume controller config generation failed due to invalid parameters
 	CVStatusInvalid CStorVolumeStatus = "Invalid"

--- a/cmd/cstor-volume-mgmt/controller/volume-controller/handler.go
+++ b/cmd/cstor-volume-mgmt/controller/volume-controller/handler.go
@@ -128,7 +128,6 @@ func (c *CStorVolumeController) cStorVolumeEventHandler(operation common.QueueOp
 			glog.Errorf("Error updating cStorVolume object: %s", err)
 			return common.CVStatusIgnore, nil
 		}
-		glog.Infof("[debug] lastKnown phase and current phase: %s, %s", lastKnownPhase, updatedCstorVolume.Status.Phase)
 		// if there is no change in the phase of the cv only then create event
 		if lastKnownPhase != updatedCstorVolume.Status.Phase {
 			err = c.createSyncUpdateEvent(c.createEventObj(updatedCstorVolume))
@@ -150,7 +149,7 @@ func (c *CStorVolumeController) cStorVolumeEventHandler(operation common.QueueOp
 // getEventType returns the event type based on the passed CStorVolumeStatus
 func getEventType(phase common.CStorVolumeStatus) string {
 	// It is normal event only when phase is Running or Degraded
-	if phase == common.CVStatusInit || phase == common.CVStatusRunning || phase == common.CVStatusDegraded {
+	if phase == common.CVStatusInit || phase == common.CVStatusHealthy || phase == common.CVStatusDegraded {
 		return v1.EventTypeNormal
 	}
 	return v1.EventTypeWarning

--- a/cmd/cstor-volume-mgmt/controller/volume-controller/handler_test.go
+++ b/cmd/cstor-volume-mgmt/controller/volume-controller/handler_test.go
@@ -178,12 +178,12 @@ func TestCreateEventObj(t *testing.T) {
 					APIVersion: "v1alpha1",
 				},
 				Status: apis.CStorVolumeStatus{
-					Phase: apis.CStorVolumePhase(common.CVStatusRunning),
+					Phase: apis.CStorVolumePhase(common.CVStatusHealthy),
 				},
 			},
 			event: &v1.Event{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "csv-1.Running",
+					Name:      "csv-1.Healthy",
 					Namespace: string(common.DefaultNameSpace),
 				},
 				InvolvedObject: v1.ObjectReference{
@@ -197,9 +197,9 @@ func TestCreateEventObj(t *testing.T) {
 				FirstTimestamp: metav1.Time{Time: time.Now()},
 				LastTimestamp:  metav1.Time{Time: time.Now()},
 				Count:          1,
-				Message:        fmt.Sprintf(common.EventMsgFormatter, "Running"),
-				Reason:         "Running",
-				Type:           getEventType(common.CStorVolumeStatus("Running")),
+				Message:        fmt.Sprintf(common.EventMsgFormatter, "Healthy"),
+				Reason:         "Healthy",
+				Type:           getEventType(common.CStorVolumeStatus("Healthy")),
 				Source: v1.EventSource{
 					Component: "mypod",
 					Host:      "mynode",
@@ -251,12 +251,12 @@ func TestGetEventType(t *testing.T) {
 		phase     common.CStorVolumeStatus
 		eventType string
 	}{
-		"Normal event Init":      {phase: common.CVStatusInit, eventType: v1.EventTypeNormal},
-		"Normal event Running":   {phase: common.CVStatusRunning, eventType: v1.EventTypeNormal},
-		"Normal event Degraded":  {phase: common.CVStatusDegraded, eventType: v1.EventTypeNormal},
-		"Warning event Error":    {phase: common.CVStatusError, eventType: v1.EventTypeWarning},
-		"Warning event Invalid":  {phase: common.CVStatusInvalid, eventType: v1.EventTypeWarning},
-		"Warning event ReadOnly": {phase: common.CVStatusRO, eventType: v1.EventTypeWarning},
+		"Normal event Init":     {phase: common.CVStatusInit, eventType: v1.EventTypeNormal},
+		"Normal event Healthy":  {phase: common.CVStatusHealthy, eventType: v1.EventTypeNormal},
+		"Normal event Degraded": {phase: common.CVStatusDegraded, eventType: v1.EventTypeNormal},
+		"Warning event Error":   {phase: common.CVStatusError, eventType: v1.EventTypeWarning},
+		"Warning event Invalid": {phase: common.CVStatusInvalid, eventType: v1.EventTypeWarning},
+		"Warning event Offline": {phase: common.CVStatusOffline, eventType: v1.EventTypeWarning},
 	}
 	for desc, ut := range tests {
 		t.Run(desc, func(t *testing.T) {

--- a/cmd/cstor-volume-mgmt/volume/volume_test.go
+++ b/cmd/cstor-volume-mgmt/volume/volume_test.go
@@ -206,7 +206,7 @@ func TestExtractReplicaStatusFromJSON(t *testing.T) {
 							"inflightRead":"0",
 							"inflightWrite":"0",
 							"inflightSync":"0",
-							"upTime":"1275"
+							"upTime":1275
 						},
 						{
 							"replicaId":"23523553",
@@ -215,7 +215,7 @@ func TestExtractReplicaStatusFromJSON(t *testing.T) {
 							"inflightRead":"0",
 							"inflightWrite":"0",
 							"inflightSync":"0",
-							"upTime":"1375"
+							"upTime":1375
 						}
 					  ]
 				   }
@@ -232,7 +232,7 @@ func TestExtractReplicaStatusFromJSON(t *testing.T) {
 						InflightRead:      "0",
 						InflightWrite:     "0",
 						InflightSync:      "0",
-						UpTime:            "1275",
+						UpTime:            1275,
 					},
 					{
 						ID:                "23523553",
@@ -241,21 +241,61 @@ func TestExtractReplicaStatusFromJSON(t *testing.T) {
 						InflightRead:      "0",
 						InflightWrite:     "0",
 						InflightSync:      "0",
-						UpTime:            "1375",
+						UpTime:            1375,
 					},
 				},
 			},
 			false,
 		},
+		"incorrect value in replicaId": {
+			`{
+				"volumeStatus":[
+				   {
+						"name" : "pvc-c7f1a961-e0e3-11e8-b49d-42010a800233",
+						"status": "Healthy",
+						"replicaStatus" : [
+						{
+							"replicaId":5523611450015704000,
+							"status":"HEALTHY",
+							"checkpointedIOSeq":"0",
+							"inflightRead":"0",
+							"inflightWrite":"0",
+							"inflightSync":"0",
+							"upTime":1275
+						},
+					  ]
+				   }
+				]
+			 }`,
+			&apis.CVStatus{
+				Name:   "pvc-c7f1a961-e0e3-11e8-b49d-42010a800233",
+				Status: "Healthy",
+				ReplicaStatuses: []apis.CVReplicaStatus{
+					{
+						ID:                "5523611450015704000",
+						Status:            "HEALTHY",
+						CheckpointedIOSeq: "0",
+						InflightRead:      "0",
+						InflightWrite:     "0",
+						InflightSync:      "0",
+						UpTime:            1275,
+					},
+				},
+			},
+			true,
+		},
 	}
 	for name, mock := range tests {
 		t.Run(name, func(t *testing.T) {
 			got, err := extractReplicaStatusFromJSON(mock.str)
-			if (err != nil) != mock.wantErr {
-				t.Errorf("extractReplicaStatusFromJSON() error = %v, wantErr %v", err != nil, mock.wantErr)
-			}
-			if !reflect.DeepEqual(got, mock.resp) {
-				t.Errorf("extractReplicaStatusFromJSON() = %v, want %v", got, mock.resp)
+			if err != nil {
+				if !mock.wantErr {
+					t.Errorf("extractReplicaStatusFromJSON() error = %v, wantErr %v", err != nil, mock.wantErr)
+				}
+			} else {
+				if !reflect.DeepEqual(got, mock.resp) {
+					t.Errorf("extractReplicaStatusFromJSON() = %v, want %v", got, mock.resp)
+				}
 			}
 		})
 	}

--- a/cmd/cstor-volume-mgmt/volume/volume_test.go
+++ b/cmd/cstor-volume-mgmt/volume/volume_test.go
@@ -189,83 +189,68 @@ func TestExtractReplicaStatusFromJSON(t *testing.T) {
 	}
 	tests := map[string]struct {
 		str     string
-		volName string
-		resp    []string
+		resp    *apis.CVStatus
 		wantErr bool
 	}{
 		"two replicas with one HEALTHY and one BAD status": {
 			`{
-				"Replica status":[
+				"volumeStatus":[
 				   {
-					  "pvc-c7f1a961-e0e3-11e8-b49d-42010a800233":[
-						 {
-							"replica":"5523611450015704000",
+						"name" : "pvc-c7f1a961-e0e3-11e8-b49d-42010a800233",
+						"status": "Healthy",
+						"replicaStatus" : [
+						{
+							"replicaId":"5523611450015704000",
 							"status":"HEALTHY",
-							"checkpointed_io_seq":0,
-							"inflight_read":0,
-							"inflight_write":0,
-							"inflight_sync":0,
-							"connected since(in seconds)":1275
-						 },
-						 {
-							"replica":"23523553",
+							"checkpointedIOSeq":"0",
+							"inflightRead":"0",
+							"inflightWrite":"0",
+							"inflightSync":"0",
+							"upTime":"1275"
+						},
+						{
+							"replicaId":"23523553",
 							"status":"BAD",
-							"checkpointed_io_seq":0,
-							"inflight_read":0,
-							"inflight_write":0,
-							"inflight_sync":0,
-							"connected since(in seconds)":1375
-						 }
+							"checkpointedIOSeq":"0",
+							"inflightRead":"0",
+							"inflightWrite":"0",
+							"inflightSync":"0",
+							"upTime":"1375"
+						}
 					  ]
 				   }
 				]
 			 }`,
-			"pvc-c7f1a961-e0e3-11e8-b49d-42010a800233",
-			[]string{"5523611450015704000:HEALTHY", "23523553:BAD"},
+			&apis.CVStatus{
+				Name:   "pvc-c7f1a961-e0e3-11e8-b49d-42010a800233",
+				Status: "Healthy",
+				ReplicaStatuses: []apis.CVReplicaStatus{
+					{
+						ID:                "5523611450015704000",
+						Status:            "HEALTHY",
+						CheckpointedIOSeq: "0",
+						InflightRead:      "0",
+						InflightWrite:     "0",
+						InflightSync:      "0",
+						UpTime:            "1275",
+					},
+					{
+						ID:                "23523553",
+						Status:            "BAD",
+						CheckpointedIOSeq: "0",
+						InflightRead:      "0",
+						InflightWrite:     "0",
+						InflightSync:      "0",
+						UpTime:            "1375",
+					},
+				},
+			},
 			false,
-		},
-		"One replica with HEALTHY status": {
-			`{
-				"Replica status":[
-				   {
-					  "pvc-c7f1a961-e0e3-11e8-b49d-42010a800233":[
-						 {
-							"replica":"5523611450015704",
-							"status":"HEALTHY",
-							"checkpointed_io_seq":0,
-							"inflight_read":0,
-							"inflight_write":0,
-							"inflight_sync":0,
-							"connected since(in seconds)":1275
-						 }
-					  ]
-				   }
-				]
-			 }`,
-			"pvc-c7f1a961-e0e3-11e8-b49d-42010a800233",
-			[]string{"5523611450015704:HEALTHY"},
-			false,
-		},
-		"Missing replicas": {
-			`{
-				"Replica status":[{"pvc-389710cf-e351-11e8-b49d-42010a800233":[]}]
-			 }`,
-			"pvc-c7f1a961-e0e3-11e8-b49d-42010a800233",
-			nil,
-			false,
-		},
-		"Invalid input": {
-			`{
-				"Replica status":[asd]
-			 }`,
-			"pvc-c7f1a961-e0e3-11e8-b49d-42010a800233",
-			nil,
-			true,
 		},
 	}
 	for name, mock := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := extractReplicaStatusFromJSON(mock.volName, mock.str)
+			got, err := extractReplicaStatusFromJSON(mock.str)
 			if (err != nil) != mock.wantErr {
 				t.Errorf("extractReplicaStatusFromJSON() error = %v, wantErr %v", err != nil, mock.wantErr)
 			}

--- a/pkg/apis/openebs.io/v1alpha1/cstor_volume.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_volume.go
@@ -57,7 +57,7 @@ type CStorVolumeStatus struct {
 
 // ReplicaStatus represents the status of a volume replica
 type ReplicaStatus struct {
-	GUID   string `json:"guid"`
+	ID     string `json:"replicaId"`
 	Status string `json:"status"`
 }
 
@@ -70,4 +70,28 @@ type CStorVolumeList struct {
 	metav1.ListMeta `json:"metadata"`
 
 	Items []CStorVolume `json:"items"`
+}
+
+// CVStatusResponse stores the reponse of istgt replica command output
+// It may contain several volumes
+type CVStatusResponse struct {
+	CVStatuses []CVStatus `json:"volumeStatus"`
+}
+
+// CVStatus stores the status of a CstorVolume obtained from response
+type CVStatus struct {
+	Name            string            `json:"name"`
+	Status          string            `json:"status"`
+	ReplicaStatuses []CVReplicaStatus `json:"replicaStatus"`
+}
+
+// ReplicaStatus stores the status of replicas
+type CVReplicaStatus struct {
+	ID                string `json:"replicaId"`
+	Status            string `json:"status"`
+	CheckpointedIOSeq string `json:"checkpointedIOSeq"`
+	InflightRead      string `json:"inflightRead"`
+	InflightWrite     string `json:"inflightWrite"`
+	InflightSync      string `json:"inflightSync"`
+	UpTime            string `json:"upTime"`
 }

--- a/pkg/apis/openebs.io/v1alpha1/cstor_volume.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_volume.go
@@ -93,5 +93,5 @@ type CVReplicaStatus struct {
 	InflightRead      string `json:"inflightRead"`
 	InflightWrite     string `json:"inflightWrite"`
 	InflightSync      string `json:"inflightSync"`
-	UpTime            string `json:"upTime"`
+	UpTime            int    `json:"upTime"`
 }


### PR DESCRIPTION
The istgtcontrol command is expected to return response in a new json
format. This PR uses the updated json format.

The response is also going to contain the overall status of the volume.
If the cv is not in error,init,invalid states then the status in
response would be updated on the CV object.

Signed-off-by: princerachit <prince.rachit@mayadata.io>

Output of cstorvolume describe:
```yaml
Status:
  Phase:  Healthy
  Replica Statuses:
    Replica Id:  2506826991850132511
    Status:      HEALTHY
    Replica Id:  6824451318329165203
    Status:      HEALTHY
    Replica Id:  3433388595249797004
    Status:      HEALTHY
Events:
  Type    Reason    Age                  From                                                                                                      Message
  ----    ------    ----                 ----                                                                                                      -------
  Normal  Init      3m48s                pvc-39ba14e8-ed51-11e8-9419-42010a800056-target-68b7c68d648qjhw, gke-prince-cluster-pool-1-1ddefaed-vl8m  Volume is in Init state
  Normal  Degraded  2m48s                pvc-39ba14e8-ed51-11e8-9419-42010a800056-target-68b7c68d648qjhw, gke-prince-cluster-pool-1-1ddefaed-vl8m  Volume is in Degraded state
  Normal  Healthy   78s                  pvc-39ba14e8-ed51-11e8-9419-42010a800056-target-68b7c68d648qjhw, gke-prince-cluster-pool-1-1ddefaed-vl8m  Volume is in Healthy state
  Normal  Synced    18s (x8 over 3m48s)  pvc-39ba14e8-ed51-11e8-9419-42010a800056-target-68b7c68d648qjhw, gke-prince-cluster-pool-1-1ddefaed-vl8m  Synced
```