### PR TITLE
feat(vol_provision): distribute cvrs randomly on its pools (#895)

### DIFF
--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -543,7 +543,7 @@ spec:
     Calculate the replica count
     Add as many poolUid to resources as there is replica count
     */}}
-    {{- $poolUids := keys .ListItems.cvolPoolList.pools }}
+    {{- $poolUids := keys .ListItems.cvolPoolList.pools | randomize }}
     {{- $replicaCount := .Config.ReplicaCount.value | int64 -}}
     repeatWith:
       resources:

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -21,14 +21,17 @@ package template
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
+	"reflect"
+	"strings"
+	"text/template"
+	"time"
+
 	"github.com/Masterminds/sprig"
 	"github.com/ghodss/yaml"
 	v1alpha1 "github.com/openebs/maya/pkg/task/v1alpha1"
 	"github.com/openebs/maya/pkg/util"
 	kubever "github.com/openebs/maya/pkg/version/kubernetes"
-	"reflect"
-	"strings"
-	"text/template"
 )
 
 // empty returns true if the given value has the zero value for its type.
@@ -780,6 +783,7 @@ func runtaskFuncs() (f template.FuncMap) {
 		"keyMap":             keyMap,
 		"splitKeyMap":        splitKeyMap,
 		"splitListTrim":      splitListTrim,
+		"randomize":          randomize,
 	}
 }
 
@@ -878,4 +882,19 @@ func AsMapOfStrings(context string, yml string, values map[string]interface{}) (
 func splitListTrim(sep, orig string) []string {
 	processedStr := strings.TrimRight(strings.TrimLeft(orig, sep), sep)
 	return strings.Split(processedStr, sep)
+}
+
+// For given []string as input, randomize API returns its randomized list
+// Example:
+// {{- $poolUids := keys .ListItems.cvolPoolList.pools | randomize }}
+func randomize(list []string) []string {
+	res := []string{}
+
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+	perm := r.Perm(len(list))
+	for _, randomIdx := range perm {
+		res = append(res, list[randomIdx])
+	}
+
+	return res
 }

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -36,10 +36,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/ghodss/yaml"
 	"reflect"
 	"testing"
 	"text/template"
+
+	"github.com/ghodss/yaml"
 )
 
 func TestAddTo(t *testing.T) {
@@ -1260,7 +1261,7 @@ kindTwo: Deployment`,
 			},
 			expectedYaml: `
 default:
-  mydeploy: 
+  mydeploy:
     kind: Deployment
 openebs:
   mypod:
@@ -1314,7 +1315,7 @@ kind: MyList
 apiVersion: v1alpha1
 items:
 # NOTE:
-#   Below range and if blocks should end with }} 
+#   Below range and if blocks should end with }}
 # If they end with -}} a new line is not formed and makes the yaml invalid
 {{- range $pkey, $val := .Values.scenario }}
   - label: {{ $pkey }}
@@ -2120,6 +2121,36 @@ all:
 			ok := reflect.DeepEqual(objExpected, objActual)
 			if !ok {
 				t.Fatalf("failed to test dynamic templating:\n\nexpected: '%s' \n\nactual: '%s'", mock.ymlExpected, buf.Bytes())
+			}
+		})
+	}
+}
+
+func TestRandomize(t *testing.T) {
+	tests := map[string]struct {
+		list []string
+		want []string
+	}{
+		"SingleKey": {
+			list: []string{
+				"key1",
+			},
+			want: []string{"key1"},
+		},
+		"TwoKeys": {
+			list: []string{
+				"key1", "key2",
+			},
+			want: []string{"key1", "key2"},
+		},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			list := randomize(mock.list)
+			if len(list) != len(mock.want) {
+				t.Fatalf("failed to test randomize: expected '%v' %d: actual '%v' %d",
+					mock.want, len(mock.want), list, len(list))
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Vishnu Itta <vitta@mayadata.io>

This is cherry-pick of https://github.com/openebs/maya/pull/895 - to distribute volume provisioning randomly on the pools related to storage class