### PR TITLE
enhance(cast engine): Add more support for operations in runtask

### DIFF
--- a/pkg/client/k8s/k8s.go
+++ b/pkg/client/k8s/k8s.go
@@ -969,14 +969,14 @@ func (k *K8sClient) PatchOEV1alpha1SPCAsRaw(name string, patchType types.PatchTy
 	return
 }
 
-// PatchOEV1alpha1CSVAsRaw patches the CSV object with the provided patches
-func (k *K8sClient) PatchOEV1alpha1CSVAsRaw(name, namespace string, patchType types.PatchType, patches []byte) (result *api_oe_v1alpha1.CStorVolume, err error) {
+// PatchOEV1alpha1CSV patches the CSV object with the provided patches
+func (k *K8sClient) PatchOEV1alpha1CSV(name, namespace string, patchType types.PatchType, patches []byte) (result *api_oe_v1alpha1.CStorVolume, err error) {
 	result, err = k.oecs.OpenebsV1alpha1().CStorVolumes(namespace).Patch(name, patchType, patches)
 	return
 }
 
-// PatchOEV1alpha1CVRAsRaw patches the CVR object with the provided patches
-func (k *K8sClient) PatchOEV1alpha1CVRAsRaw(name, namespace string, patchType types.PatchType, patches []byte) (result *api_oe_v1alpha1.CStorVolumeReplica, err error) {
+// PatchOEV1alpha1CVR patches the CVR object with the provided patches
+func (k *K8sClient) PatchOEV1alpha1CVR(name, namespace string, patchType types.PatchType, patches []byte) (result *api_oe_v1alpha1.CStorVolumeReplica, err error) {
 	result, err = k.oecs.OpenebsV1alpha1().CStorVolumeReplicas(namespace).Patch(name, patchType, patches)
 	return
 }

--- a/pkg/client/k8s/k8s.go
+++ b/pkg/client/k8s/k8s.go
@@ -63,6 +63,9 @@ const (
 	// DeploymentKK is a K8s Deployment Kind
 	DeploymentKK K8sKind = "Deployment"
 
+	// ReplicaSetKK is a K8s ReplicaSet Kind
+	ReplicaSetKK K8sKind = "ReplicaSet"
+
 	// ConfigMapKK is a K8s ConfigMap Kind
 	ConfigMapKK K8sKind = "ConfigMap"
 
@@ -860,6 +863,12 @@ func (k *K8sClient) extnV1B1DeploymentOps() typed_ext_v1beta1.DeploymentInterfac
 	return k.cs.ExtensionsV1beta1().Deployments(k.ns)
 }
 
+// extnV1B1ReplicaSetOps is a utility function that provides an instance capable of
+// executing various k8s ReplicaSet related operations.
+func (k *K8sClient) extnV1B1ReplicaSetOps() typed_ext_v1beta1.ReplicaSetInterface {
+	return k.cs.ExtensionsV1beta1().ReplicaSets(k.ns)
+}
+
 // GetDeployment fetches the K8s Deployment with the provided name
 func (k *K8sClient) GetDeployment(name string, opts mach_apis_meta_v1.GetOptions) (*api_extn_v1beta1.Deployment, error) {
 	if k.Deployment != nil {
@@ -960,6 +969,18 @@ func (k *K8sClient) PatchOEV1alpha1SPCAsRaw(name string, patchType types.PatchTy
 	return
 }
 
+// PatchOEV1alpha1CSVAsRaw patches the CSV object with the provided patches
+func (k *K8sClient) PatchOEV1alpha1CSVAsRaw(name, namespace string, patchType types.PatchType, patches []byte) (result *api_oe_v1alpha1.CStorVolume, err error) {
+	result, err = k.oecs.OpenebsV1alpha1().CStorVolumes(namespace).Patch(name, patchType, patches)
+	return
+}
+
+// PatchOEV1alpha1CVRAsRaw patches the CVR object with the provided patches
+func (k *K8sClient) PatchOEV1alpha1CVRAsRaw(name, namespace string, patchType types.PatchType, patches []byte) (result *api_oe_v1alpha1.CStorVolumeReplica, err error) {
+	result, err = k.oecs.OpenebsV1alpha1().CStorVolumeReplicas(namespace).Patch(name, patchType, patches)
+	return
+}
+
 // PatchExtnV1B1DeploymentAsRaw patches the K8s Deployment with the provided patches
 func (k *K8sClient) PatchExtnV1B1DeploymentAsRaw(name string, patchType types.PatchType, patches []byte) (result []byte, err error) {
 	result, err = k.cs.ExtensionsV1beta1().RESTClient().Patch(patchType).
@@ -972,9 +993,31 @@ func (k *K8sClient) PatchExtnV1B1DeploymentAsRaw(name string, patchType types.Pa
 	return
 }
 
+// PatchCoreV1ServiceAsRaw patches the K8s Service with the provided patches
+func (k *K8sClient) PatchCoreV1ServiceAsRaw(name string, patchType types.PatchType, patches []byte) (result []byte, err error) {
+	result, err = k.cs.CoreV1().RESTClient().Patch(patchType).
+		Namespace(k.ns).
+		Resource("services").
+		Name(name).
+		Body(patches).
+		DoRaw()
+
+	return
+}
+
 // DeleteExtnV1B1Deployment deletes the K8s Deployment with the provided name
 func (k *K8sClient) DeleteExtnV1B1Deployment(name string) error {
 	dops := k.extnV1B1DeploymentOps()
+	// ensure all the dependants are deleted
+	deletePropagation := mach_apis_meta_v1.DeletePropagationForeground
+	return dops.Delete(name, &mach_apis_meta_v1.DeleteOptions{
+		PropagationPolicy: &deletePropagation,
+	})
+}
+
+// DeleteExtnV1B1ReplicaSet deletes the K8s ReplicaSet with the provided name
+func (k *K8sClient) DeleteExtnV1B1ReplicaSet(name string) error {
+	dops := k.extnV1B1ReplicaSetOps()
 	// ensure all the dependants are deleted
 	deletePropagation := mach_apis_meta_v1.DeletePropagationForeground
 	return dops.Delete(name, &mach_apis_meta_v1.DeleteOptions{

--- a/pkg/task/identity.go
+++ b/pkg/task/identity.go
@@ -82,6 +82,10 @@ func (i taskIdentifier) isDeployment() bool {
 	return i.identity.Kind == string(m_k8s_client.DeploymentKK)
 }
 
+func (i taskIdentifier) isReplicaSet() bool {
+	return i.identity.Kind == string(m_k8s_client.ReplicaSetKK)
+}
+
 func (i taskIdentifier) isJob() bool {
 	return i.identity.Kind == string(m_k8s_client.JobKK)
 }
@@ -168,6 +172,10 @@ func (i taskIdentifier) isOEV1alpha1CSP() bool {
 
 func (i taskIdentifier) isExtnV1B1Deploy() bool {
 	return i.isExtnV1B1() && i.isDeployment()
+}
+
+func (i taskIdentifier) isExtnV1B1ReplicaSet() bool {
+	return i.isExtnV1B1() && i.isReplicaSet()
 }
 
 func (i taskIdentifier) isBatchV1Job() bool {

--- a/pkg/task/meta.go
+++ b/pkg/task/meta.go
@@ -339,8 +339,16 @@ func (m *metaTaskExecutor) isPutCoreV1Service() bool {
 	return m.identifier.isCoreV1Service() && m.isPut()
 }
 
+func (m *metaTaskExecutor) isPatchCoreV1Service() bool {
+	return m.identifier.isCoreV1Service() && m.isPatch()
+}
+
 func (m *metaTaskExecutor) isDeleteExtnV1B1Deploy() bool {
 	return m.identifier.isExtnV1B1Deploy() && m.isDelete()
+}
+
+func (m *metaTaskExecutor) isDeleteExtnV1B1ReplicaSet() bool {
+	return m.identifier.isExtnV1B1ReplicaSet() && m.isDelete()
 }
 
 func (m *metaTaskExecutor) isDeleteAppsV1B1Deploy() bool {
@@ -381,6 +389,10 @@ func (m *metaTaskExecutor) isGetStorageV1SC() bool {
 
 func (m *metaTaskExecutor) isGetBatchV1Job() bool {
 	return m.identifier.isBatchV1Job() && m.isGet()
+}
+
+func (m *metaTaskExecutor) isGetExtnV1B1Deploy() bool {
+	return m.identifier.isExtnV1B1Deploy() && m.isGet()
 }
 
 func (m *metaTaskExecutor) isDeleteBatchV1Job() bool {
@@ -436,6 +448,14 @@ func (m *metaTaskExecutor) isDeleteOEV1alpha1CSV() bool {
 
 func (m *metaTaskExecutor) isDeleteOEV1alpha1CVR() bool {
 	return m.identifier.isOEV1alpha1CVR() && m.isDelete()
+}
+
+func (m *metaTaskExecutor) isPatchOEV1alpha1CSV() bool {
+	return m.identifier.isOEV1alpha1CV() && m.isPatch()
+}
+
+func (m *metaTaskExecutor) isPatchOEV1alpha1CVR() bool {
+	return m.identifier.isOEV1alpha1CVR() && m.isPatch()
 }
 
 func (m *metaTaskExecutor) isListOEV1alpha1Disk() bool {

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -604,23 +604,19 @@ func (m *taskExecutor) patchOEV1alpha1CSV() (err error) {
 	if err != nil {
 		return
 	}
-
 	pe, err := newTaskPatchExecutor(patch)
 	if err != nil {
 		return
 	}
-
 	raw, err := pe.toJson()
 	if err != nil {
 		return
 	}
-
 	// patch the CStor Volume
-	csv, err := m.getK8sClient().PatchOEV1alpha1CSVAsRaw(m.getTaskObjectName(), m.getTaskRunNamespace(), pe.patchType(), raw)
+	csv, err := m.getK8sClient().PatchOEV1alpha1CSV(m.getTaskObjectName(), m.getTaskRunNamespace(), pe.patchType(), raw)
 	if err != nil {
 		return
 	}
-
 	util.SetNestedField(m.templateValues, csv, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
@@ -631,23 +627,19 @@ func (m *taskExecutor) patchOEV1alpha1CVR() (err error) {
 	if err != nil {
 		return
 	}
-
 	pe, err := newTaskPatchExecutor(patch)
 	if err != nil {
 		return
 	}
-
 	raw, err := pe.toJson()
 	if err != nil {
 		return
 	}
-
 	// patch the CStor Volume Replica
-	cvr, err := m.getK8sClient().PatchOEV1alpha1CVRAsRaw(m.getTaskObjectName(), m.getTaskRunNamespace(), pe.patchType(), raw)
+	cvr, err := m.getK8sClient().PatchOEV1alpha1CVR(m.getTaskObjectName(), m.getTaskRunNamespace(), pe.patchType(), raw)
 	if err != nil {
 		return
 	}
-
 	util.SetNestedField(m.templateValues, cvr, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
@@ -694,23 +686,19 @@ func (m *taskExecutor) patchCoreV1Service() (err error) {
 	if err != nil {
 		return
 	}
-
 	pe, err := newTaskPatchExecutor(patch)
 	if err != nil {
 		return
 	}
-
 	raw, err := pe.toJson()
 	if err != nil {
 		return
 	}
-
 	// patch the service
 	service, err := m.getK8sClient().PatchCoreV1ServiceAsRaw(m.getTaskObjectName(), pe.patchType(), raw)
 	if err != nil {
 		return
 	}
-
 	util.SetNestedField(m.templateValues, service, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
@@ -764,14 +752,12 @@ func (m *taskExecutor) deleteExtnV1B1Deployment() (err error) {
 // the RunTask
 func (m *taskExecutor) deleteExtnV1B1ReplicaSet() (err error) {
 	objectNames := strings.Split(strings.TrimSpace(m.getTaskObjectName()), ",")
-
 	for _, name := range objectNames {
 		err = m.getK8sClient().DeleteExtnV1B1ReplicaSet(strings.TrimSpace(name))
 		if err != nil {
 			return
 		}
 	}
-
 	return
 }
 
@@ -845,7 +831,6 @@ func (m *taskExecutor) getExtnV1B1Deployment() (err error) {
 	if err != nil {
 		return
 	}
-
 	util.SetNestedField(m.templateValues, deploy, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -91,6 +91,11 @@ func (m *taskExecutor) getTaskObjectName() string {
 	return m.metaTaskExec.getObjectName()
 }
 
+// getTaskRunNamespace gets the task's run namespace
+func (m *taskExecutor) getTaskRunNamespace() string {
+	return m.metaTaskExec.getRunNamespace()
+}
+
 // getK8sClient gets the kubernetes client to execute this task
 func (m *taskExecutor) getK8sClient() *m_k8s_client.K8sClient {
 	return m.metaTaskExec.getK8sClient()
@@ -348,8 +353,14 @@ func (m *taskExecutor) ExecuteIt() (err error) {
 		err = m.patchOEV1alpha1SPC()
 	} else if m.metaTaskExec.isPutCoreV1Service() {
 		err = m.putCoreV1Service()
+	} else if m.metaTaskExec.isPatchCoreV1Service() {
+		err = m.patchCoreV1Service()
 	} else if m.metaTaskExec.isDeleteExtnV1B1Deploy() {
 		err = m.deleteExtnV1B1Deployment()
+	} else if m.metaTaskExec.isDeleteExtnV1B1ReplicaSet() {
+		err = m.deleteExtnV1B1ReplicaSet()
+	} else if m.metaTaskExec.isGetExtnV1B1Deploy() {
+		err = m.getExtnV1B1Deployment()
 	} else if m.metaTaskExec.isDeleteAppsV1B1Deploy() {
 		err = m.deleteAppsV1B1Deployment()
 	} else if m.metaTaskExec.isDeleteCoreV1Service() {
@@ -378,6 +389,10 @@ func (m *taskExecutor) ExecuteIt() (err error) {
 		err = m.deleteOEV1alpha1CSV()
 	} else if m.metaTaskExec.isDeleteOEV1alpha1CVR() {
 		err = m.deleteOEV1alpha1CVR()
+	} else if m.metaTaskExec.isPatchOEV1alpha1CSV() {
+		err = m.patchOEV1alpha1CSV()
+	} else if m.metaTaskExec.isPatchOEV1alpha1CVR() {
+		err = m.patchOEV1alpha1CVR()
 	} else if m.metaTaskExec.isList() {
 		err = m.listK8sResources()
 	} else if m.metaTaskExec.isGetStorageV1SC() {
@@ -583,6 +598,60 @@ func (m *taskExecutor) patchOEV1alpha1SPC() (err error) {
 	return
 }
 
+// patchOEV1alpha1CSV will patch a CStorVolume as defined in the task
+func (m *taskExecutor) patchOEV1alpha1CSV() (err error) {
+	patch, err := asTaskPatch("patchCSV", m.runtask.Spec.Task, m.templateValues)
+	if err != nil {
+		return
+	}
+
+	pe, err := newTaskPatchExecutor(patch)
+	if err != nil {
+		return
+	}
+
+	raw, err := pe.toJson()
+	if err != nil {
+		return
+	}
+
+	// patch the CStor Volume
+	csv, err := m.getK8sClient().PatchOEV1alpha1CSVAsRaw(m.getTaskObjectName(), m.getTaskRunNamespace(), pe.patchType(), raw)
+	if err != nil {
+		return
+	}
+
+	util.SetNestedField(m.templateValues, csv, string(v1alpha1.CurrentJSONResultTLP))
+	return
+}
+
+// patchOEV1alpha1CVR will patch a CStorVolumeReplica as defined in the task
+func (m *taskExecutor) patchOEV1alpha1CVR() (err error) {
+	patch, err := asTaskPatch("patchCVR", m.runtask.Spec.Task, m.templateValues)
+	if err != nil {
+		return
+	}
+
+	pe, err := newTaskPatchExecutor(patch)
+	if err != nil {
+		return
+	}
+
+	raw, err := pe.toJson()
+	if err != nil {
+		return
+	}
+
+	// patch the CStor Volume Replica
+	cvr, err := m.getK8sClient().PatchOEV1alpha1CVRAsRaw(m.getTaskObjectName(), m.getTaskRunNamespace(), pe.patchType(), raw)
+	if err != nil {
+		return
+	}
+
+	util.SetNestedField(m.templateValues, cvr, string(v1alpha1.CurrentJSONResultTLP))
+	return
+}
+
 // patchAppsV1B1Deploy will patch a Deployment object in a kubernetes cluster.
 // The patch specifications as configured in the RunTask
 func (m *taskExecutor) patchAppsV1B1Deploy() (err error) {
@@ -615,6 +684,34 @@ func (m *taskExecutor) patchExtnV1B1Deploy() (err error) {
 	}
 
 	util.SetNestedField(m.templateValues, deploy, string(v1alpha1.CurrentJSONResultTLP))
+	return
+}
+
+// patchCoreV1Service will patch a Service where the patch specifications
+// are configured in the RunTask
+func (m *taskExecutor) patchCoreV1Service() (err error) {
+	patch, err := asTaskPatch("CoreV1ServicePatch", m.runtask.Spec.Task, m.templateValues)
+	if err != nil {
+		return
+	}
+
+	pe, err := newTaskPatchExecutor(patch)
+	if err != nil {
+		return
+	}
+
+	raw, err := pe.toJson()
+	if err != nil {
+		return
+	}
+
+	// patch the service
+	service, err := m.getK8sClient().PatchCoreV1ServiceAsRaw(m.getTaskObjectName(), pe.patchType(), raw)
+	if err != nil {
+		return
+	}
+
+	util.SetNestedField(m.templateValues, service, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
 
@@ -655,6 +752,21 @@ func (m *taskExecutor) deleteExtnV1B1Deployment() (err error) {
 
 	for _, name := range objectNames {
 		err = m.getK8sClient().DeleteExtnV1B1Deployment(strings.TrimSpace(name))
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+// deleteExtnV1B1ReplicaSet will delete one or more ReplicaSets as specified in
+// the RunTask
+func (m *taskExecutor) deleteExtnV1B1ReplicaSet() (err error) {
+	objectNames := strings.Split(strings.TrimSpace(m.getTaskObjectName()), ",")
+
+	for _, name := range objectNames {
+		err = m.getK8sClient().DeleteExtnV1B1ReplicaSet(strings.TrimSpace(name))
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

This PR will introduce the following supports in runtask -

1. Patch operation for services.
2. Get operation for deployment(extensions/v1beta1).
3. Delete operation for replicaset(extensions/v1beta1).
4. Patch operation for CStor volumes.
5. Patch operation for CStor volume replicas(cvr).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests

Signed-off-by: sagarkrsd <sagar.kumar@openebs.io>