### PR TITLE
feat(volume-mgmt,pool-mgmt): Make sync period of controller configurable

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/common/common.go
+++ b/cmd/cstor-pool-mgmt/controller/common/common.go
@@ -94,7 +94,7 @@ const (
 	// PoolNameHandlerInterval is used when expected pool is not present.
 	PoolNameHandlerInterval = 5 * time.Second
 	// SharedInformerInterval is used to sync watcher controller.
-	SharedInformerInterval = 15 * time.Second
+	SharedInformerInterval = 30 * time.Second
 	// ResourceWorkerInterval is used for resource sync.
 	ResourceWorkerInterval = time.Second
 	// InitialZreplRetryInterval is used while initially starting controller.

--- a/cmd/cstor-pool-mgmt/controller/start-controller/controller_test.go
+++ b/cmd/cstor-pool-mgmt/controller/start-controller/controller_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2018 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package startcontroller
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestGetSyncInterval(t *testing.T) {
+	tests := map[string]struct {
+		resyncInterval string
+		expectedResult time.Duration
+	}{
+		"resync environment variable is missing": {
+			resyncInterval: "",
+			expectedResult: 30 * time.Second,
+		},
+		"resync environment variable is non numeric": {
+			resyncInterval: "sfdgg",
+			expectedResult: 30 * time.Second,
+		},
+		"resync interval is set to zero(0)": {
+			resyncInterval: "0",
+			expectedResult: 30 * time.Second,
+		},
+		"resync interval is correct": {
+			resyncInterval: "13",
+			expectedResult: 13 * time.Second,
+		},
+	}
+
+	for name, mock := range tests {
+		os.Setenv("RESYNC_INTERVAL", mock.resyncInterval)
+		defer os.Unsetenv("RESYNC_INTERVAL")
+		t.Run(name, func(t *testing.T) {
+			interval := getSyncInterval()
+			if interval != mock.expectedResult {
+				t.Errorf("unable to get correct resync interval, expected: %v got %v", mock.expectedResult, interval)
+			}
+		})
+	}
+}

--- a/cmd/cstor-volume-mgmt/controller/common/common.go
+++ b/cmd/cstor-volume-mgmt/controller/common/common.go
@@ -25,6 +25,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// DefaultSharedInformerInterval is used to sync watcher controller.
+const DefaultSharedInformerInterval = 30 * time.Second
+
 const (
 	// CStorVolume is the controller to be watched
 	CStorVolume = "cStorVolume"

--- a/cmd/cstor-volume-mgmt/controller/start-controller/controller_test.go
+++ b/cmd/cstor-volume-mgmt/controller/start-controller/controller_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2018 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package startcontroller
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestGetSyncInterval(t *testing.T) {
+	tests := map[string]struct {
+		resyncInterval string
+		expectedResult time.Duration
+	}{
+		"resync environment variable is missing": {
+			resyncInterval: "",
+			expectedResult: 30 * time.Second,
+		},
+		"resync environment variable is non numeric": {
+			resyncInterval: "sfdgg",
+			expectedResult: 30 * time.Second,
+		},
+		"resync interval is set to zero(0)": {
+			resyncInterval: "0",
+			expectedResult: 30 * time.Second,
+		},
+		"resync interval is correct": {
+			resyncInterval: "13",
+			expectedResult: 13 * time.Second,
+		},
+	}
+
+	for name, mock := range tests {
+		os.Setenv("RESYNC_INTERVAL", mock.resyncInterval)
+		defer os.Unsetenv("RESYNC_INTERVAL")
+		t.Run(name, func(t *testing.T) {
+			interval := getSyncInterval()
+			if interval != mock.expectedResult {
+				t.Errorf("unable to get correct resync interval, expected: %v got %v", mock.expectedResult, interval)
+			}
+		})
+	}
+}

--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -67,6 +67,10 @@ spec:
   # in the format expected by Kubernetes
   - name: AuxResourceLimits
     value: "none"
+  # ResyncInterval specifies duration after which a controller should
+  # resync the resource status
+  - name: ResyncInterval
+    value: "30"
   taskNamespace: {{env "OPENEBS_NAMESPACE"}}
   run:
     tasks:
@@ -311,6 +315,8 @@ spec:
               # OPENEBS_IO_CSTOR_ID env has UID of cStorPool CR.
             - name: OPENEBS_IO_CSTOR_ID
               value: {{ pluck .ListItems.currentRepeatResource .ListItems.nodeUidMap.nodeUid |first | splitList " " | first}}
+            - name: RESYNC_INTERVAL
+              value: {{ .Config.ResyncInterval.value }}
           volumes:
           - name: device
             hostPath:

--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -68,6 +68,10 @@ spec:
   # to iSCSI Volume (i.e OpenEBS Persistent Volume)
   - name: Lun
     value: "0"
+  # ResyncInterval specifies duration after which a controller should
+  # resync the resource status
+  - name: ResyncInterval
+    value: "30"
   taskNamespace: {{env "OPENEBS_NAMESPACE"}}
   run:
     tasks:
@@ -449,6 +453,8 @@ spec:
             env:
             - name: OPENEBS_IO_CSTOR_VOLUME_ID
               value: {{ .TaskResult.cvolcreateputvolume.cstorid }}
+            - name: RESYNC_INTERVAL
+              value: {{ .Config.ResyncInterval.value }}
             - name: NODE_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Sometimes it is desired to alter the sync period of cstor-volume-mgmt or
cstor-pool-mgmt so that we get the update on CVR cr or CSV cr status as
desired.

The sync interval is configurable and it can be set using
.Config.ResyncInterval as a cas config.

Signed-off-by: princerachit <prince.rachit@mayadata.io>