### PR TITLE
feat(CAS_Template)add liveness for cstor pool

### DIFF
--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -215,6 +215,16 @@ spec:
               protocol: TCP
             - containerPort: 3232
               protocol: TCP
+            livenessProbe:
+              exec:
+                command:
+                - /bin/sh
+                - -c
+                - zfs set io.openebs:livenesstimestap='$(date)' cstor-$OPENEBS_IO_CSTOR_ID
+              failureThreshold: 3
+              initialDelaySeconds: 300
+              periodSeconds: 10
+              timeoutSeconds: 30
             securityContext:
               privileged: true
             volumeMounts:
@@ -226,6 +236,10 @@ spec:
               mountPath: {{ .Config.SparseDir.value }}
             - name: udev
               mountPath: /run/udev
+            env:
+              # OPENEBS_IO_CSTOR_ID env has UID of cStorPool CR.
+            - name: OPENEBS_IO_CSTOR_ID
+              value: {{.TaskResult.putcstorpoolcr.objectUID}}
               # To avoid clash between terminating and restarting pod
               # in case older zrepl gets deleted faster, we keep initial delay
             lifecycle:


### PR DESCRIPTION
This PR will add liveness check for cstor-pool container.
There are scenarios where I/O can be hung and in that case we may need to restart the cstor-pool container.
Signed-off-by: Ashutosh Kumar <ashutosh.kumar@openebs.io>
