### PR TITLE
Enhancements and changes to GitLab CI YAML.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,8 +4,11 @@ stages:
   - cleanup
 build-maya:
    stage: build
+   only:
+     refs:
+       - ^v[0-9][.][0-9][.]x|master?$
    before_script:
-     - export COMMIT=${CI_COMMIT_SHA:0:8}
+     - export COMMIT=${CI_COMMIT_SHORT_SHA}
      - export GOPATH=$HOME/go
      - export PATH=$HOME/go/bin:$PATH
      - mkdir -p $HOME/go/src/github.com/openebs/maya
@@ -44,13 +47,17 @@ build-maya:
 
 baseline-image:
   stage: baseline
+  only:
+    refs:
+      - ^v[0-9][.][0-9][.]x|master?$
   script:
      - pwd
      - export BRANCH=${CI_COMMIT_REF_NAME}
      - echo $BRANCH
-     - export COMMIT=${CI_COMMIT_SHA:0:8}
+     - export COMMIT=${CI_COMMIT_SHORT_SHA}
      - echo $COMMIT
      - git clone https://github.com/openebs/e2e-infrastructure.git
+     - git checkout $BRANCH
      - cd e2e-infrastructure/baseline
      - ansible-playbook commit-writer.yml --extra-vars "branch=$BRANCH repo=$CI_PROJECT_NAME commit=$COMMIT"
      - git status
@@ -58,14 +65,18 @@ baseline-image:
      - git status
      - git commit -m "updated $CI_PROJECT_NAME commit:$COMMIT"
      - git push  https://$user:$pass@github.com/openebs/e2e-infrastructure.git --all
-     - curl -X POST -F token=$AZURE -F ref=master https://gitlab.openebs.ci/api/v4/projects/2/trigger/pipeline
-     - curl -X POST -F token=$EKS -F ref=master https://gitlab.openebs.ci/api/v4/projects/3/trigger/pipeline
-     - curl -X POST -F token=$GKE -F ref=master https://gitlab.openebs.ci/api/v4/projects/5/trigger/pipeline
+     - curl -X POST -F variable[MAYA_BRANCH]=$BRANCH -F token=$PACKET -F ref=k8s-1-11 https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
+     - curl -X POST -F variable[MAYA_BRANCH]=$BRANCH -F token=$PACKET -F ref=k8s-1-12 https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
+     - curl -X POST -F variable[MAYA_BRANCH]=$BRANCH -F token=$PACKET -F ref=k8s-1-13 https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
+
 clean-maya:
   when: always
   stage: cleanup
+  only:
+    refs:
+      - ^v[0-9][.][0-9][.]x|master?$
   script:
-    - sudo minikube delete
+    - sudo minikube delete || true
     - sudo rm -r ~/go
     - sudo docker images 
     - sudo docker image prune -a --force

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,9 +65,9 @@ baseline-image:
      - git status
      - git commit -m "updated $CI_PROJECT_NAME commit:$COMMIT"
      - git push  https://$user:$pass@github.com/openebs/e2e-infrastructure.git --all
-     - curl -X POST -F variable[MAYA_BRANCH]=$BRANCH -F token=$PACKET -F ref=k8s-1-11 https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
-     - curl -X POST -F variable[MAYA_BRANCH]=$BRANCH -F token=$PACKET -F ref=k8s-1-12 https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
-     - curl -X POST -F variable[MAYA_BRANCH]=$BRANCH -F token=$PACKET -F ref=k8s-1-13 https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
+     - curl -X POST -F variable[INFRA_BRANCH]=$BRANCH -F token=$PACKET -F ref=k8s-1-11 https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
+     - curl -X POST -F variable[INFRA_BRANCH]=$BRANCH -F token=$PACKET -F ref=k8s-1-12 https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
+     - curl -X POST -F variable[INFRA_BRANCH]=$BRANCH -F token=$PACKET -F ref=k8s-1-13 https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
 
 clean-maya:
   when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ build-maya:
    stage: build
    only:
      refs:
-       - ^v[0-9][.][0-9][.]x|master?$
+       - ^(v[0-9][.][0-9][.]x|master)?$
    before_script:
      - export COMMIT=${CI_COMMIT_SHORT_SHA}
      - export GOPATH=$HOME/go
@@ -49,7 +49,7 @@ baseline-image:
   stage: baseline
   only:
     refs:
-      - ^v[0-9][.][0-9][.]x|master?$
+      - ^(v[0-9][.][0-9][.]x|master)?$
   script:
      - pwd
      - export BRANCH=${CI_COMMIT_REF_NAME}
@@ -74,7 +74,7 @@ clean-maya:
   stage: cleanup
   only:
     refs:
-      - ^v[0-9][.][0-9][.]x|master?$
+      - ^(v[0-9][.][0-9][.]x|master)?$
   script:
     - sudo minikube delete || true
     - sudo rm -r ~/go

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ build-maya:
    stage: build
    only:
      refs:
-       - ^(v[0-9][.][0-9][.]x|master)?$
+       - /^(v[0-9][.][0-9][.]x|master)?$/
    before_script:
      - export COMMIT=${CI_COMMIT_SHORT_SHA}
      - export GOPATH=$HOME/go
@@ -49,7 +49,7 @@ baseline-image:
   stage: baseline
   only:
     refs:
-      - ^(v[0-9][.][0-9][.]x|master)?$
+      - /^(v[0-9][.][0-9][.]x|master)?$/
   script:
      - pwd
      - export BRANCH=${CI_COMMIT_REF_NAME}
@@ -74,7 +74,7 @@ clean-maya:
   stage: cleanup
   only:
     refs:
-      - ^(v[0-9][.][0-9][.]x|master)?$
+      - /^(v[0-9][.][0-9][.]x|master)?$/
   script:
     - sudo minikube delete || true
     - sudo rm -r ~/go


### PR DESCRIPTION




<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Check for master and .x branches for build to trigger by using only:
refs option.
- Use the new CI_COMMIT_SHORT_SHA env to get the short commit SHA.
- Push the commit details to respective branches on e2e-infrastructure.
- Pass the branch details of MAYA to the platform repos to checkout
e2e-infrastructure for that particular branch when the infra-setup stage
is run.
- Deprecate GKE, EKS and AKS platforms.
- Run Packet platform, with k8s 1.11, 1.12 and 1.13 for master branch.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Signed-off-by: Uday Kiran Y <uday.kiran@openebs.io>

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests