### PR TITLE
feat(provision): adds SC annotation to openebs volume components

### DIFF
--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -78,6 +78,7 @@ spec:
     - cstor-volume-create-getpvc-default
     - cstor-volume-create-listclonecstorvolumereplicacr-default
     - cstor-volume-create-listcstorpoolcr-default
+    - cstor-volume-create-getstorageclass-default
     - cstor-volume-create-puttargetservice-default
     - cstor-volume-create-putcstorvolumecr-default
     - cstor-volume-create-puttargetdeployment-default
@@ -216,6 +217,22 @@ spec:
     {{- $poolsNodeList | keyMap "cvolPoolNodeList" .ListItems | noop -}}
     {{- end }}
 ---
+#runTask to get storageclass info
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: cstor-volume-create-getstorageclass-default
+spec:
+  meta: |
+    id: creategetsc
+    apiVersion: storage.k8s.io/v1
+    kind: StorageClass
+    objectName: {{ .Volume.storageclass }}
+    action: get
+  post: |
+    {{- $resourceVer := jsonpath .JsonResult "{.metadata.resourceVersion}" -}}
+    {{- trim $resourceVer | saveAs "creategetsc.storageClassVersion" .TaskResult | noop -}}
+---
 # runTask to create cStor target service
 apiVersion: openebs.io/v1alpha1
 kind: RunTask
@@ -242,6 +259,10 @@ spec:
     apiVersion: v1
     kind: Service
     metadata:
+      annotations:
+        openebs.io/storage-class-ref: | 
+          name: {{ .Volume.storageclass }}
+          resourceVersion: {{ .TaskResult.creategetsc.storageClassVersion }}
       labels:
         openebs.io/target-service: cstor-target-svc
         openebs.io/storage-engine-type: cstor
@@ -298,6 +319,9 @@ spec:
       annotations:
         openebs.io/fs-type: {{ .Config.FSType.value }}
         openebs.io/lun: {{ .Config.Lun.value }}
+        openebs.io/storage-class-ref: | 
+          name: {{ .Volume.storageclass }}
+          resourceVersion: {{ .TaskResult.creategetsc.storageClassVersion }}
       labels:
         openebs.io/persistent-volume: {{ .Volume.owner }}
         openebs.io/version: {{ .CAST.version }}
@@ -356,6 +380,9 @@ spec:
         openebs.io/volume-monitor: "true"
         {{- end}}
         openebs.io/volume-type: cstor
+        openebs.io/storage-class-ref: | 
+          name: {{ .Volume.storageclass }}
+          resourceVersion: {{ .TaskResult.creategetsc.storageClassVersion }}
     spec:
       replicas: 1
       selector:
@@ -372,13 +399,17 @@ spec:
             app: cstor-volume-manager
             openebs.io/target: cstor-target
             openebs.io/persistent-volume: {{ .Volume.owner }}
+            openebs.io/storage-class: {{ .Volume.storageclass }}
             openebs.io/persistent-volume-claim: {{ .Volume.pvc }}
-          {{- if eq $isMonitor "true" }}
           annotations:
+            openebs.io/storage-class-ref: | 
+              name: {{ .Volume.storageclass }}
+              resourceVersion: {{ .TaskResult.creategetsc.storageClassVersion }}
+            {{- if eq $isMonitor "true" }}
             prometheus.io/path: /metrics
             prometheus.io/port: "9500"
             prometheus.io/scrape: "true"
-          {{- end}}
+            {{- end}}
         spec:
           serviceAccountName: {{ .Config.PVCServiceAccountName.value | default .Config.ServiceAccountName.value }}
           {{- if ne $targetAffinityVal "none" }}
@@ -562,6 +593,9 @@ spec:
         openebs.io/source-volume: {{ .Volume.sourceVolume }}
         {{- end }}
         cstorpool.openebs.io/hostname: {{ pluck .ListItems.currentRepeatResource .ListItems.cvolPoolNodeList.pools | first }}
+        openebs.io/storage-class-ref: | 
+          name: {{ .Volume.storageclass }}
+          resourceVersion: {{ .TaskResult.creategetsc.storageClassVersion }}
       finalizers: ["cstorvolumereplica.openebs.io/finalizer"]
     spec:
       capacity: {{ .Volume.capacity }}

