### PR TITLE
[TA5006] feat(exporter): add pool exporter yaml in runTask

### DIFF
--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -174,7 +174,7 @@ spec:
     {{- $auxResourceRequestsVal := fromYaml .Config.AuxResourceRequests.value -}}
     {{- $setAuxResourceLimits := .Config.AuxResourceLimits.value | default "none" -}}
     {{- $auxResourceLimitsVal := fromYaml .Config.AuxResourceLimits.value -}}
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1beta1
     kind: Deployment
     metadata:
       name: {{.TaskResult.putcstorpoolcr.objectName}}
@@ -184,13 +184,15 @@ spec:
         app: cstor-pool
         openebs.io/version: {{ .CAST.version }}
         openebs.io/cas-template-name: {{ .CAST.castName }}
+      annotations:
+        monitoring: pool_exporter_prometheus
       ownerReferences:
       - apiVersion: openebs.io/v1alpha1
         blockOwnerDeletion: true
         controller: true
         kind: CStorPool
         name: {{ .TaskResult.putcstorpoolcr.objectName }}
-        uid: {{ .TaskResult.putcstorpoolcr.objectUID }}    
+        uid: {{ .TaskResult.putcstorpoolcr.objectUID }}
     spec:
       strategy:
         type: Recreate
@@ -201,8 +203,9 @@ spec:
       template:
         metadata:
           labels:
-            monitoring: pool_exporter_prometheus
+            app: cstor-pool
           annotations:
+            monitoring: pool_exporter_prometheus
             prometheus.io/path: /metrics
             prometheus.io/port: "9500"
             prometheus.io/scrape: "true"

--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -31,6 +31,10 @@ spec:
   # communicates with cstor iscsi target
   - name: CstorPoolImage
     value: {{env "OPENEBS_IO_CSTOR_POOL_IMAGE" | default "openebs/cstor-pool:latest"}}
+  # CstorPoolExporterImage is the container image that executes zpool and zfs binary
+  # to export various volume and pool metrics
+  - name: CstorPoolExporterImage
+    value: {{env "OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE" | default "openebs/m-exporter:latest"}}
   # CstorPoolMgmtImage runs cstor pool and cstor volume replica related CRUD
   # operations
   - name: CstorPoolMgmtImage
@@ -53,7 +57,7 @@ spec:
     value: {{env "OPENEBS_SERVICE_ACCOUNT"}}
   # PoolResourceRequests allow you to specify resource requests that need to be available
   # before scheduling the containers. If not specified, the default is to use the limits
-  # from PoolResourceLimits or the default requests set in the cluster. 
+  # from PoolResourceLimits or the default requests set in the cluster.
   - name: PoolResourceRequests
     value: "none"
   # PoolResourceLimits allow you to set the limits on memory and cpu for pool pods
@@ -197,6 +201,11 @@ spec:
       template:
         metadata:
           labels:
+            monitoring: pool_exporter_prometheus
+          annotations:
+            prometheus.io/path: /metrics
+            prometheus.io/port: "9500"
+            prometheus.io/scrape: "true"
             app: cstor-pool
             openebs.io/storage-pool-claim: {{.Storagepool.owner}}
         spec:
@@ -272,9 +281,6 @@ spec:
                 {{ $rKey }}: {{ $rLimit }}
               {{- end }}
               {{- end }}
-            ports:
-            - containerPort: 9500
-              protocol: TCP
             securityContext:
               privileged: true
             volumeMounts:
@@ -300,6 +306,37 @@ spec:
                   fieldPath: metadata.namespace
             - name: RESYNC_INTERVAL
               value: {{ .Config.ResyncInterval.value }}
+          - name: maya-exporter
+            image: {{ .Config.CstorPoolExporterImage.value }}
+            resources:
+              {{- if ne $setAuxResourceRequests "none" }}
+              requests:
+              {{- range $rKey, $rLimit := $auxResourceRequestsVal }}
+                {{ $rKey }}: {{ $rLimit }}
+              {{- end }}
+              {{- end }}
+              {{- if ne $setAuxResourceLimits "none" }}
+              limits:
+              {{- range $rKey, $rLimit := $auxResourceLimitsVal }}
+                {{ $rKey }}: {{ $rLimit }}
+              {{- end }}
+              {{- end }}
+            command:
+			- maya-exporter
+            args:
+            - "-e=pool"
+            ports:
+            - containerPort: 9500
+              protocol: TCP
+            volumeMounts:
+            - mountPath: /dev
+              name: device
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: {{ .Config.SparseDir.value }}
+              name: sparse
+            - mountPath: /run/udev
+              name: udev
           volumes:
           - name: device
             hostPath:

--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -185,7 +185,7 @@ spec:
         openebs.io/version: {{ .CAST.version }}
         openebs.io/cas-template-name: {{ .CAST.castName }}
       annotations:
-        monitoring: pool_exporter_prometheus
+        openebs.io/monitoring: pool_exporter_prometheus
       ownerReferences:
       - apiVersion: openebs.io/v1alpha1
         blockOwnerDeletion: true
@@ -205,11 +205,10 @@ spec:
           labels:
             app: cstor-pool
           annotations:
-            monitoring: pool_exporter_prometheus
+            openebs.io/monitoring: pool_exporter_prometheus
             prometheus.io/path: /metrics
             prometheus.io/port: "9500"
             prometheus.io/scrape: "true"
-            app: cstor-pool
             openebs.io/storage-pool-claim: {{.Storagepool.owner}}
         spec:
           serviceAccountName: {{ .Config.ServiceAccountName.value }}

--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -322,7 +322,7 @@ spec:
               {{- end }}
               {{- end }}
             command:
-			- maya-exporter
+            - maya-exporter
             args:
             - "-e=pool"
             ports:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Add pool exporter yaml in existing cstor-pool-create-putcstorpooldeployment-default
runTask. Pool exporter will be used as sidecar.

**Additional Info for Reviewer**:
Following env should be added into `openebs-operator.yaml` which will be used by m-apiserver for deployment purpose.
```
 - name: OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE                                                                                                               
   value: "utkarshmani1997/m-exporter:pool-exporter7"
```
Helm chart need to be updated accordingly.

**Checklist:**
- [x] Fixes openebs/openebs#2419
- [ ] Labelled this PR & related issue with `documentation` tag
- [x] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [x] Labelled this PR & related issue with `requires-upgrade` tag
- [x] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests


Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>
