### PR TITLE
feat(csp):put lease mechanism on csp object

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/common/common.go
+++ b/cmd/cstor-pool-mgmt/controller/common/common.go
@@ -135,8 +135,8 @@ const (
 	QOpAdd     QueueOperation = "add"
 	QOpDestroy QueueOperation = "destroy"
 	QOpModify  QueueOperation = "modify"
-	// QOpStatusSync is the operation for updating the status on cstor pool object.
-	QOpStatusSync QueueOperation = "statusSync"
+	// QOpSync is the operation for syncing(reconciling) on cstor pool object.
+	QOpSync QueueOperation = "Sync"
 )
 
 // namespace defines kubernetes namespace specified for cvr.

--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openebs/maya/cmd/cstor-pool-mgmt/pool"
 	"github.com/openebs/maya/cmd/cstor-pool-mgmt/volumereplica"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	"github.com/openebs/maya/pkg/lease/v1alpha1"
 	"github.com/openebs/maya/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -43,20 +44,33 @@ func (c *CStorPoolController) syncHandler(key string, operation common.QueueOper
 	if err != nil {
 		return err
 	}
-	status, err := c.cStorPoolEventHandler(operation, cStorPoolGot)
+	var newCspLease lease.Leaser
+	newCspLease = &lease.Lease{cStorPoolGot, lease.CspLeaseKey, c.clientset, c.kubeclientset}
+	csp, err := newCspLease.Hold()
+	cspObject, ok := csp.(*apis.CStorPool)
+	if !ok {
+		fmt.Errorf("expected csp object but got %#v", cspObject)
+	}
+	if err != nil {
+		glog.Errorf("Could not acquire lease on csp object:%v", err)
+		return err
+	}
+	glog.Infof("Lease acquired successfully on csp %s ", cspObject.Name)
+
+	status, err := c.cStorPoolEventHandler(operation, cspObject)
 	if status == "" {
 		glog.Warning("Empty status recieved for csp status in sync handler")
 		return nil
 	}
-	cStorPoolGot.Status.Phase = apis.CStorPoolPhase(status)
+	cspObject.Status.Phase = apis.CStorPoolPhase(status)
 	if err != nil {
 		glog.Errorf(err.Error())
-		_, err := c.clientset.OpenebsV1alpha1().CStorPools().Update(cStorPoolGot)
+		_, err := c.clientset.OpenebsV1alpha1().CStorPools().Update(cspObject)
 		if err != nil {
 			return err
 		}
-		glog.Infof("cStorPool:%v, %v; Status: %v", cStorPoolGot.Name,
-			string(cStorPoolGot.GetUID()), cStorPoolGot.Status.Phase)
+		glog.Infof("cStorPool:%v, %v; Status: %v", cspObject.Name,
+			string(cspObject.GetUID()), cspObject.Status.Phase)
 		return err
 	}
 	// Synchronize cstor pool used and free capacity fields on CSP object.
@@ -64,16 +78,16 @@ func (c *CStorPoolController) syncHandler(key string, operation common.QueueOper
 	// ToDo: Move status sync (of csp) here from cStorPoolEventHandler function.
 	// ToDo: Instead of having statusSync, capacitySync we can make it generic resource sync which syncs all the
 	// ToDo: requried fields on CSP ( Some code re-organization will be required)
-	c.syncCsp(cStorPoolGot)
-	_, err = c.clientset.OpenebsV1alpha1().CStorPools().Update(cStorPoolGot)
+	c.syncCsp(cspObject)
+	_, err = c.clientset.OpenebsV1alpha1().CStorPools().Update(cspObject)
 	if err != nil {
-		c.recorder.Event(cStorPoolGot, corev1.EventTypeWarning, string(common.FailedSynced), string(common.MessageResourceSyncFailure)+err.Error())
+		c.recorder.Event(cspObject, corev1.EventTypeWarning, string(common.FailedSynced), string(common.MessageResourceSyncFailure)+err.Error())
 		return err
 	} else {
-		c.recorder.Event(cStorPoolGot, corev1.EventTypeNormal, string(common.SuccessSynced), string(common.MessageResourceSyncSuccess))
+		c.recorder.Event(cspObject, corev1.EventTypeNormal, string(common.SuccessSynced), string(common.MessageResourceSyncSuccess))
 	}
-	glog.Infof("cStorPool:%v, %v; Status: %v", cStorPoolGot.Name,
-		string(cStorPoolGot.GetUID()), cStorPoolGot.Status.Phase)
+	glog.Infof("cStorPool:%v, %v; Status: %v", cspObject.Name,
+		string(cspObject.GetUID()), cspObject.Status.Phase)
 	return nil
 }
 

