### PR TITLE
feat(CRD): add custom column for openebs CRD's

### DIFF
--- a/pkg/install/v1alpha1/openebs_crds.go
+++ b/pkg/install/v1alpha1/openebs_crds.go
@@ -134,6 +134,30 @@ spec:
     # shortNames allow shorter string to match your resource on the CLI
     shortNames:
     - csp
+  additionalPrinterColumns:
+  - JSONPath: .status.capacity.used
+    name: Allocated
+    description: The amount of storage space within the pool that has been physically allocated
+    type: string
+  - JSONPath: .status.capacity.free
+    name: Free
+    description: The amount of free space available in the pool
+    type: string
+  - JSONPath: .status.capacity.total
+    name: Capacity
+    description: Total size of the storage pool
+    type: string
+  - JSONPath: .status.phase
+    name: Status
+    description: Identifies the current health of the pool
+    type: string
+  - JSONPath: .spec.poolSpec.poolType
+    name: Type
+    description: The type of the storage pool
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -157,6 +181,14 @@ spec:
     # shortNames allow shorter string to match your resource on the CLI
     shortNames:
     - cstorvolume
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    name: Status
+    description: Identifies the current health of the target
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -180,6 +212,22 @@ spec:
     # shortNames allow shorter string to match your resource on the CLI
     shortNames:
     - cvr
+  additionalPrinterColumns:
+  - JSONPath: .status.capacity.used
+    name: Used
+    description: The amount of space that is "logically" consumed by this dataset
+    type: string
+  - JSONPath: .status.capacity.totalAllocated
+    name: Allocated
+    description: The amount of disk space consumed by a dataset and all its descendents
+    type: string
+  - JSONPath: .status.phase
+    name: Status
+    description: Identifies the current health of the replicas
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -203,6 +251,18 @@ spec:
     # shortNames allow shorter string to match your resource on the CLI
     shortNames:
     - disk
+  additionalPrinterColumns:
+  - JSONPath: .spec.capacity.storage
+    name: Size
+    description: Identifies the disk size(in Bytes)
+    type: string
+  - JSONPath: .status.state
+    name: Status
+    description: Identifies the current health of the disk
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
 ---
 `
 


### PR DESCRIPTION
This commit will add custom column for openebs
cstorvolume, cstorvolumereplica, disk, cstorpool
custom resources.

After adding this feature we can able to list down the
required specific info like status, size etc using
`kubectl get` command

for example:
```
$ kubectl get csp -n openebs
NAME                     ALLOCATED   FREE    CAPACITY    STATUS    TYPE       AGE
sparse-claim-auto-lja7   125K        9.94G   9.94G       Healthy   striped    1h

$ kubectl get cvr -n openebs
NAME                                                              USED  ALLOCATED  STATUS    AGE
pvc-9ca83170-01e3-11e9-812f-54e1ad0c1ccc-sparse-claim-auto-lja7   6K    6K         Healthy   1h

$ kubectl get cstorvolume -n openebs
NAME                                        STATUS    AGE
pvc-9ca83170-01e3-11e9-812f-54e1ad0c1ccc    Healthy   4h

$ kubectl get disk
NAME                                      SIZE          STATUS   AGE
sparse-5a92ced3e2ee21eac7b930f670b5eab5   10737418240   Active   10m

```

Note: Starting with Kubernetes 1.11, we can use customize columns

Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->
