### PR TITLE
fix(cstor_volume): Missing namespace and target details in volume list response when cstor volume target is deployed in PVC namespace

### DIFF
--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -592,14 +592,7 @@ metadata:
 spec:
   meta: |
     {{- $isClone := .Volume.isCloneEnable | default "false" -}}
-    {{- $runNamespace := printf "%s, %s" .Config.RunNamespace.value .Volume.runNamespace -}}
-    {{- $nss := $runNamespace | default "" | splitList ", " -}}
     id: listlistsvc
-    repeatWith:
-      metas:
-      {{- range $k, $ns := $nss }}
-      - runNamespace: {{ $ns }}
-      {{- end }}
     apiVersion: v1
     kind: Service
     action: list
@@ -621,14 +614,7 @@ metadata:
 spec:
   meta: |
     {{- $isClone := .Volume.isCloneEnable | default "false" -}}
-    {{- $runNamespace := .Config.RunNamespace.value -}}
-    {{- $nss := $runNamespace | default "" | splitList ", " -}}
     id: listlistctrl
-    repeatWith:
-      metas:
-      {{- range $k, $ns := $nss }}
-      - runNamespace: {{ $ns }}
-      {{- end }}
     apiVersion: v1
     kind: Pod
     action: list


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

Volume list run task currently searches target pods and services in `openebs` namespace due to which the namespace name and other target details can be populated when the target is deployed in PVC namespace.

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
-> Fixes <no value> error in volume list response when cstor volume is provisioned in PVC namespace by removing the namespace iteration, as list action without namespace will fetch resources from all the available namespace in k8s.

**Which issue this PR fixes** : https://github.com/openebs/openebs/issues/2317

** Steps to verify** :
-> Provision cstor volume in pvc namespace. Refer here https://medium.com/@princerachit/87e1d37d5d64.
-> Run ``` mayactl volume list``` or do a curl to volume list api of mayaAPIserver.


**Special notes for your reviewer**:
     `{{- $isClone := .Volume.isCloneEnable | default "false" -}}`	 this seems to be of no use. should be remove this ?