### PR TITLE
refactor(CAST): Changes jiva and cstor deployment strategy to `Recreate`

### DIFF
--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -395,6 +395,8 @@ spec:
           resourceVersion: {{ .TaskResult.creategetsc.storageClassVersion }}
     spec:
       replicas: 1
+      strategy:
+        type: Recreate
       selector:
         matchLabels:
           app: cstor-volume-manager

--- a/pkg/install/v1alpha1/jiva_volume.go
+++ b/pkg/install/v1alpha1/jiva_volume.go
@@ -755,6 +755,8 @@ spec:
       name: {{ .Volume.owner }}-ctrl
     spec:
       replicas: 1
+      strategy:
+        type: Recreate
       selector:
         matchLabels:
           openebs.io/controller: jiva-controller
@@ -917,6 +919,8 @@ spec:
       name: {{ .Volume.owner }}-rep
     spec:
       replicas: {{ .Config.ReplicaCount.value }}
+      strategy:
+        type: Recreate
       selector:
         matchLabels:
           openebs.io/replica: jiva-replica


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

This commit changes the target and replica deployment strategy to `Recreate`
as `Rolling Update` can make and the update stuck or can cause problem in
replica sync as all replicas should be at the same version during sync.

<!--  Thanks for sending a pull request!  Here are some tips for you -->

