### PR TITLE
fix(m-apiserver): Fire volume events only if volume creation is successful

### DIFF
--- a/cmd/maya-apiserver/app/server/volume_endpoint_v1alpha1.go
+++ b/cmd/maya-apiserver/app/server/volume_endpoint_v1alpha1.go
@@ -123,11 +123,11 @@ func (v *volumeAPIOpsV1alpha1) create() (*v1alpha1.CASVolume, error) {
 	}
 
 	cvol, err := vOps.Create()
-	volumeEvents(cvol, "volume-provision")
 	if err != nil {
 		glog.Errorf("failed to create cas template based volume: error '%s'", err.Error())
 		return nil, CodedError(500, err.Error())
 	}
+	volumeEvents(cvol, "volume-provision")
 	glog.Infof("cas template based volume created successfully: name '%s'", cvol.Name)
 
 	return cvol, nil


### PR DESCRIPTION
If volume creation fails then the value in `cvol` object would be nil.
This was causing panic when volumeevents function was being called.

Fixed this by checking error first.

Fixes: https://github.com/openebs/openebs/issues/2305
Signed-off-by: princerachit <prince.rachit@mayadata.io>
