### PR TITLE
enhance(Runtask): Remove hardcoding of jiva delete scrub image

### DIFF
--- a/pkg/install/v1alpha1/jiva_volume.go
+++ b/pkg/install/v1alpha1/jiva_volume.go
@@ -237,6 +237,8 @@ metadata:
   name: jiva-volume-delete-default
 spec:
   defaultConfig:
+  - name: ScrubImage
+    value: "quay.io/openebs/openebs-tools:3.8"
   # RetainReplicaData specifies whether jiva replica data folder 
   # should be cleared or retained. 
   - name: RetainReplicaData
@@ -1235,7 +1237,7 @@ spec:
               type: ""
           containers:
           - name: sjr
-            image: quay.io/openebs/openebs-tools:3.8
+            image: {{ .Config.ScrubImage.value }}
             command: 
             - sh
             - -c


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

This commit removes the hardcoding of jiva volume delete scrub job image in RunTask which will allow users to override the image name from storage-class. The image can be overridden by explicitly providing the values in `cas.openebs.io/config` in annotations of jiva storage-class.

If no image is provided then `quay.io/openebs/openebs-tools:3.8` will be taken as the default image.

Example of storageclass to achieve this:
```
---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: jiva-scrub-image
  annotations:
    openebs.io/cas-type: jiva
    cas.openebs.io/config: |
      - name: ScrubImage
        value: ashishranjan738/openebs-tools:latest
provisioner: openebs.io/provisioner-iscsi
---
```

**Which issue this PR fixes** :
https://github.com/openebs/openebs/issues/2344

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
