### PR TITLE
refactor(CAST): Changes jiva and cstor deployment strategy to `Recreate`

### DIFF
--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -368,6 +368,8 @@ spec:
         openebs.io/volume-type: cstor
     spec:
       replicas: 1
+      strategy:
+        type: Recreate
       selector:
         matchLabels:
           app: cstor-volume-manager

--- a/pkg/install/v1alpha1/jiva_volume.go
+++ b/pkg/install/v1alpha1/jiva_volume.go
@@ -748,6 +748,8 @@ spec:
       name: {{ .Volume.owner }}-ctrl
     spec:
       replicas: 1
+      strategy:
+        type: Recreate
       selector:
         matchLabels:
           openebs.io/controller: jiva-controller
@@ -904,6 +906,8 @@ spec:
       name: {{ .Volume.owner }}-rep
     spec:
       replicas: {{ .Config.ReplicaCount.value }}
+      strategy:
+        type: Recreate
       selector:
         matchLabels:
           openebs.io/replica: jiva-replica


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

This commit changes the target and replica deployment strategy to `Recreate`
as `Rolling Update` can make and the update stuck or can cause problem in
replica sync as all replicas should be at the same version during sync.

<!--  Thanks for sending a pull request!  Here are some tips for you -->


