### PR TITLE
feat(volume distribution, cstor replica, pool anti-affinity): adds support to distribute data across cstor storagepools

### DIFF
--- a/pkg/algorithm/cstorpoolselect/v1alpha1/select.go
+++ b/pkg/algorithm/cstorpoolselect/v1alpha1/select.go
@@ -1,0 +1,261 @@
+package v1alpha1
+
+import (
+	"errors"
+	"strings"
+	"text/template"
+
+	csp "github.com/openebs/maya/pkg/cstorpool/v1alpha2"
+	cvr "github.com/openebs/maya/pkg/cstorvolumereplica/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type labelKey string
+
+const (
+	preferReplicaAntiAffinityLabel labelKey = "openebs.io/preferred-replica-anti-affinity"
+	replicaAntiAffinityLabel       labelKey = "openebs.io/replica-anti-affinity"
+)
+
+// policyName is a type that caters to
+// naming of various pool selection
+// policies
+type policyName string
+
+const (
+	// antiAffinityLabelPolicyName is the name of the
+	// policy that applies anti-affinity rule based on
+	// label
+	antiAffinityLabelPolicyName policyName = "anti-affinity-label"
+
+	// preferAntiAffinityLabelPolicyName is the name of
+	// the policy that does a best effort while applying
+	// anti-affinity rule based on label
+	preferAntiAffinityLabelPolicyName policyName = "prefer-anti-affinity-label"
+)
+
+// policy exposes the contracts that need
+// to be satisfied by any pool selection
+// implementation
+type policy interface {
+	name() policyName
+	filter([]string) ([]string, error)
+}
+
+// antiAffinityLabel is a pool selection
+// policy implementation
+type antiAffinityLabel struct {
+	labelSelector string
+}
+
+// name returns the name of this
+// policy
+func (p antiAffinityLabel) name() policyName {
+	return antiAffinityLabelPolicyName
+}
+
+// filter excludes the pool(s) if they are
+// already associated with the label
+// selector. In other words, it applies anti
+// affinity rule against the provided list of
+// pools.
+func (l antiAffinityLabel) filter(poolUIDs []string) ([]string, error) {
+	if l.labelSelector == "" {
+		return poolUIDs, nil
+	}
+	// pools that are already associated with
+	// this label should be excluded
+	//
+	// NOTE: we try without giving any namespace
+	// so that it lists from all available
+	// namespaces
+	cvrs, err := cvr.KubeClient().List("", metav1.ListOptions{LabelSelector: l.labelSelector})
+	if err != nil {
+		return nil, err
+	}
+	exclude := cvr.ListBuilder().WithListObject(cvrs).List().GetPoolUIDs()
+	plist := csp.ListBuilder().WithUIDs(poolUIDs...).List()
+	return plist.FilterUIDs(csp.IsNotUID(exclude...)), nil
+}
+
+// preferAntiAffinityLabel is a pool
+// selection policy implementation
+type preferAntiAffinityLabel struct {
+	antiAffinityLabel
+}
+
+// name returns the name of this policy
+func (p preferAntiAffinityLabel) name() policyName {
+	return preferAntiAffinityLabelPolicyName
+}
+
+// filter piggybacks on antiAffinityLabel policy
+// with the difference being; this logic returns all
+// the provided pools if there are no pools that
+// satisfy antiAffinity rule
+func (p preferAntiAffinityLabel) filter(poolUIDs []string) ([]string, error) {
+	plist, err := p.antiAffinityLabel.filter(poolUIDs)
+	if err != nil {
+		return nil, err
+	}
+	if len(plist) > 0 {
+		return plist, nil
+	}
+	return poolUIDs, nil
+}
+
+// selection enables selecting required pools
+// based on the registered policies
+//
+// NOTE:
+//  There can be cases where multiple policies
+// can be set to determine the required pools
+//
+// NOTE:
+//  This code will evolve as we try implementing
+// different set of policies
+type selection struct {
+	// list of original pools aginst whom
+	// selection will be made
+	poolUIDs []string
+
+	// selection is based on these policies
+	policies []policy
+}
+
+// buildOption is a typed function that
+// abstracts configuring a selection instance
+type buildOption func(*selection)
+
+// newSelection returns a new instance of
+// selection
+func newSelection(poolUIDs []string, opts ...buildOption) *selection {
+	s := &selection{poolUIDs: poolUIDs}
+	for _, o := range opts {
+		if o != nil {
+			o(s)
+		}
+	}
+	return s
+}
+
+// isPolicy determines if the provided policy
+// needs to be considered during selection
+func (s *selection) isPolicy(p policyName) bool {
+	for _, pol := range s.policies {
+		if pol.name() == p {
+			return true
+		}
+	}
+	return false
+}
+
+// isPreferAntiAffinityLabel determines if
+// prefer anti affinity label needs to be
+// considered during selection
+func (s *selection) isPreferAntiAffinityLabel() bool {
+	return s.isPolicy(preferAntiAffinityLabelPolicyName)
+}
+
+// isAntiAffinityLabel determines if anti affinity
+// label needs to be considered during
+// selection
+func (s *selection) isAntiAffinityLabel() bool {
+	return s.isPolicy(antiAffinityLabelPolicyName)
+}
+
+// PreferAntiAffinityLabel adds anti affinity label
+// as a preferred policy to be used during pool
+// selection
+func PreferAntiAffinityLabel(lbl string) buildOption {
+	return func(s *selection) {
+		p := preferAntiAffinityLabel{antiAffinityLabel{labelSelector: lbl}}
+		s.policies = append(s.policies, p)
+	}
+}
+
+// AntiAffinityLabel adds anti affinity label
+// as a policy to be used during pool selection
+func AntiAffinityLabel(lbl string) buildOption {
+	return func(s *selection) {
+		a := antiAffinityLabel{labelSelector: lbl}
+		s.policies = append(s.policies, a)
+	}
+}
+
+// GetBuildOptionByLabelSelector returns the appropriate
+// buildOptions based on the input label
+func GetBuildOptionByLabelSelector(labels ...string) []buildOption {
+	var opts []buildOption
+	for _, label := range labels {
+		if strings.Contains(label, string(preferReplicaAntiAffinityLabel)) {
+			opts = append(opts, PreferAntiAffinityLabel(label))
+		} else if strings.Contains(label, string(replicaAntiAffinityLabel)) {
+			opts = append(opts, AntiAffinityLabel(label))
+		}
+	}
+	return opts
+}
+
+// validate runs some validations/checks
+// against this selection instance
+func (s *selection) validate() error {
+	if s.isAntiAffinityLabel() && s.isPreferAntiAffinityLabel() {
+		return errors.New("invalid selection: both antiAffinityLabel and preferAntiAffinityLabel policies can not be together")
+	}
+	return nil
+}
+
+// filter returns the final list of pools that
+// gets selected, after passing the original list
+// of pools through the registered selection policies
+func (s *selection) filter() ([]string, error) {
+	var (
+		filtered []string
+		err      error
+	)
+	if len(s.policies) == 0 {
+		return s.poolUIDs, nil
+	}
+	// make a copy of original pool UIDs
+	filtered = append(filtered, s.poolUIDs...)
+	for _, policy := range s.policies {
+		filtered, err = policy.filter(filtered)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return filtered, nil
+}
+
+// FilterWithBuildOptions will return filtered pool UIDs
+// from the provided list based on pool
+// selection options
+func FilterWithBuildOptions(origPoolUIDs []string, opts []buildOption) ([]string, error) {
+	return Filter(origPoolUIDs, opts...)
+}
+
+// Filter will return filtered pool UIDs
+// from the provided list based on pool
+// selection options
+func Filter(origPoolUIDs []string, opts ...buildOption) ([]string, error) {
+	if len(opts) == 0 {
+		return origPoolUIDs, nil
+	}
+	s := newSelection(origPoolUIDs, opts...)
+	err := s.validate()
+	if err != nil {
+		return nil, err
+	}
+	return s.filter()
+}
+
+// TemplateFunctions exposes a few functions as go template functions
+func TemplateFunctions() template.FuncMap {
+	return template.FuncMap{
+		"cspGetPolicyByLabelSelector": GetBuildOptionByLabelSelector,
+		"cspFilter":                   FilterWithBuildOptions,
+		"cspAntiAffinity":             AntiAffinityLabel,
+		"cspPreferAntiAffinity":       PreferAntiAffinityLabel,
+	}
+}

--- a/pkg/algorithm/cstorpoolselect/v1alpha1/select_test.go
+++ b/pkg/algorithm/cstorpoolselect/v1alpha1/select_test.go
@@ -1,0 +1,159 @@
+package v1alpha1
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPreferAntiAffinityLabel(t *testing.T) {
+	tests := map[string]struct {
+		label          string
+		expectedoutput policy
+	}{
+		"Mock Test 1": {"label1", preferAntiAffinityLabel{antiAffinityLabel{labelSelector: "label1"}}},
+		"Mock Test 2": {"label2", preferAntiAffinityLabel{antiAffinityLabel{labelSelector: "label2"}}},
+		"Mock Test 3": {"label3", preferAntiAffinityLabel{antiAffinityLabel{labelSelector: "label3"}}},
+		"Mock Test 4": {"label4", preferAntiAffinityLabel{antiAffinityLabel{labelSelector: "label4"}}},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			bo := PreferAntiAffinityLabel(test.label)
+			s := &selection{}
+			bo(s)
+			if !reflect.DeepEqual(s.policies[len(s.policies)-1], test.expectedoutput) {
+				t.Fatalf("test %q failed : expected %v but got %v", name, test.expectedoutput, s.policies[len(s.policies)-1])
+			}
+		})
+	}
+}
+
+func TestAntiAffinityLabel(t *testing.T) {
+	tests := map[string]struct {
+		mocklabel      string
+		expectedoutput policy
+	}{
+		"Mock Test 1": {"label1", antiAffinityLabel{labelSelector: "label1"}},
+		"Mock Test 2": {"label2", antiAffinityLabel{labelSelector: "label2"}},
+		"Mock Test 3": {"label3", antiAffinityLabel{labelSelector: "label3"}},
+		"Mock Test 4": {"label4", antiAffinityLabel{labelSelector: "label4"}},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			bo := AntiAffinityLabel(test.mocklabel)
+			s := &selection{}
+			bo(s)
+			if !reflect.DeepEqual(s.policies[len(s.policies)-1], test.expectedoutput) {
+				t.Fatalf("test %q failed : expected %v but got %v", name, test.expectedoutput, s.policies[len(s.policies)-1])
+			}
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := map[string]struct {
+		isPreferAntiAffinity, isAntiAffinity bool
+		expectedError                        bool
+	}{
+		"Mock Test 1": {false, false, false},
+		"Mock Test 2": {true, false, false},
+		"Mock Test 3": {false, true, false},
+		"Mock Test 4": {true, true, true},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockSelection := &selection{}
+			if test.isAntiAffinity {
+				p := AntiAffinityLabel("antiAffinity")
+				p(mockSelection)
+			}
+
+			if test.isPreferAntiAffinity {
+				p := PreferAntiAffinityLabel("preferedAntiAffinity")
+				p(mockSelection)
+			}
+
+			err := mockSelection.validate()
+			if test.expectedError && err == nil {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !test.expectedError && err != nil {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestTemplateFunctions(t *testing.T) {
+	tests := map[string]struct {
+		expectedLength int
+	}{
+		"Test 1": {3},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			p := TemplateFunctions()
+			if len(p) != test.expectedLength {
+				t.Fatalf("test %q failed: expected items %v but got %v", name, test.expectedLength, len(p))
+			}
+		})
+	}
+}
+
+func TestName(t *testing.T) {
+	tests := map[string]struct {
+		Invoker      policy
+		expectedName string
+	}{
+		"Test 1": {antiAffinityLabel{}, "anti-affinity-label"},
+		"Test 2": {preferAntiAffinityLabel{}, "prefer-anti-affinity-label"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			n := test.Invoker.name()
+			if !reflect.DeepEqual(string(n), test.expectedName) {
+				t.Fatalf("test %q failed : expected %v but got %v", name, test.expectedName, string(n))
+			}
+		})
+	}
+}
+
+func TestNewSelection(t *testing.T) {
+	tests := map[string]struct {
+		expectedUIDs, expectedBuildOptions                 int
+		UIDs, preferAntiAffinityLabels, AntiAffinityLabels []string
+	}{
+		"Test 1": {1, 2, []string{"uid1"}, []string{"PAlabel1"}, []string{"Alabel1"}},
+		"Test 2": {2, 3, []string{"uid1", "uid2"}, []string{"PAlabel1", "PAlabel2"}, []string{"Alabel1"}},
+		"Test 3": {3, 3, []string{"uid1", "uid2", "uid3"}, []string{"PAlabel1"}, []string{"Alabel1", "Alabel2"}},
+		"Test 4": {4, 4, []string{"uid1", "uid2", "uid3", "uid4"}, []string{"PAlabel1", "PAlabel2", "PAlabel3"}, []string{"Alabel1"}},
+		"Test 5": {5, 4, []string{"uid1", "uid2", "uid3", "uid4", "uid5"}, []string{"PAlabel1"}, []string{"Alabel1", "Alabel2", "Alabel3"}},
+		"Test 6": {6, 5, []string{"uid1", "uid2", "uid3", "uid4", "uid5", "uid6"}, []string{"PAlabel1", "PAlabel2", "PAlabel3", "PAlabel4"}, []string{"Alabel1"}},
+		"Test 7": {7, 5, []string{"uid1", "uid2", "uid3", "uid4", "uid5", "uid6", "uid7"}, []string{"PAlabel1"}, []string{"Alabel1", "Alabel2", "Alabel3", "Alabel4"}},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockBuildOptions := []buildOption{}
+			for _, lab := range test.AntiAffinityLabels {
+				mockBuildOptions = append(mockBuildOptions, AntiAffinityLabel(lab))
+			}
+
+			for _, lab := range test.preferAntiAffinityLabels {
+				mockBuildOptions = append(mockBuildOptions, PreferAntiAffinityLabel(lab))
+			}
+
+			p := newSelection(test.UIDs, mockBuildOptions...)
+			if len(p.policies) != test.expectedBuildOptions {
+				t.Fatalf("test %q failed: expected %v but got %v", name, test.expectedBuildOptions, len(p.policies))
+			}
+			if len(p.poolUIDs) != test.expectedUIDs {
+				t.Fatalf("test %q failed: expected %v but got %v", name, test.expectedUIDs, p.poolUIDs)
+			}
+		})
+	}
+}