--- a/cmd/cstor-pool-mgmt/controller/pool-controller/new_pool_controller.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/new_pool_controller.go
@@ -135,8 +135,8 @@ func NewCStorPoolController(
 			// Two different versions of the same CStorPool will always have different RVs.
 			if newCStorPool.ResourceVersion == oldCStorPool.ResourceVersion {
 				// Synchronize Cstor pool status
-				q.Operation = common.QOpStatusSync
-				glog.Infof("cStorPool status sync event for %s", newCStorPool.ObjectMeta.Name)
+				q.Operation = common.QOpSync
+				glog.Infof("cStorPool sync event for %s", newCStorPool.ObjectMeta.Name)
 				controller.recorder.Event(newCStorPool, corev1.EventTypeNormal, string(common.SuccessSynced), string(common.StatusSynced))
 			} else if IsDestroyEvent(newCStorPool) {
 				q.Operation = common.QOpDestroy

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -139,7 +139,7 @@ func (c *CStorVolumeReplicaController) cVREventHandler(operation common.QueueOpe
 			return string(apis.CVRStatusOffline), err
 		}
 		return "", nil
-	case common.QOpStatusSync:
+	case common.QOpSync:
 		glog.Infof("Synchronizing CstorVolumeReplica status for volume %s", cVR.ObjectMeta.Name)
 		status, err := c.getCVRStatus(cVR)
 		if err != nil {

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/new_replica_controller.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/new_replica_controller.go
@@ -134,7 +134,7 @@ func NewCStorVolumeReplicaController(
 			// Periodic resync will send update events for all known cStorReplica.
 			// Two different versions of the same cStorReplica will always have different RVs.
 			if newCVR.ResourceVersion == oldCVR.ResourceVersion {
-				q.Operation = common.QOpStatusSync
+				q.Operation = common.QOpSync
 				glog.Infof("CstorVolumeReplica status sync event for %s", newCVR.ObjectMeta.Name)
 				controller.recorder.Event(newCVR, corev1.EventTypeNormal, string(common.SuccessSynced), string(common.StatusSynced))
 			} else if IsDestroyEvent(newCVR) {

--- a/cmd/cstor-pool-mgmt/pool/pool.go
+++ b/cmd/cstor-pool-mgmt/pool/pool.go
@@ -116,7 +116,6 @@ func createPoolBuilder(cStorPool *apis.CStorPool) []string {
 	}
 
 	return createAttr
-
 }
 
 // CheckValidPool checks for validity of CStorPool resource.

--- a/pkg/lease/v1alpha1/csp_lease.go
+++ b/pkg/lease/v1alpha1/csp_lease.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2018 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package lease
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/golang/glog"
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	env "github.com/openebs/maya/pkg/env/v1alpha1"
+	"github.com/openebs/maya/pkg/patch/v1alpha1"
+	"k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"strings"
+)
+
+const (
+	// CspLeaseKey is the key that will be used to acquire lease on csp object.
+	// It will be present in csp annotations.
+	// If key has an empty value, that means no one has acquired a lease on csp object.
+	CspLeaseKey = "openebs.io/csp-lease"
+	// PatchOperation is the strategy of patch operation.
+	PatchOperation = "replace"
+	// PatchPath is the path to the field on csp object which need to be patched.
+	PatchPath = "/metadata/annotations/openebs.io~1csp-lease"
+	PodName   = "POD_NAME"
+	NameSpace = "NAMESPACE"
+)
+
+// Hold is the implenetation of method from interface Leases
+// It will try to hold a lease on csp object.
+func (sl *Lease) Hold() (interface{}, error) {
+	// Get the lease value.
+	cspObject, ok := sl.Object.(*apis.CStorPool)
+	if !ok {
+		return nil, fmt.Errorf("expected csp object for leasing but got %#v", cspObject)
+	}
+	leaseValue := cspObject.Annotations[sl.LeaseKey]
+	var leaseValueObj LeaseContract
+	var err error
+	if !(strings.TrimSpace(leaseValue) == "") {
+		leaseValueObj, err = parseLeaseValue(leaseValue)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// If the pod which has already acquired lease and want again to acquire,grant it.
+	if leaseValueObj.Holder == env.Get(NameSpace)+"/"+env.Get(PodName) {
+		return cspObject, nil
+	}
+	// If leaseValue is empty acquire lease.
+	// If leaseValue is empty check whether it is expired.
+	// If leaseValue is not empty and not expired check whether the holder is live.
+	if strings.TrimSpace(leaseValue) == "" || isLeaseExpired(leaseValueObj) || !sl.isLeaderLive(leaseValueObj) {
+		podName, err := sl.getPodName()
+		if err != nil {
+			return nil, err
+		}
+		csp, err := sl.Update(podName)
+		if err != nil {
+			return nil, err
+		}
+		return csp, nil
+	}
+	// If none of the above three conditions are met, lease can not be acquired.
+	return nil, fmt.Errorf("lease on csp already acquired by a live pod")
+}
+
+// Update will update a lease on csp depending on type of update that is required.
+// We have following type of update strategy:
+// 1.putKeyValue
+// 2.putValue
+// 3.putUpdatedValue
+// See the functions(below) for more details on update strategy
+func (sl *Lease) Update(podName string) (interface{}, error) {
+	newCspObject := sl.Object.(*apis.CStorPool)
+	if newCspObject.Annotations == nil {
+		sl.putKeyValue(podName, newCspObject)
+	} else if newCspObject.Annotations[sl.LeaseKey] == "" {
+		sl.putValue(podName, newCspObject)
+	} else {
+		sl.putUpdatedValue(podName, newCspObject)
+	}
+	csp, err := sl.Oecs.OpenebsV1alpha1().CStorPools().Update(newCspObject)
+	return csp, err
+}
+
+// Release method is implementation of  to release lease on a given csp.
+func (sl *Lease) Release() {
+	err := sl.patchCspLeaseAnnotation()
+	if err != nil {
+		newErr := fmt.Errorf("Lease could not be removed:%v", err)
+		runtime.HandleError(newErr)
+	}
+	glog.Info("Lease removed successfully on csp")
+}
+
+func (sl *Lease) getPodName() (string, error) {
+	podName := env.Get(PodName)
+	if strings.TrimSpace(podName) == "" {
+		return "", fmt.Errorf("Pod name not found in env variable")
+	}
+	podNameSpace := env.Get(NameSpace)
+	if strings.TrimSpace(podName) == "" {
+		return "", fmt.Errorf("Pod namespace not found in env variable")
+	}
+	return podNameSpace + "/" + podName, nil
+}
+
+// patchCspLeaseAnnotation will patch the lease key annotation on csp object to release the lease
+func (sl *Lease) patchCspLeaseAnnotation() error {
+	cspObject, ok := sl.Object.(*apis.CStorPool)
+	if !ok {
+		return fmt.Errorf("expected csp object for leasing but got %#v", cspObject)
+	}
+	leaseValueObj, err := parseLeaseValue(cspObject.Annotations[CspLeaseKey])
+	leaseValueObj.Holder = ""
+	newLeaseValue, err := json.Marshal(leaseValueObj)
+	if err != nil {
+		return err
+	}
+
+	cspPatch, err := patch.NewPatchPayload(PatchOperation, PatchPath, string(newLeaseValue))
+	if err != nil {
+		return fmt.Errorf("unable to form payload to patch csp:%s", err)
+	}
+	_, err = sl.Patch(cspObject.Name, "", types.JSONPatchType, cspPatch)
+	if err != nil {
+		return fmt.Errorf("unable to patch csp %s :%v", cspObject.Name, err)
+	}
+	return nil
+}
+
+// isLeaderLive checks whether the holder of lease is live or not
+// If the holder is not live or does not exists the function will return true.
+
+// If the holder of lease is not live or does not exists the lease can be acquired
+// by the other contestant(i.e. pool pod)
+func (sl *Lease) isLeaderLive(leaseValueObj LeaseContract) bool {
+	holderName := leaseValueObj.Holder
+	podDetails := strings.Split(holderName, "/")
+	// Check whether the holder is live or not
+	pod, _ := sl.Kubeclientset.CoreV1().Pods(podDetails[0]).Get(podDetails[1], meta_v1.GetOptions{})
+	if pod == nil {
+		return false
+	}
+	podStatus := pod.Status.Phase
+	if string(podStatus) != string(v1.PodRunning) {
+		return false
+	}
+
+	return true
+}
+
+// A lease is expired if it has a empty holder name.
+// The holder of lease can only expire the lease.
+// isLeaseExpired return true if the lease is expired.
+func isLeaseExpired(leaseValueObj LeaseContract) bool {
+	if strings.TrimSpace(leaseValueObj.Holder) == "" {
+		return true
+	}
+	return false
+}
+
+// parseLeaseValue will parse a leaseValue string to lease object
+func parseLeaseValue(leaseValue string) (LeaseContract, error) {
+	leaseValueObj := &LeaseContract{}
+	err := json.Unmarshal([]byte(leaseValue), leaseValueObj)
+	if err != nil {
+		return LeaseContract{}, err
+	}
+	return *leaseValueObj, nil
+}
+
+// putKeyValue function will update lease on such CSP which was not acquired by any pod ever in its lifetime.
+func (sl *Lease) putKeyValue(podName string, newCspObject *apis.CStorPool) (*apis.CStorPool, error) {
+	// make a map that should contain the lease key in csp
+	mapLease := make(map[string]string)
+	leaseValueObj := &LeaseContract{
+		podName,
+		1,
+	}
+	leaseValue, err := json.Marshal(leaseValueObj)
+	if err != nil {
+		return nil, err
+	}
+	// Fill the map lease key with lease value
+	mapLease[sl.LeaseKey] = string(leaseValue)
+	newCspObject.Annotations = mapLease
+	return newCspObject, nil
+}
+
+// putValue function will update lease on CSP if the holder of lease has released the lease successfully.
+func (sl *Lease) putValue(podName string, newCspObject *apis.CStorPool) (*apis.CStorPool, error) {
+	leaseValueObj := &LeaseContract{
+		podName,
+		1,
+	}
+	leaseValue, err := json.Marshal(leaseValueObj)
+	if err != nil {
+		return nil, err
+	}
+	newCspObject.Annotations[sl.LeaseKey] = string(leaseValue)
+	return newCspObject, nil
+}
+
+// putUpdatedValue function will update lease on CSP if the holder of lease has died before releasing the lease.
+func (sl *Lease) putUpdatedValue(podName string, newCspObject *apis.CStorPool) (*apis.CStorPool, error) {
+	leaseValueObj, err := parseLeaseValue(newCspObject.Annotations[sl.LeaseKey])
+	if err != nil {
+		return nil, err
+	}
+	leaseValueObj.LeaderTransition++
+	leaseValueObj.Holder = podName
+	leaseValue, err := json.Marshal(leaseValueObj)
+	if err != nil {
+		return nil, err
+	}
+	newCspObject.Annotations[sl.LeaseKey] = string(leaseValue)
+	return newCspObject, nil
+}
+
+// Patch is the specific implementation if Patch() interface for patching CSP objects.
+// Similarly, we can have for other objects, if required.
+func (sl *Lease) Patch(name string, nameSpace string, patchType types.PatchType, patches []byte) (*apis.CStorPool, error) {
+	obj, err := sl.Oecs.OpenebsV1alpha1().CStorPools().Patch(name, patchType, patches)
+	return obj, err
+}

--- a/pkg/lease/v1alpha1/csp_lease.go
+++ b/pkg/lease/v1alpha1/csp_lease.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package lease
 
 import (
@@ -166,12 +167,17 @@ func (sl *Lease) isLeaderALive(leaseValueObj LeaseContract) bool {
 		if errors.IsNotFound(err) {
 			return false
 		}
+		glog.Warningf("Could not fetch the pod which have acquired the lease on CSP:%s", err)
 		return true
 	}
 	if pod == nil {
 		return false
 	}
 	podStatus := pod.Status.Phase
+	if string(podStatus) == string(v1.PodUnknown) {
+		glog.Warning("Could not get the pod status which have acquired the lease on CSP")
+		return true
+	}
 	if string(podStatus) != string(v1.PodRunning) {
 		return false
 	}

--- a/pkg/lease/v1alpha1/csp_lease_test.go
+++ b/pkg/lease/v1alpha1/csp_lease_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2018 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package lease
+
+import (
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+
+	"github.com/golang/glog"
+	openebs "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset"
+	openebsFakeClientset "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset/fake"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"os"
+	"strconv"
+	"testing"
+)
+
+type fakeClientset struct {
+	oecs openebs.Interface
+}
+
+// CspCreator will create fake csp objects
+func (focs *fakeClientset) CspCreator(poolName string, CspLeaseKeyPresent bool, CspLeaseKeyValue string) *apis.CStorPool {
+	var cspObject *apis.CStorPool
+	if CspLeaseKeyPresent {
+		cspObject = &apis.CStorPool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: poolName,
+				Annotations: map[string]string{
+					CspLeaseKey: "{\"holder\":\"" + CspLeaseKeyValue + "\",\"leaderTransition\":1}",
+				},
+			},
+		}
+	} else {
+		cspObject = &apis.CStorPool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: poolName,
+			},
+		}
+	}
+	cspGot, err := focs.oecs.OpenebsV1alpha1().CStorPools().Create(cspObject)
+	if err != nil {
+		glog.Error(err)
+	}
+	return cspGot
+}
+
+// Create 5 fake pods that will compete to acquire lease on csp
+func PodCreator(fakeKubeClient kubernetes.Interface, podName string) {
+	for i := 1; i <= 5; i++ {
+		podObjet := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: podName + strconv.Itoa(i),
+			},
+			Status: v1.PodStatus{
+				Phase: v1.PodRunning,
+			},
+		}
+		_, err := fakeKubeClient.CoreV1().Pods("openebs").Create(podObjet)
+		if err != nil {
+			glog.Error("Fake pod object could not be created:", err)
+		}
+	}
+}
+func TestHold(t *testing.T) {
+	// Get a fake openebs client set
+	focs := &fakeClientset{
+		oecs: openebsFakeClientset.NewSimpleClientset(),
+	}
+
+	fakeKubeClient := k8sfake.NewSimpleClientset()
+
+	// Make a map of string(key) to struct(value).
+	// Key of map describes test case behaviour.
+	// Value of map is the test object.
+	PodCreator(fakeKubeClient, "pool-pod")
+	tests := map[string]struct {
+		// fakestoragepoolclaim holds the fake storagepoolcalim object in test cases.
+		fakestoragepoolclaim *apis.CStorPool
+		storagePoolClaimName string
+		podName              string
+		podNamespace         string
+		// expectedResult holds the expected error for the test case under run.
+		expectedError bool
+		// expectedResult holds the expected lease value the test case under run.
+		expectedResult string
+	}{
+		// TestCase#1
+		"SPC#1 Lease Not acquired": {
+			fakestoragepoolclaim: focs.CspCreator("pool1", false, ""),
+			podName:              "pool-pod1",
+			podNamespace:         "openebs",
+			expectedError:        false,
+			expectedResult:       "{\"holder\":\"openebs/pool-pod1\",\"leaderTransition\":1}",
+		},
+
+		// TestCase#2
+		"SPC#2 Lease already acquired": {
+			fakestoragepoolclaim: focs.CspCreator("pool2", true, "openebs/pool-pod1"),
+			podName:              "pool-pod2",
+			podNamespace:         "openebs",
+			expectedError:        true,
+			expectedResult:       "{\"holder\":\"openebs/pool-pod1\",\"leaderTransition\":1}",
+		},
+		// TestCase#3
+		"SPC#3 Lease already acquired": {
+			fakestoragepoolclaim: focs.CspCreator("pool3", true, "openebs/pool-pod6"),
+			podName:              "pool-pod2",
+			podNamespace:         "openebs",
+			expectedError:        false,
+			expectedResult:       "{\"holder\":\"openebs/pool-pod2\",\"leaderTransition\":2}",
+		},
+		// TestCase#4
+		"SPC#4 Lease Not acquired": {
+			fakestoragepoolclaim: focs.CspCreator("pool4", true, ""),
+			podName:              "pool-pod3",
+			podNamespace:         "openebs",
+			expectedError:        false,
+			expectedResult:       "{\"holder\":\"openebs/pool-pod3\",\"leaderTransition\":2}",
+		},
+	}
+
+	// Iterate over whole map to run the test cases.
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var newCspLease Lease
+			var gotError bool
+			os.Setenv(string(PodName), test.podName)
+			os.Setenv(string(NameSpace), test.podNamespace)
+			newCspLease = Lease{test.fakestoragepoolclaim, CspLeaseKey, focs.oecs, fakeKubeClient}
+			// Hold is the function under test.
+			_, err := newCspLease.Hold()
+			if err == nil {
+				gotError = false
+			} else {
+				gotError = true
+			}
+			//If the result does not matches expectedResult, test case fails.
+			if gotError != test.expectedError {
+				t.Errorf("Test case failed:expected nil error but got error:'%v'", err)
+			}
+			// Check for lease value
+			cspGot, err := focs.oecs.OpenebsV1alpha1().CStorPools().Get(test.fakestoragepoolclaim.Name, metav1.GetOptions{})
+			if cspGot.Annotations[CspLeaseKey] != test.expectedResult {
+				t.Errorf("Test case failed: expected lease value '%v' but got '%v' ", test.expectedResult, cspGot.Annotations[CspLeaseKey])
+
+			}
+			os.Unsetenv(string(PodName))
+			os.Unsetenv(string(NameSpace))
+		})
+	}
+}

