### PR TITLE
[TA4936] fix(exporter): allow one connection per request with istgt (…

### DIFF
--- a/cmd/maya-exporter/app/collector/collector.go
+++ b/cmd/maya-exporter/app/collector/collector.go
@@ -102,23 +102,26 @@ func (c *collector) Describe(ch chan<- *prometheus.Desc) {
 //
 // Collect implements Collect method of prometheus.Collector interface.
 func (c *collector) Collect(ch chan<- prometheus.Metric) {
+
 	var (
 		err         error
 		volumeStats v1.VolumeStats
 		stats       stats
 	)
 
+	glog.V(2).Info("Get metrics")
 	metrics := &c.metrics
 	if volumeStats, err = c.get(); err != nil {
 		glog.Errorln(err)
 		c.setError(err)
 	}
 
+	glog.V(2).Info("Parse metrics")
 	stats = c.parse(volumeStats, metrics)
 
 	c.set(stats)
-
 	// collect the metrics extracted by collect method
+	glog.V(2).Info("Collect metrics")
 	for _, col := range c.collectors() {
 		col.Collect(ch)
 	}

--- a/cmd/maya-exporter/app/collector/cstor_test.go
+++ b/cmd/maya-exporter/app/collector/cstor_test.go
@@ -26,8 +26,10 @@ var (
 	ImproperJSONFormatedResponse = `IOSTATS  { \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"UpTime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\", \"RevisionCounter\":\"1000\", \"ReplicaCounter\":\"3\", \"Replicas\":[{\"Address\":\"tcp://172.18.0.3:9502\",\"Mode\":\"DEGRADED\"},{\"Address\":\"tcp://172.18.0.4:9502\",\"Mode\":\"HEALTHY\"},{\"Address\":\"tcp://172.18.0.5:9502\",\"Mode\":\"HEALTHY\"}] }\r\nOK IOSTATS\r\n`
 )
 
-func fakeCstor() *cstor {
-	return &cstor{}
+func fakeCstor(path string) *cstor {
+	return &cstor{
+		socketPath: path,
+	}
 }
 
 func runFakeUnixServer(t *testing.T, wg *sync.WaitGroup, response string) {
@@ -182,10 +184,6 @@ func TestCstorCollector(t *testing.T) {
 			Unlink(t)
 			prometheus.Unregister(col)
 			server.Close()
-
-			if tt.isFakeServerRequired {
-				c.close()
-			}
 		})
 	}
 }
@@ -246,12 +244,12 @@ func TestUnmarshal(t *testing.T) {
 }
 
 func TestInitiateConnection(t *testing.T) {
-	c := fakeCstor()
+	c := fakeCstor("/tmp")
 	dialFunc = func(path string) (net.Conn, error) {
 		return nil, fmt.Errorf("No connection available")
 	}
 
-	err := c.initiateConnection("/tmp")
+	err := c.initiateConnection()
 	if err == nil {
 		t.Fatalf("initiateConnection(%s): expected: error, got: nil", "/tmp")
 	}

--- a/cmd/maya-exporter/app/collector/jiva.go
+++ b/cmd/maya-exporter/app/collector/jiva.go
@@ -58,7 +58,7 @@ func (j *jiva) getVolumeStats(obj *v1.VolumeStats) error {
 	if err != nil {
 		return err
 	}
-	glog.Info("Got response: ", string(body))
+	glog.V(2).Info("Got response: ", string(body))
 	err = json.Unmarshal(body, &obj)
 
 	if err != nil {

--- a/cmd/maya-exporter/app/collector/metrics.go
+++ b/cmd/maya-exporter/app/collector/metrics.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"encoding/json"
 
+	"github.com/golang/glog"
 	v1 "github.com/openebs/maya/pkg/stats/v1alpha1"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -244,7 +245,7 @@ func (v *stats) getReplicaCount() {
 	)
 	for _, rep := range v.replicas {
 		switch rep.Mode {
-		case readOnly, degraded:
+		case readOnly, writeOnly, degraded:
 			ro++
 		case readWrite, healthy:
 			rw++
@@ -270,6 +271,7 @@ func (v *stats) getVolumeStatus() volumeStatus {
 func parseFloat64(entity json.Number, metrics *metrics) float64 {
 	num, err := entity.Float64()
 	if err != nil {
+		glog.Error("failed to parse, err: ", err)
 		metrics.parseErrorCounter.Inc()
 	}
 	return num

--- a/cmd/maya-exporter/app/collector/types.go
+++ b/cmd/maya-exporter/app/collector/types.go
@@ -23,6 +23,7 @@ const (
 )
 
 const (
+	writeOnly       = v1.ReplicaMode("WO")
 	readOnly        = v1.ReplicaMode("RO")
 	degraded        = v1.ReplicaMode("DEGRADED")
 	readWrite       = v1.ReplicaMode("RW")

--- a/cmd/maya-exporter/app/command/server.go
+++ b/cmd/maya-exporter/app/command/server.go
@@ -7,6 +7,7 @@ package command
 import (
 	"encoding/json"
 	"net/http"
+	_ "net/http/pprof"
 
 	"github.com/prometheus/client_golang/prometheus"
 


### PR DESCRIPTION


1. Allow only one connection for each request.
2. Observed panic in chaos testing in str comparison, where it was
   trying to access the index which is not read.
3. Added missing "WO" status for jiva.
4. Add `net/http/pprof` for debug purpose.

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->