--- a/pkg/cstorpool/v1alpha2/cstorpool.go
+++ b/pkg/cstorpool/v1alpha2/cstorpool.go
@@ -1,0 +1,98 @@
+package v1alpha2
+
+import (
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type csp struct {
+	// actual cstor pool object
+	object *apis.CStorPool
+}
+
+// predicate defines an abstraction
+// to determine conditional checks
+// against the provided csp instance
+type predicate func(*csp) bool
+
+type predicateList []predicate
+
+// all returns true if all the predicates
+// succeed against the provided csp
+// instance
+func (l predicateList) all(c *csp) bool {
+	for _, pred := range l {
+		if !pred(c) {
+			return false
+		}
+	}
+	return true
+}
+
+// IsNotUID returns true if provided csp
+// instance's UID does not match with any
+// of the provided UIDs
+func IsNotUID(uids ...string) predicate {
+	return func(c *csp) bool {
+		for _, uid := range uids {
+			if uid == string(c.object.GetUID()) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+type cspList struct {
+	// list of cstor pools
+	items []*csp
+}
+
+// FilterUIDs will filter the csp instances
+// if all the predicates succeed against that
+// csp. The filtered csp instances' UIDs will
+// be returned
+func (l *cspList) FilterUIDs(p ...predicate) []string {
+	var (
+		filtered []string
+		plist    predicateList
+	)
+	plist = append(plist, p...)
+	for _, csp := range l.items {
+		if plist.all(csp) {
+			filtered = append(filtered, string(csp.object.GetUID()))
+		}
+	}
+	return filtered
+}
+
+// listBuilder enables building a
+// list of csp instances
+type listBuilder struct {
+	list *cspList
+}
+
+// ListBuilder returns a new instance of
+// listBuilder object
+func ListBuilder() *listBuilder {
+	return &listBuilder{list: &cspList{}}
+}
+
+// WithUIDs builds a list of cstor pools
+// based on the provided pool UIDs
+func (b *listBuilder) WithUIDs(poolUIDs ...string) *listBuilder {
+	for _, uid := range poolUIDs {
+		obj := &apis.CStorPool{}
+		obj.SetUID(types.UID(uid))
+		item := &csp{object: obj}
+		b.list.items = append(b.list.items, item)
+	}
+	return b
+}
+
+// List returns the list of csp
+// instances that were built by
+// this builder
+func (b *listBuilder) List() *cspList {
+	return b.list
+}

--- a/pkg/cstorpool/v1alpha2/cstorpool_test.go
+++ b/pkg/cstorpool/v1alpha2/cstorpool_test.go
@@ -1,0 +1,170 @@
+package v1alpha2
+
+import (
+	"testing"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func mockAlwaysTrue(*csp) bool  { return true }
+func mockAlwaysFalse(*csp) bool { return false }
+
+func TestAll(t *testing.T) {
+	tests := map[string]struct {
+		Predicates     predicateList
+		expectedOutput bool
+	}{
+		// Positive predicates
+		"Positive Predicate 1": {[]predicate{mockAlwaysTrue}, true},
+		"Positive Predicate 2": {[]predicate{mockAlwaysTrue, mockAlwaysTrue}, true},
+		"Positive Predicate 3": {[]predicate{mockAlwaysTrue, mockAlwaysTrue, mockAlwaysTrue}, true},
+		// Negative Predicates
+		"Negative Predicate 1": {[]predicate{mockAlwaysFalse}, false},
+		"Negative Predicate 2": {[]predicate{mockAlwaysTrue, mockAlwaysFalse}, false},
+		"Negative Predicate 3": {[]predicate{mockAlwaysFalse, mockAlwaysTrue}, false},
+		"Negative Predicate 4": {[]predicate{mockAlwaysFalse, mockAlwaysFalse}, false},
+		"Negative Predicate 5": {[]predicate{mockAlwaysFalse, mockAlwaysTrue, mockAlwaysTrue}, false},
+		"Negative Predicate 6": {[]predicate{mockAlwaysTrue, mockAlwaysFalse, mockAlwaysTrue}, false},
+		"Negative Predicate 7": {[]predicate{mockAlwaysTrue, mockAlwaysTrue, mockAlwaysFalse}, false},
+		"Negative Predicate 8": {[]predicate{mockAlwaysTrue, mockAlwaysFalse, mockAlwaysFalse}, false},
+		"Negative Predicate 9": {[]predicate{mockAlwaysFalse, mockAlwaysFalse, mockAlwaysFalse}, false},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			if output := mock.Predicates.all(&csp{}); output != mock.expectedOutput {
+				t.Fatalf("test %q failed: expected %v \n got : %v \n", name, mock.expectedOutput, output)
+			}
+		})
+	}
+}
+
+func TestIsNotUID(t *testing.T) {
+	tests := map[string]struct {
+		cspuid         types.UID
+		uids           []string
+		expectedOutput bool
+	}{
+		// Positive Test
+		"Positive 1": {"uid6", []string{"uid1", "uid2", "uid3", "uid4"}, true},
+		"Positive 2": {"uid7", []string{"uid1", "uid2", "uid3", "uid4"}, true},
+		"Positive 3": {"uid8", []string{"uid1", "uid2", "uid3", "uid4"}, true},
+		"Positive 4": {"uid9", []string{"uid1", "uid2", "uid3", "uid4"}, true},
+		"Positive 5": {"uid10", []string{"uid1", "uid2", "uid3", "uid4"}, true},
+
+		// Negative Test
+		"Negative 1": {"uid1", []string{"uid1", "uid2", "uid3", "uid4", "uid5"}, false},
+		"Negative 2": {"uid2", []string{"uid1", "uid2", "uid3", "uid4", "uid5"}, false},
+		"Negative 3": {"uid3", []string{"uid1", "uid2", "uid3", "uid4", "uid5"}, false},
+		"Negative 4": {"uid4", []string{"uid1", "uid2", "uid3", "uid4", "uid5"}, false},
+		"Negative 5": {"uid5", []string{"uid1", "uid2", "uid3", "uid4", "uid5"}, false},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockCSP := &csp{&apis.CStorPool{ObjectMeta: metav1.ObjectMeta{UID: mock.cspuid}}}
+			p := IsNotUID(mock.uids...)
+			if output := p(mockCSP); output != mock.expectedOutput {
+				t.Fatalf("test %q failed: expected %v \n got : %v \n", name, mock.expectedOutput, output)
+			}
+		})
+	}
+}
+
+func TestFilterUIDs(t *testing.T) {
+	tests := map[string]struct {
+		Predicates     predicateList
+		UIDs           []types.UID
+		expectedOutput []string
+	}{
+		// With all Positive predicates
+		"Positive 1": {[]predicate{mockAlwaysTrue}, []types.UID{"uid1", "uid2", "uid3"}, []string{"uid1", "uid2", "uid3"}},
+		"Positive 2": {[]predicate{mockAlwaysTrue, mockAlwaysTrue}, []types.UID{"uid1", "uid2", "uid3"}, []string{"uid1", "uid2", "uid3"}},
+		"Positive 3": {[]predicate{mockAlwaysTrue, mockAlwaysTrue}, []types.UID{"uid1", "uid2"}, []string{"uid1", "uid2"}},
+		//  With all negative predicates
+		"Negative 1": {[]predicate{mockAlwaysFalse}, []types.UID{"uid1", "uid2", "uid3"}, []string{}},
+		"Negative 2": {[]predicate{mockAlwaysFalse, mockAlwaysFalse}, []types.UID{"uid1", "uid2", "uid3"}, []string{}},
+		"Negative 3": {[]predicate{mockAlwaysFalse, mockAlwaysFalse}, []types.UID{"uid1", "uid2", "uid3"}, []string{}},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			cspL := &cspList{}
+			for _, uid := range mock.UIDs {
+				t := &csp{&apis.CStorPool{}}
+				t.object.SetUID(uid)
+				cspL.items = append(cspL.items, t)
+			}
+			output := cspL.FilterUIDs(mock.Predicates...)
+			if len(mock.expectedOutput) != len(output) {
+				t.Fatalf("test %q failed: expected %v \n got : %v \n", name, mock.expectedOutput, output)
+			}
+			for index, val := range output {
+				if val != mock.expectedOutput[index] {
+					t.Fatalf("test %q failed: expected %v \n got : %v \n", name, mock.expectedOutput, output)
+				}
+			}
+		})
+	}
+}
+
+func TestWithUIDs(t *testing.T) {
+	tests := map[string]struct {
+		expectedUIDs []string
+	}{
+		"UID set 1":  {[]string{}},
+		"UID set 2":  {[]string{"uid1"}},
+		"UID set 3":  {[]string{"uid1", "uid2"}},
+		"UID set 4":  {[]string{"uid1", "uid2", "uid3"}},
+		"UID set 5":  {[]string{"uid1", "uid2", "uid3", "uid4"}},
+		"UID set 6":  {[]string{"uid1", "uid2", "uid3", "uid4", "uid5"}},
+		"UID set 7":  {[]string{"uid1", "uid2", "uid3", "uid4", "uid5", "uid6"}},
+		"UID set 8":  {[]string{"uid1", "uid2", "uid3", "uid4", "uid5", "uid6", "uid7"}},
+		"UID set 9":  {[]string{"uid1", "uid2", "uid3", "uid4", "uid5", "uid6", "uid7", "uid8"}},
+		"UID set 10": {[]string{"uid1", "uid2", "uid3", "uid4", "uid5", "uid6", "uid7", "uid8", "uid9"}},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			lb := ListBuilder().WithUIDs(mock.expectedUIDs...)
+			if len(lb.list.items) != len(mock.expectedUIDs) {
+				t.Fatalf("test %q failed: expected %v \n got : %v \n", name, mock.expectedUIDs, lb.list.items)
+			}
+			for index, val := range lb.list.items {
+				if string(val.object.GetUID()) != mock.expectedUIDs[index] {
+					t.Fatalf("test %q failed: expected %v \n got : %v \n", name, mock.expectedUIDs[index], string(val.object.GetUID()))
+				}
+			}
+		})
+	}
+}
+
+func TestList(t *testing.T) {
+	tests := map[string]struct {
+		expectedUIDs []string
+	}{
+		"UID set 1":  {[]string{}},
+		"UID set 2":  {[]string{"uid1"}},
+		"UID set 3":  {[]string{"uid1", "uid2"}},
+		"UID set 4":  {[]string{"uid1", "uid2", "uid3"}},
+		"UID set 5":  {[]string{"uid1", "uid2", "uid3", "uid4"}},
+		"UID set 6":  {[]string{"uid1", "uid2", "uid3", "uid4", "uid5"}},
+		"UID set 7":  {[]string{"uid1", "uid2", "uid3", "uid4", "uid5", "uid6"}},
+		"UID set 8":  {[]string{"uid1", "uid2", "uid3", "uid4", "uid5", "uid6", "uid7"}},
+		"UID set 9":  {[]string{"uid1", "uid2", "uid3", "uid4", "uid5", "uid6", "uid7", "uid8"}},
+		"UID set 10": {[]string{"uid1", "uid2", "uid3", "uid4", "uid5", "uid6", "uid7", "uid8", "uid9"}},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			lb := ListBuilder().WithUIDs(mock.expectedUIDs...).List()
+			if len(lb.items) != len(mock.expectedUIDs) {
+				t.Fatalf("test %q failed: expected %v \n got : %v \n", name, mock.expectedUIDs, lb.items)
+			}
+			for index, val := range lb.items {
+				if string(val.object.GetUID()) != mock.expectedUIDs[index] {
+					t.Fatalf("test %q failed: expected %v \n got : %v \n", name, mock.expectedUIDs[index], string(val.object.GetUID()))
+				}
+			}
+		})
+	}
+}

