### PR TITLE
(WIP)Adds a openebs.io/csp-disk-hash Annotation in csp CR

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/common/common.go
+++ b/cmd/cstor-pool-mgmt/controller/common/common.go
@@ -17,7 +17,11 @@ limitations under the License.
 package common
 
 import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
 	"reflect"
+	"sort"
 	"sync"
 	"time"
 
@@ -257,4 +261,15 @@ func Init() {
 	// Making RunnerVar to use RealRunner
 	pool.RunnerVar = util.RealRunner{}
 	volumereplica.RunnerVar = util.RealRunner{}
+}
+
+// CalculateHash is to calulate the hash of Disk CR's
+func CalculateHash(diskList []string) (string, error) {
+	sort.Strings(diskList)
+	jsonEncodedValue, err := json.Marshal(diskList)
+	if err != nil {
+		return "", err
+	}
+	hashBytes := md5.Sum(jsonEncodedValue)
+	return hex.EncodeToString(hashBytes[:]), nil
 }


### PR DESCRIPTION
**What this PR does**:
This PR will calculate a hash value for disk CRs present which are in CSP diskList

**why we need it**:
To quick start on Day2 operations.

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->