### PR TITLE
feat(install, cast) add kubernetes version as label to default CASTemplates

### DIFF
--- a/pkg/apis/openebs.io/v1alpha1/cas_keys.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_keys.go
@@ -43,19 +43,6 @@ const (
 	// OpenEBS
 	OpenEBSVersionKey CASKey = "openebs.io/version"
 
-	// VersionKey is the label key which provides the installed version of
-	// OpenEBS
-	//
-	// NOTE:
-	// This can be used for openebs specific custom resources where namespacing
-	// the key is not mandatory. The org specific namespace details is already
-	// present in the apiVersion itself. This also helps to parse version key
-	// easily.
-	VersionKey CASKey = "version"
-
-	// CASTNameKey is the key to fetch name of CAS template
-	CASTNameKey CASKey = "castName"
-
 	// CASConfigKey is the key to fetch configurations w.r.t a CAS entity
 	CASConfigKey CASKey = "cas.openebs.io/config"
 
@@ -74,6 +61,36 @@ const (
 	// StorageClassHeaderKey is the key to fetch name of StorageClass
 	// This key is present only in get request headers
 	StorageClassHeaderKey CASKey = "storageclass"
+)
+
+// CASPlainKey represents a openebs key used either in resource annotation 
+// or label
+//
+// NOTE:
+//  PlainKey (i.e. without 'openebs.io/' ) helps to parse key via 
+// go templating
+type CASPlainKey string
+
+const(
+	// OpenEBSVersionPlainKey is the label key which provides the installed 
+	// version of OpenEBS
+	OpenEBSVersionPlainKey CASPlainKey = "version"
+
+	// CASTNamePlainKey is the key to fetch name of CAS template
+	CASTNamePlainKey CASPlainKey = "castName"
+)
+
+// KubePlainKey represents a kubernetes key used either in resource annotation 
+// or label
+//
+// NOTE:
+//  PlainKey (i.e. without 'kubernetes.io/' ) helps to parse key via 
+// go templating
+type KubePlainKey string
+
+const (
+	// KubeServerVersionPlainKey is the key to fetch Kubernetes server version
+	KubeServerVersionPlainKey KubePlainKey = "kubeVersion"
 )
 
 // DeprecatedKey is a typed string to represent deprecated annotations' or

--- a/pkg/client/k8s/v1alpha1/k8s.go
+++ b/pkg/client/k8s/v1alpha1/k8s.go
@@ -26,7 +26,7 @@ import (
 func GetServerVersion() (*version.Info, error) {
 	cs, err := Clientset().Get()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get apiserver version:")
+		return nil, errors.Wrapf(err, "failed to get apiserver version")
 	}
 	return cs.Discovery().ServerVersion()
 }

--- a/pkg/msg/v1alpha1/msg.go
+++ b/pkg/msg/v1alpha1/msg.go
@@ -203,6 +203,10 @@ func (m Msgs) Errors() (f Msgs) {
 	return m.Filter(IsErr)
 }
 
+func (m Msgs) HasError() bool {
+	return len(m.Errors().Items) != 0
+}
+
 func (m Msgs) NonErrors() (f Msgs) {
 	return m.Filter(IsNotErr)
 }

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ghodss/yaml"
 	v1alpha1 "github.com/openebs/maya/pkg/task/v1alpha1"
 	"github.com/openebs/maya/pkg/util"
+	kubever "github.com/openebs/maya/pkg/version/kubernetes"
 	"reflect"
 	"strings"
 	"text/template"
@@ -791,6 +792,10 @@ func allCustomFuncs() template.FuncMap {
 	}
 	rc := runCommandFuncs()
 	for k, v := range rc {
+		f[k] = v
+	}
+	kVer := kubever.TemplateFunctions()
+	for k, v := range kVer {
 		f[k] = v
 	}
 	return f

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -19,11 +19,14 @@ limitations under the License.
 // into understanding the standard templating features used
 // by maya
 //
-// NOTE on templating:
+// Guides on go templating:
 //
-// BuiltIn funcs: https://golang.org/src/text/template/funcs.go
+// Built-in funcs:
+// - https://golang.org/src/text/template/funcs.go
+//
 // Custom template funcs:
 // - https://github.com/Masterminds/sprig/tree/master/docs
+//
 // Templating guides:
 // - https://github.com/kubernetes/helm/tree/master/docs/chart_template_guide
 // - https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html

--- a/pkg/version/kubernetes/version.go
+++ b/pkg/version/kubernetes/version.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2018 The OpenEBS Authors
+Copyright 2018 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// NOTE:
+// Some pieces of code was borrowed from:
+// - k8s.io/apimachinery/pkg/version/helpers.go
+package kubernetes
+
+import (
+	msg "github.com/openebs/maya/pkg/msg/v1alpha1"
+	"github.com/pkg/errors"
+	kubeval "k8s.io/apimachinery/pkg/util/validation"
+	"regexp"
+	"strconv"
+	"strings"
+	"text/template"
+)
+
+type releaseType int
+
+const (
+	// Bigger the release type number, higher priority it is
+	versionTypeAlpha releaseType = iota
+	versionTypeBeta
+	versionTypeGA
+)
+
+const (
+	invalidVersionValue = "invalid"
+)
+
+// expression is the regular expression for kubernetes aware version
+// strings
+//
+// NOTE:
+// - ^v implies every kubernetes version starts with character 'v'
+// - () evaluates the regular expression & stores it if match is a success
+// - x? implies zero or one x prefer one; where x is the regular expression
+// - ?: implies the expected regular expression going forward
+const expression = "^v([\\d]+)(?:.)([\\d]+)(?:.)([\\d]+)(?:-(alpha|beta|gke|eks))?(?:.([\\d]+))?"
+
+var regex = regexp.MustCompile(expression)
+
+// A kubernetes aware version is looks like following:
+// `vmajor.minor.patch.release.releaseNumber`
+//
+// NOTE:
+// Below are a few valid kubernetes versions
+// v1.0.0
+// v1.11.1+a0ce1bf1
+// v1.12.1-alpha
+// v1.12.2-alpha.10
+// v0.4.5-gke
+// v0.4.6-gke.113
+// v0.4.5-eks
+// v0.4.6-eks.11
+type version struct {
+	orig          string      // original version received
+	major         int         // version major value
+	minor         int         // version minor value
+	patch         int         // version patch value
+	release       releaseType // represents if this is Alpha, Beta or GA release
+	releaseNumber int         // extra digits that comes after the release type
+	*msg.Msgs
+}
+
+func parse(v string) version {
+	var err error
+	ver := version{orig: v, Msgs: &msg.Msgs{}}
+	submatches := regex.FindStringSubmatch(v)
+	if len(submatches) != 6 {
+		ver.AddError(errors.Errorf("failed to parse version '%s'", v))
+		return ver
+	}
+	if ver.major, err = strconv.Atoi(submatches[1]); err != nil {
+		ver.AddError(errors.Errorf("invalid major version found in '%s'", v))
+		return ver
+	}
+	if ver.minor, err = strconv.Atoi(submatches[2]); err != nil {
+		ver.AddError(errors.Errorf("invalid minor version found in '%s'", v))
+		return ver
+	}
+	if ver.patch, err = strconv.Atoi(submatches[3]); err != nil {
+		ver.AddError(errors.Errorf("invalid patch version found in '%s'", v))
+		return ver
+	}
+	switch submatches[4] {
+	case "alpha":
+		ver.release = versionTypeAlpha
+	case "beta":
+		ver.release = versionTypeBeta
+	default:
+		// "eks", "gke", "dev", "", or any word other than "alpha" or "beta" are
+		// categorized as "ga" i.e. general availability
+		ver.release = versionTypeGA
+	}
+	// we ignore error due to release number
+	ver.releaseNumber, _ = strconv.Atoi(submatches[5])
+	return ver
+}
+
+// AsLabelValue sanitizes the provided version by making it eligible to be
+// used as a kubernetes resource's label value
+func AsLabelValue(v string) string {
+	var (
+		sanitized string
+		errs      []string
+	)
+	errs = kubeval.IsValidLabelValue(v)
+	if len(errs) == 0 {
+		return v
+	}
+	submatches := regex.FindStringSubmatch(v)
+	if len(submatches) != 6 {
+		sanitized = invalidVersionValue
+	} else {
+		sanitized = submatches[0]
+	}
+	errs = kubeval.IsValidLabelValue(sanitized)
+	if len(errs) == 0 {
+		return sanitized
+	}
+	return invalidVersionValue
+}
+
+// Compare compares two kubernetes aware version strings
+func Compare(v1, v2 string) int {
+	if v1 == v2 {
+		return 0
+	}
+	ver1 := parse(v1)
+	ver2 := parse(v2)
+	switch {
+	case ver1.HasError() && ver2.HasError():
+		return strings.Compare(v2, v1)
+	case ver1.HasError() && !ver2.HasError():
+		return -1
+	case !ver1.HasError() && ver2.HasError():
+		return 1
+	}
+	if ver1.major > ver2.major {
+		return 1
+	} else if ver1.major < ver2.major {
+		return -1
+	} else if ver1.minor > ver2.minor {
+		return 1
+	} else if ver1.minor < ver2.minor {
+		return -1
+	} else if ver1.patch > ver2.patch {
+		return 1
+	} else if ver1.patch < ver2.patch {
+		return -1
+	} else if int(ver1.release) > int(ver2.release) {
+		return 1
+	} else if int(ver1.release) < int(ver2.release) {
+		return -1
+	} else if ver1.releaseNumber > ver2.releaseNumber {
+		return 1
+	} else if ver1.releaseNumber < ver2.releaseNumber {
+		return -1
+	}
+	return 0
+}
+
+// Equals returns true if both the provided kubernetes aware versions
+// are equal
+func Equals(v1, v2 string) bool {
+	return Compare(v1, v2) == 0
+}
+
+// GreaterThan returns true if kubernetes aware version v1 is
+// greater than kubernetes aware version v2
+func GreaterThan(v1, v2 string) bool {
+	return Compare(v1, v2) > 0
+}
+
+// GreaterThanOrEquals returns true if kubernetes aware version v1
+// is either greater than or equal to kubernetes aware version v2
+func GreaterThanOrEquals(v1, v2 string) bool {
+	return GreaterThan(v1, v2) || Equals(v1, v2)
+}
+
+// LessThan returns true if kubernetes aware version v1 is less than
+// kubernetes aware version v2
+func LessThan(v1, v2 string) bool {
+	return Compare(v1, v2) < 0
+}
+
+// LessThanOrEquals returns true if kubernetes aware version v1 is
+// either less than or equal to kubernetes aware version v2
+func LessThanOrEquals(v1, v2 string) bool {
+	return LessThan(v1, v2) || Equals(v1, v2)
+}
+
+// TemplateFunctions exposes a few functions as go template functions
+func TemplateFunctions() template.FuncMap {
+	return template.FuncMap{
+		"kubeVersionCompare": Compare,
+		"kubeVersionEq":      Equals,
+		"kubeVersionGt":      GreaterThan,
+		"kubeVersionGte":     GreaterThanOrEquals,
+		"kubeVersionLt":      LessThan,
+		"kubeVersionLte":     LessThanOrEquals,
+	}
+}

--- a/pkg/version/kubernetes/version_test.go
+++ b/pkg/version/kubernetes/version_test.go
@@ -1,0 +1,417 @@
+/*
+Copyright 2018 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"bytes"
+	"github.com/ghodss/yaml"
+	"reflect"
+	"testing"
+	"text/template"
+)
+
+func TestParse(t *testing.T) {
+	tests := map[string]struct {
+		version string
+		isError bool
+	}{
+		// valid kubernetes versions
+		"valid 1":  {"v1.11.0", false},
+		"valid 2":  {"v0.0.1", false},
+		"valid 3":  {"v1.0.0", false},
+		"valid 4":  {"v0.1.0", false},
+		"valid 5":  {"v0.1.0-alpha", false},
+		"valid 6":  {"v0.1.0-alpha.123", false},
+		"valid 7":  {"v0.1.0-beta", false},
+		"valid 8":  {"v0.1.0-beta.11", false},
+		"valid 9":  {"v0.1.0-gke", false},
+		"valid 10": {"v0.1.0-gke.123", false},
+		"valid 11": {"v0.1.0-eks", false},
+		"valid 12": {"v0.1.0-eks.11", false},
+		"valid 13": {"v0.1.0+abcfde23", false},
+		"valid 14": {"v0.1.0-dev", false},
+		"valid 15": {"v0.1.0-master", false},
+		"valid 16": {"v0.1.0-anything", false},
+		"valid 17": {"v0.1.0-anything.junk", false},
+		// invalid kubernetes versions
+		"invalid 1": {"1.11.0", true},
+		"invalid 2": {"v0.1", true},
+		"invalid 3": {"v1", true},
+		"invalid 4": {"0.1", true},
+		"invalid 5": {"1.0.0-alpha", true},
+		"invalid 6": {"v1.0-alpha", true},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			v := parse(mock.version)
+			if !mock.isError && v.HasError() {
+				t.Fatalf("test '%s' failed: expected 'no error' actual 'error':\n'%s'", name, v.Errors())
+			}
+		})
+	}
+}
+
+func TestAsLabelValue(t *testing.T) {
+	tests := map[string]struct {
+		version  string
+		expected string
+	}{
+		// valid kubernetes versions
+		"valid 1":  {"v1.11.0", "v1.11.0"},
+		"valid 2":  {"v0.0.1", "v0.0.1"},
+		"valid 3":  {"v1.0.0", "v1.0.0"},
+		"valid 4":  {"v0.1.0", "v0.1.0"},
+		"valid 5":  {"v0.1.0-alpha", "v0.1.0-alpha"},
+		"valid 6":  {"v0.1.0-alpha.123", "v0.1.0-alpha.123"},
+		"valid 7":  {"v0.1.0-beta", "v0.1.0-beta"},
+		"valid 8":  {"v0.1.0-beta.11", "v0.1.0-beta.11"},
+		"valid 9":  {"v0.1.0-gke", "v0.1.0-gke"},
+		"valid 10": {"v0.1.0-gke.123", "v0.1.0-gke.123"},
+		"valid 11": {"v0.1.0-eks", "v0.1.0-eks"},
+		"valid 12": {"v0.1.0-eks.11", "v0.1.0-eks.11"},
+		"valid 13": {"v0.1.0-dev", "v0.1.0-dev"},
+		"valid 14": {"v0.1.0-master", "v0.1.0-master"},
+		"valid 15": {"v0.1.0-anything", "v0.1.0-anything"},
+		"valid 16": {"v0.1.0-anything.junk", "v0.1.0-anything.junk"},
+		// invalid kubernetes versions
+		"invalid 1": {"1.11.0", "1.11.0"},
+		"invalid 2": {"v0.1", "v0.1"},
+		"invalid 3": {"v1", "v1"},
+		"invalid 4": {"0.1", "0.1"},
+		"invalid 5": {"1.0.0-alpha", "1.0.0-alpha"},
+		"invalid 6": {"v1.0-alpha", "v1.0-alpha"},
+		// invalid label value
+		"invalid label 1": {"v0.1.0+abcfde23", "v0.1.0"},
+		"invalid label 2": {"v11+abcfde23", invalidVersionValue},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			v := AsLabelValue(mock.version)
+			if mock.expected != v {
+				t.Fatalf("test '%s' failed: expected '%s' actual '%s'", name, mock.expected, v)
+			}
+		})
+	}
+}
+
+func TestCompare(t *testing.T) {
+	tests := map[string]struct {
+		version1 string
+		version2 string
+		expected int
+	}{
+		// equals
+		"valid & eq - 1": {"v1.0.0", "v1.0.0", 0},
+		"valid & eq - 2": {"v1.0.0-alpha", "v1.0.0-alpha", 0},
+		"valid & eq - 3": {"v1.0.0-beta", "v1.0.0-beta", 0},
+		"valid & eq - 4": {"v1.0.0-dev", "v1.0.0-dev", 0},
+		"valid & eq - 5": {"v1.0.0-dev", "v1.0.0", 0},
+		"valid & eq - 6": {"v1.0.0", "v1.0.0-ga", 0},
+		// greater than
+		"valid & gt - 1": {"v1.0.1", "v1.0.0", 1},
+		"valid & gt - 2": {"v2.0.1", "v1.10.0", 1},
+		"valid & gt - 3": {"v0.0.10", "v0.0.5", 1},
+		"valid & gt - 4": {"v0.0.5-beta", "v0.0.5-alpha", 1},
+		"valid & gt - 5": {"v0.0.5", "v0.0.5-alpha", 1},
+		"valid & gt - 6": {"v0.0.5-beta.2", "v0.0.5-beta.1", 1},
+		// less than
+		"valid & lt - 1": {"v0.0.1", "v0.0.5", -1},
+		"valid & lt - 2": {"v0.1.1", "v0.2.0", -1},
+		"valid & lt - 3": {"v1.1.1", "v2.0.0", -1},
+		"valid & lt - 4": {"v1.0.5-alpha", "v1.0.5-beta", -1},
+		"valid & lt - 5": {"v1.0.5-beta", "v1.0.5", -1},
+		"valid & lt - 6": {"v1.0.5-alpha.12", "v1.0.5-alpha.21", -1},
+		// invalid
+		"invalid first ver":  {"1.1.1", "v2.0.0", -1},
+		"invalid second ver": {"v1.1.1", "2.0.0", 1},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := Compare(mock.version1, mock.version2)
+			if mock.expected != c {
+				t.Fatalf("test '%s' failed: expected '%d' actual '%d'", name, mock.expected, c)
+			}
+		})
+	}
+}
+
+func TestEquals(t *testing.T) {
+	tests := map[string]struct {
+		version1 string
+		version2 string
+		expected bool
+	}{
+		// equals
+		"valid & eq - 1": {"v1.0.0", "v1.0.0", true},
+		"valid & eq - 2": {"v1.0.0-alpha", "v1.0.0-alpha", true},
+		"valid & eq - 3": {"v1.0.0-beta", "v1.0.0-beta", true},
+		"valid & eq - 4": {"v1.0.0-dev", "v1.0.0-dev", true},
+		"valid & eq - 5": {"v1.0.0-dev", "v1.0.0", true},
+		"valid & eq - 6": {"v1.0.0", "v1.0.0-ga", true},
+		// greater than
+		"valid & gt - 1": {"v1.0.1", "v1.0.0", false},
+		"valid & gt - 2": {"v2.0.1", "v1.10.0", false},
+		"valid & gt - 3": {"v0.0.10", "v0.0.5", false},
+		"valid & gt - 4": {"v0.0.5-beta", "v0.0.5-alpha", false},
+		"valid & gt - 5": {"v0.0.5", "v0.0.5-alpha", false},
+		"valid & gt - 6": {"v0.0.5-beta.2", "v0.0.5-beta.1", false},
+		// less than
+		"valid & lt - 1": {"v0.0.1", "v0.0.5", false},
+		"valid & lt - 2": {"v0.1.1", "v0.2.0", false},
+		"valid & lt - 3": {"v1.1.1", "v2.0.0", false},
+		"valid & lt - 4": {"v1.0.5-alpha", "v1.0.5-beta", false},
+		"valid & lt - 5": {"v1.0.5-beta", "v1.0.5", false},
+		"valid & lt - 6": {"v1.0.5-alpha.12", "v1.0.5-alpha.21", false},
+		// invalid
+		"invalid first ver":  {"1.1.1", "v2.0.0", false},
+		"invalid second ver": {"v1.1.1", "2.0.0", false},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := Equals(mock.version1, mock.version2)
+			if mock.expected != c {
+				t.Fatalf("test '%s' failed: expected '%t' actual '%t'", name, mock.expected, c)
+			}
+		})
+	}
+}
+
+func TestGreaterThan(t *testing.T) {
+	tests := map[string]struct {
+		version1 string
+		version2 string
+		expected bool
+	}{
+		// equals
+		"valid & eq - 1": {"v1.0.0", "v1.0.0", false},
+		"valid & eq - 2": {"v1.0.0-alpha", "v1.0.0-alpha", false},
+		"valid & eq - 3": {"v1.0.0-beta", "v1.0.0-beta", false},
+		"valid & eq - 4": {"v1.0.0-dev", "v1.0.0-dev", false},
+		"valid & eq - 5": {"v1.0.0-dev", "v1.0.0", false},
+		"valid & eq - 6": {"v1.0.0", "v1.0.0-ga", false},
+		// greater than
+		"valid & gt - 1": {"v1.0.1", "v1.0.0", true},
+		"valid & gt - 2": {"v2.0.1", "v1.10.0", true},
+		"valid & gt - 3": {"v0.0.10", "v0.0.5", true},
+		"valid & gt - 4": {"v0.0.5-beta", "v0.0.5-alpha", true},
+		"valid & gt - 5": {"v0.0.5", "v0.0.5-alpha", true},
+		"valid & gt - 6": {"v0.0.5-beta.2", "v0.0.5-beta.1", true},
+		// less than
+		"valid & lt - 1": {"v0.0.1", "v0.0.5", false},
+		"valid & lt - 2": {"v0.1.1", "v0.2.0", false},
+		"valid & lt - 3": {"v1.1.1", "v2.0.0", false},
+		"valid & lt - 4": {"v1.0.5-alpha", "v1.0.5-beta", false},
+		"valid & lt - 5": {"v1.0.5-beta", "v1.0.5", false},
+		"valid & lt - 6": {"v1.0.5-alpha.12", "v1.0.5-alpha.21", false},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := GreaterThan(mock.version1, mock.version2)
+			if mock.expected != c {
+				t.Fatalf("test '%s' failed: expected '%t' actual '%t'", name, mock.expected, c)
+			}
+		})
+	}
+}
+
+func TestGreaterThanOrEquals(t *testing.T) {
+	tests := map[string]struct {
+		version1 string
+		version2 string
+		expected bool
+	}{
+		// equals
+		"valid & eq - 1": {"v1.0.0", "v1.0.0", true},
+		"valid & eq - 2": {"v1.0.0-alpha", "v1.0.0-alpha", true},
+		"valid & eq - 3": {"v1.0.0-beta", "v1.0.0-beta", true},
+		"valid & eq - 4": {"v1.0.0-dev", "v1.0.0-dev", true},
+		"valid & eq - 5": {"v1.0.0-dev", "v1.0.0", true},
+		"valid & eq - 6": {"v1.0.0", "v1.0.0-ga", true},
+		// greater than
+		"valid & gt - 1": {"v1.0.1", "v1.0.0", true},
+		"valid & gt - 2": {"v2.0.1", "v1.10.0", true},
+		"valid & gt - 3": {"v0.0.10", "v0.0.5", true},
+		"valid & gt - 4": {"v0.0.5-beta", "v0.0.5-alpha", true},
+		"valid & gt - 5": {"v0.0.5", "v0.0.5-alpha", true},
+		"valid & gt - 6": {"v0.0.5-beta.2", "v0.0.5-beta.1", true},
+		// less than
+		"valid & lt - 1": {"v0.0.1", "v0.0.5", false},
+		"valid & lt - 2": {"v0.1.1", "v0.2.0", false},
+		"valid & lt - 3": {"v1.1.1", "v2.0.0", false},
+		"valid & lt - 4": {"v1.0.5-alpha", "v1.0.5-beta", false},
+		"valid & lt - 5": {"v1.0.5-beta", "v1.0.5", false},
+		"valid & lt - 6": {"v1.0.5-alpha.12", "v1.0.5-alpha.21", false},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := GreaterThanOrEquals(mock.version1, mock.version2)
+			if mock.expected != c {
+				t.Fatalf("test '%s' failed: expected '%t' actual '%t'", name, mock.expected, c)
+			}
+		})
+	}
+}
+
+func TestLessThan(t *testing.T) {
+	tests := map[string]struct {
+		version1 string
+		version2 string
+		expected bool
+	}{
+		// equals
+		"valid & eq - 1": {"v1.0.0", "v1.0.0", false},
+		"valid & eq - 2": {"v1.0.0-alpha", "v1.0.0-alpha", false},
+		"valid & eq - 3": {"v1.0.0-beta", "v1.0.0-beta", false},
+		"valid & eq - 4": {"v1.0.0-dev", "v1.0.0-dev", false},
+		"valid & eq - 5": {"v1.0.0-dev", "v1.0.0", false},
+		"valid & eq - 6": {"v1.0.0", "v1.0.0-ga", false},
+		// greater than
+		"valid & gt - 1": {"v1.0.1", "v1.0.0", false},
+		"valid & gt - 2": {"v2.0.1", "v1.10.0", false},
+		"valid & gt - 3": {"v0.0.10", "v0.0.5", false},
+		"valid & gt - 4": {"v0.0.5-beta", "v0.0.5-alpha", false},
+		"valid & gt - 5": {"v0.0.5", "v0.0.5-alpha", false},
+		"valid & gt - 6": {"v0.0.5-beta.2", "v0.0.5-beta.1", false},
+		// less than
+		"valid & lt - 1": {"v0.0.1", "v0.0.5", true},
+		"valid & lt - 2": {"v0.1.1", "v0.2.0", true},
+		"valid & lt - 3": {"v1.1.1", "v2.0.0", true},
+		"valid & lt - 4": {"v1.0.5-alpha", "v1.0.5-beta", true},
+		"valid & lt - 5": {"v1.0.5-beta", "v1.0.5", true},
+		"valid & lt - 6": {"v1.0.5-alpha.12", "v1.0.5-alpha.21", true},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := LessThan(mock.version1, mock.version2)
+			if mock.expected != c {
+				t.Fatalf("test '%s' failed: expected '%t' actual '%t'", name, mock.expected, c)
+			}
+		})
+	}
+}
+
+func TestLessThanOrEquals(t *testing.T) {
+	tests := map[string]struct {
+		version1 string
+		version2 string
+		expected bool
+	}{
+		// equals
+		"valid & eq - 1": {"v1.0.0", "v1.0.0", true},
+		"valid & eq - 2": {"v1.0.0-alpha", "v1.0.0-alpha", true},
+		"valid & eq - 3": {"v1.0.0-beta", "v1.0.0-beta", true},
+		"valid & eq - 4": {"v1.0.0-dev", "v1.0.0-dev", true},
+		"valid & eq - 5": {"v1.0.0-dev", "v1.0.0", true},
+		"valid & eq - 6": {"v1.0.0", "v1.0.0-ga", true},
+		// greater than
+		"valid & gt - 1": {"v1.0.1", "v1.0.0", false},
+		"valid & gt - 2": {"v2.0.1", "v1.10.0", false},
+		"valid & gt - 3": {"v0.0.10", "v0.0.5", false},
+		"valid & gt - 4": {"v0.0.5-beta", "v0.0.5-alpha", false},
+		"valid & gt - 5": {"v0.0.5", "v0.0.5-alpha", false},
+		"valid & gt - 6": {"v0.0.5-beta.2", "v0.0.5-beta.1", false},
+		// less than
+		"valid & lt - 1": {"v0.0.1", "v0.0.5", true},
+		"valid & lt - 2": {"v0.1.1", "v0.2.0", true},
+		"valid & lt - 3": {"v1.1.1", "v2.0.0", true},
+		"valid & lt - 4": {"v1.0.5-alpha", "v1.0.5-beta", true},
+		"valid & lt - 5": {"v1.0.5-beta", "v1.0.5", true},
+		"valid & lt - 6": {"v1.0.5-alpha.12", "v1.0.5-alpha.21", true},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := LessThanOrEquals(mock.version1, mock.version2)
+			if mock.expected != c {
+				t.Fatalf("test '%s' failed: expected '%t' actual '%t'", name, mock.expected, c)
+			}
+		})
+	}
+}
+
+func TestTemplateFuncs(t *testing.T) {
+	tests := map[string]struct {
+		versions map[string]string
+		template string
+		expected string
+	}{
+		"all in one": {
+			versions: map[string]string{
+				"version1": "v1.0.1-alpha.21",
+				"version2": "v1.0.1-beta",
+				"version3": "v1.1.1",
+				"version4": "v1.1.1-ga",
+			},
+			template: `
+one: {{kubeVersionEq .version3 .version4}}
+two: {{kubeVersionEq .version1 .version2}}
+three: {{kubeVersionGt .version3 .version4}}
+four: {{kubeVersionGte .version3 .version4}}
+five: {{kubeVersionLt .version3 .version4}}
+six: {{kubeVersionLte .version3 .version4}}
+seven: {{kubeVersionGt .version1 .version2}}
+eight: {{kubeVersionLt .version1 .version2}}
+nine: {{kubeVersionLt .version2 .version4}}
+`,
+			expected: `
+one: true
+two: false
+three: false
+four: true
+five: false
+six: true
+seven: false
+eight: true
+nine: true
+`,
+		},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			tpl := template.New("KubeVersionTemplating").Funcs(TemplateFunctions())
+			tpl, err := tpl.Parse(mock.template)
+			if err != nil {
+				t.Fatalf("test '%s' failed: expected 'no template parse error': actual '%s'", name, err.Error())
+			}
+			// buf is an io.Writer implementation
+			// as required by the template
+			var buf bytes.Buffer
+			// execute the parsed yaml against the values
+			// & write the result into the buffer
+			err = tpl.Execute(&buf, mock.versions)
+			if err != nil {
+				t.Fatalf("test failed: expected 'no template execution error': actual '%s'", err.Error())
+			}
+			// buffer that represents a YAML can be unmarshalled into a map of any objects
+			var objActual map[string]interface{}
+			err = yaml.Unmarshal(buf.Bytes(), &objActual)
+			if err != nil {
+				t.Fatalf("test failed: expected 'no error on un-marshalling templated bytes': actual '%s'", err.Error())
+			}
+			// unmarshall the expected yaml into a map of any objects
+			var objExpected map[string]interface{}
+			err = yaml.Unmarshal([]byte(mock.expected), &objExpected)
+			if err != nil {
+				t.Fatalf("test failed: expected 'no error on un-marshalling expected bytes': actual '%s'", err.Error())
+			}
+			// compare expected vs. actual object
+			ok := reflect.DeepEqual(objExpected, objActual)
+			if !ok {
+				t.Fatalf("test failed:\n\nexpected yaml: '%s' \n\nactual yaml: '%s'", mock.expected, buf.Bytes())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit adds kubernetes version as a label to CASTemplate e.g. `kubeVersion: v1.9.7-gke.11`. In addition, a number of version related template functions have been exposed that can be used during
go templating.

Below are the introduced template functions:
- kubeVersionCompare
- kubeVersionEq
- kubeVersionGt
- kubeVersionGte
- kubeVersionLt
- kubeVersionLte

Below is a sample CASTemplate that gets installed due to this changes:
```yaml
apiVersion: openebs.io/v1alpha1
kind: CASTemplate
metadata:
  labels:
    castName: storage-pool-read-default-0.8.0
    kubeVersion: v1.9.7-gke.11
    version: 0.8.0
  name: storage-pool-read-default-0.8.0
```

Setting version as a label in CASTemplate results in having this label as a part of cast config that can be used via go templating in mapped RunTasks, for example:
`if {{ kubeVersionEq .CAST.kubeVersion "v1.10.1.alpha" }}`

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
