### PR TITLE
[US3000][TA3959] feat(usage health) Send openebs periodic health events

### DIFF
--- a/cmd/maya-apiserver/app/command/start.go
+++ b/cmd/maya-apiserver/app/command/start.go
@@ -184,7 +184,8 @@ func Run(cmd *cobra.Command, c *CmdStartOptions) error {
 	}()
 
 	if env.Truthy(env.OpenEBSEnableAnalytics) {
-		usage.New().Build().InstallBuilder().Send()
+		usage.New().Build().InstallBuilder(true).Send()
+		go usage.PingCheck()
 	}
 
 	// Wait for exit

--- a/pkg/env/v1alpha1/env.go
+++ b/pkg/env/v1alpha1/env.go
@@ -184,6 +184,20 @@ func Get(envKey ENVKey) (value string) {
 	return getEnv(string(envKey))
 }
 
+// GetOrDefault fetches value from the provided environment variable
+// which on empty returns the defaultValue
+// NOTE: os.Getenv is used here instead of os.LookupEnv because it is
+// not required to know if the environment variable is defined on the system
+func GetOrDefault(e ENVKey, defaultValue string) (value string) {
+	envValue := Get(e)
+	if len(envValue) == 0 {
+		// ENV not defined or set to ""
+		return defaultValue
+	} else {
+		return envValue
+	}
+}
+
 // Lookup looks up an environment variable
 //
 // NOTE:

--- a/pkg/usage/const.go
+++ b/pkg/usage/const.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2018 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package usage
+
+const (
+	// GAclientID is the unique code of OpenEBS project in Google Analytics
+	GAclientID string = "UA-127388617-1"
+
+	// supported events categories
+
+	// Install event is sent on pod starts
+	InstallEvent string = "install"
+	// Ping event is sent periodically
+	Ping string = "ping"
+	// VolumeProvision event is sent when a volume is created
+	VolumeProvision string = "volume-provision"
+	//VolumeDeprovision event is sent when a volume is deleted
+	VolumeDeprovision string = "volume-deprovision"
+
+	AppName string = "OpenEBS"
+
+	// Event labels
+	RunningStatus      string = "running"
+	EventLabelNode     string = "nodes"
+	EventLabelCapacity string = "capacity"
+
+	// Event action
+	Replica             string = "replica:"
+	DefaultReplicaCount string = "replica:3"
+)

--- a/pkg/usage/ping.go
+++ b/pkg/usage/ping.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2018 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package usage
+
+import (
+	"time"
+
+	menv "github.com/openebs/maya/pkg/env/v1alpha1"
+)
+
+var OpenEBSPingPeriod menv.ENVKey = "OPENEBS_IO_ANALYTICS_PING_INTERVAL"
+
+const (
+	// defaultPingPeriod sets the default ping heartbeat interval
+	defaultPingPeriod time.Duration = 24 * time.Hour
+	// minimumPingPeriod sets the minimum possible configurable
+	// heartbeat period, if a value lower than this will be set, the
+	// defaultPingPeriod will be used
+	minimumPingPeriod time.Duration = 1 * time.Hour
+)
+
+// PingCheck sends ping events to Google Analytics
+func PingCheck() {
+	// Create a new usage field
+	u := New()
+	duration := getPingPeriod()
+	ticker := time.NewTicker(duration)
+	for _ = range ticker.C {
+		u.Build().
+			InstallBuilder(true).
+			SetCategory(Ping).
+			Send()
+	}
+}
+
+// getPingPeriod sets the duration of health events, defaults to 24
+func getPingPeriod() time.Duration {
+	value := menv.GetOrDefault(OpenEBSPingPeriod, string(defaultPingPeriod))
+	duration, _ := time.ParseDuration(value)
+	// Sanitychecks for setting time duration of health events
+	// This way, we are checking for negative and zero time duration and we
+	// also have a minimum possible configurable time duration between health events
+	if duration < minimumPingPeriod {
+		// Avoid corner case when the ENV value is undesirable
+		return time.Duration(defaultPingPeriod)
+	} else {
+		return time.Duration(duration)
+	}
+}

