### PR TITLE
Implements a packge to calculate hash for given objects

### DIFF
--- a/pkg/hash/v1alpha1/hash.go
+++ b/pkg/hash/v1alpha1/hash.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hash
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"github.com/pkg/errors"
+)
+
+// CalculateHash constructs the hash for any type of object
+func CalculateHash(obj interface{}) (string, error) {
+
+	// Convert the given object into json encoded bytes
+	jsonEncodedValues, err := json.Marshal(obj)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to convert the object to jsonEncoded format")
+	}
+	hashBytes := md5.Sum(jsonEncodedValues)
+	return hex.EncodeToString(hashBytes[:]), nil
+}

--- a/pkg/hash/v1alpha1/hash.go
+++ b/pkg/hash/v1alpha1/hash.go
@@ -23,13 +23,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-// CalculateHash constructs the hash for any type of object
-func CalculateHash(obj interface{}) (string, error) {
+// Hash constructs the hash value for any type of object
+func Hash(obj interface{}) (string, error) {
 
 	// Convert the given object into json encoded bytes
 	jsonEncodedValues, err := json.Marshal(obj)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to convert the object to jsonEncoded format")
+		return "", errors.Wrapf(err, "failed to convert the object to json encoded format")
 	}
 	hashBytes := md5.Sum(jsonEncodedValues)
 	return hex.EncodeToString(hashBytes[:]), nil

--- a/pkg/hash/v1alpha1/hash_test.go
+++ b/pkg/hash/v1alpha1/hash_test.go
@@ -4,73 +4,89 @@ import (
 	"testing"
 )
 
-func TestCalculateHash(t *testing.T) {
+func TestHashList(t *testing.T) {
 	fakeTestList := map[string][]string{
 		"list1": []string{},
-		"list2": []string{"disk-1", "disk-2", "disk-3"},
-		"list3": []string{"disk-4", "disk-5", "disk-6"},
+		"list2": []string{"list-1", "list-2", "list-3"},
+		"list3": []string{"list-4", "list-5", "list-6"},
 	}
 
+	for _, test := range fakeTestList {
+		fakeHash, err := Hash(test)
+		if err != nil {
+			t.Errorf("Failed to calculate the hash expected string but got: '%s' Error: '%v'", fakeHash, err)
+		}
+	}
+	fakeHash, err := Hash(fakeTestList)
+	if err != nil {
+		t.Errorf("Failed to calculate the hash expected string but got: '%s' Error: '%v'", fakeHash, err)
+	}
+}
+
+func TestHashStruct(t *testing.T) {
 	fakeStruct := map[string]struct {
-		poolName string
-		diskList []string
+		name string
+		list []string
 	}{
 		"struct1": {
-			poolName: "",
-			diskList: fakeTestList["list1"],
+			name: "",
+			list: []string{},
 		},
 		"struct2": {
-			poolName: "cstor-875654-8430812-093432-4235584",
-			diskList: fakeTestList["list2"],
+			name: "abcdefgh",
+			list: []string{"abc-1", "abc-2", "abc-3"},
 		},
 		"struct3": {
-			poolName: "cstor-12321-8930812-093812-84309284",
-			diskList: fakeTestList["list3"],
+			name: "jklmnop",
+			list: []string{"abcde", "abcdf", "hash"},
 		},
+	}
+	for _, test := range fakeStruct {
+		fakeHash, err := Hash(test)
+		if err != nil {
+			t.Errorf("Failed to calculate the hash expected string but got: '%s' Error: '%v'", fakeHash, err)
+		}
+	}
+	fakeHash, err := Hash(fakeStruct)
+	if err != nil {
+		t.Errorf("Failed to calculate the hash expected string but got: '%s' Error: '%v'", fakeHash, err)
+	}
+}
+
+func TestHashInnerStruct(t *testing.T) {
+	type fakeStruct struct {
+		name string
+		list []string
 	}
 	fakeComplexStruct := map[int]struct {
 		innerStructNum int
 		innerStruct    struct {
-			poolName string
-			diskList []string
+			name string
+			list []string
 		}
 	}{
 		1: {
 			innerStructNum: 1,
-			innerStruct:    fakeStruct["struct1"],
+			innerStruct: fakeStruct{
+				name: "",
+				list: []string{},
+			},
 		},
 		2: {
 			innerStructNum: 2,
-			innerStruct:    fakeStruct["struct2"],
+			innerStruct: fakeStruct{
+				name: "hashInnerStruct",
+				list: []string{"hash1", "hash2", "hash3", "hash4"},
+			},
 		},
 	}
-	for _, test := range fakeTestList {
-		fakeHash, err := CalculateHash(test)
-		if err != nil {
-			t.Errorf("Failed to calculate the hash expected string but got: '%s' Error: '%v'", fakeHash, err)
-		}
-	}
-	for _, test := range fakeStruct {
-		fakeHash, err := CalculateHash(test)
-		if err != nil {
-			t.Errorf("Failed to calculate the hash expected string but got: '%s' Error: '%v'", fakeHash, err)
-		}
-	}
 	for _, test := range fakeComplexStruct {
-		fakeHash, err := CalculateHash(test)
+		fakeHash, err := Hash(test)
 		if err != nil {
 			t.Errorf("Failed to calculate the hash expected string but got: '%s' Error: '%v'", fakeHash, err)
 		}
 	}
-	fakeHash, err := CalculateHash(fakeTestList)
-	if err != nil {
-		t.Errorf("Failed to calculate the hash expected string but got: '%s' Error: '%v'", fakeHash, err)
-	}
-	fakeHash, err = CalculateHash(fakeStruct)
-	if err != nil {
-		t.Errorf("Failed to calculate the hash expected string but got: '%s' Error: '%v'", fakeHash, err)
-	}
-	fakeHash, err = CalculateHash(fakeComplexStruct)
+	fakeHash, err := Hash(fakeComplexStruct)
 	if err != nil {
 		t.Errorf("Failed to calculate the hash expected string but got: '%s' Error: '%v'", fakeHash, err)
 	}

--- a/pkg/hash/v1alpha1/hash_test.go
+++ b/pkg/hash/v1alpha1/hash_test.go
@@ -1,0 +1,77 @@
+package hash
+
+import (
+	"testing"
+)
+
+func TestCalculateHash(t *testing.T) {
+	fakeTestList := map[string][]string{
+		"list1": []string{},
+		"list2": []string{"disk-1", "disk-2", "disk-3"},
+		"list3": []string{"disk-4", "disk-5", "disk-6"},
+	}
+
+	fakeStruct := map[string]struct {
+		poolName string
+		diskList []string
+	}{
+		"struct1": {
+			poolName: "",
+			diskList: fakeTestList["list1"],
+		},
+		"struct2": {
+			poolName: "cstor-875654-8430812-093432-4235584",
+			diskList: fakeTestList["list2"],
+		},
+		"struct3": {
+			poolName: "cstor-12321-8930812-093812-84309284",
+			diskList: fakeTestList["list3"],
+		},
+	}
+	fakeComplexStruct := map[int]struct {
+		innerStructNum int
+		innerStruct    struct {
+			poolName string
+			diskList []string
+		}
+	}{
+		1: {
+			innerStructNum: 1,
+			innerStruct:    fakeStruct["struct1"],
+		},
+		2: {
+			innerStructNum: 2,
+			innerStruct:    fakeStruct["struct2"],
+		},
+	}
+	for _, test := range fakeTestList {
+		fakeHash, err := CalculateHash(test)
+		if err != nil {
+			t.Errorf("Failed to calculate the hash expected string but got: '%s' Error: '%v'", fakeHash, err)
+		}
+	}
+	for _, test := range fakeStruct {
+		fakeHash, err := CalculateHash(test)
+		if err != nil {
+			t.Errorf("Failed to calculate the hash expected string but got: '%s' Error: '%v'", fakeHash, err)
+		}
+	}
+	for _, test := range fakeComplexStruct {
+		fakeHash, err := CalculateHash(test)
+		if err != nil {
+			t.Errorf("Failed to calculate the hash expected string but got: '%s' Error: '%v'", fakeHash, err)
+		}
+	}
+	fakeHash, err := CalculateHash(fakeTestList)
+	if err != nil {
+		t.Errorf("Failed to calculate the hash expected string but got: '%s' Error: '%v'", fakeHash, err)
+	}
+	fakeHash, err = CalculateHash(fakeStruct)
+	if err != nil {
+		t.Errorf("Failed to calculate the hash expected string but got: '%s' Error: '%v'", fakeHash, err)
+	}
+	fakeHash, err = CalculateHash(fakeComplexStruct)
+	if err != nil {
+		t.Errorf("Failed to calculate the hash expected string but got: '%s' Error: '%v'", fakeHash, err)
+	}
+}


### PR DESCRIPTION
**What this PR does**:
This PR implements a package to calculate the hash for the given object.

**why we need it**:
Decision maker for day2 operations.

**Usage:**
```
---
apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: mirroredexternalspc
  annotations:
    cas.openebs.io/config: |
      - name: CstorPoolImage
        value: openebs/cstor-pool:ci
      - name: CstorPoolMgmtImage
        value: openebs/cstor-pool-mgmt:ci
spec:
  name: mirroredexternalspc
  type: disk
  maxPools: 3
  poolSpec:
    poolType: mirrored
  disks:
    diskList:
      - disk-2bfe6b64844a2fa6029264222bee9857
      - disk-6a6bc74e0c4036c12bc6acfc2835f103
      - disk-a85acac653297ff19e58d88a5507b7d8
      - disk-b1396f8f4834a4a5bdbb8d74c858b709
      - disk-cc545c5217d6b5f68454aea48c8cb1ba
      - disk-e1ace2ff1ad8e492d195b7dbb1e10b99
 ```
We can pass anything from the above structure to hash function to get hash vale

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>