--- a/pkg/cstorpool/v1alpha2/doc.go
+++ b/pkg/cstorpool/v1alpha2/doc.go
@@ -1,0 +1,4 @@
+package v1alpha2
+
+// This package caters to cstorpool related operations that
+// are a part of overall volume related provisioning.

--- a/pkg/cstorvolumereplica/v1alpha1/cstorvolumereplica.go
+++ b/pkg/cstorvolumereplica/v1alpha1/cstorvolumereplica.go
@@ -1,0 +1,64 @@
+package v1alpha1
+
+import (
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+)
+
+const (
+	cstorPoolUIDLabelKey string = "cstorpool.openebs.io/uid"
+)
+
+type cvr struct {
+	// actual cstor volume replica
+	// object
+	object apis.CStorVolumeReplica
+}
+
+type cvrList struct {
+	// list of cstor volume replicas
+	items []cvr
+}
+
+// GetPoolUIDs returns a list of cstor pool
+// UIDs corresponding to cstor volume replica
+// instances
+func (l *cvrList) GetPoolUIDs() []string {
+	var uids []string
+	for _, cvr := range l.items {
+		uid := cvr.object.GetLabels()[cstorPoolUIDLabelKey]
+		uids = append(uids, uid)
+	}
+	return uids
+}
+
+// listBuilder enables building
+// an instance of cvrList
+type listBuilder struct {
+	list *cvrList
+}
+
+// ListBuilder returns a new instance
+// of listBuilder
+func ListBuilder() *listBuilder {
+	return &listBuilder{list: &cvrList{}}
+}
+
+// WithListObject builds the list of cvr
+// instances based on the provided
+// cvr api instances
+func (b *listBuilder) WithListObject(list *apis.CStorVolumeReplicaList) *listBuilder {
+	if list == nil {
+		return b
+	}
+	for _, c := range list.Items {
+		b.list.items = append(b.list.items, cvr{object: c})
+	}
+	return b
+}
+
+// List returns the list of cvr
+// instances that was built by this
+// builder
+func (b *listBuilder) List() *cvrList {
+	return b.list
+}

