### PR TITLE
ephemeral(set_quorum): Setting quorum as on for newly created cStorVo…

### DIFF
--- a/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
+++ b/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"encoding/json"
+
 	"github.com/golang/glog"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	"github.com/openebs/maya/pkg/util"
@@ -148,7 +149,7 @@ func builldVolumeCreateCommand(cStorVolumeReplica *apis.CStorVolumeReplica, full
 	openebsTargetIP := "io.openebs:targetip=" + cStorVolumeReplica.Spec.TargetIP
 
 	createVolCmd = append(createVolCmd, CreateCmd,
-		"-b", "4K", "-s", "-o", "compression=on",
+		"-b", "4K", "-s", "-o", "compression=on", "-o", "quorum=on",
 		"-o", openebsTargetIP, "-o", openebsVolname,
 		"-V", cStorVolumeReplica.Spec.Capacity, fullVolName)
 
@@ -164,7 +165,7 @@ func builldVolumeCloneCommand(cStorVolumeReplica *apis.CStorVolumeReplica, snapN
 	openebsTargetIP := "io.openebs:targetip=" + cStorVolumeReplica.Spec.TargetIP
 
 	cloneVolCmd = append(cloneVolCmd, CloneCmd,
-		"-o", "compression=on", "-o", openebsTargetIP,
+		"-o", "compression=on", "-o", openebsTargetIP, "-o", "quorum=on",
 		"-o", openebsVolname, snapName, fullVolName)
 
 	return cloneVolCmd


### PR DESCRIPTION
…lumeReplicas

To support ephemeral usecase, cstor volume replicas at ZFS layer have a property 'quorum'. Setting this to ON makes the ZFS volume to be part of quorum decisions at target. And, setting this to OFF makes target to accept this replica (currently, new replicas are not allowed to connect), and triggers rebuild on this ZFS volume, and, ZFS volume automatically sets 'quorum' as ON once the rebuilding is done.
This ZFS property 'quorum' is something that can't be changed from 'ON' to 'OFF', but, other transitions are allowed.
This PR is to set 'quorum' property as 'on' for newly created ZFS volumes and clones.

Please note that, as part of ephemeral support, pending work is setting this 'quorum' property to 'off' in case of pool and its ZFS volumes recreation.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>