### PR TITLE
feat(cvr): add zfs volume status on cvr object

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/common/common.go
+++ b/cmd/cstor-pool-mgmt/controller/common/common.go
@@ -92,7 +92,7 @@ const (
 	// PoolNameHandlerInterval is used when expected pool is not present.
 	PoolNameHandlerInterval = 5 * time.Second
 	// SharedInformerInterval is used to sync watcher controller.
-	SharedInformerInterval = 5 * time.Minute
+	SharedInformerInterval = 15 * time.Second
 	// ResourceWorkerInterval is used for resource sync.
 	ResourceWorkerInterval = time.Second
 	// InitialZreplRetryInterval is used while initially starting controller.

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -134,7 +134,7 @@ func (c *CStorVolumeReplicaController) cVREventHandler(operation common.QueueOpe
 		}
 		return "", nil
 	case common.QOpStatusSync:
-		glog.Infof("Synchronizing CstorVolumeReplica status for pool %s", cVR.ObjectMeta.Name)
+		glog.Infof("Synchronizing CstorVolumeReplica status for volume %s", cVR.ObjectMeta.Name)
 		status, err := c.getCVRStatus(cVR)
 		if err != nil {
 			glog.Errorf("Unable to get volume status:%s", err.Error())

--- a/cmd/cstor-pool-mgmt/volumereplica/volumereplica_test.go
+++ b/cmd/cstor-pool-mgmt/volumereplica/volumereplica_test.go
@@ -33,19 +33,24 @@ type TestRunner struct{}
 // RunCombinedOutput is to mock Real runner exec.
 func (r TestRunner) RunCombinedOutput(command string, args ...string) ([]byte, error) {
 	var cs []string
+	var env []string
 	var cmd *exec.Cmd
-	cs = append(cs, args...)
-	cmd = exec.Command(os.Args[0], cs...)
 	switch args[0] {
 	case "create":
 		cs = []string{"-test.run=TestCreaterProcess", "--"}
-		cmd.Env = []string{"createErr=nil"}
-		break
+		env = []string{"createErr=nil"}
 	case "destroy":
 		cs = []string{"-test.run=TestDestroyerProcess", "--"}
-		cmd.Env = []string{"destroyErr=nil"}
-		break
+		env = []string{"destroyErr=nil"}
+	case StatsCmd:
+		// Create command arguments
+		cs = []string{"-test.run=TestStatusHelperProcess", "--", command}
+		// Set env varibles for the 'TestStatusHelperProcess' function which runs as a process.
+		env = []string{"GO_WANT_STATUS_HELPER_PROCESS=1", "StatusType=" + os.Getenv("StatusType")}
 	}
+	cs = append(cs, args...)
+	cmd = exec.Command(os.Args[0], cs...)
+	cmd.Env = env
 	stdout, err := cmd.CombinedOutput()
 	return stdout, err
 }
@@ -105,6 +110,108 @@ func TestDestroyerProcess(*testing.T) {
 	}
 	defer os.Exit(0)
 	fmt.Println(nil)
+}
+
+// TestStatusHelperProcess is a function that is run as a process to get the mocked std output
+func TestStatusHelperProcess(*testing.T) {
+	// Following constants are different mocked output for `zfs status` command for
+	// different statuses.
+	const (
+		mockedStatusOutputHealthy = `{
+  "stats": [
+    {
+      "name": "cstor-183f17c6-ed8b-11e8-87fd-42010a800087/pvc-9e91f938-ee23-11e8-87fd-42010a800087",
+      "status": "Healthy",
+      "rebuildStatus": "INIT",
+      "isIOAckSenderCreated": 0,
+      "isIOReceiverCreated": 0,
+      "runningIONum": 0,
+      "checkpointedIONum": 0,
+      "degradedCheckpointedIONum": 0,
+      "checkpointedTime": 0,
+      "rebuildBytes": 0,
+      "rebuildCnt": 0,
+      "rebuildDoneCnt": 0,
+      "rebuildFailedCnt": 0
+    }
+  ]
+}`
+		mockedStatusOutputOffline = `{
+  "stats": [
+    {
+      "name": "cstor-183f17c6-ed8b-11e8-87fd-42010a800087/pvc-9e91f938-ee23-11e8-87fd-42010a800087",
+      "status": "Offline",
+      "rebuildStatus": "INIT",
+      "isIOAckSenderCreated": 0,
+      "isIOReceiverCreated": 0,
+      "runningIONum": 0,
+      "checkpointedIONum": 0,
+      "degradedCheckpointedIONum": 0,
+      "checkpointedTime": 0,
+      "rebuildBytes": 0,
+      "rebuildCnt": 0,
+      "rebuildDoneCnt": 0,
+      "rebuildFailedCnt": 0
+    }
+  ]
+}`
+		mockedStatusOutputRebuilding = `{
+  "stats": [
+    {
+      "name": "cstor-183f17c6-ed8b-11e8-87fd-42010a800087/pvc-9e91f938-ee23-11e8-87fd-42010a800087",
+      "status": "Rebuilding",
+      "rebuildStatus": "INIT",
+      "isIOAckSenderCreated": 0,
+      "isIOReceiverCreated": 0,
+      "runningIONum": 0,
+      "checkpointedIONum": 0,
+      "degradedCheckpointedIONum": 0,
+      "checkpointedTime": 0,
+      "rebuildBytes": 0,
+      "rebuildCnt": 0,
+      "rebuildDoneCnt": 0,
+      "rebuildFailedCnt": 0
+    }
+  ]
+}`
+		mockedStatusOutputDegraded = `{
+  "stats": [
+    {
+      "name": "cstor-183f17c6-ed8b-11e8-87fd-42010a800087/pvc-9e91f938-ee23-11e8-87fd-42010a800087",
+      "status": "Degraded",
+      "rebuildStatus": "INIT",
+      "isIOAckSenderCreated": 0,
+      "isIOReceiverCreated": 0,
+      "runningIONum": 0,
+      "checkpointedIONum": 0,
+      "degradedCheckpointedIONum": 0,
+      "checkpointedTime": 0,
+      "rebuildBytes": 0,
+      "rebuildCnt": 0,
+      "rebuildDoneCnt": 0,
+      "rebuildFailedCnt": 0
+    }
+  ]
+}`
+	)
+	if os.Getenv("GO_WANT_STATUS_HELPER_PROCESS") != "1" {
+		return
+	}
+	// Pick the mocked output as specified by the env variable.
+	if os.Getenv("StatusType") == ZfsStatusHealthy {
+		fmt.Fprint(os.Stdout, mockedStatusOutputHealthy)
+	}
+	if os.Getenv("StatusType") == ZfsStatusDegraded {
+		fmt.Fprint(os.Stdout, mockedStatusOutputDegraded)
+	}
+	if os.Getenv("StatusType") == ZfsStatusOffline {
+		fmt.Fprint(os.Stdout, mockedStatusOutputOffline)
+	}
+	if os.Getenv("StatusType") == ZfsStatusRebuilding {
+		fmt.Fprint(os.Stdout, mockedStatusOutputRebuilding)
+	}
+
+	defer os.Exit(0)
 }
 
 // TestCreateVolumeReplica is to test cStorVolumeReplica creation.
@@ -309,6 +416,63 @@ func TestParseCapacityUnit(t *testing.T) {
 			if gotVolumeCapacity != test.expectedVolumeCapacity {
 				t.Errorf("Test case failed as expected capacity '%v' but got '%v'", test.expectedVolumeCapacity, gotVolumeCapacity)
 			}
+		})
+	}
+}
+
+// TestPoolStatus tests Status function which retunr cvr status.
+func TestVolumeStatus(t *testing.T) {
+	testPoolResource := map[string]struct {
+		// cvrName holds the name of zfs volume(not the cvr object name).
+		volumeName string
+		// MockedOutputType holds the type for which the mocked output should be taken e.g.
+		// for 'ZfsStatusHealthy' type a mocked output of `zfs stats` command for Healthy type is taken.
+		mockedOutputType string
+		// expectedStatus is the status that is expected for the test case.
+		expectedStatus string
+	}{
+		// ToDo : Test case for error status.
+		"#1 OnlineVolumeStatus": {
+			volumeName:       "cstor-183f17c6-ed8b-11e8-87fd-42010a800087/pvc-9e91f938-ee23-11e8-87fd-42010a800087",
+			mockedOutputType: ZfsStatusHealthy,
+			expectedStatus:   "Healthy",
+		},
+		"#2 OfflineVolumeStatus": {
+			volumeName:       "cstor-183f17c6-ed8b-11e8-87fd-42010a800087/pvc-9e91f938-ee23-11e8-87fd-42010a800087",
+			mockedOutputType: ZfsStatusOffline,
+			expectedStatus:   "Offline",
+		},
+		"#3 DegradedVolumeStatus": {
+			volumeName:       "cstor-183f17c6-ed8b-11e8-87fd-42010a800087/pvc-9e91f938-ee23-11e8-87fd-42010a800087",
+			mockedOutputType: ZfsStatusDegraded,
+			expectedStatus:   "Degraded",
+		},
+		"#4 RebuildingVolumeStatus": {
+			volumeName:       "cstor-183f17c6-ed8b-11e8-87fd-42010a800087/pvc-9e91f938-ee23-11e8-87fd-42010a800087",
+			mockedOutputType: ZfsStatusRebuilding,
+			expectedStatus:   "Rebuilding",
+		},
+		"#5 ErrorVolumeStatus": {
+			volumeName:       "cstor-183f17c6-ed8b-11e8-87fd-42010a800087/pvc-9e91f938-ee23-11e8-87fd-42010a800087",
+			mockedOutputType: ZfsStatusRebuilding,
+			expectedStatus:   "Rebuilding",
+		},
+	}
+	for name, test := range testPoolResource {
+		t.Run(name, func(t *testing.T) {
+			// Set env variable "StatusType" to "mockedOutputType"
+			// It will help to decide which mocked output should be considered as a std output.
+			os.Setenv("StatusType", test.mockedOutputType)
+			RunnerVar = TestRunner{}
+			gotStatus, err := Status(test.volumeName)
+			if err != nil {
+				t.Fatal("Some error occured in getting volume status:", err)
+			}
+			if test.expectedStatus != gotStatus {
+				t.Errorf("Test case failed as expected status '%s' but got '%s'", test.expectedStatus, gotStatus)
+			}
+			// Unset the "StatusType" env variable
+			os.Unsetenv("StatusType")
 		})
 	}
 }

