### PR TITLE
fix(cli): change info to describe in mayactl helptext

### DIFF
--- a/cmd/mayactl/app/command/volume.go
+++ b/cmd/mayactl/app/command/volume.go
@@ -85,10 +85,10 @@ Examples:
    $ mayactl volume stats --volname <vol> --namespace test
 
  # Info of a Volume:
-   $ mayactl volume info --volname <vol>
+   $ mayactl volume describe --volname <vol>
 
  # Info of a Volume created in 'test' namespace:
-   $ mayactl volume info --volname <vol> --namespace test
+   $ mayactl volume describe --volname <vol> --namespace test
 
  # Delete a Volume:
    $ mayactl volume delete --volname <vol>


### PR DESCRIPTION
**What this PR does / why we need it**:
`volume info` command has been changed to `volume describe` ,
which is not updated in mayactl helptexts.

Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->



**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
