### PR TITLE
enhance(CAST): Adds support for Target and Replica Toleration

### DIFF
--- a/pkg/install/v1alpha1/jiva_volume.go
+++ b/pkg/install/v1alpha1/jiva_volume.go
@@ -54,6 +54,38 @@ spec:
     value: "default"
   - name: VolumeMonitor
     enabled: "true"
+  # TargetTolerations allows you to specify the tolerations for target
+  # Example: 
+  # - name: TargetTolerations
+  #   value: |-
+  #      t1:
+  #        key: "key1"
+  #        operator: "Equal"
+  #        value: "value1"
+  #        effect: "NoSchedule"
+  #      t2:
+  #        key: "key1"
+  #        operator: "Equal"
+  #        value: "value1"
+  #        effect: "NoExecute"
+  - name: TargetTolerations
+    value: "none"
+  # ReplicaTolerations allows you to specify the tolerations for target
+  # Example: 
+  # - name: ReplicaTolerations
+  #   value: |-
+  #      t1:
+  #        key: "key1"
+  #        operator: "Equal"
+  #        value: "value1"
+  #        effect: "NoSchedule"
+  #      t2:
+  #        key: "key1"
+  #        operator: "Equal"
+  #        value: "value1"
+  #        effect: "NoExecute"
+  - name: ReplicaTolerations
+    value: "none"
   - name: EvictionTolerations
     value: |-
       t1:
@@ -728,6 +760,8 @@ spec:
     {{- $hasNodeSelector := .Config.TargetNodeSelector.value | default "none" -}}
     {{- $nodeSelectorVal := fromYaml .Config.TargetNodeSelector.value -}}
     {{- $targetAffinityVal := .TaskResult.creategetpvc.targetAffinity -}}
+    {{- $hasTargetToleration := .Config.TargetTolerations.value | default "none" -}}
+    {{- $targetTolerationVal := fromYaml .Config.TargetTolerations.value -}}
     apiVersion: extensions/v1beta1
     Kind: Deployment
     metadata:
@@ -872,6 +906,14 @@ spec:
             key: node.kubernetes.io/unreachable
             operator: Exists
             tolerationSeconds: 0
+          {{- if ne $hasTargetToleration "none" }}
+          {{- range $k, $v := $targetTolerationVal }}
+          -
+          {{- range $kk, $vv := $v }}
+            {{ $kk }}: {{ $vv }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
 ---
 apiVersion: openebs.io/v1alpha1
 kind: RunTask
@@ -897,6 +939,8 @@ spec:
     {{- $replicaAntiAffinityVal := .TaskResult.creategetpvc.replicaAntiAffinity -}}
     {{- $hasNodeSelector := .Config.ReplicaNodeSelector.value | default "none" -}}
     {{- $nodeSelectorVal := fromYaml .Config.ReplicaNodeSelector.value -}}
+    {{- $hasReplicaToleration := .Config.ReplicaTolerations.value | default "none" -}}
+    {{- $replicaTolerationVal := fromYaml .Config.ReplicaTolerations.value -}}
     apiVersion: extensions/v1beta1
     kind: Deployment
     metadata:
@@ -1007,6 +1051,14 @@ spec:
           tolerations:
           {{- if ne $isEvictionTolerations "none" }}
           {{- range $k, $v := $evictionTolerationsVal }}
+          -
+          {{- range $kk, $vv := $v }}
+            {{ $kk }}: {{ $vv }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- if ne $hasReplicaToleration "none" }}
+          {{- range $k, $v := $replicaTolerationVal }}
           -
           {{- range $kk, $vv := $v }}
             {{ $kk }}: {{ $vv }}


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

This commit adds:
1. Target and Replica Toleration policies to jiva and 
2. Target Toleration policy to cstor volumes 
Above policies can be used in storageclass.

Example of **jiva** storage class for using the above policies:
```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-jiva-default
  annotations:
    openebs.io/cas-type: jiva
    cas.openebs.io/config: |
      - name: ReplicaCount
        value: "1"
      - name: StoragePool
        value: default
      - name: TargetTolerations
        value: |
          t1:
            key: "key1"
            operator: "Equal"
            value: "value1"
            effect: "NoSchedule"
          t2:
            key: "key1"
            operator: "Equal"
            value: "value1"
            effect: "NoExecute"
      - name: ReplicaTolerations
        value: |
          t1:
            key: "key1"
            operator: "Equal"
            value: "value1"
            effect: "NoSchedule"
          t2:
            key: "key1"
            operator: "Equal"
            value: "value1"
            effect: "NoExecute"
```

Example of **cstor** storageclass for using the above policies:
```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-cstor-sparse
  annotations:
    openebs.io/cas-type: cstor
    cas.openebs.io/config: |
      - name: StoragePoolClaim
        value: "cstor-sparse-pool"
      - name: ReplicaCount
        value: "1"
      - name: TargetTolerations
        value: |
          t1:
            key: "key1"
            operator: "Equal"
            value: "value1"
            effect: "NoSchedule"
          t2:
            key: "key1"
            operator: "Equal"
            value: "value1"
            effect: "NoExecute"
```