--- a/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
@@ -42,10 +42,10 @@ const (
 
 // CStorVolumeReplica describes a cstor volume resource created as custom resource
 type CStorVolumeReplica struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              CStorVolumeReplicaSpec   `json:"spec"`
-	Status            CStorVolumeReplicaStatus `json:"status"`
+	metav1.TypeMeta                 `json:",inline"`
+	metav1.ObjectMeta               `json:"metadata,omitempty"`
+	Spec   CStorVolumeReplicaSpec   `json:"spec"`
+	Status CStorVolumeReplicaStatus `json:"status"`
 }
 
 // CStorVolumeReplicaSpec is the spec for a CStorVolumeReplica resource
@@ -62,9 +62,15 @@ const (
 	// CVRStatusEmpty ensures the create operation is to be done, if import fails.
 	CVRStatusEmpty CStorVolumeReplicaPhase = ""
 	// CVRStatusOnline ensures the resource is available.
-	CVRStatusOnline CStorVolumeReplicaPhase = "Online"
+	CVRStatusOnline CStorVolumeReplicaPhase = "Healthy"
 	// CVRStatusOffline ensures the resource is not available.
 	CVRStatusOffline CStorVolumeReplicaPhase = "Offline"
+	// CVRStatusDegraded means that the rebuilding has not yet started.
+	CVRStatusDegraded CStorVolumeReplicaPhase = "Degraded"
+	// CVRStatusRebuilding means that the volume is in re-building phase.
+	CVRStatusRebuilding CStorVolumeReplicaPhase = "Rebuilding"
+	// CVRStatusRebuilding means that the volume status could not be found.
+	CVRStatusError CStorVolumeReplicaPhase = "Error"
 	// CVRStatusDeletionFailed ensures the resource deletion has failed.
 	CVRStatusDeletionFailed CStorVolumeReplicaPhase = "DeletionFailed"
 	// CVRStatusInvalid ensures invalid resource.

--- a/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
@@ -72,13 +72,13 @@ const (
 	// CVRStatusRebuilding means that the volume status could not be found.
 	CVRStatusError CStorVolumeReplicaPhase = "Error"
 	// CVRStatusDeletionFailed ensures the resource deletion has failed.
-	CVRStatusDeletionFailed CStorVolumeReplicaPhase = "DeletionFailed"
+	CVRStatusDeletionFailed CStorVolumeReplicaPhase = "Error"
 	// CVRStatusInvalid ensures invalid resource.
 	CVRStatusInvalid CStorVolumeReplicaPhase = "Invalid"
 	// CVRStatusErrorDuplicate ensures error due to duplicate resource.
-	CVRStatusErrorDuplicate CStorVolumeReplicaPhase = "ErrorDuplicate"
+	CVRStatusErrorDuplicate CStorVolumeReplicaPhase = "Invalid"
 	// CVRStatusPending ensures pending task of cvr resource.
-	CVRStatusPending CStorVolumeReplicaPhase = "Pending"
+	CVRStatusPending CStorVolumeReplicaPhase = "Init"
 )
 
 // CStorVolumeReplicaStatus is for handling status of cvr.


### PR DESCRIPTION
This PR will do following:
Put zfs volume status on cvr object on every rsync.
Example cvr object :

```json
{
    "apiVersion": "openebs.io/v1alpha1",
    "kind": "CStorVolumeReplica",
    "metadata": {
        "annotations": {
            "cstorpool.openebs.io/hostname": "gke-cstor-it-default-pool-e84f5225-p7jk"
        },
        "creationTimestamp": "2018-11-22T06:55:38Z",
        "finalizers": [
            "cstorvolumereplica.openebs.io/finalizer"
        ],
        "generation": 1,
        "labels": {
            "cstorpool.openebs.io/name": "sparse-claim-auto-edf5",
            "cstorpool.openebs.io/uid": "183f17c6-ed8b-11e8-87fd-42010a800087",
            "cstorvolume.openebs.io/name": "pvc-9e91f938-ee23-11e8-87fd-42010a800087",
            "openebs.io/cas-template-name": "cstor-volume-create-default-0.8.0",
            "openebs.io/persistent-volume": "pvc-9e91f938-ee23-11e8-87fd-42010a800087",
            "openebs.io/version": "0.8.0"
        },
        "name": "pvc-9e91f938-ee23-11e8-87fd-42010a800087-sparse-claim-auto-edf5",
        "namespace": "openebs",
        "resourceVersion": "8312211",
        "selfLink": "/apis/openebs.io/v1alpha1/namespaces/openebs/cstorvolumereplicas/pvc-9e91f938-ee23-11e8-87fd-42010a800087-sparse-claim-auto-edf5",
        "uid": "9eb4d155-ee23-11e8-87fd-42010a800087"
    },
    "spec": {
        "capacity": "1G",
        "targetIP": "10.43.249.52"
    },
    "status": {
        "phase": "Healthy"
    }
}
```
**Notice the status.phase field on the object.**
Please go through following link for more details:
https://docs.google.com/document/d/1ZXzCGMricl3TeOgpzfxYJTJM_KuRs8Rrv_wc1RoY3X4/edit#bookmark=id.5nb7rexjdah0
Signed-off-by: sonasingh46 <sonasingh46@gmail.com>