### PR TITLE
fix(cast): Add default status of created cstorvolume as Init.

### DIFF
--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -276,7 +276,7 @@ spec:
       iqn: iqn.2016-09.com.openebs.cstor:{{ .Volume.owner }}
       targetPortal: {{ .TaskResult.cvolcreateputsvc.clusterIP }}:3260
       targetPort: 3260
-      status: ""
+      status: "Init"
       replicationFactor: {{ $replicaCount }}
       consistencyFactor: {{ div $replicaCount 2 | floor | add1 }}
 ---


### PR DESCRIPTION
The empty string in status does not very well expreses the status of
the cstor volume therefore as soon as it gets created it should always
have Init as status.

Signed-off-by: princerachit <prince.rachit@mayadata.io>

