### PR TITLE
[US4131]fix(cstor_operator): add all disk on node for pool provisioning

### DIFF
--- a/cmd/maya-apiserver/spc-watcher/select_disk.go
+++ b/cmd/maya-apiserver/spc-watcher/select_disk.go
@@ -179,7 +179,7 @@ func diskSelector(nodeDiskMap map[string]*diskList, poolType, provisioningType s
 			}
 		}
 		if poolType == string(v1alpha1.PoolTypeMirroredCPV) {
-			for i := 0; i < diskCount/2*2; i = i + 2 {
+			for i := 0; i < (diskCount/2)*2; i = i + 2 {
 				selectedDisk.disks.items = append(selectedDisk.disks.items, val.items[i])
 				selectedDisk.disks.items = append(selectedDisk.disks.items, val.items[i+1])
 			}

--- a/cmd/maya-apiserver/spc-watcher/select_disk_test.go
+++ b/cmd/maya-apiserver/spc-watcher/select_disk_test.go
@@ -19,11 +19,12 @@ package spc
 import (
 	"testing"
 	//openebsFakeClientset "github.com/openebs/maya/pkg/client/clientset/versioned/fake"
+	"strconv"
+
 	"github.com/golang/glog"
 	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	openebsFakeClientset "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strconv"
 )
 
 func (focs *clientSet) FakeDiskCreator() {
@@ -146,7 +147,7 @@ func TestNodeDiskAlloter(t *testing.T) {
 				},
 			},
 		},
-			1,
+			3,
 			false,
 		},
 		// Test Case #6
@@ -179,7 +180,23 @@ func TestNodeDiskAlloter(t *testing.T) {
 			0,
 			false,
 		},
+		// Test Case #8
+		"manualSPC8": {&v1alpha1.StoragePoolClaim{
+			Spec: v1alpha1.StoragePoolClaimSpec{
+				Type: "disk",
+				PoolSpec: v1alpha1.CStorPoolAttr{
+					PoolType: "mirrored",
+				},
+				Disks: v1alpha1.DiskAttr{
+					DiskList: []string{"disk1", "disk2", "disk3", "disk4"},
+				},
+			},
+		},
+			4,
+			false,
+		},
 	}
+
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			diskList, err := focs.nodeDiskAlloter(test.fakeCasPool)

--- a/cmd/maya-apiserver/spc-watcher/select_disk_test.go
+++ b/cmd/maya-apiserver/spc-watcher/select_disk_test.go
@@ -195,6 +195,21 @@ func TestNodeDiskAlloter(t *testing.T) {
 			4,
 			false,
 		},
+		// Test Case #8
+		"manualSPC9": {&v1alpha1.StoragePoolClaim{
+			Spec: v1alpha1.StoragePoolClaimSpec{
+				Type: "disk",
+				PoolSpec: v1alpha1.CStorPoolAttr{
+					PoolType: "mirrored",
+				},
+				Disks: v1alpha1.DiskAttr{
+					DiskList: []string{"disk1", "disk2", "disk3"},
+				},
+			},
+		},
+			2,
+			false,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
This PR will do following:
Use all usable disks attached on node for pool provisioning.

fixes https://github.com/openebs/openebs/issues/2346

Deails about this fix can be found at https://github.com/openebs/openebs/issues/2346

Signed-off-by: Ashutosh Kumar <ashutosh.kumar@openebs.io>