### PR TITLE
fix(cstor_operator): filter SP correctly based on SPC

### DIFF
--- a/pkg/cstorpool/v1alpha1/kubernetes_client.go
+++ b/pkg/cstorpool/v1alpha1/kubernetes_client.go
@@ -29,7 +29,7 @@ func (k *KubernetesClient) Get(name string) (*CStorPool, error) {
 
 // List is kubernetes client implementation to list disk.
 func (k *KubernetesClient) List(opts v1.ListOptions) (*CStorPoolList, error) {
-	dl, err := k.Clientset.OpenebsV1alpha1().CStorPools().List(v1.ListOptions{})
+	dl, err := k.Clientset.OpenebsV1alpha1().CStorPools().List(opts)
 	return &CStorPoolList{dl, nil, nil}, err
 }
 

--- a/pkg/sp/v1alpha1/kubernetes_client.go
+++ b/pkg/sp/v1alpha1/kubernetes_client.go
@@ -29,7 +29,7 @@ func (k *KubernetesClient) Get(name string) (*StoragePool, error) {
 
 // List is kubernetes client implementation to list disk.
 func (k *KubernetesClient) List(opts v1.ListOptions) (*StoragePoolList, error) {
-	spList, err := k.Clientset.OpenebsV1alpha1().StoragePools().List(v1.ListOptions{})
+	spList, err := k.Clientset.OpenebsV1alpha1().StoragePools().List(opts)
 	return &StoragePoolList{spList, nil, nil}, err
 }
 


### PR DESCRIPTION
This PR will do following:

When a pool is created, it is checked that for that SPC no two pools
are created on the same node.
For this,we figure out existing SP for the given SPC by passing SPC name
to the SP list options.

The list options in list of SP was not passed correctly which caused to
give a list of SP which was created due to other SPC.
So this stopped a SPC to create pool on nodes that was used by other SPC
to create pools.

This PR fixes this.

Signed-off-by: Ashutosh Kumar <ashutosh.kumar@openebs.io>