--- a/pkg/lease/v1alpha1/lease.go
+++ b/pkg/lease/v1alpha1/lease.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2018 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lease
+
+import (
+	clientset "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset"
+	"k8s.io/client-go/kubernetes"
+)
+
+// LeaseContract struct will be used as a value of lease key that will
+// give information about an acquired lease on object
+// The struct object will be parsed to string which will be then
+// put as a value to the lease key of object annotation.
+type LeaseContract struct {
+	// Holder is the namespace/name of the pod who acquires the lease
+	Holder string `json:"holder"`
+	// LeaderTransition is the count of lease that has been taken on the object
+	// in its lifetime.
+	// e.g. One of the pod takes a lease on the object and release and then some other
+	// pod (or even the same pod ) takes a lease again on the object its leaderTransition
+	// value is 1.
+	// If an object has leaderTranisiton value equal to 'n' that means it was leased
+	// 'n+1' times in its lifetime by distinct, same or some distinct and some same pods.
+	LeaderTransition int `json:"leaderTransition"`
+	// More specific details can be added here that will describe the
+	// current state of lease in more details.
+	// e.g. acquiredTimeStamp, self-release etc
+	// acquiredTimeStamp will tell when the lease was acquired
+	// self-release will tell whether the lease was removed by the acquirer or not
+}
+
+// Leaser is an interface which assists in getting and releasing lease on an object
+type Leaser interface {
+	// Hold will try to get a lease, in case of failure it will return error
+	Hold() (interface{}, error)
+	// Update will update the lease value on the object
+	Update(leaseValue string) (interface{}, error)
+	// Release will remove the acquired lease on the object
+	Release()
+}
+
+// Lease is the struct which will implement the Leases interface
+type Lease struct {
+	// Object is the object over which lease is to be taken
+	Object interface{}
+	// leaseKey is lease key on object
+	LeaseKey string
+	// oecs is the openebs clientset
+	Oecs clientset.Interface
+	// kubeclientset is a standard kubernetes clientset
+	Kubeclientset kubernetes.Interface
+}

