### PR TITLE
fix(exporter): remove unused metrics for jiva

### DIFF
--- a/cmd/maya-exporter/app/collector/jiva.go
+++ b/cmd/maya-exporter/app/collector/jiva.go
@@ -79,8 +79,6 @@ func (j *jiva) parse(volStats v1.VolumeStats, metrics *metrics) stats {
 	stats.casType = "jiva"
 	stats.reads = parseFloat64(volStats.Reads, metrics)
 	stats.writes = parseFloat64(volStats.Writes, metrics)
-	stats.totalReadBytes = parseFloat64(volStats.TotalReadBytes, metrics)
-	stats.totalWriteBytes = parseFloat64(volStats.TotalWriteBytes, metrics)
 	stats.totalReadTime = parseFloat64(volStats.TotalReadTime, metrics)
 	stats.totalWriteTime = parseFloat64(volStats.TotalWriteTime, metrics)
 	stats.totalReadBlockCount = parseFloat64(volStats.TotalReadBlockCount, metrics)


### PR DESCRIPTION
Due to recent PR #944 , we have added logs for the errors, which
was logging following error beacuse "TotalReadBytes" and
"TotalWriteBytes" is not there in jiva and hence returning "" which
is not parseable.

```
E0220 10:44:56.158188   17778 metrics.go:274] failed to parse, err: strconv.ParseFloat: parsing "": invalid syntax
```

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>
