### PR TITLE
fix(policies): support for resource requests on side-cars (#889)

### DIFF
--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -63,6 +63,10 @@ spec:
   #      memory: 1Gi
   - name: PoolResourceLimits
     value: "none"
+  # AuxResourceRequests allow you to set requests on side cars. Requests have to be specified
+  # in the format expected by Kubernetes
+  - name: AuxResourceRequests
+    value: "none"
   # AuxResourceLimits allow you to set limits on side cars. Limits have to be specified
   # in the format expected by Kubernetes
   - name: AuxResourceLimits
@@ -220,6 +224,8 @@ spec:
     {{- $resourceRequestsVal := fromYaml .Config.PoolResourceRequests.value -}}
     {{- $setResourceLimits := .Config.PoolResourceLimits.value | default "none" -}}
     {{- $resourceLimitsVal := fromYaml .Config.PoolResourceLimits.value -}}
+    {{- $setAuxResourceRequests := .Config.AuxResourceRequests.value | default "none" -}}
+    {{- $auxResourceRequestsVal := fromYaml .Config.AuxResourceRequests.value -}}
     {{- $setAuxResourceLimits := .Config.AuxResourceLimits.value | default "none" -}}
     {{- $auxResourceLimitsVal := fromYaml .Config.AuxResourceLimits.value -}}
     apiVersion: extensions/v1beta1
@@ -290,13 +296,19 @@ spec:
                     command: ["/bin/sh", "-c", "sleep 2"]
           - name: cstor-pool-mgmt
             image: {{ .Config.CstorPoolMgmtImage.value }}
-            {{- if ne $setAuxResourceLimits "none" }}
             resources:
+              {{- if ne $setAuxResourceRequests "none" }}
+              requests:
+              {{- range $rKey, $rLimit := $auxResourceRequestsVal }}
+                {{ $rKey }}: {{ $rLimit }}
+              {{- end }}
+              {{- end }}
+              {{- if ne $setAuxResourceLimits "none" }}
               limits:
               {{- range $rKey, $rLimit := $auxResourceLimitsVal }}
                 {{ $rKey }}: {{ $rLimit }}
               {{- end }}
-            {{- end }}
+              {{- end }}
             ports:
             - containerPort: 9500
               protocol: TCP


### PR DESCRIPTION
Ref: https://github.com/openebs/openebs/issues/2294

With 0.7.0, there was support for configuring resource
limits on the pool and volume pod side-cars using
AuxilaryResourceLimits. With this PR, added the support
to specify AuxilaryResourceRequests.

This feature is useful in cases where user has to specify
minimum requests like ephemeral storage etc. to avoid
erroneous eviction by K8s as described in the above issue.

Also, some of the resource types are very version dependent
so keeping this as generic and not providing any defaults in
this PR.

In the future, it is possible that OpenEBS Operator could
automatically determine the version and set default values
on the generated default Storage Class.

Signed-off-by: kmova <kiran.mova@openebs.io>
(cherry picked from commit 9f12a28fe7b755e21715fb627c89b0054c22e87f)

