### PR TITLE
fix(volume-event) Send volume event request metric to GA

### DIFF
--- a/cmd/maya-apiserver/app/server/volume_endpoint_v1alpha1.go
+++ b/cmd/maya-apiserver/app/server/volume_endpoint_v1alpha1.go
@@ -34,7 +34,7 @@ type volumeAPIOpsV1alpha1 struct {
 }
 
 func volumeEvents(cvol *v1alpha1.CASVolume, method string) {
-	if menv.Truthy(menv.OpenEBSEnableAnalytics) {
+	if menv.Truthy(menv.OpenEBSEnableAnalytics) && cvol != nil {
 		usage.New().Build().ApplicationBuilder().
 			SetApplicationName(cvol.Spec.CasType).
 			SetDocumentTitle(cvol.ObjectMeta.Name).
@@ -121,13 +121,12 @@ func (v *volumeAPIOpsV1alpha1) create() (*v1alpha1.CASVolume, error) {
 	if err != nil {
 		return nil, CodedError(400, err.Error())
 	}
-
 	cvol, err := vOps.Create()
+	volumeEvents(vol, "volume-provision")
 	if err != nil {
 		glog.Errorf("failed to create cas template based volume: error '%s'", err.Error())
 		return nil, CodedError(500, err.Error())
 	}
-	volumeEvents(cvol, "volume-provision")
 	glog.Infof("cas template based volume created successfully: name '%s'", cvol.Name)
 
 	return cvol, nil
@@ -214,7 +213,7 @@ func (v *volumeAPIOpsV1alpha1) delete(volumeName string) (*v1alpha1.CASVolume, e
 	}
 
 	cvol, err := vOps.Delete()
-	volumeEvents(cvol, "volume-deprovision")
+	volumeEvents(vol, "volume-deprovision")
 	if err != nil {
 		glog.Errorf("failed to delete cas template based volume: error '%s'", err.Error())
 		if isNotFound(err) {


### PR DESCRIPTION
Earlier the event was sent to Google Analytics after the event had been
successfully processed.
Now the event will be sent everytime it has been successfully received
as specified in the request body.

Signed-off-by: Harsh Vardhan <harsh.vardhan@mayadata.io>

**What this PR does / why we need it**:
A bug was reported where, m-apiserver wasn't sending back the error to `openebs-provisioner` because a nil pointer dereference had occurred before
```
I1128 12:39:15.579893       7 logs.go:43] http: panic serving 10.130.0.1:46696: runtime error: invalid memory address or nil pointer dereference
goroutine 4770 [running]:
net/http.(*conn).serve.func1(0xc420854dc0)
    /home/travis/.gimme/versions/go1.10.3.linux.amd64/src/net/http/server.go:1726 +0xd0
panic(0x13ffaa0, 0x2036d10)
    /home/travis/.gimme/versions/go1.10.3.linux.amd64/src/runtime/panic.go:502 +0x229
github.com/openebs/maya/cmd/maya-apiserver/app/server.volumeEvents(0x0, 0x15f1d44, 0x10)
    /home/travis/gopath/src/github.com/openebs/maya/cmd/maya-apiserver/app/server/volume_endpoint_v1alpha1.go:39 +0x83
```
It happened because `vOps.Create()` returned `nil, error`, this change-set checks for `nil` values and avoids a similar condition for a volume delete event.

If a user has enabled sending anonymous metrics, this change will send volume-operation data as received from the provisioner. 

**Which issue this PR fixes**
improvement: https://github.com/openebs/openebs/issues/2305