--- a/pkg/cstorvolumereplica/v1alpha1/cstorvolumereplica_test.go
+++ b/pkg/cstorvolumereplica/v1alpha1/cstorvolumereplica_test.go
@@ -1,0 +1,107 @@
+package v1alpha1
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+)
+
+func TestGetPoolUIDs(t *testing.T) {
+	tests := map[string]struct {
+		cvrUIDs, expectedString []string
+	}{
+		//  UIDS are present
+		"Present 1": {[]string{"uid1"}, []string{"uid1"}},
+		"Present 2": {[]string{"uid1", "uid2"}, []string{"uid1", "uid2"}},
+		"Present 3": {[]string{"uid1", "uid2", "uid3"}, []string{"uid1", "uid2", "uid3"}},
+		"Present 4": {[]string{"uid1", "uid2", "uid3", "uid4"}, []string{"uid1", "uid2", "uid3", "uid4"}},
+		// UIDS are not present
+		"Not Present 1": {[]string{""}, []string{""}},
+		"Not Present 2": {[]string{"", ""}, []string{"", ""}},
+		"Not Present 3": {[]string{"", "", ""}, []string{"", "", ""}},
+		"Not Present 4": {[]string{"", "", "", ""}, []string{"", "", "", ""}},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			cvrItems := []cvr{}
+			for _, p := range mock.cvrUIDs {
+				cvrItems = append(cvrItems, cvr{apis.CStorVolumeReplica{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{cstorPoolUIDLabelKey: p}}}})
+			}
+			cvr := &cvrList{items: cvrItems}
+			if output := cvr.GetPoolUIDs(); !reflect.DeepEqual(output, mock.expectedString) {
+				t.Fatalf("test %q failed: expected %v \n got : %v \n", name, mock.expectedString, output)
+			}
+		})
+	}
+}
+
+func TestWithListObject(t *testing.T) {
+	tests := map[string]struct {
+		expectedUIDs []string
+	}{
+		"UID set 1":  {[]string{}},
+		"UID set 2":  {[]string{"uid1"}},
+		"UID set 3":  {[]string{"uid1", "uid2"}},
+		"UID set 4":  {[]string{"uid1", "uid2", "uid3"}},
+		"UID set 5":  {[]string{"uid1", "uid2", "uid3", "uid4"}},
+		"UID set 6":  {[]string{"uid1", "uid2", "uid3", "uid4", "uid5"}},
+		"UID set 7":  {[]string{"uid1", "uid2", "uid3", "uid4", "uid5", "uid6"}},
+		"UID set 8":  {[]string{"uid1", "uid2", "uid3", "uid4", "uid5", "uid6", "uid7"}},
+		"UID set 9":  {[]string{"uid1", "uid2", "uid3", "uid4", "uid5", "uid6", "uid7", "uid8"}},
+		"UID set 10": {[]string{"uid1", "uid2", "uid3", "uid4", "uid5", "uid6", "uid7", "uid8", "uid9"}},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			cvrItems := []apis.CStorVolumeReplica{}
+			for _, p := range mock.expectedUIDs {
+				cvrItems = append(cvrItems, apis.CStorVolumeReplica{ObjectMeta: metav1.ObjectMeta{Name: p, Labels: map[string]string{cstorPoolUIDLabelKey: p}}})
+			}
+
+			b := ListBuilder().WithListObject(&apis.CStorVolumeReplicaList{Items: cvrItems})
+			for index, ob := range b.list.items {
+				if !reflect.DeepEqual(ob.object, cvrItems[index]) {
+					t.Fatalf("test %q failed: expected %v \n got : %v \n", name, cvrItems[index], ob.object)
+				}
+			}
+		})
+	}
+}
+
+func TestList(t *testing.T) {
+	tests := map[string]struct {
+		expectedUIDs []string
+	}{
+		"UID set 1":  {[]string{}},
+		"UID set 2":  {[]string{"uid1"}},
+		"UID set 3":  {[]string{"uid1", "uid2"}},
+		"UID set 4":  {[]string{"uid1", "uid2", "uid3"}},
+		"UID set 5":  {[]string{"uid1", "uid2", "uid3", "uid4"}},
+		"UID set 6":  {[]string{"uid1", "uid2", "uid3", "uid4", "uid5"}},
+		"UID set 7":  {[]string{"uid1", "uid2", "uid3", "uid4", "uid5", "uid6"}},
+		"UID set 8":  {[]string{"uid1", "uid2", "uid3", "uid4", "uid5", "uid6", "uid7"}},
+		"UID set 9":  {[]string{"uid1", "uid2", "uid3", "uid4", "uid5", "uid6", "uid7", "uid8"}},
+		"UID set 10": {[]string{"uid1", "uid2", "uid3", "uid4", "uid5", "uid6", "uid7", "uid8", "uid9"}},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			cvrItems := []apis.CStorVolumeReplica{}
+			for _, p := range mock.expectedUIDs {
+				cvrItems = append(cvrItems, apis.CStorVolumeReplica{ObjectMeta: metav1.ObjectMeta{Name: p, Labels: map[string]string{cstorPoolUIDLabelKey: p}}})
+			}
+
+			b := ListBuilder().WithListObject(&apis.CStorVolumeReplicaList{Items: cvrItems}).List()
+			if len(b.items) != len(cvrItems) {
+				t.Fatalf("test %q failed: expected %v \n got : %v \n", name, len(cvrItems), len(b.items))
+			}
+
+			for index, ob := range b.items {
+				if !reflect.DeepEqual(ob.object, cvrItems[index]) {
+					t.Fatalf("test %q failed: expected %v \n got : %v \n", name, cvrItems[index], ob.object)
+				}
+			}
+		})
+	}
+}

