### PR TITLE
fix(cvr): remove status based selection of csp for cvr(s).

### DIFF
--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -182,17 +182,12 @@ spec:
     If clone is not enabled then override changes of previous runtask
     */}}
     {{- if eq $isClone "false" }}
-    {{/*
-    Check if enough online pools are present to create replicas.
-    If pools are not present error out.
-    Save the cstorpool's uid:name into .ListItems.cvolPoolList otherwise
-    */}}
     {{- $replicaCount := int64 .Config.ReplicaCount.value | saveAs "rc" .ListItems -}}
-    {{- $poolsList := jsonpath .JsonResult "{range .items[?(@.status.phase=='Online')]}pkey=pools,{@.metadata.uid}={@.metadata.name};{end}" | trim | default "" | splitListTrim ";" -}}
+    {{- $poolsList := jsonpath .JsonResult "{range .items[*]}pkey=pools,{@.metadata.uid}={@.metadata.name};{end}" | trim | default "" | splitListTrim ";" -}}
     {{- $poolsList | saveAs "pl" .ListItems -}}
     {{- len $poolsList | gt $replicaCount | verifyErr "not enough pools available to create replicas" | saveAs "cvolcreatelistpool.verifyErr" .TaskResult | noop -}}
     {{- $poolsList | keyMap "cvolPoolList" .ListItems | noop -}}
-    {{- $poolsNodeList := jsonpath .JsonResult "{range .items[?(@.status.phase=='Online')]}pkey=pools,{@.metadata.uid}={@.metadata.labels.kubernetes\\.io/hostname};{end}" | trim | default "" | splitList ";" -}}
+    {{- $poolsNodeList := jsonpath .JsonResult "{range .items[*]}pkey=pools,{@.metadata.uid}={@.metadata.labels.kubernetes\\.io/hostname};{end}" | trim | default "" | splitList ";" -}}
     {{- $poolsNodeList | keyMap "cvolPoolNodeList" .ListItems | noop -}}
     {{- end }}
 ---


### PR DESCRIPTION
Only those CSP(s) were selected for volume replica that had 'Online' status.
This PR will allow selection of CSP for  replica irrespective of their status.
In near future volume distribution will enhance selection of CVR. 
Signed-off-by: sonasingh46 <sonasingh46@gmail.com>