--- a/pkg/patch/v1alpha1/patch.go
+++ b/pkg/patch/v1alpha1/patch.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2018 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	"encoding/json"
+	clientset "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+// ClientSet struct holds kubernetes and openebs clientsets.
+type ClientSet struct {
+	// kubeclientset is a standard kubernetes clientset
+	Kubeclientset kubernetes.Interface
+	// clientset is a openebs custom resource package generated for custom API group.
+	OpenebsClientset clientset.Interface
+}
+
+// Patch is the struct based on standards of JSON patch.
+type Patch struct {
+	// Op defines the operation
+	Op string `json:"op"`
+	// Path defines the key path
+	// eg. for
+	// {
+	//  	"Name": "openebs"
+	//	    Category: {
+	//		  "Inclusive": "v1",
+	//		  "Rank": "A"
+	//	     }
+	// }
+	// The path of 'Inclusive' would be
+	// "/Name/Category/Inclusive"
+	Path  string      `json:"path"`
+	Value interface{} `json:"value"`
+}
+
+// Patcher interface has Patch function which can be implemented for several objects that needs to be patched.
+type Patcher interface {
+	Patch(name string, nameSpace string, patchType types.PatchType, patches []byte) (interface{}, error)
+}
+
+// NewPatchPayload constructs the patch payload fo any type of object.
+func NewPatchPayload(operation string, path string, value interface{}) ([]byte, error) {
+	PatchPayload := make([]Patch, 1)
+	PatchPayload[0].Op = operation
+	PatchPayload[0].Path = path
+	PatchPayload[0].Value = value
+	payload, err := json.Marshal(PatchPayload)
+	return payload, err
+}


