### PR TITLE
feat(pool-mgmt): Add ephemeral support in cstor-pool-mgmt

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler_test.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler_test.go
@@ -93,6 +93,30 @@ func TestGetPoolResource(t *testing.T) {
 				Status: apis.CStorPoolStatus{},
 			},
 		},
+		"img3PoolResource": {
+			expectedPoolName: "existingpool",
+			test: &apis.CStorPool{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool3",
+					UID:  types.UID("existingpool"),
+				},
+				Spec: apis.CStorPoolSpec{
+					Disks: apis.DiskAttr{
+						DiskList: []string{"/tmp/img3.img"},
+					},
+					PoolSpec: apis.CStorPoolAttr{
+						CacheFile:        "/tmp/pool3.cache",
+						PoolType:         "striped",
+						OverProvisioning: false,
+					},
+				},
+				Status: apis.CStorPoolStatus{
+					Phase:    "Healthy",
+					Capacity: apis.CStorPoolCapacityAttr{},
+				},
+			},
+		},
 	}
 	for desc, ut := range testPoolResource {
 		// Create Pool resource

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -183,7 +183,7 @@ func (c *CStorVolumeReplicaController) cVRAddEventHandler(cVR *apis.CStorVolumeR
 	}
 
 	// IsEmptyStatus is to check if initial status of cVR object is empty.
-	if IsEmptyStatus(cVR) || IsPendingStatus(cVR) || IsRecreateStatus(cVR) {
+	if IsEmptyStatus(cVR) || IsInitStatus(cVR) || IsRecreateStatus(cVR) {
 		err := volumereplica.CreateVolumeReplica(cVR, fullVolName, quorum)
 		if err != nil {
 			glog.Errorf("cVR creation failure: %v", err.Error())
@@ -297,9 +297,9 @@ func IsEmptyStatus(cVR *apis.CStorVolumeReplica) bool {
 	return false
 }
 
-// IsPendingStatus is to check if the status of cStorVolumeReplica object is pending.
-func IsPendingStatus(cVR *apis.CStorVolumeReplica) bool {
-	if string(cVR.Status.Phase) == string(apis.CVRStatusPending) {
+// IsInitStatus is to check if the status of cStorVolumeReplica object is pending.
+func IsInitStatus(cVR *apis.CStorVolumeReplica) bool {
+	if string(cVR.Status.Phase) == string(apis.CVRStatusInit) {
 		glog.Infof("cVR pending: %v", string(cVR.ObjectMeta.UID))
 		return true
 	}

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/new_replica_controller.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/new_replica_controller.go
@@ -114,7 +114,14 @@ func NewCStorVolumeReplicaController(
 			q.Operation = common.QOpAdd
 			glog.Infof("cStorVolumeReplica Added event : %v, %v", cVR.ObjectMeta.Name, string(cVR.ObjectMeta.UID))
 			controller.recorder.Event(cVR, corev1.EventTypeNormal, string(common.SuccessSynced), string(common.MessageCreateSynced))
-			cVR.Status.Phase = apis.CVRStatusPending
+
+			// For New request phase of cVR will be empty
+			if IsEmptyStatus(cVR) {
+				cVR.Status.Phase = apis.CVRStatusPending
+			} else {
+				cVR.Status.Phase = apis.CVRStatusRecreate
+			}
+
 			cVR, _ = controller.clientset.OpenebsV1alpha1().CStorVolumeReplicas(cVR.Namespace).Update(cVR)
 			controller.enqueueCStorReplica(cVR, q)
 		},

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/new_replica_controller.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/new_replica_controller.go
@@ -116,8 +116,10 @@ func NewCStorVolumeReplicaController(
 			controller.recorder.Event(cVR, corev1.EventTypeNormal, string(common.SuccessSynced), string(common.MessageCreateSynced))
 
 			// For New request phase of cVR will be empty
+			// ToDO: Need to have an annotation in CSP and CVR which will state
+			// about recreation events.
 			if IsEmptyStatus(cVR) {
-				cVR.Status.Phase = apis.CVRStatusPending
+				cVR.Status.Phase = apis.CVRStatusInit
 			} else {
 				cVR.Status.Phase = apis.CVRStatusRecreate
 			}

--- a/cmd/cstor-pool-mgmt/volumereplica/volumereplica_test.go
+++ b/cmd/cstor-pool-mgmt/volumereplica/volumereplica_test.go
@@ -246,7 +246,7 @@ func TestSetCachefileProcess(*testing.T) {
 
 // TestCreateVolumeReplica is to test cStorVolumeReplica creation.
 func TestCreateVolumeReplica(t *testing.T) {
-	fakeQuorum := true
+	fakeQuorums := []bool{true, false}
 	testPoolResource := map[string]struct {
 		expectedError error
 		test          *apis.CStorVolumeReplica
@@ -269,9 +269,11 @@ func TestCreateVolumeReplica(t *testing.T) {
 		},
 	}
 	RunnerVar = TestRunner{}
-	obtainedErr := CreateVolumeReplica(testPoolResource["Valid-vol1Resource"].test, "abcd123/dcba", fakeQuorum)
-	if testPoolResource["Valid-vol1Resource"].expectedError != obtainedErr {
-		t.Fatalf("Expected: %v, Got: %v", testPoolResource["Valid-vol1Resource"].expectedError, obtainedErr)
+	for _, fakeQuorum := range fakeQuorums {
+		obtainedErr := CreateVolumeReplica(testPoolResource["Valid-vol1Resource"].test, "abcd123/dcba", fakeQuorum)
+		if testPoolResource["Valid-vol1Resource"].expectedError != obtainedErr {
+			t.Fatalf("Expected: %v, Got: %v", testPoolResource["Valid-vol1Resource"].expectedError, obtainedErr)
+		}
 	}
 }
 

--- a/cmd/cstor-pool-mgmt/volumereplica/volumereplica_test.go
+++ b/cmd/cstor-pool-mgmt/volumereplica/volumereplica_test.go
@@ -246,6 +246,7 @@ func TestSetCachefileProcess(*testing.T) {
 
 // TestCreateVolumeReplica is to test cStorVolumeReplica creation.
 func TestCreateVolumeReplica(t *testing.T) {
+	fakeQuorum := true
 	testPoolResource := map[string]struct {
 		expectedError error
 		test          *apis.CStorVolumeReplica
@@ -268,7 +269,7 @@ func TestCreateVolumeReplica(t *testing.T) {
 		},
 	}
 	RunnerVar = TestRunner{}
-	obtainedErr := CreateVolumeReplica(testPoolResource["Valid-vol1Resource"].test, "abcd123/dcba")
+	obtainedErr := CreateVolumeReplica(testPoolResource["Valid-vol1Resource"].test, "abcd123/dcba", fakeQuorum)
 	if testPoolResource["Valid-vol1Resource"].expectedError != obtainedErr {
 		t.Fatalf("Expected: %v, Got: %v", testPoolResource["Valid-vol1Resource"].expectedError, obtainedErr)
 	}

--- a/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
@@ -79,6 +79,8 @@ const (
 	CVRStatusErrorDuplicate CStorVolumeReplicaPhase = "Invalid"
 	// CVRStatusPending ensures pending task of cvr resource.
 	CVRStatusPending CStorVolumeReplicaPhase = "Init"
+	// CVRStatusRecreate ensures recreation task of cvr resource.
+	CVRStatusRecreate CStorVolumeReplicaPhase = "Recreate"
 )
 
 // CStorVolumeReplicaStatus is for handling status of cvr.

--- a/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
@@ -77,8 +77,8 @@ const (
 	CVRStatusInvalid CStorVolumeReplicaPhase = "Invalid"
 	// CVRStatusErrorDuplicate ensures error due to duplicate resource.
 	CVRStatusErrorDuplicate CStorVolumeReplicaPhase = "Invalid"
-	// CVRStatusPending ensures pending task of cvr resource.
-	CVRStatusPending CStorVolumeReplicaPhase = "Init"
+	// CVRStatusInit ensures Init task of cvr resource.
+	CVRStatusInit CStorVolumeReplicaPhase = "Init"
 	// CVRStatusRecreate ensures recreation task of cvr resource.
 	CVRStatusRecreate CStorVolumeReplicaPhase = "Recreate"
 )


### PR DESCRIPTION
### Why we need this:
When cstor pool is **re-created** on the node (_e.g. node reboots with blank data as disks were ephemeral_), then the volumes need to be re-created by setting the **quorum** to _false_. 

_NOTE: Based on the quorum value, cstor target will decide whether the replica is considered for quorum decision._

### What this PR does:
This feature is hereby known as **ephemeral support**. This is implemented by setting the **quorum** property to _false_, for the volumes which are created on the nodes that are replacing existing nodes.
 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/openebs/openebs/issues/2358


Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>