### PR TITLE
enhance(mayactl): add SC and access mode information in volume list

### DIFF
--- a/cmd/mayactl/app/command/volumes_list.go
+++ b/cmd/mayactl/app/command/volumes_list.go
@@ -71,7 +71,7 @@ func (c *CmdVolumeOptions) RunVolumesList(cmd *cobra.Command) error {
 		}
 		out[i+2] = fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s", item.ObjectMeta.Namespace,
 			item.ObjectMeta.Name,
-			item.Status.Reason, item.Spec.CasType, item.Spec.Capacity, getAnnotationValue("openebs.io/storage-class", item), getAnnotationValue("openebs.io/access-mode", item))
+			item.Status.Reason, item.Spec.CasType, item.Spec.Capacity, item.ObjectMeta.Annotations["openebs.io/storage-class"], item.Spec.AccessMode)
 	}
 	if len(out) == 2 {
 		fmt.Println("No Volumes are running")
@@ -79,11 +79,4 @@ func (c *CmdVolumeOptions) RunVolumesList(cmd *cobra.Command) error {
 	}
 	fmt.Println(util.FormatList(out))
 	return nil
-}
-
-func getAnnotationValue(key string, vol v1alpha1.CASVolume) string {
-	if val, present := vol.ObjectMeta.Annotations[key]; present {
-		return val
-	}
-	return "N/A"
 }

--- a/cmd/mayactl/app/command/volumes_list.go
+++ b/cmd/mayactl/app/command/volumes_list.go
@@ -63,15 +63,15 @@ func (c *CmdVolumeOptions) RunVolumesList(cmd *cobra.Command) error {
 	}
 
 	out := make([]string, len(cvols.Items)+2)
