### PR TITLE
feat(vol_provision): distribute cvrs randomly on its pools

### DIFF
--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -574,7 +574,7 @@ spec:
     Calculate the replica count
     Add as many poolUid to resources as there is replica count
     */}}
-    {{- $poolUids := keys .ListItems.cvolPoolList.pools }}
+    {{- $poolUids := keys .ListItems.cvolPoolList.pools | randomize }}
     {{- $replicaCount := .Config.ReplicaCount.value | int64 -}}
     repeatWith:
       resources:

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -21,14 +21,17 @@ package template
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
+	"reflect"
+	"strings"
+	"text/template"
+	"time"
+
 	"github.com/Masterminds/sprig"
 	"github.com/ghodss/yaml"
 	v1alpha1 "github.com/openebs/maya/pkg/task/v1alpha1"
 	"github.com/openebs/maya/pkg/util"
 	kubever "github.com/openebs/maya/pkg/version/kubernetes"
-	"reflect"
-	"strings"
-	"text/template"
 )
 
 // empty returns true if the given value has the zero value for its type.
@@ -780,6 +783,7 @@ func runtaskFuncs() (f template.FuncMap) {
 		"keyMap":             keyMap,
 		"splitKeyMap":        splitKeyMap,
 		"splitListTrim":      splitListTrim,
+		"randomize":          randomize,
 	}
 }
 
@@ -878,4 +882,19 @@ func AsMapOfStrings(context string, yml string, values map[string]interface{}) (
 func splitListTrim(sep, orig string) []string {
 	processedStr := strings.TrimRight(strings.TrimLeft(orig, sep), sep)
 	return strings.Split(processedStr, sep)
+}
+
+// For given []string as input, randomize API returns its randomized list
+// Example:
+// {{- $poolUids := keys .ListItems.cvolPoolList.pools | randomize }}
+func randomize(list []string) []string {
+	res := []string{}
+
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+	perm := r.Perm(len(list))
+	for _, idx := range perm {
+		res = append(res, list[idx])
+	}
+
+	return res
 }

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -36,10 +36,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/ghodss/yaml"
 	"reflect"
 	"testing"
 	"text/template"
+
+	"github.com/ghodss/yaml"
 )
 
 func TestAddTo(t *testing.T) {
@@ -1260,7 +1261,7 @@ kindTwo: Deployment`,
 			},
 			expectedYaml: `
 default:
-  mydeploy: 
+  mydeploy:
     kind: Deployment
 openebs:
   mypod:
@@ -1314,7 +1315,7 @@ kind: MyList
 apiVersion: v1alpha1
 items:
 # NOTE:
-#   Below range and if blocks should end with }} 
+#   Below range and if blocks should end with }}
 # If they end with -}} a new line is not formed and makes the yaml invalid
 {{- range $pkey, $val := .Values.scenario }}
   - label: {{ $pkey }}
@@ -2120,6 +2121,37 @@ all:
 			ok := reflect.DeepEqual(objExpected, objActual)
 			if !ok {
 				t.Fatalf("failed to test dynamic templating:\n\nexpected: '%s' \n\nactual: '%s'", mock.ymlExpected, buf.Bytes())
+			}
+		})
+	}
+}
+
+func TestRandomize(t *testing.T) {
+	tests := map[string]struct {
+		list []string
+		want []string
+	}{
+		"SingeKey": {
+			list: []string{
+				"key1",
+			},
+			want: []string{"key1"},
+		},
+		"TwoKeys": {
+			list: []string{
+				"key1", "key2",
+			},
+			want: []string{"key1", "key2"},
+		},
+
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			list := randomize(mock.list)
+			if len(list) != len(mock.want) {
+				t.Fatalf("failed to test randomize: expected '%v' %d: actual '%v' %d",
+				    mock.want, len(mock.want), list, len(list))
 			}
 		})
 	}


### PR DESCRIPTION
Currently, CVRs are created on the pools in the order in which they are obtained. But, the order of pools that is received will be same every time. So, current distribution of volume provision will happen more on the pools that are in the start of the list.

This PR is to randomly select the pools on which CVRs are created, so that the distribution of volume provision happens randomly.

With 3 pools, and replicaCount being 1 for PVC, below is the output of distribution of 7 volumes provisioning:
```
$ for pool in `kubectl get pod -n openebs | grep cstor-sparse | awk '{print $1}'`; do kubectl exec -it -c cstor-pool -n openebs $pool -- zfs list; done
NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT
cstor-37ce1096-1be0-11e9-9938-42010a80002a                                            143K  9.63G   512B  /cstor-37ce1096-1be0-11e9-9938-42010a80002a
cstor-37ce1096-1be0-11e9-9938-42010a80002a/pvc-084e3c82-1be1-11e9-9938-42010a80002a     6K  9.63G     6K  -
cstor-37ce1096-1be0-11e9-9938-42010a80002a/pvc-79b94d73-1be0-11e9-9938-42010a80002a     6K  9.63G     6K  -
NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT
cstor-37974ff1-1be0-11e9-9938-42010a80002a                                            140K  9.63G   512B  /cstor-37974ff1-1be0-11e9-9938-42010a80002a
cstor-37974ff1-1be0-11e9-9938-42010a80002a/pvc-1c2b3ff4-1be1-11e9-9938-42010a80002a     6K  9.63G     6K  -
cstor-37974ff1-1be0-11e9-9938-42010a80002a/pvc-f3df31d7-1be0-11e9-9938-42010a80002a     6K  9.63G     6K  -
NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT
cstor-37e590c5-1be0-11e9-9938-42010a80002a                                            168K  9.63G   512B  /cstor-37e590c5-1be0-11e9-9938-42010a80002a
cstor-37e590c5-1be0-11e9-9938-42010a80002a/pvc-9b292a80-1be0-11e9-9938-42010a80002a     6K  9.63G     6K  -
cstor-37e590c5-1be0-11e9-9938-42010a80002a/pvc-b4019ebc-1be0-11e9-9938-42010a80002a     6K  9.63G     6K  -
cstor-37e590c5-1be0-11e9-9938-42010a80002a/pvc-e4f90d10-1be0-11e9-9938-42010a80002a     6K  9.63G     6K  -
```

Signed-off-by: Vishnu Itta <vitta@mayadata.io>