### PR DESCRIPTION
**This PR adds CSP lease mechanism to avoid pool corruption issue in case of pool pod restarts.**
**This PR also add pool create/import resync logic in case of create/import failure in previous event.**
**Description:**
Add lease mechanism on csp object which will ensure that
no two pool pods process the csp object concurrently which
can lead to pool corruption.

**Summary:**
1. Once a pool pod comes into existence it takes a lease on its corresponding CSP.
2. Lease is taken by putting some information on the CSP object annotation. This `some information` is nothing but the `pod name` who acquires the lease and `leader transition`. `Leader transition` value( numeric) will tell how many times different pods have acquired the CSP. 
3. Once lease has been take by a pool pod it does not release the lease ever in its lifetime becoming dedicated leader for the CSP.
4. In case the pool pod dies due to any unexception, a new pod will come up and try to acquire the lease after checking the liveness of previous pod. If the previous leader is live the lease cannot be taken else it becomes the leader.
5.  After taking the lease -- pool pod keeps doing the reconciliation and before any reconciliation starts the pod tries to acquire the lease on CSP. Now the lease has already been taken by the pod and tries again to take lease and if the pod sees itself as the leader -- again the lease is successful for the pod to continue with the reconciliation. 
6. Create event is sent only once to the pool pod.In case of failure to create/import pool in create event there should be a way to import/create the pool as part of resync activity.This commit adds pool import/create logic in resync activity.Pool import/create will only be tried if the pool has not been created/imported successfully in the previous event.

