### PR TITLE
ref(volume-event) Set default CASType to jiva

### DIFF
--- a/cmd/maya-apiserver/app/server/volume_endpoint_v1alpha1.go
+++ b/cmd/maya-apiserver/app/server/volume_endpoint_v1alpha1.go
@@ -37,7 +37,7 @@ type volumeAPIOpsV1alpha1 struct {
 func volumeEvents(cvol *v1alpha1.CASVolume, method string) {
 	if menv.Truthy(menv.OpenEBSEnableAnalytics) && cvol != nil {
 		usage.New().Build().ApplicationBuilder().
-			SetApplicationName(cvol.Spec.CasType).
+			SetVolumeType(cvol.Spec.CasType, method).
 			SetDocumentTitle(cvol.ObjectMeta.Name).
 			SetLabel(usage.EventLabelCapacity).
 			SetReplicaCount(cvol.Spec.Replicas, method).

--- a/pkg/usage/const.go
+++ b/pkg/usage/const.go
@@ -40,4 +40,7 @@ const (
 	// Event action
 	Replica             string = "replica:"
 	DefaultReplicaCount string = "replica:3"
+
+	// Event application name constant for volume event
+	DefaultCASType string = "jiva"
 )

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -201,6 +201,17 @@ func (u *Usage) SetVolumeCapacity(volCapG string) *Usage {
 	return u
 }
 
+// Wrapper for setting the default storage-engine for volume-provision event
+func (u *Usage) SetVolumeType(volType, method string) *Usage {
+	if method == VolumeProvision && volType == "" {
+		// Set the default storage engine, if not specified in the request
+		u.SetApplicationName(DefaultCASType)
+	} else {
+		u.SetApplicationName(volType)
+	}
+	return u
+}
+
 // Wrapper for setting replica count for volume events
 // NOTE: This doesn't get the replica count in a volume de-provision event.
 // TODO: Pick the current value of replica-count from the CAS-engine


### PR DESCRIPTION
**What this PR does / why we need it**:
- This change sets the Default CASType to `jiva` when it isn't specified in the volume-create request.

**Which issue this PR fixes** 
improvement: https://github.com/openebs/openebs/issues/2257

Signed-off-by: Harsh Vardhan <harsh.vardhan@mayadata.io>