--- a/pkg/usage/ping_test.go
+++ b/pkg/usage/ping_test.go
@@ -1,0 +1,42 @@
+package usage
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestGetPingPeriod(t *testing.T) {
+	beforeFunc := func(value string) {
+		if err := os.Setenv(string(OpenEBSPingPeriod), value); err != nil {
+			t.Logf("Unable to set environment variable")
+		}
+	}
+	afterFunc := func() {
+		if err := os.Unsetenv(string(OpenEBSPingPeriod)); err != nil {
+			t.Logf("Unable to unset environment variable")
+		}
+	}
+	testSuite := map[string]struct {
+		OpenEBSPingPeriodValue string
+		ExpectedPeriodValue    time.Duration
+	}{
+		"24 seconds":          {"24s", 86400000000000},
+		"24 minutes":          {"24m", 86400000000000},
+		"24 hours":            {"24h", 86400000000000},
+		"Negative 24 hours":   {"-24h", 86400000000000},
+		"Random string input": {"Apache", 86400000000000},
+		"Two hours":           {"2h", 7200000000000},
+		"Three hundred hours": {"300h", 1080000000000000},
+		"Fifty two seconds":   {"52000000000ns", 86400000000000},
+		"Empty env value":     {"", 86400000000000},
+	}
+	for testKey, testData := range testSuite {
+		beforeFunc(testData.OpenEBSPingPeriodValue)
+		evaluatedValue := getPingPeriod()
+		if evaluatedValue != testData.ExpectedPeriodValue {
+			t.Fatalf("Tests failed for %s, expected=%d, got=%d", testKey, testData.ExpectedPeriodValue, evaluatedValue)
+		}
+		afterFunc()
+	}
+}

--- a/pkg/usage/size.go
+++ b/pkg/usage/size.go
@@ -19,6 +19,7 @@ package usage
 import units "github.com/docker/go-units"
 
 // toGigaUnits converts a size from xB to bytes where x={k,m,g,t,p...}
+// and return the number of Gigabytes as an integer
 // 1 gigabyte=1000 megabyte
 func toGigaUnits(size string) (int64, error) {
 	sizeInBytes, err := units.FromHumanSize(size)

--- a/pkg/usage/versionset.go
+++ b/pkg/usage/versionset.go
@@ -76,16 +76,16 @@ func (v *versionSet) fetchAndSetVersion() error {
 }
 
 // getVersion is a wrapper over fetchAndSetVersion
-func (v *versionSet) getVersion() error {
-	// If ENVs aren't set, fetch the required values from the
-	// K8s APIserver
-	if _, present := env.Lookup(openEBSversion); !present {
+func (v *versionSet) getVersion(override bool) error {
+	// If ENVs aren't set or the override is true, fetch the required
+	// values from the K8s APIserver
+	if _, present := env.Lookup(openEBSversion); !present || override {
 		if err := v.fetchAndSetVersion(); err != nil {
 			glog.Error(err.Error())
 			return err
 		}
 	}
-	// Fetch data from ENV instead
+	// Fetch data from ENV
 	v.id = env.Get(clusterUUID)
 	v.k8sArch = env.Get(clusterArch)
 	v.k8sVersion = env.Get(clusterVersion)


### PR DESCRIPTION
**What this PR does / why we need it**:
It is required to know about running openebs instances around the world and collect **periodic** anonymous information from clusters on user's consent.

**Which issue this PR fixes**
improvement: https://github.com/openebs/openebs/issues/2257

**Special notes for your reviewer**:
[old]
_To test the things, I have set the time duration to every ONE MINUTE, this will be changed to every ONE DAY, after it is tested by Travis-CI and other instances at openebs.ci_
[current]

1. If a volume is provisioned without replica-count details and if a user consents on sharing usage data with us, the replica-count value on our analytics dashboard will show up as `3` on `volume-provision` event.
2. This won't happen on a `volume-deprovision` event because of `pkg/usage/usage.go` L#213 which will only set it on volume-create. 
I pushed the condition inside `pkg/usage` as I felt it doesn't fit directly into the core business logic of `m-apiserver`
3. `OPENEBS_IO_HEALTH_ANALYTICS_PERIOD` if defined with `time.ParseDuration(string)` compatible values will be picked up, if not defined, our default value, i.e. `24 * time.Hour`  will be picked up.
4. A new func in `pkg/env` which returns the _passed default values_ if the string length of the env-value of `OPENEBS_IO_ANALYTICS_PING_INTERVAL` is `zero`, this prevents excess nesting of if-else code.