### PR TITLE
feat(provisioning): add pod affinity expr to cstor target pod

### DIFF
--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -71,6 +71,7 @@ spec:
   taskNamespace: {{env "OPENEBS_NAMESPACE"}}
   run:
     tasks:
+    - cstor-volume-create-getpvc-default
     - cstor-volume-create-listclonecstorvolumereplicacr-default
     - cstor-volume-create-listcstorpoolcr-default
     - cstor-volume-create-puttargetservice-default
@@ -132,6 +133,24 @@ spec:
     - cstor-volume-list-listtargetpod-default
     - cstor-volume-list-listcstorvolumereplicacr-default
   output: cstor-volume-list-output-default
+---
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: cstor-volume-create-getpvc-default
+spec:
+  meta: |
+    id: creategetpvc
+    apiVersion: v1
+    runNamespace: {{ .Volume.runNamespace }}
+    kind: PersistentVolumeClaim
+    objectName: {{ .Volume.pvc }}
+    action: get
+  post: |
+    {{- $replicaAntiAffinity := jsonpath .JsonResult "{.metadata.labels.openebs\\.io/replica-anti-affinity}" | trim | default "none" -}}
+    {{- $replicaAntiAffinity | saveAs "creategetpvc.replicaAntiAffinity" .TaskResult | noop -}}
+    {{- $targetAffinity := jsonpath .JsonResult "{.metadata.labels.openebs\\.io/target-affinity}" | trim | default "none" -}}
+    {{- $targetAffinity | saveAs "creategetpvc.targetAffinity" .TaskResult | noop -}}
 ---
 # This RunTask is meant to be run only during clone create requests.
 # However, clone & volume creation follow the same CASTemplate specifications.
@@ -311,6 +330,7 @@ spec:
     {{- $resourceLimitsVal := fromYaml .Config.TargetResourceLimits.value -}}
     {{- $setAuxResourceLimits := .Config.AuxResourceLimits.value | default "none" -}}
     {{- $auxResourceLimitsVal := fromYaml .Config.AuxResourceLimits.value -}}
+    {{- $targetAffinityVal := .TaskResult.creategetpvc.targetAffinity -}}
     apiVersion: apps/v1beta1
     Kind: Deployment
     metadata:
@@ -348,6 +368,19 @@ spec:
             openebs.io/persistent-volume-claim: {{ .Volume.pvc }}
         spec:
           serviceAccountName: {{ .Config.PVCServiceAccountName.value | default .Config.ServiceAccountName.value }}
+          {{- if ne $targetAffinityVal "none" }}
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: openebs.io/target-affinity
+                    operator: In
+                    values:
+                    - {{ $targetAffinityVal }}
+                topologyKey: kubernetes.io/hostname
+                namespaces: [{{.Volume.runNamespace}}]
+          {{- end }}
           containers:
           - image: {{ .Config.VolumeTargetImage.value }}
             name: cstor-istgt


### PR DESCRIPTION
When application and volume target pod are located in different nodes, a node down event on node containing target pod will cause the IO to break for the application.

It is sometimes desirable to **co-locate** the target pod on the same node as the application pod.

This commit uses the application pod label to create the affinity. The user will have to specify the following label on both application and PVC:
```yaml
  openebs.io/target-affinity: <unique application name>
```
The volume target pod will have the following pod affinity rule:
```
  affinity:
    podAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector:
          matchExpressions:
          - key: openebs.io/target-affinity
            operator: In
            values:
            - <unique application name>
        topologyKey: kubernetes.io/hostname
        namespaces: ["pvc-namespace"]
```

The following cases have been tested:
- Create without target-affinity label. The target pod is independent of the application.
- With target-affinity:
  * The target pod will be scheduled on the same node as the application. The node should have enough resources to schedule the target pod.
  * When target pod is killed, it is re-scheduled back on to the same node as application.
  * When application node is brought down, the target pod waits for the application pod to be scheduled and will get scheduled onto that node.

**Note** If the application pod is evicted due to resource constraints, target still remains on the source node. The target will move to the application pod, if the node it is running is shutdown or drained or target pod is restarted as part of upgrade.

Some **alternate solutions** for achieving in future k8s versions:
- enhance volume topology
- make target as a side car to application pod

**Note:** This feature works only for cases where there is a 1-1 mapping between a application and PVC. _Not recommended for STS where PVC is specified as a template_.

Signed-off-by: princerachit <prince.rachit@mayadata.io>