-	out[0] = "Namespace|Name|Status|Type|Capacity"
-	out[1] = "---------|----|------|----|--------"
-	for i, items := range cvols.Items {
-		if len(items.Status.Reason) == 0 {
-			items.Status.Reason = volumeStatusOK
+	out[0] = "Namespace|Name|Status|Type|Capacity|Storage Class|Access Mode"
+	out[1] = "---------|----|------|----|--------|-------------|-----------"
+	for i, item := range cvols.Items {
+		if len(item.Status.Reason) == 0 {
+			item.Status.Reason = volumeStatusOK
 		}
-		out[i+2] = fmt.Sprintf("%s|%s|%s|%s|%s", items.ObjectMeta.Namespace,
-			items.ObjectMeta.Name,
-			items.Status.Reason, items.Spec.CasType, items.Spec.Capacity)
+		out[i+2] = fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s", item.ObjectMeta.Namespace,
+			item.ObjectMeta.Name,
+			item.Status.Reason, item.Spec.CasType, item.Spec.Capacity, getAnnotationValue("openebs.io/storage-class", item), getAnnotationValue("openebs.io/access-mode", item))
 	}
 	if len(out) == 2 {
 		fmt.Println("No Volumes are running")
@@ -79,4 +79,11 @@ func (c *CmdVolumeOptions) RunVolumesList(cmd *cobra.Command) error {
 	}
 	fmt.Println(util.FormatList(out))
 	return nil
+}
+
+func getAnnotationValue(key string, vol v1alpha1.CASVolume) string {
+	if val, present := vol.ObjectMeta.Annotations[key]; present {
+		return val
+	}
+	return "N/A"
 }

--- a/cmd/mayactl/app/command/volumes_list.go
+++ b/cmd/mayactl/app/command/volumes_list.go
@@ -63,7 +63,7 @@ func (c *CmdVolumeOptions) RunVolumesList(cmd *cobra.Command) error {
 	}
 
 	out := make([]string, len(cvols.Items)+2)
-	out[0] = "Namespace|Name|Status|Type|Capacity|Storage Class|Access Mode"
+	out[0] = "Namespace|Name|Status|Type|Capacity|StorageClass|Access Mode"
 	out[1] = "---------|----|------|----|--------|-------------|-----------"
 	for i, item := range cvols.Items {
 		if len(item.Status.Reason) == 0 {

--- a/pkg/apis/openebs.io/v1alpha1/cas_volume.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_volume.go
@@ -119,6 +119,8 @@ type CASVolumeSpec struct {
 	FSType string `json:"fsType"`
 	// Lun will specify the lun number 0, 1.. on iSCSI Volume. (default: 0)
 	Lun int32 `json:"lun"`
+	// AccessMode will hold the access mode of this volume
+	AccessMode string `json:"accessMode"`
 }
 
 // CASVolumeStatus provides status of a cas volume

--- a/pkg/apis/openebs.io/v1alpha1/cas_volume.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_volume.go
@@ -101,25 +101,25 @@ type CASVolume struct {
 
 // CASVolumeSpec has the properties of a cas volume
 type CASVolumeSpec struct {
-	// Capacity will hold the capacity of this Volume
+	// Capacity of a volume will hold the capacity of the Volume
 	Capacity string `json:"capacity"`
-	// Iqn will hold the iqn value of this Volume
+	// Iqn of a volume will hold the iqn value of the Volume
 	Iqn string `json:"iqn"`
-	// TargetPortal will hold the target portal for this volume
+	// TargetPortal of a volume will hold the target portal of the volume
 	TargetPortal string `json:"targetPortal"`
-	// TargetIP will hold the targetIP for this Volume
+	// TargetIP of a volume will hold the targetIP of the Volume
 	TargetIP string `json:"targetIP"`
-	// TargetPort will hold the targetIP for this Volume
+	// TargetPort of a volume will hold the targetIP of the Volume
 	TargetPort string `json:"targetPort"`
-	// Replicas will hold the replica count for this volume
+	// Replicas of a volume will hold the replica count of the volume
 	Replicas string `json:"replicas"`
-	// CasType will hold the storage engine used to provision this volume
+	// CasType of a volume will hold the storage engine used to provision the volume
 	CasType string `json:"casType"`
-	// FSType will specify the format type - ext4(default), xfs of PV
+	// FSType of a volume will specify the format type - ext4(default), xfs of PV
 	FSType string `json:"fsType"`
-	// Lun will specify the lun number 0, 1.. on iSCSI Volume. (default: 0)
+	// Lun of volume will specify the lun number 0, 1.. on iSCSI Volume. (default: 0)
 	Lun int32 `json:"lun"`
-	// AccessMode will hold the access mode of this volume
+	// AccessMode of a volume will hold the access mode of the volume
 	AccessMode string `json:"accessMode"`
 }
 

--- a/pkg/client/k8s/k8s.go
+++ b/pkg/client/k8s/k8s.go
@@ -678,6 +678,17 @@ func (k *K8sClient) ListCoreV1PVCAsRaw(opts mach_apis_meta_v1.ListOptions) (resu
 	return
 }
 
+// ListCoreV1PVAsRaw fetches a list of K8s PVs with the provided options
+func (k *K8sClient) ListCoreV1PVAsRaw(opts mach_apis_meta_v1.ListOptions) (result []byte, err error) {
+	result, err = k.cs.CoreV1().RESTClient().Get().
+		Namespace(k.ns).
+		Resource("persistentvolumes").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		DoRaw()
+
+	return
+}
+
 // ListCoreV1PodAsRaw fetches a list of K8s Pods as per the provided options
 func (k *K8sClient) ListCoreV1PodAsRaw(opts mach_apis_meta_v1.ListOptions) (result []byte, err error) {
 	result, err = k.cs.CoreV1().RESTClient().Get().

--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -712,7 +712,6 @@ spec:
           name: {{ $name }}
           namespace: {{ $namespace }}
           annotations:
-            openebs.io/access-mode: {{ $accessMode }}
             openebs.io/storage-class: {{ $storageClass }}
             openebs.io/cluster-ips: {{ $clusterIP }}
             openebs.io/volume-size: {{ $capacity }}
@@ -725,6 +724,7 @@ spec:
           targetPort: 3260
           replicas: {{ $replicaName | default "" | splitList ", " | len }}
           casType: cstor
+          accessMode: {{ $accessMode | default "" }}
     {{- end -}}
 ---
 # runTask to list cStor target deployment service

--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -712,7 +712,7 @@ spec:
           name: {{ $name }}
           namespace: {{ $namespace }}
           annotations:
-            openebs.io/storage-class: {{ $storageClass }}
+            openebs.io/storage-class: {{ $storageClass | default "" }}
             openebs.io/cluster-ips: {{ $clusterIP }}
             openebs.io/volume-size: {{ $capacity }}
             openebs.io/controller-status: {{ $targetStatus | default "" | replace "true" "running" | replace "false" "notready" }}

--- a/pkg/install/v1alpha1/jiva_volume.go
+++ b/pkg/install/v1alpha1/jiva_volume.go
@@ -362,7 +362,6 @@ spec:
           name: {{ $name }}
           namespace: {{ $ns }}
           annotations:
-            openebs.io/access-mode: {{ $pvInfo.accessModes | default "" }}
             openebs.io/storage-class: {{ $pvInfo.storageClass | default "" }}
             vsm.openebs.io/controller-ips: {{ $controllerIP }}
             vsm.openebs.io/cluster-ips: {{ $clusterIP }}
@@ -383,6 +382,7 @@ spec:
             openebs.io/controller-status: {{ $controllerStatus | replace "true" "running" | replace "false" "notready" | replace " " "," }}
             openebs.io/targetportals: {{ $clusterIP }}:3260
         spec:
+          accessMode: {{ $pvInfo.accessModes | default "" }}
           capacity: {{ $capacity }}
           iqn: iqn.2016-09.com.openebs.jiva:{{ $name }}
           targetPortal: {{ $clusterIP }}:3260

--- a/pkg/task/meta.go
+++ b/pkg/task/meta.go
@@ -355,6 +355,10 @@ func (m *metaTaskExecutor) isListCoreV1PVC() bool {
 	return m.identifier.isCoreV1PVC() && m.isList()
 }
 
+func (m *metaTaskExecutor) isListCoreV1PV() bool {
+	return m.identifier.isCoreV1PV() && m.isList()
+}
+
 func (m *metaTaskExecutor) isListCoreV1Pod() bool {
 	return m.identifier.isCoreV1Pod() && m.isList()
 }

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -933,6 +933,8 @@ func (m *taskExecutor) listK8sResources() (err error) {
 		op, err = kc.ListAppsV1B1DeploymentAsRaw(opts)
 	} else if m.metaTaskExec.isListCoreV1PVC() {
 		op, err = kc.ListCoreV1PVCAsRaw(opts)
+	} else if m.metaTaskExec.isListCoreV1PV() {
+		op, err = kc.ListCoreV1PVAsRaw(opts)
 	} else if m.metaTaskExec.isListOEV1alpha1Disk() {
 		op, err = kc.ListOEV1alpha1DiskRaw(opts)
 	} else if m.metaTaskExec.isListOEV1alpha1SP() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->
This PR does the following things.
-> Enhances CAS Engine to list PersistentVolume which will helpful in listing information of persistent volumes using Runtask.
-> Adds Runtask to fetch storageclass and access mode information for cstor and jiva which will helpful for clients that depends on m-apiserver for information related to volumes.
-> Adds access mode and storageclass information in volume list API which can be consumed by clients like mayactl.
-> Adds StorageClass and access mode information in mayactl ```volume list``` command which will be useful for users.
-> Output of `mayactl volume list`:
```
Namespace  Name                                      Status   Type   Capacity  Storage Class         Access Mode
---------  ----                                      ------   ----   --------  -------------         -----------
default    pvc-c530cae3-140c-11e9-9348-b4b686bd0cff  Running  jiva   5G        openebs-jiva-default  ReadWriteOnce
openebs    pvc-c53033e9-140c-11e9-9348-b4b686bd0cff  Running  cstor  5G        openebs-cstor-sparse  ReadWriteOnce
``` 
-> Output of response from list endpoint:
```
{
  "items": [
    {
      "apiVersion": "v1alpha1",
      "kind": "CASVolume",
      "metadata": {
        "annotations": {
          "vsm.openebs.io/replica-status": "running",
          "openebs.io/controller-ips": "172.17.0.8",
          "openebs.io/iqn": "iqn.2016-09.com.openebs.jiva:pvc-09158135-149c-11e9-a935-b4b686bd0cff",
          "openebs.io/replica-count": "1",
          "openebs.io/replica-ips": "172.17.0.7",
          "vsm.openebs.io/cluster-ips": "10.0.0.153",
          "openebs.io/storage-class": "openebs-jiva-default",
          "openebs.io/targetportals": "10.0.0.153:3260",
          "vsm.openebs.io/iqn": "iqn.2016-09.com.openebs.jiva:pvc-09158135-149c-11e9-a935-b4b686bd0cff",
          "vsm.openebs.io/replica-count": "1",
          "openebs.io/controller-status": "running,running",
          "openebs.io/volume-size": "5G",
          "vsm.openebs.io/controller-ips": "172.17.0.8",
          "vsm.openebs.io/volume-size": "5G",
          "openebs.io/cluster-ips": "10.0.0.153",
          "openebs.io/replica-status": "running",
          "vsm.openebs.io/controller-status": "running,running",
          "vsm.openebs.io/replica-ips": "172.17.0.7",
          "vsm.openebs.io/targetportals": "10.0.0.153:3260"
        },
        "name": "pvc-09158135-149c-11e9-a935-b4b686bd0cff",
        "namespace": "default"
      },
      "spec": {
        "accessMode": "ReadWriteOnce",
        "capacity": "5G",
        "casType": "jiva",
        "fsType": "",
        "iqn": "iqn.2016-09.com.openebs.jiva:pvc-09158135-149c-11e9-a935-b4b686bd0cff",
        "lun": 0,
        "replicas": "1",
        "targetIP": "10.0.0.153",
        "targetPort": "3260",
        "targetPortal": "10.0.0.153:3260"
      },
      "status": {
        "Message": "",
        "Phase": "",
        "Reason": ""
      }
    },
    {
      "apiVersion": "v1alpha1",
      "kind": "CASVolume",
      "metadata": {
        "annotations": {
          "openebs.io/storage-class": "openebs-cstor-sparse",
          "openebs.io/volume-size": "5G",
          "openebs.io/cluster-ips": "10.0.0.135",
          "openebs.io/controller-status": "running running running"
        },
        "name": "pvc-09151006-149c-11e9-a935-b4b686bd0cff",
        "namespace": "openebs"
      },
      "spec": {
        "accessMode": "ReadWriteOnce",
        "capacity": "5G",
        "casType": "cstor",
        "fsType": "",
        "iqn": "iqn.2016-09.com.openebs.cstor:pvc-09151006-149c-11e9-a935-b4b686bd0cff",
        "lun": 0,
        "replicas": "1",
        "targetIP": "10.0.0.135",
        "targetPort": "3260",
        "targetPortal": "10.0.0.135:3260"
      },
      "status": {
        "Message": "",
        "Phase": "",
        "Reason": ""
      }
    }
  ],
  "metadata": {},
  "metalist": {}
}

```

The above enhancements are good to have in openebs.

**Which issue this PR fixes** : 
https://github.com/openebs/openebs/issues/1981
https://github.com/openebs/openebs/issues/1994

**Special notes for your reviewer**:
-> If the values are not present in the response the default value will be "<none>".