--- a/pkg/cstorvolumereplica/v1alpha1/kubernetes.go
+++ b/pkg/cstorvolumereplica/v1alpha1/kubernetes.go
@@ -1,0 +1,96 @@
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	clientset "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset"
+	kclient "github.com/openebs/maya/pkg/client/k8s/v1alpha1"
+)
+
+// getClientsetFn is a typed function that
+// abstracts fetching of internal clientset
+type getClientsetFn func() (clientset *clientset.Clientset, err error)
+
+// listFn is a typed function that abstracts
+// listing of cstor volume replica instances
+type listFn func(cli *clientset.Clientset, namespace string, opts metav1.ListOptions) (*apis.CStorVolumeReplicaList, error)
+
+// kubeclient enables kubernetes API operations
+// on cstor volume replica instance
+type kubeclient struct {
+	// clientset refers to cstor volume replica's
+	// clientset that will be responsible to
+	// make kubernetes API calls
+	clientset *clientset.Clientset
+
+	// functions useful during mocking
+	getClientset getClientsetFn
+	list         listFn
+}
+
+// kubeclientBuildOption defines the abstraction
+// to build a kubeclient instance
+type kubeclientBuildOption func(*kubeclient)
+
+// withDefaults sets the default options
+// of kubeclient instance
+func (k *kubeclient) withDefaults() {
+	if k.getClientset == nil {
+		k.getClientset = func() (clients *clientset.Clientset, err error) {
+			config, err := kclient.Config().Get()
+			if err != nil {
+				return nil, err
+			}
+			return clientset.NewForConfig(config)
+		}
+	}
+	if k.list == nil {
+		k.list = func(cli *clientset.Clientset, namespace string, opts metav1.ListOptions) (*apis.CStorVolumeReplicaList, error) {
+			return cli.OpenebsV1alpha1().CStorVolumeReplicas(namespace).List(opts)
+		}
+	}
+}
+
+// WithKubeClient sets the kubernetes client against
+// the kubeclient instance
+func WithKubeClient(c *clientset.Clientset) kubeclientBuildOption {
+	return func(k *kubeclient) {
+		k.clientset = c
+	}
+}
+
+// KubeClient returns a new instance of kubeclient meant for
+// cstor volume replica operations
+func KubeClient(opts ...kubeclientBuildOption) *kubeclient {
+	k := &kubeclient{}
+	for _, o := range opts {
+		o(k)
+	}
+	k.withDefaults()
+	return k
+}
+
+// getClientOrCached returns either a new instance
+// of kubernetes client or its cached copy
+func (k *kubeclient) getClientOrCached() (*clientset.Clientset, error) {
+	if k.clientset != nil {
+		return k.clientset, nil
+	}
+	c, err := k.getClientset()
+	if err != nil {
+		return nil, err
+	}
+	k.clientset = c
+	return k.clientset, nil
+}
+
+// List returns a list of cstor volume replica
+// instances present in kubernetes cluster
+func (k *kubeclient) List(namespace string, opts metav1.ListOptions) (*apis.CStorVolumeReplicaList, error) {
+	cli, err := k.getClientOrCached()
+	if err != nil {
+		return nil, err
+	}
+	return k.list(cli, namespace, opts)
+}