--- a/pkg/install/v1alpha1/jiva_volume.go
+++ b/pkg/install/v1alpha1/jiva_volume.go
@@ -541,6 +541,10 @@ spec:
     apiVersion: v1
     Kind: Service
     metadata:
+      annotations:
+        openebs.io/storage-class-ref: | 
+          name: {{ .Volume.storageclass }}
+          resourceVersion: {{ .TaskResult.creategetsc.storageClassVersion }}
       labels:
         openebs.io/storage-engine-type: jiva
         openebs.io/cas-type: jiva
@@ -733,6 +737,9 @@ spec:
         openebs.io/version: {{ .CAST.version }}
         openebs.io/cas-template-name: {{ .CAST.castName }}
       annotations:
+        openebs.io/storage-class-ref: | 
+          name: {{ .Volume.storageclass }}
+          resourceVersion: {{ .TaskResult.creategetsc.storageClassVersion }}
         {{- if eq $isMonitor "true" }}
         openebs.io/volume-monitor: "true"
         {{- end}}
@@ -756,6 +763,9 @@ spec:
             openebs.io/persistent-volume: {{ .Volume.owner }}
             openebs.io/persistent-volume-claim: {{ .Volume.pvc }}
           annotations:
+            openebs.io/storage-class-ref: | 
+                name: {{ .Volume.storageclass }}
+                resourceVersion: {{ .TaskResult.creategetsc.storageClassVersion }}
             openebs.io/fs-type: {{ .Config.FSType.value }}
             openebs.io/lun: {{ .Config.Lun.value }}
             {{- if eq $isMonitor "true" }}
@@ -889,6 +899,9 @@ spec:
         openebs.io/version: {{ .CAST.version }}
         openebs.io/cas-template-name: {{ .CAST.castName }}
       annotations:
+        openebs.io/storage-class-ref: | 
+          name: {{ .Volume.storageclass }}
+          resourceVersion: {{ .TaskResult.creategetsc.storageClassVersion }}
         openebs.io/capacity: {{ .Volume.capacity }}
         openebs.io/storage-pool: {{ .Config.StoragePool.value }}
       name: {{ .Volume.owner }}-rep
@@ -908,6 +921,9 @@ spec:
             openebs.io/replica-anti-affinity: {{ $replicaAntiAffinityVal }}
             {{- end }}
           annotations:
+            openebs.io/storage-class-ref: | 
+              name: {{ .Volume.storageclass }}
+              resourceVersion: {{ .TaskResult.creategetsc.storageClassVersion }}
             openebs.io/capacity: {{ .Volume.capacity }}
             openebs.io/storage-pool: {{ .Config.StoragePool.value }}
         spec:


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

This PR adds storage class annotation in OpenEBS provisioned volume components like target svc, deployments and replica deployments

The label name is `openebs.io/storage-class-ref`.

-> An example of service after this PR.
```
apiVersion: v1
kind: Service
metadata:
  annotations:
    openebs.io/storage-class-ref: |
      name: openebs-jiva-default
      resourceVersion: 564
  creationTimestamp: "2019-01-16T11:45:15Z"
  labels:
    openebs.io/cas-template-name: jiva-volume-create-default-0.8.0
    openebs.io/cas-type: jiva
    openebs.io/controller-service: jiva-controller-svc
    openebs.io/persistent-volume: pvc-3003f407-1984-11e9-b1bb-b4b686bd0cff
    openebs.io/persistent-volume-claim: jiva-pvc
    openebs.io/storage-engine-type: jiva
    openebs.io/version: 0.8.0
    pvc: jiva-pvc
  name: pvc-3003f407-1984-11e9-b1bb-b4b686bd0cff-ctrl-svc
  namespace: default
  resourceVersion: "607"
  selfLink: /api/v1/namespaces/default/services/pvc-3003f407-1984-11e9-b1bb-b4b686bd0cff-ctrl-svc
  uid: 30705ebb-1984-11e9-b1bb-b4b686bd0cff

```