**Following is the look of CSP object after lease has been acquired on it by a pool pod:**
```yaml
apiVersion: openebs.io/v1alpha1
  kind: CStorPool
  metadata:
    annotations:
      openebs.io/csp-lease: '{"holder":"openebs/cstor-sparse-pool-o7xk-65bcdd675b-s9qll","leaderTransition":1}'
    creationTimestamp: 2018-12-03T07:21:03Z
    generation: 1
    labels:
      kubernetes.io/hostname: gke-cstor-it-default-pool-e84f5225-mvw8
      openebs.io/cas-template-name: cstor-pool-create-default-0.8.0
      openebs.io/storage-pool-claim: cstor-sparse-pool
      openebs.io/version: 0.8.0
    name: cstor-sparse-pool-o7xk
    resourceVersion: "11181219"
    selfLink: /apis/openebs.io/v1alpha1/cstorpools/cstor-sparse-pool-o7xk
    uid: fdce27a9-f6cb-11e8-90a2-42010a8000c5
  spec:
    disks:
      diskList:
      - /var/openebs/sparse/0-ndm-sparse.img
    poolSpec:
      cacheFile: /tmp/cstor-sparse-pool.cache
      overProvisioning: false
      poolType: striped
  status:
    capacity:
      free: 9.94G
      total: 9.94G
      used: 270K
    phase: Healthy
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```
**Note the annotation of the object**
**ToDo: Move SPC lease mechanism to this package(lease package)**

Signed-off-by: sonasingh46 <sonasingh46@gmail.com>
