### PR TITLE
fix(BUILDMETA): update BUILDMETA based on TRAVIS_TAG

### DIFF
--- a/buildscripts/build.sh
+++ b/buildscripts/build.sh
@@ -19,6 +19,11 @@ else
     GIT_COMMIT="$(git rev-parse HEAD)"
 fi
 
+# Set BUILDMETA based on travis tag
+if [[ -n "$TRAVIS_TAG" ]] && [[ $TRAVIS_TAG != *"RC"* ]]; then
+    echo "released" > BUILDMETA
+fi
+
 # Get the version details
 VERSION="$(cat $GOPATH/src/github.com/openebs/maya/VERSION)"
 VERSION_META="$(cat $GOPATH/src/github.com/openebs/maya/BUILDMETA)"


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>
This commit changes the
BUILDMETA to `released` based on the TRAVIS_TAG to automate the release
process.

The BUILDMETA file is changed to `released` if TRAVIS_TAG doesnot contain
`RC` and is not empty.
