### PR TITLE
refactor(cstor-volume): Use replica status from response to fill cv.

### DIFF
--- a/cmd/cstor-volume-mgmt/volume/volume_test.go
+++ b/cmd/cstor-volume-mgmt/volume/volume_test.go
@@ -224,7 +224,7 @@ func TestExtractReplicaStatusFromJSON(t *testing.T) {
 			&apis.CVStatus{
 				Name:   "pvc-c7f1a961-e0e3-11e8-b49d-42010a800233",
 				Status: "Healthy",
-				ReplicaStatuses: []apis.CVReplicaStatus{
+				ReplicaStatuses: []apis.ReplicaStatus{
 					{
 						ID:                "5523611450015704000",
 						Status:            "HEALTHY",
@@ -270,7 +270,7 @@ func TestExtractReplicaStatusFromJSON(t *testing.T) {
 			&apis.CVStatus{
 				Name:   "pvc-c7f1a961-e0e3-11e8-b49d-42010a800233",
 				Status: "Healthy",
-				ReplicaStatuses: []apis.CVReplicaStatus{
+				ReplicaStatuses: []apis.ReplicaStatus{
 					{
 						ID:                "5523611450015704000",
 						Status:            "HEALTHY",

--- a/pkg/apis/openebs.io/v1alpha1/cstor_volume.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_volume.go
@@ -55,12 +55,6 @@ type CStorVolumeStatus struct {
 	ReplicaStatuses []ReplicaStatus  `json:"replicaStatuses,omitempty"`
 }
 
-// ReplicaStatus represents the status of a volume replica
-type ReplicaStatus struct {
-	ID     string `json:"replicaId"`
-	Status string `json:"status"`
-}
-
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +resource:path=cstorvolume
 
@@ -80,13 +74,13 @@ type CVStatusResponse struct {
 
 // CVStatus stores the status of a CstorVolume obtained from response
 type CVStatus struct {
-	Name            string            `json:"name"`
-	Status          string            `json:"status"`
-	ReplicaStatuses []CVReplicaStatus `json:"replicaStatus"`
+	Name            string          `json:"name"`
+	Status          string          `json:"status"`
+	ReplicaStatuses []ReplicaStatus `json:"replicaStatus"`
 }
 
 // ReplicaStatus stores the status of replicas
-type CVReplicaStatus struct {
+type ReplicaStatus struct {
 	ID                string `json:"replicaId"`
 	Status            string `json:"status"`
 	CheckpointedIOSeq string `json:"checkpointedIOSeq"`


### PR DESCRIPTION
The response from istgt was being parsed and then updated in the cv's
replica statuses field.

```yaml
Modified above logic to directly fill replica statuses in cv using
response.
Status:
  Phase:  Healthy
  Replica Statuses:
    Checkpointed IO Seq:  0
    Inflight Read:        0
    Inflight Sync:        0
    Inflight Write:       0
    Replica Id:           11858145003581796177
    Status:               HEALTHY
    Up Time:              516
    Checkpointed IO Seq:  0
    Inflight Read:        0
    Inflight Sync:        0
    Inflight Write:       0
    Replica Id:           16413594999089341547
    Status:               HEALTHY
    Up Time:              515
    Checkpointed IO Seq:  0
    Inflight Read:        0
    Inflight Sync:        0
    Inflight Write:       0
    Replica Id:           3693374404252622418
    Status:               HEALTHY
    Up Time:              513
Events:
  Type    Reason    Age                   From                                                                                                      Message
  ----    ------    ----                  ----                                                                                                      -------
  Normal  Init      9m56s                 pvc-1f552baf-ed6e-11e8-9419-42010a800056-target-5467c985fdcgv9q, gke-prince-cluster-pool-1-1ddefaed-bx8j  Volume is in Init state
  Normal  Degraded  8m56s                 pvc-1f552baf-ed6e-11e8-9419-42010a800056-target-5467c985fdcgv9q, gke-prince-cluster-pool-1-1ddefaed-bx8j  Volume is in Degraded state
  Normal  Healthy   7m26s                 pvc-1f552baf-ed6e-11e8-9419-42010a800056-target-5467c985fdcgv9q, gke-prince-cluster-pool-1-1ddefaed-bx8j  Volume is in Healthy state
  Normal  Synced    26s (x20 over 9m56s)  pvc-1f552baf-ed6e-11e8-9419-42010a800056-target-5467c985fdcgv9q, gke-prince-cluster-pool-1-1ddefaed-bx8j  Synced
```