### PR TITLE
Hiding mayactl snapshot command for 0.8 release

### DIFF
--- a/cmd/mayactl/app/command/commands.go
+++ b/cmd/mayactl/app/command/commands.go
@@ -20,7 +20,7 @@ import (
 	"os"
 
 	"github.com/openebs/maya/cmd/mayactl/app/command/pool"
-	"github.com/openebs/maya/cmd/mayactl/app/command/snapshot"
+	//"github.com/openebs/maya/cmd/mayactl/app/command/snapshot"
 	"github.com/openebs/maya/pkg/client/mapiserver"
 	"github.com/spf13/cobra"
 )
@@ -55,7 +55,7 @@ func NewMayaCommand() *cobra.Command {
 		NewCmdCompletion(cmd),
 		NewCmdVersion(),
 		NewCmdVolume(),
-		snapshot.NewCmdSnapshot(),
+		//snapshot.NewCmdSnapshot(),
 		pool.NewCmdPool(),
 	)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Stash mayactl snapshot command for 0.8 release.

Note:
1. Tested the changes by executing 
```
mayactl --help
Maya means 'Magic' a tool for storage orchestration

Usage:
  mayactl [command]

Available Commands:
  completion  Outputs shell completion code for the specified shell (bash or zsh)
  help        Help about any command
  pool        Provides operations related to a storage pool
  version     Prints version and other details relevant to maya
  volume      Provides operations related to a Volume

Flags:
      --alsologtostderr                  log to standard error as well as files
  -h, --help                             help for mayactl
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --logtostderr                      log to standard error instead of files
  -m, --mapiserver string                Maya API Service IP address. You can obtain the IP address using kubectl get svc -n < namespace where openebs is installed >
  -p, --mapiserverport string            Maya API Service Port. (default "5656")
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
  -v, --v Level                          log level for V logs
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

Use "mayactl [command] --help" for more information about a command.
```

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

