### PR TITLE
fix(monitoring): add default prometheus scrape annotations

### DIFF
--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -371,6 +371,12 @@ spec:
             openebs.io/target: cstor-target
             openebs.io/persistent-volume: {{ .Volume.owner }}
             openebs.io/persistent-volume-claim: {{ .Volume.pvc }}
+          {{- if eq $isMonitor "true" }}
+          annotations:
+            prometheus.io/path: /metrics
+            prometheus.io/port: "9500"
+            prometheus.io/scrape: "true"
+          {{- end}}
         spec:
           serviceAccountName: {{ .Config.PVCServiceAccountName.value | default .Config.ServiceAccountName.value }}
           {{- if ne $targetAffinityVal "none" }}

--- a/pkg/install/v1alpha1/jiva_volume.go
+++ b/pkg/install/v1alpha1/jiva_volume.go
@@ -714,6 +714,11 @@ spec:
           annotations:
             openebs.io/fs-type: {{ .Config.FSType.value }}
             openebs.io/lun: {{ .Config.Lun.value }}
+            {{- if eq $isMonitor "true" }}
+            prometheus.io/path: /metrics
+            prometheus.io/port: "9500"
+            prometheus.io/scrape: "true"
+            {{- end}}
         spec:
           {{- if ne $hasNodeSelector "none" }}
           nodeSelector:


### PR DESCRIPTION
For monitoring the OpenEBS volumes, the user had to setup
the prometheus config with a scarping job to collect metrics
from openebs volume target pods. There are multiple ports
accessible, and the job had to drop the irrelevant ports.

This PR helps in setting up the default prometheus
annotations that specify the scrape path and port.

Signed-off-by: kmova <kiran.mova@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
