### PR TITLE
chore(install): Add spc reference in target deployment label.

### DIFF
--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -324,6 +324,7 @@ spec:
         openebs.io/persistent-volume-claim: {{ .Volume.pvc }}
         openebs.io/version: {{ .CAST.version }}
         openebs.io/cas-template-name: {{ .CAST.castName }}
+        openebs.io/storage-pool-claim: {{ .Config.StoragePoolClaim.value }}
       annotations:
         {{- if eq $isMonitor "true" }}
         openebs.io/volume-monitor: "true"


### PR DESCRIPTION
It would be useful to a reference of spc in the target deployment
when upgrading openebs.

Added label `openebs.io/storage-pool-claim` to the deployment.

Signed-off-by: princerachit <prince.rachit@mayadata.io>