### PR TITLE
[WIP] refactor(CAST): adds default value for status in jiva volume list

### DIFF
--- a/pkg/install/v1alpha1/jiva_volume.go
+++ b/pkg/install/v1alpha1/jiva_volume.go
@@ -406,8 +406,8 @@ spec:
             vsm.openebs.io/replica-count: {{ $replicaIP | default "" | splitList ", " | len }}
             vsm.openebs.io/volume-size: {{ $capacity }}
             vsm.openebs.io/replica-ips: {{ $replicaIP }}
-            vsm.openebs.io/replica-status: {{ $replicaStatus | replace "true" "running" | replace "false" "notready" }}
-            vsm.openebs.io/controller-status: {{ $controllerStatus | replace "true" "running" | replace "false" "notready" | replace " " "," }}
+            vsm.openebs.io/replica-status: {{ $replicaStatus | default "" | replace "true" "running" | replace "false" "notready" }}
+            vsm.openebs.io/controller-status: {{ $controllerStatus | default "" | replace "true" "running" | replace "false" "notready" | replace " " "," }}
             vsm.openebs.io/targetportals: {{ $clusterIP }}:3260
             openebs.io/controller-ips: {{ $controllerIP }}
             openebs.io/cluster-ips: {{ $clusterIP }}
@@ -415,8 +415,8 @@ spec:
             openebs.io/replica-count: {{ $replicaIP | default "" | splitList ", " | len }}
             openebs.io/volume-size: {{ $capacity }}
             openebs.io/replica-ips: {{ $replicaIP }}
-            openebs.io/replica-status: {{ $replicaStatus | replace "true" "running" | replace "false" "notready" }}
-            openebs.io/controller-status: {{ $controllerStatus | replace "true" "running" | replace "false" "notready" | replace " " "," }}
+            openebs.io/replica-status: {{ $replicaStatus | default "" | replace "true" "running" | replace "false" "notready" }}
+            openebs.io/controller-status: {{ $controllerStatus | default "" | replace "true" "running" | replace "false" "notready" | replace " " "," }}
             openebs.io/targetportals: {{ $clusterIP }}:3260
         spec:
           accessMode: {{ $pvInfo.accessModes | default "" }}

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -1649,6 +1649,26 @@ kind: Pod
 				},
 			},
 		},
+		//
+		// start of test scenario
+		//
+		"133": {
+			templateInYaml: `
+{{- jsonpath .JsonDoc "{.Labels}" | replace "running" "true" | replace "stopped" "false" | noop -}}
+`,
+			templateValues: map[string]interface{}{
+				"JsonDoc": mockJsonMarshal(&MockJson{
+					Labels: map[string]string{
+						"openebs.io/replica-status": "running",
+					},
+					Name: "test-vol",
+				}),
+				"Values": map[string]interface{}{},
+			},
+			expectedYaml: `
+`,
+			expectedTemplateValues: map[string]interface{}{},
+		},
 	}
 
 	for name, mock := range tests {


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

**What this PR does / why we need it**: 
-> This commit adds a safety check in jiva volume list Runtask which will prevent the Runtask from failing if the status cannot be retrieved from the k8s.
-> This safety check use empty string if the status is not found from k8s.

**Which issue this PR fixes** : fixes #870 

**Special notes for your reviewer**:
-> This could be the reason of mayactl volume list failure.