--- a/pkg/cstorvolumereplica/v1alpha1/kubernetes_test.go
+++ b/pkg/cstorvolumereplica/v1alpha1/kubernetes_test.go
@@ -1,0 +1,174 @@
+package v1alpha1
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	client "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset"
+	clientset "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func fakeGetClientset() (clientset *clientset.Clientset, err error) {
+	return &client.Clientset{}, nil
+}
+
+func fakeListfn(cli *clientset.Clientset, namespace string, opts metav1.ListOptions) (*apis.CStorVolumeReplicaList, error) {
+	return &apis.CStorVolumeReplicaList{}, nil
+}
+
+func fakeListErrfn(cli *clientset.Clientset, namespace string, opts metav1.ListOptions) (*apis.CStorVolumeReplicaList, error) {
+	return &apis.CStorVolumeReplicaList{}, errors.New("some error")
+}
+
+func fakeSetClientset(k *kubeclient) {
+	k.clientset = &client.Clientset{}
+}
+
+func fakeSetNilClientset(k *kubeclient) {
+	k.clientset = nil
+}
+
+func fakeGetNilErrClientSet() (clientset *clientset.Clientset, err error) {
+	return nil, nil
+}
+
+func fakeGetErrClientSet() (clientset *clientset.Clientset, err error) {
+	return nil, errors.New("Some error")
+}
+
+func fakeClientSet(k *kubeclient) {}
+
+func TestWithDefaults(t *testing.T) {
+	tests := map[string]struct {
+		expectListFn, expectGetClientset bool
+	}{
+		"When mockclient is empty":                {true, true},
+		"When mockclient contains getClientsetFn": {false, true},
+		"When mockclient contains ListFn":         {true, false},
+		"When mockclient contains both":           {true, true},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			fc := &kubeclient{}
+			if !mock.expectListFn {
+				fc.list = fakeListfn
+			}
+			if !mock.expectGetClientset {
+				fc.getClientset = fakeGetClientset
+			}
+
+			fc.withDefaults()
+			if mock.expectListFn && fc.list == nil {
+				t.Fatalf("test %q failed: expected fc.list not to be empty", name)
+			}
+			if mock.expectGetClientset && fc.getClientset == nil {
+				t.Fatalf("test %q failed: expected fc.getClientset not to be empty", name)
+			}
+		})
+	}
+}
+
+func TestWithKubeClient(t *testing.T) {
+	tests := map[string]struct {
+		Clientset             *client.Clientset
+		expectKubeClientEmpty bool
+	}{
+		"Clientset is empty":     {nil, true},
+		"Clientset is not empty": {&client.Clientset{}, false},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			h := WithKubeClient(mock.Clientset)
+			fake := &kubeclient{}
+			h(fake)
+			if mock.expectKubeClientEmpty && fake.clientset != nil {
+				t.Fatalf("test %q failed expected fake.clientset to be empty", name)
+			}
+			if !mock.expectKubeClientEmpty && fake.clientset == nil {
+				t.Fatalf("test %q failed expected fake.clientset not to be empty", name)
+			}
+		})
+	}
+}
+
+func TestKubeClient(t *testing.T) {
+	tests := map[string]struct {
+		expectClientSet bool
+		opts            []kubeclientBuildOption
+	}{
+		"Positive 1": {true, []kubeclientBuildOption{fakeSetClientset}},
+		"Positive 2": {true, []kubeclientBuildOption{fakeSetClientset, fakeClientSet}},
+		"Positive 3": {true, []kubeclientBuildOption{fakeSetClientset, fakeClientSet, fakeClientSet}},
+
+		"Negative 1": {false, []kubeclientBuildOption{fakeSetNilClientset}},
+		"Negative 2": {false, []kubeclientBuildOption{fakeSetNilClientset, fakeClientSet}},
+		"Negative 3": {false, []kubeclientBuildOption{fakeSetNilClientset, fakeClientSet, fakeClientSet}},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := KubeClient(mock.opts...)
+			if !mock.expectClientSet && c.clientset != nil {
+				t.Fatalf("test %q failed expected fake.clientset to be empty", name)
+			}
+			if mock.expectClientSet && c.clientset == nil {
+				t.Fatalf("test %q failed expected fake.clientset not to be empty", name)
+			}
+		})
+	}
+}
+
+func TestGetClientOrCached(t *testing.T) {
+	tests := map[string]struct {
+		expectErr  bool
+		KubeClient *kubeclient
+	}{
+		// Positive tests
+		"Positive 1": {false, &kubeclient{nil, fakeGetNilErrClientSet, fakeListfn}},
+		"Positive 2": {false, &kubeclient{&client.Clientset{}, fakeGetNilErrClientSet, fakeListfn}},
+		// Negative tests
+		"Negative 1": {true, &kubeclient{nil, fakeGetErrClientSet, fakeListfn}},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			c, err := mock.KubeClient.getClientOrCached()
+			if mock.expectErr && err == nil {
+				t.Fatalf("test %q failed : expected error not to be nil but got %v", name, err)
+			}
+			if !reflect.DeepEqual(c, mock.KubeClient.clientset) {
+				t.Fatalf("test %q failed : expected clientset %v but got %v", name, mock.KubeClient.clientset, c)
+			}
+		})
+	}
+}
+
+func TestKubenetesList(t *testing.T) {
+	tests := map[string]struct {
+		getClientset getClientsetFn
+		list         listFn
+		expectErr    bool
+	}{
+		"Test 1": {fakeGetErrClientSet, fakeListfn, true},
+		"Test 2": {fakeGetClientset, fakeListfn, false},
+		"Test 3": {fakeGetClientset, fakeListErrfn, true},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			k := kubeclient{getClientset: mock.getClientset, list: mock.list}
+			_, err := k.List("", metav1.ListOptions{})
+			if mock.expectErr && err == nil {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && err != nil {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/Masterminds/sprig"
 	"github.com/ghodss/yaml"
+	poolselection "github.com/openebs/maya/pkg/algorithm/cstorpoolselect/v1alpha1"
 	v1alpha1 "github.com/openebs/maya/pkg/task/v1alpha1"
 	"github.com/openebs/maya/pkg/util"
 	kubever "github.com/openebs/maya/pkg/version/kubernetes"
@@ -63,6 +64,14 @@ func empty(given interface{}) bool {
 		return false
 	}
 	return true
+}
+
+// ifNotNil returns the second argument if first is not nil
+func ifNotNil(this, then interface{}) interface{} {
+	if !empty(this) {
+		return then
+	}
+	return this
 }
 
 // VersionMismatchError represents an error due to version mismatch
@@ -784,6 +793,7 @@ func runtaskFuncs() (f template.FuncMap) {
 		"splitKeyMap":        splitKeyMap,
 		"splitListTrim":      splitListTrim,
 		"randomize":          randomize,
+		"IfNotNil":           ifNotNil,
 	}
 }
 
@@ -798,8 +808,12 @@ func allCustomFuncs() template.FuncMap {
 	for k, v := range rc {
 		f[k] = v
 	}
-	kVer := kubever.TemplateFunctions()
-	for k, v := range kVer {
+	ver := kubever.TemplateFunctions()
+	for k, v := range ver {
+		f[k] = v
+	}
+	ps := poolselection.TemplateFunctions()
+	for k, v := range ps {
 		f[k] = v
 	}
 	return f


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

###  Why we need this PR
Users want to deploy applications using StatefulSet with application replication factor **"> 1"** and volume replication factor **"= 1"**; provided this application has the ability to replicate data across nodes in a given cluster. Some examples of such applications are _Cassandra_, _ElastiSearch_, _MongoDB_, etc. In other words, each instance of this kind of application(s) consume one volume and from the application p.o.v all these per-instance volumes should spread out across nodes to ensure High Availability of the application.

### What this PR does
This commit adds the ability in cstor to correlate & hence distribute single replica volumes across pools _(which are in turn deployed in separate nodes)_ when application consuming all these volumes is deployed as a StatefulSet.

#### Below are supported anti-affinity features:
- `openebs.io/replica-anti-affinity: <unique_identification_of_app_in_cluster>`
- `openebs.io/preferred-replica-anti-affinity: <unique_identification_of_app_in_cluster>`

Below is an example of a statefulset.yaml that makes use of `openebs.io/replica-anti-affinity`:
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  annotations:
    cas.openebs.io/config: |
      - name: StoragePoolClaim
        value: "cstor-sparse-pool"
      - name: ReplicaCount
        value: "1"
    openebs.io/cas-type: cstor
  name: openebs-cstor-sparse-sts
provisioner: openebs.io/provisioner-iscsi
reclaimPolicy: Delete
volumeBindingMode: Immediate
---
apiVersion: v1
kind: Service
metadata:
  labels:
    app: busybox1
  name: busybox1
spec:
  clusterIP: None
  selector:
    app: busybox1
---
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: busybox1
  labels:
    app: busybox1
spec:
  serviceName: busybox1
  replicas: 1
  selector:
    matchLabels:
      app: busybox1
      openebs.io/replica-anti-affinity: busybox1
  template:
    metadata:
      labels:
        app: busybox1
        openebs.io/replica-anti-affinity: busybox1
    spec:
      terminationGracePeriodSeconds: 1800
      containers:
      - name: busybox1
        image: ubuntu
        imagePullPolicy: IfNotPresent
        command:
          - sleep
          - infinity
        volumeMounts:
        - name: busybox1
          mountPath: /busybox1
  volumeClaimTemplates:
  - metadata:
      name: busybox1
    spec:
      accessModes: [ "ReadWriteOnce" ]
      storageClassName: openebs-cstor-sparse-sts
      resources:
        requests:
          storage: 1Gi
```

fixes # https://github.com/openebs/openebs/issues/2389