### PR TITLE
enhance(mayactl): add application details in mayactl and improved sparse storage class

### DIFF
--- a/cmd/mayactl/app/command/volume_info.go
+++ b/cmd/mayactl/app/command/volume_info.go
@@ -78,6 +78,12 @@ type cstorReplicaInfo struct {
 	IP         string
 }
 
+// applicationsDetails stores information about the application connected to the volume
+type applicationsDetails struct {
+	PodName      string
+	PodNamespace string
+}
+
 // NewCmdVolumeInfo displays OpenEBS Volume information.
 func NewCmdVolumeInfo() *cobra.Command {
 	cmd := &cobra.Command{
@@ -186,6 +192,13 @@ Replica Details :
 {{ printf "%s\t" $value.Name }} {{ printf "%s\t" $value.Status }} {{ printf "%s\t" $value.PoolName }} {{ $value.NodeName }} {{end}}
 `
 
+		applicationInfoTemplate = `
+Application Details:
+--------------------
+Application Pod Name: {{.PodName}}
+Application Pod Namespace: {{.PodNamespace}}
+`
+
 		portalTemplate = `
 Portal Details :
 ----------------
@@ -208,6 +221,12 @@ Replica Count     :   {{.ReplicaCount}}
 		v.GetReplicaCount(),
 		v.GetControllerNode(),
 	}
+
+	applicationInfo := applicationsDetails{
+		PodName:      v.Volume.ObjectMeta.Annotations["openebs.io/application-pod-name"],
+		PodNamespace: v.Volume.ObjectMeta.Annotations["openebs.io/application-pod-namespace"],
+	}
+
 	tmpl, err := template.New("VolumeInfo").Parse(portalTemplate)
 	if err != nil {
 		fmt.Println("Error displaying output, found error :", err)
@@ -218,6 +237,19 @@ Replica Count     :   {{.ReplicaCount}}
 		fmt.Println("Error displaying volume details, found error :", err)
 		return nil
 	}
+
+	tmpl, err = template.New("VolumeInfo").Parse(applicationInfoTemplate)
+	if err != nil {
+		fmt.Println("Error displaying output, found error :", err)
+		return nil
+	}
+
+	err = tmpl.Execute(os.Stdout, applicationInfo)
+	if err != nil {
+		fmt.Println("Error displaying volume details, found error :", err)
+		return nil
+	}
+
 	if v.GetCASType() == string(JivaStorageEngine) {
 		replicaCount, _ = strconv.Atoi(v.GetReplicaCount())
 		// This case will occur only if user has manually specified zero replica.

--- a/cmd/mayactl/app/command/volume_info.go
+++ b/cmd/mayactl/app/command/volume_info.go
@@ -28,7 +28,7 @@ import (
 	k8sclient "github.com/openebs/maya/pkg/client/k8s"
 	"github.com/openebs/maya/pkg/client/mapiserver"
 	"github.com/openebs/maya/pkg/util"
-	"github.com/openebs/maya/types/v1"
+	v1 "github.com/openebs/maya/types/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -195,8 +195,8 @@ Replica Details :
 		applicationInfoTemplate = `
 Application Details:
 --------------------
-Application Pod Name: {{.PodName}}
-Application Pod Namespace: {{.PodNamespace}}
+Application Pod Name      : {{.PodName}}
+Application Pod Namespace : {{.PodNamespace}}
 `
 
 		portalTemplate = `

--- a/pkg/install/v1alpha1/cstor_sparse_pool_claim.go
+++ b/pkg/install/v1alpha1/cstor_sparse_pool_claim.go
@@ -19,8 +19,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	menv "github.com/openebs/maya/pkg/env/v1alpha1"
 	"strconv"
+
+	menv "github.com/openebs/maya/pkg/env/v1alpha1"
 )
 
 const cstorSparsePoolYamls = `
@@ -34,6 +35,8 @@ metadata:
     cas.openebs.io/config: |
       - name: StoragePoolClaim
         value: "cstor-sparse-pool"
+      - name: ReplicaCount
+        value: "3"
       #- name: TargetResourceLimits
       #  value: |-
       #      memory: 1Gi

--- a/pkg/install/v1alpha1/jiva_volume.go
+++ b/pkg/install/v1alpha1/jiva_volume.go
@@ -32,7 +32,6 @@ spec:
     - jiva-volume-read-listtargetservice-default
     - jiva-volume-read-listtargetpod-default
     - jiva-volume-read-listreplicapod-default
-    - jiva-volume-read-listpv-default
     - jiva-volume-read-listpods-default
   output: jiva-volume-read-output-default
   fallback: jiva-volume-read-default-0.6.0
@@ -411,6 +410,7 @@ spec:
     {{- jsonpath .JsonResult "{.items[*].metadata.name}" | trim | saveAs "readlistsvc.items" .TaskResult | noop -}}
     {{- .TaskResult.readlistsvc.items | notFoundErr "controller service not found" | saveIf "readlistsvc.notFoundErr" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.items[*].spec.clusterIP}" | trim | saveAs "readlistsvc.clusterIP" .TaskResult | noop -}}
+    {{- jsonpath .JsonResult "{.items[*].metadata.labels.openebs\\.io/persistent-volume-claim}" | default "" | trim | saveAs "readlistsvc.pvcName" .TaskResult | noop -}}
 ---
 apiVersion: openebs.io/v1alpha1
 kind: RunTask
@@ -457,34 +457,17 @@ spec:
 apiVersion: openebs.io/v1alpha1
 kind: RunTask
 metadata:
-  name: jiva-volume-read-listpv-default
-spec:
-  meta: |
-    id: readlistpv
-    apiVersion: v1
-    kind: PersistentVolume
-    action: list
-  post: |
-    {{- $pvName := .Volume.owner -}}
-    {{- $pvcNamePath:= printf "{.items[?(@.metadata.name==%q)].spec.claimRef.name}" $pvName -}}
-    {{- $pvcNamespacePath:= printf "{.items[?(@.metadata.name==%q)].spec.claimRef.namespace}" $pvName -}}
-    {{- jsonpath .JsonResult $pvcNamePath | default "" | saveAs "readlistpv.pvcname" .TaskResult -}}
-    {{- jsonpath .JsonResult $pvcNamespacePath | default "" | saveAs "readlistpv.pvcnamespace" .TaskResult -}}
----
-apiVersion: openebs.io/v1alpha1
-kind: RunTask
-metadata:
   name: jiva-volume-read-listpods-default
 spec:
   meta: |
     id: readlistpod
     apiVersion: v1
     kind: Pod
-    runNamespace: {{ .TaskResult.readlistpv.pvcnamespace }}
-    disable: {{ $length := len .TaskResult.readlistpv.pvcname }}{{ if gt $length 0 }}false{{ else }}true{{ end }}
+    runNamespace: {{ .Volume.runNamespace }}
+    disable: {{ $length := len .TaskResult.readlistsvc.pvcName }}{{ if gt $length 0 }}false{{ else }}true{{ end }}
     action: list
   post: |
-    {{- $pvcName:= .TaskResult.readlistpv.pvcname -}}
+    {{- $pvcName:= .TaskResult.readlistsvc.pvcName -}}
     {{- $applicationNamePath:= printf "{.items[?(@.spec.volumes[*].persistentVolumeClaim.claimName=='%s')].metadata.name}" $pvcName -}}
     {{- $applicationNamespacePath:= printf "{.items[?(@.spec.volumes[*].persistentVolumeClaim.claimName=='%s')].metadata.namespace}" $pvcName -}}
     {{- jsonpath .JsonResult $applicationNamePath | saveAs "readlistpod.applicationPodName" .TaskResult -}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->
These PR does the following things
-> This PR adds application pod name and application namespace details in volume read request. 
-> This PR adds application details in mayactl volume describe command. The details currently include the application name and application namespace as of now.
-> This PR also adds ReplicaCount field in `openebs-cstor-sparse` storage class to make it similar to `openebs-jiva-default`.

-> Output of openebs-cstor-sparse :
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  annotations:
    cas.openebs.io/config: |
      - name: StoragePoolClaim
        value: "cstor-sparse-pool"
      - name: ReplicaCount
        value: "3"
      #- name: TargetResourceLimits
      #  value: |-
      #      memory: 1Gi
      #      cpu: 200m
      #- name: AuxResourceLimits
      #  value: |-
      #      memory: 0.5Gi
      #      cpu: 50m
    openebs.io/cas-type: cstor
  creationTimestamp: "2019-01-11T12:40:54Z"
  name: openebs-cstor-sparse
  resourceVersion: "2568"
  selfLink: /apis/storage.k8s.io/v1/storageclasses/openebs-cstor-sparse
  uid: 229c4145-159e-11e9-a262-b4b686bd0cff
provisioner: openebs.io/provisioner-iscsi
reclaimPolicy: Delete
volumeBindingMode: Immediate
``` 

-> Output of new response for volume read:

```
{
  "apiVersion": "v1alpha1",
  "kind": "CASVolume",
  "metadata": {
    "annotations": {
      "openebs.io/controller-status": "running,running,running",
      "openebs.io/cvr-names": "pvc-55154c45-15a1-11e9-a262-b4b686bd0cff-cstor-sparse-pool-4lxy",
      "openebs.io/node-names": "127.0.0.1",
      "openebs.io/pool-names": "cstor-sparse-pool-4lxy",
      "openebs.io/application-pod-name": "N/A",
      "openebs.io/application-pod-namespace": "N/A",
      "openebs.io/controller-ips": "172.17.0.10",
      "openebs.io/controller-node-name": "127.0.0.1"
    },
    "name": "pvc-55154c45-15a1-11e9-a262-b4b686bd0cff"
  },
  "spec": {
    "accessMode": "",
    "capacity": "5G",
    "casType": "cstor",
    "fsType": "ext4",
    "iqn": "iqn.2016-09.com.openebs.cstor:pvc-55154c45-15a1-11e9-a262-b4b686bd0cff",
    "lun": 0,
    "replicas": "1",
    "targetIP": "10.0.0.18",
    "targetPort": "3260",
    "targetPortal": "10.0.0.18:3260"
  },
  "status": {
    "Message": "",
    "Phase": "",
    "Reason": ""
  }
}
```

-> output of new mayactl volume describe:
```
Portal Details :
----------------
IQN               :   iqn.2016-09.com.openebs.cstor:pvc-520fdb78-172c-11e9-9a3c-b4b686bd0cff
Volume            :   pvc-520fdb78-172c-11e9-9a3c-b4b686bd0cff
Portal            :   10.0.0.78:3260
Size              :   4G
Controller Status :   running,running,running
Controller Node   :   127.0.0.1
Replica Count     :   1

Application Details:
--------------------
Application Pod Name      : N/A
Application Pod Namespace : N/A

Replica Details :
-----------------
NAME                                                                STATUS      POOL NAME                  NODE
----                                                                ------      ---------                  -----
pvc-520fdb78-172c-11e9-9a3c-b4b686bd0cff-cstor-sparse-pool-4uut     Running     cstor-sparse-pool-4uut     127.0.0.1
```

**Which issue this PR fixes** : https://github.com/openebs/openebs/issues/1993

**Special notes for your reviewer**:
Note: The default value will be N/A if application information is not present. 