### PR TITLE
feat(cstor volume, sts): add cstor volume provisioning support in StatefulSet applications

### DIFF
--- a/pkg/algorithm/cstorpoolselect/v1alpha1/select.go
+++ b/pkg/algorithm/cstorpoolselect/v1alpha1/select.go
@@ -11,16 +11,47 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// cvrListFn abstracts fetching of a list of cstor
+// volume replicas
+type cvrListFn func(namespace string, opts metav1.ListOptions) (*apis.CStorVolumeReplicaList, error)
+
 type labelKey string
 
 const (
+	// preferReplicaAntiAffinty is the label key
+	// that refers to preferring of replica
+	// anti affinity policy
 	preferReplicaAntiAffinityLabel labelKey = "openebs.io/preferred-replica-anti-affinity"
-	replicaAntiAffinityLabel       labelKey = "openebs.io/replica-anti-affinity"
+
+	// replicaAntiAffinty is the label key
+	// that refers to replica anti affinity policy
+	replicaAntiAffinityLabel labelKey = "openebs.io/replica-anti-affinity"
 )
 
-// cvrListFn abstracts fetching of a list of cstor
-//  volume replicas
-type cvrListFn func(namespace string, opts metav1.ListOptions) (*apis.CStorVolumeReplicaList, error)
+type annotationKey string
+
+const (
+	// scheduleOnHost is the annotation key
+	// that refers to hostname to schedule
+	// the replica
+	scheduleOnHostAnnotation annotationKey = "volume.kubernetes.io/selected-node"
+)
+
+type priority int
+
+const (
+	// lowPriority refers to the priority
+	// given to a selection policy
+	lowPriority priority = 1
+
+	// mediumPriority refers to the priority
+	// given to a selection policy
+	mediumPriority priority = 2
+
+	// highPriority refers to the priority
+	// given to a selection policy
+	highPriority priority = 3
+)
 
 // policyName is a type that caters to
 // naming of various pool selection
@@ -28,23 +59,97 @@ type cvrListFn func(namespace string, opts metav1.ListOptions) (*apis.CStorVolum
 type policyName string
 
 const (
-	// antiAffinityLabelPolicyName is the name of the
-	// policy that applies anti-affinity rule based on
-	// label
-	antiAffinityLabelPolicyName policyName = "anti-affinity-label"
+	// antiAffinityLabelPolicy is the name of the
+	// policy that applies anti-affinity rule against
+	// storage placement
+	antiAffinityLabelPolicy policyName = "anti-affinity-label"
 
-	// preferAntiAffinityLabelPolicyName is the name of
+	// preferAntiAffinityLabelPolicy is the name of
 	// the policy that does a best effort while applying
-	// anti-affinity rule based on label
-	preferAntiAffinityLabelPolicyName policyName = "prefer-anti-affinity-label"
+	// anti-affinity rule against storage placement
+	preferAntiAffinityLabelPolicy policyName = "prefer-anti-affinity-label"
+
+	// scheduleOnHostAnnotationPolicy is the name of
+	// the policy that selects the given host to
+	// place storage
+	scheduleOnHostAnnotationPolicy policyName = "schedule-on-host"
+
+	// preferScheduleonHostPolicy is the name of
+	// the policy that does a best effort to select
+	// the given host to place storage
+	preferScheduleOnHostAnnotationPolicy policyName = "prefer-schedule-on-host"
 )
 
-// policy exposes the contracts that need
+// policy exposes contracts that need
 // to be satisfied by any pool selection
 // implementation
 type policy interface {
+	priority() priority
 	name() policyName
-	filter([]string) ([]string, error)
+	filter(*csp.CSPList) (*csp.CSPList, error)
+}
+
+// scheduleOnHost is a pool selection
+// implementation
+type scheduleOnHost struct {
+	// hostName holds the name of the
+	// host on which storage needs to
+	// be scheduled
+	hostName string
+}
+
+// priority returns the priority of the
+// policy implementation
+func (p scheduleOnHost) priority() priority {
+	return mediumPriority
+}
+
+// name returns the name of the policy
+// implementation
+func (p scheduleOnHost) name() policyName {
+	return scheduleOnHostAnnotationPolicy
+}
+
+// filter selects the pools available on the host
+// for which the policy has been applied
+func (p scheduleOnHost) filter(pools *csp.CSPList) (*csp.CSPList, error) {
+	if p.hostName == "" {
+		return pools, nil
+	}
+	filteredPools := pools.Filter(csp.HasAnnotation(string(scheduleOnHostAnnotation), p.hostName))
+	return filteredPools, nil
+}
+
+// preferScheduleOnHost is pool selection
+// implementation
+type preferScheduleOnHost struct {
+	scheduleOnHost
+}
+
+// priority return the priority of the policy
+// implementation
+func (p preferScheduleOnHost) priority() priority {
+	return mediumPriority
+}
+
+// name returns the name of the policy
+// implementation
+func (p preferScheduleOnHost) name() policyName {
+	return preferScheduleOnHostAnnotationPolicy
+}
+
+// filter piggybacks on scheduleOnHost policy with
+// the difference being this logic returns the
+// provided pools if no pools are found on the host
+func (p preferScheduleOnHost) filter(pools *csp.CSPList) (*csp.CSPList, error) {
+	plist, err := p.scheduleOnHost.filter(pools)
+	if err != nil {
+		return nil, err
+	}
+	if len(plist.GetPoolUIDs()) == 0 {
+		return pools, nil
+	}
+	return plist, nil
 }
 
 // antiAffinityLabel is a pool selection
@@ -58,16 +163,20 @@ type antiAffinityLabel struct {
 	cvrList cvrListFn
 }
 
-// defaultCVRList is the default
-// implementation of cvrListFn
 func defaultCVRList() cvrListFn {
 	return cvr.KubeClient().List
+}
+
+// priority returns the priority of
+// this policy
+func (p antiAffinityLabel) priority() priority {
+	return lowPriority
 }
 
 // name returns the name of this
 // policy
 func (p antiAffinityLabel) name() policyName {
-	return antiAffinityLabelPolicyName
+	return antiAffinityLabelPolicy
 }
 
 // filter excludes the pool(s) if they are
@@ -75,9 +184,9 @@ func (p antiAffinityLabel) name() policyName {
 // selector. In other words, it applies anti
 // affinity rule against the provided list of
 // pools.
-func (l antiAffinityLabel) filter(poolUIDs []string) ([]string, error) {
-	if l.labelSelector == "" {
-		return poolUIDs, nil
+func (p antiAffinityLabel) filter(pools *csp.CSPList) (*csp.CSPList, error) {
+	if p.labelSelector == "" {
+		return pools, nil
 	}
 	// pools that are already associated with
 	// this label should be excluded
@@ -85,13 +194,13 @@ func (l antiAffinityLabel) filter(poolUIDs []string) ([]string, error) {
 	// NOTE: we try without giving any namespace
 	// so that it lists from all available
 	// namespaces
-	cvrs, err := l.cvrList("", metav1.ListOptions{LabelSelector: l.labelSelector})
+	cvrs, err := p.cvrList("", metav1.ListOptions{LabelSelector: p.labelSelector})
 	if err != nil {
 		return nil, err
 	}
-	exclude := cvr.ListBuilder().WithListObject(cvrs).List().GetPoolUIDs()
-	plist := csp.ListBuilder().WithUIDs(poolUIDs...).List()
-	return plist.FilterUIDs(csp.IsNotUID(exclude...)), nil
+
+	exclude := cvr.ListBuilder().WithAPIList(cvrs).List().GetPoolUIDs()
+	return pools.Filter(csp.IsNotUID(exclude...)), nil
 }
 
 // preferAntiAffinityLabel is a pool
@@ -102,22 +211,122 @@ type preferAntiAffinityLabel struct {
 
 // name returns the name of this policy
 func (p preferAntiAffinityLabel) name() policyName {
-	return preferAntiAffinityLabelPolicyName
+	return preferAntiAffinityLabelPolicy
 }
 
 // filter piggybacks on antiAffinityLabel policy
 // with the difference being; this logic returns all
 // the provided pools if there are no pools that
 // satisfy antiAffinity rule
-func (p preferAntiAffinityLabel) filter(poolUIDs []string) ([]string, error) {
-	plist, err := p.antiAffinityLabel.filter(poolUIDs)
+func (p preferAntiAffinityLabel) filter(pools *csp.CSPList) (*csp.CSPList, error) {
+	plist, err := p.antiAffinityLabel.filter(pools)
 	if err != nil {
-		return nil, err
+		return plist, err
 	}
-	if len(plist) > 0 {
+	if len(plist.GetPoolUIDs()) > 0 {
 		return plist, nil
 	}
-	return poolUIDs, nil
+	return pools, nil
+}
+
+type executionMode string
+
+const (
+	// multiExection enables execution of
+	// more than one policy during a selection
+	multiExecution executionMode = "multi-mode"
+
+	// singleExecution enables execution of
+	// only one policy during a seclection
+	singleExection executionMode = "single-mode"
+)
+
+type policyList struct {
+	items map[priority][]policy
+}
+
+func (pl *policyList) getAll() []policy {
+	if len(pl.items) == 0 {
+		return nil
+	}
+	var all []policy
+	for _, policies := range pl.items {
+		all = append(all, policies...)
+	}
+	return all
+}
+
+func (pl *policyList) add(p policy) {
+	pl.items[p.priority()] = append(pl.items[p.priority()], p)
+}
+
+func (pl *policyList) sortByPriority() []policy {
+	var sorted []policy
+	if len(pl.items) == 0 {
+		return sorted
+	}
+	for i := highPriority; i >= lowPriority; i-- {
+		if len(pl.items[i]) == 0 {
+			continue
+		}
+		sorted = append(sorted, pl.items[i]...)
+	}
+	return sorted
+}
+
+type policyListPredicate func(*policyList) bool
+
+func hasPolicy(name policyName) policyListPredicate {
+	return func(pl *policyList) bool {
+		if len(pl.items) == 0 {
+			return false
+		}
+		all := pl.getAll()
+		for _, policy := range all {
+			if policy.name() == name {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func hasHighPriorityPolicy() policyListPredicate {
+	return func(pl *policyList) bool {
+		if len(pl.items) == 0 {
+			return false
+		}
+		return len(pl.items[highPriority]) != 0
+	}
+}
+
+func hasMediumPriorityPolicy() policyListPredicate {
+	return func(pl *policyList) bool {
+		if len(pl.items) == 0 {
+			return false
+		}
+		return len(pl.items[mediumPriority]) != 0
+	}
+}
+
+func hasLowPriorityPolicy() policyListPredicate {
+	return func(pl *policyList) bool {
+		if len(pl.items) == 0 {
+			return false
+		}
+		return len(pl.items[lowPriority]) != 0
+	}
+}
+
+func (pl *policyList) getTopPriority() policy {
+	if hasHighPriorityPolicy()(pl) {
+		return pl.items[highPriority][0]
+	} else if hasMediumPriorityPolicy()(pl) {
+		return pl.items[mediumPriority][0]
+	} else if hasLowPriorityPolicy()(pl) {
+		return pl.items[lowPriority][0]
+	}
+	return nil
 }
 
 // selection enables selecting required pools
@@ -133,51 +342,64 @@ func (p preferAntiAffinityLabel) filter(poolUIDs []string) ([]string, error) {
 type selection struct {
 	// list of original pools aginst whom
 	// selection will be made
-	poolUIDs []string
+	pools *csp.CSPList
 
 	// selection is based on these policies
-	policies []policy
+	policies *policyList
+
+	// mode flags if selection can consider
+	// multiple policies to select the pools
+	mode executionMode
 }
 
 // buildOption is a typed function that
 // abstracts configuring a selection instance
 type buildOption func(*selection)
 
+func withDefaultSelection(s *selection) {
+	if string(s.mode) == "" {
+		s.mode = singleExection
+	}
+}
+
 // newSelection returns a new instance of
 // selection
-func newSelection(poolUIDs []string, opts ...buildOption) *selection {
-	s := &selection{poolUIDs: poolUIDs}
+func newSelection(pools *csp.CSPList, opts ...buildOption) *selection {
+	s := &selection{pools: pools, policies: &policyList{map[priority][]policy{}}}
 	for _, o := range opts {
 		if o != nil {
 			o(s)
 		}
 	}
+	withDefaultSelection(s)
 	return s
 }
 
-// isPolicy determines if the provided policy
-// needs to be considered during selection
-func (s *selection) isPolicy(p policyName) bool {
-	for _, pol := range s.policies {
-		if pol.name() == p {
-			return true
-		}
+// hasPolicy determines if the provided policy
+// is part of the selection
+func (s *selection) hasPolicy(p policyName) bool {
+	return hasPolicy(p)(s.policies)
+}
+
+// hasPreferAntiAffinityLabel determines if
+// prefer anti affinity label is part of
+// the selection
+func (s *selection) hasPreferAntiAffinityLabel() bool {
+	return s.hasPolicy(preferAntiAffinityLabelPolicy)
+}
+
+// hasAntiAffinityLabel determines if anti affinity
+// label is part of the selection
+func (s *selection) hasAntiAffinityLabel() bool {
+	return s.hasPolicy(antiAffinityLabelPolicy)
+}
+
+// ExecutionMode sets the execution mode
+// against the provided selection instance
+func ExecutionMode(m executionMode) buildOption {
+	return func(s *selection) {
+		s.mode = m
 	}
-	return false
-}
-
-// isPreferAntiAffinityLabel determines if
-// prefer anti affinity label needs to be
-// considered during selection
-func (s *selection) isPreferAntiAffinityLabel() bool {
-	return s.isPolicy(preferAntiAffinityLabelPolicyName)
-}
-
-// isAntiAffinityLabel determines if anti affinity
-// label needs to be considered during
-// selection
-func (s *selection) isAntiAffinityLabel() bool {
-	return s.isPolicy(antiAffinityLabelPolicyName)
 }
 
 // PreferAntiAffinityLabel adds anti affinity label
@@ -186,7 +408,7 @@ func (s *selection) isAntiAffinityLabel() bool {
 func PreferAntiAffinityLabel(lbl string) buildOption {
 	return func(s *selection) {
 		p := preferAntiAffinityLabel{antiAffinityLabel{labelSelector: lbl, cvrList: defaultCVRList()}}
-		s.policies = append(s.policies, p)
+		s.policies.add(p)
 	}
 }
 
@@ -194,20 +416,32 @@ func PreferAntiAffinityLabel(lbl string) buildOption {
 // as a policy to be used during pool selection
 func AntiAffinityLabel(lbl string) buildOption {
 	return func(s *selection) {
-		a := antiAffinityLabel{labelSelector: lbl, cvrList: defaultCVRList()}
-		s.policies = append(s.policies, a)
+		p := antiAffinityLabel{labelSelector: lbl, cvrList: defaultCVRList()}
+		s.policies.add(p)
 	}
 }
 
-// GetBuildOptionByLabelSelector returns the appropriate
-// buildOptions based on the input label
-func GetBuildOptionByLabelSelector(labels ...string) []buildOption {
+// PreferScheduleOnHostAnnotation adds preferScheduleOnHost
+// as a policy to be used during pool selection
+func PreferScheduleOnHostAnnotation(hostNameAnnotation string) buildOption {
+	hostName := strings.TrimPrefix(hostNameAnnotation, string(scheduleOnHostAnnotation)+"=")
+	return func(s *selection) {
+		p := preferScheduleOnHost{scheduleOnHost{hostName: hostName}}
+		s.policies.add(p)
+	}
+}
+
+// GetPolicies returns the appropriate selection
+// policies based on the provided values
+func GetPolicies(values ...string) []buildOption {
 	var opts []buildOption
-	for _, label := range labels {
-		if strings.Contains(label, string(preferReplicaAntiAffinityLabel)) {
-			opts = append(opts, PreferAntiAffinityLabel(label))
-		} else if strings.Contains(label, string(replicaAntiAffinityLabel)) {
-			opts = append(opts, AntiAffinityLabel(label))
+	for _, val := range values {
+		if strings.Contains(val, string(scheduleOnHostAnnotation)) {
+			opts = append(opts, PreferScheduleOnHostAnnotation(val))
+		} else if strings.Contains(val, string(preferReplicaAntiAffinityLabel)) {
+			opts = append(opts, PreferAntiAffinityLabel(val))
+		} else if strings.Contains(val, string(replicaAntiAffinityLabel)) {
+			opts = append(opts, AntiAffinityLabel(val))
 		}
 	}
 	return opts
@@ -216,7 +450,7 @@ func GetBuildOptionByLabelSelector(labels ...string) []buildOption {
 // validate runs some validations/checks
 // against this selection instance
 func (s *selection) validate() error {
-	if s.isAntiAffinityLabel() && s.isPreferAntiAffinityLabel() {
+	if s.hasAntiAffinityLabel() && s.hasPreferAntiAffinityLabel() {
 		return errors.New("invalid selection: both antiAffinityLabel and preferAntiAffinityLabel policies can not be together")
 	}
 	return nil
@@ -225,40 +459,37 @@ func (s *selection) validate() error {
 // filter returns the final list of pools that
 // gets selected, after passing the original list
 // of pools through the registered selection policies
-func (s *selection) filter() ([]string, error) {
-	var (
-		filtered []string
-		err      error
-	)
-	if len(s.policies) == 0 {
-		return s.poolUIDs, nil
+func (s *selection) filter() (*csp.CSPList, error) {
+	var err error
+	if s.policies == nil || len(s.policies.items) == 0 || s.pools == nil || len(s.pools.GetPoolUIDs()) == 0 {
+		return s.pools, nil
 	}
 	// make a copy of original pool UIDs
-	filtered = append(filtered, s.poolUIDs...)
-	for _, policy := range s.policies {
+	filtered := csp.ListBuilder().WithList(s.pools).List()
+	// Sorting policies based on the priority
+	policies := s.policies.sortByPriority()
+	// Executing policy filters
+	for _, policy := range policies {
 		filtered, err = policy.filter(filtered)
 		if err != nil {
 			return nil, err
+		}
+		// stopping here if running as
+		// singleExecution mode
+		if s.mode == singleExection {
+			break
 		}
 	}
 	return filtered, nil
 }
 
-// FilterWithBuildOptions will return filtered pool UIDs
-// from the provided list based on pool
-// selection options
-func FilterWithBuildOptions(origPoolUIDs []string, opts []buildOption) ([]string, error) {
-	return Filter(origPoolUIDs, opts...)
-}
-
-// Filter will return filtered pool UIDs
-// from the provided list based on pool
-// selection options
-func Filter(origPoolUIDs []string, opts ...buildOption) ([]string, error) {
-	if len(opts) == 0 {
-		return origPoolUIDs, nil
+// Filter will filter the provided pools
+// based on pool selection policies
+func Filter(entries *csp.CSPList, opts ...buildOption) (*csp.CSPList, error) {
+	if entries == nil {
+		return entries, nil
 	}
-	s := newSelection(origPoolUIDs, opts...)
+	s := newSelection(entries, opts...)
 	err := s.validate()
 	if err != nil {
 		return nil, err
@@ -266,12 +497,24 @@ func Filter(origPoolUIDs []string, opts ...buildOption) ([]string, error) {
 	return s.filter()
 }
 
-// TemplateFunctions exposes a few functions as go template functions
+// FilterPoolIDs will filter the provided pools
+// based on pool selection policies
+func FilterPoolIDs(entries *csp.CSPList, opts []buildOption) ([]string, error) {
+	plist, err := Filter(entries, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return plist.GetPoolUIDs(), nil
+}
+
+// TemplateFunctions exposes a few functions as
+// go template functions
 func TemplateFunctions() template.FuncMap {
 	return template.FuncMap{
-		"cspGetPolicyByLabelSelector": GetBuildOptionByLabelSelector,
-		"cspFilter":                   FilterWithBuildOptions,
-		"cspAntiAffinity":             AntiAffinityLabel,
-		"cspPreferAntiAffinity":       PreferAntiAffinityLabel,
+		"cspGetPolicies":        GetPolicies,
+		"cspFilterPoolIDs":      FilterPoolIDs,
+		"cspAntiAffinity":       AntiAffinityLabel,
+		"cspPreferAntiAffinity": PreferAntiAffinityLabel,
+		"preferScheduleOnHost":  PreferScheduleOnHostAnnotation,
 	}
 }

--- a/pkg/cstorpool/v1alpha2/cstorpool.go
+++ b/pkg/cstorpool/v1alpha2/cstorpool.go
@@ -1,9 +1,15 @@
 package v1alpha2
 
 import (
+	"text/template"
+
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
 )
+
+type annotationKey string
+
+const scheduleOnHostAnnotation annotationKey = "volume.kubernetes.io/selected-node"
 
 type csp struct {
 	// actual cstor pool object
@@ -43,24 +49,39 @@ func IsNotUID(uids ...string) predicate {
 	}
 }
 
-type cspList struct {
+// HasAnnotation returns true if provided annotation
+// key and value are present in the provided CSP
+// instance
+func HasAnnotation(key, value string) predicate {
+	return func(c *csp) bool {
+		val, ok := c.object.GetAnnotations()[key]
+		if ok {
+			return val == value
+		}
+		return false
+	}
+}
+
+// CSPList holds the list of cstorpools
+type CSPList struct {
 	// list of cstor pools
 	items []*csp
 }
 
-// FilterUIDs will filter the csp instances
+// Filter will filter the csp instances
 // if all the predicates succeed against that
-// csp. The filtered csp instances' UIDs will
-// be returned
-func (l *cspList) FilterUIDs(p ...predicate) []string {
-	var (
-		filtered []string
-		plist    predicateList
-	)
+// csp.
+func (l *CSPList) Filter(p ...predicate) *CSPList {
+	var plist predicateList
 	plist = append(plist, p...)
+	if len(plist) == 0 {
+		return l
+	}
+
+	filtered := ListBuilder().List()
 	for _, csp := range l.items {
 		if plist.all(csp) {
-			filtered = append(filtered, string(csp.object.GetUID()))
+			filtered.items = append(filtered.items, csp)
 		}
 	}
 	return filtered
@@ -69,30 +90,81 @@ func (l *cspList) FilterUIDs(p ...predicate) []string {
 // listBuilder enables building a
 // list of csp instances
 type listBuilder struct {
-	list *cspList
+	list *CSPList
 }
 
 // ListBuilder returns a new instance of
 // listBuilder object
 func ListBuilder() *listBuilder {
-	return &listBuilder{list: &cspList{}}
+	return &listBuilder{list: &CSPList{}}
 }
 
 // WithUIDs builds a list of cstor pools
 // based on the provided pool UIDs
 func (b *listBuilder) WithUIDs(poolUIDs ...string) *listBuilder {
 	for _, uid := range poolUIDs {
-		obj := &apis.CStorPool{}
-		obj.SetUID(types.UID(uid))
-		item := &csp{object: obj}
-		b.list.items = append(b.list.items, item)
+		obj := &csp{&apis.CStorPool{}}
+		obj.object.SetUID(types.UID(uid))
+		b.list.items = append(b.list.items, obj)
 	}
+	return b
+}
+
+// WithUIDNodeMap builds a cspList based on the provided
+// map of uid and nodename
+func (b *listBuilder) WithUIDNode(UIDNode map[string]string) *listBuilder {
+	for k, v := range UIDNode {
+		obj := &csp{&apis.CStorPool{}}
+		obj.object.SetUID(types.UID(k))
+		obj.object.SetAnnotations(map[string]string{string(scheduleOnHostAnnotation): v})
+		b.list.items = append(b.list.items, obj)
+	}
+	return b
+}
+
+// WithCStorPool builds the list based on the provided
+// *apis.CStorPool instances
+func (b *listBuilder) WithList(pools *CSPList) *listBuilder {
+	if pools == nil {
+		return b
+	}
+	b.list.items = append(b.list.items, pools.items...)
 	return b
 }
 
 // List returns the list of csp
 // instances that were built by
 // this builder
-func (b *listBuilder) List() *cspList {
+func (b *listBuilder) List() *CSPList {
 	return b.list
+}
+
+// GetPoolUIDs retuns the UIDs of the pools
+// available in the list
+func (l *CSPList) GetPoolUIDs() []string {
+	uids := []string{}
+	for _, pool := range l.items {
+		uids = append(uids, string(pool.object.GetUID()))
+	}
+	return uids
+}
+
+// newListFromUIDNode exposes WithUIDNodeMap
+// to CAS Templates
+func newListFromUIDNode(UIDNodeMap map[string]string) *CSPList {
+	return ListBuilder().WithUIDNode(UIDNodeMap).List()
+}
+
+// newListFromUIDs exposes WithUIDs to CASTemplates
+func newListFromUIDs(uids []string) *CSPList {
+	return ListBuilder().WithUIDs(uids...).List()
+}
+
+// TemplateFunctions exposes a few functions as go
+// template functions
+func TemplateFunctions() template.FuncMap {
+	return template.FuncMap{
+		"createCSPListFromUIDs":       newListFromUIDs,
+		"createCSPListFromUIDNodeMap": newListFromUIDNode,
+	}
 }

--- a/pkg/cstorvolumereplica/v1alpha1/cstorvolumereplica.go
+++ b/pkg/cstorvolumereplica/v1alpha1/cstorvolumereplica.go
@@ -43,10 +43,10 @@ func ListBuilder() *listBuilder {
 	return &listBuilder{list: &cvrList{}}
 }
 
-// WithListObject builds the list of cvr
+// WithAPIList builds the list of cvr
 // instances based on the provided
 // cvr api instances
-func (b *listBuilder) WithListObject(list *apis.CStorVolumeReplicaList) *listBuilder {
+func (b *listBuilder) WithAPIList(list *apis.CStorVolumeReplicaList) *listBuilder {
 	if list == nil {
 		return b
 	}

--- a/pkg/cstorvolumereplica/v1alpha1/cstorvolumereplica_test.go
+++ b/pkg/cstorvolumereplica/v1alpha1/cstorvolumereplica_test.go
@@ -60,7 +60,7 @@ func TestWithListObject(t *testing.T) {
 				cvrItems = append(cvrItems, apis.CStorVolumeReplica{ObjectMeta: metav1.ObjectMeta{Name: p, Labels: map[string]string{cstorPoolUIDLabelKey: p}}})
 			}
 
-			b := ListBuilder().WithListObject(&apis.CStorVolumeReplicaList{Items: cvrItems})
+			b := ListBuilder().WithAPIList(&apis.CStorVolumeReplicaList{Items: cvrItems})
 			for index, ob := range b.list.items {
 				if !reflect.DeepEqual(ob.object, cvrItems[index]) {
 					t.Fatalf("test %q failed: expected %v \n got : %v \n", name, cvrItems[index], ob.object)
@@ -92,7 +92,7 @@ func TestList(t *testing.T) {
 				cvrItems = append(cvrItems, apis.CStorVolumeReplica{ObjectMeta: metav1.ObjectMeta{Name: p, Labels: map[string]string{cstorPoolUIDLabelKey: p}}})
 			}
 
-			b := ListBuilder().WithListObject(&apis.CStorVolumeReplicaList{Items: cvrItems}).List()
+			b := ListBuilder().WithAPIList(&apis.CStorVolumeReplicaList{Items: cvrItems}).List()
 			if len(b.items) != len(cvrItems) {
 				t.Fatalf("test %q failed: expected %v \n got : %v \n", name, len(cvrItems), len(b.items))
 			}

--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -106,10 +106,10 @@ spec:
   taskNamespace: {{env "OPENEBS_NAMESPACE"}}
   run:
     tasks:
+    - cstor-volume-create-getstorageclass-default
     - cstor-volume-create-getpvc-default
     - cstor-volume-create-listclonecstorvolumereplicacr-default
     - cstor-volume-create-listcstorpoolcr-default
-    - cstor-volume-create-getstorageclass-default
     - cstor-volume-create-puttargetservice-default
     - cstor-volume-create-putcstorvolumecr-default
     - cstor-volume-create-puttargetdeployment-default
@@ -185,12 +185,21 @@ spec:
     objectName: {{ .Volume.pvc }}
     action: get
   post: |
+    {{- $hostName := jsonpath .JsonResult "{.metadata.annotations.volume\\.kubernetes\\.io/selected-node}" | trim | default "" -}}
+    {{- $hostName | saveAs "creategetpvc.hostName" .TaskResult | noop -}}
     {{- $replicaAntiAffinity := jsonpath .JsonResult "{.metadata.labels.openebs\\.io/replica-anti-affinity}" | trim | default "" -}}
     {{- $replicaAntiAffinity | saveAs "creategetpvc.replicaAntiAffinity" .TaskResult | noop -}}
     {{- $preferredReplicaAntiAffinity := jsonpath .JsonResult "{.metadata.labels.openebs\\.io/preferred-replica-anti-affinity}" | trim | default "" -}}
     {{- $preferredReplicaAntiAffinity | saveAs "creategetpvc.preferredReplicaAntiAffinity" .TaskResult | noop -}}
     {{- $targetAffinity := jsonpath .JsonResult "{.metadata.labels.openebs\\.io/target-affinity}" | trim | default "none" -}}
     {{- $targetAffinity | saveAs "creategetpvc.targetAffinity" .TaskResult | noop -}}
+    {{- $stsTargetAffinity := jsonpath .JsonResult "{.metadata.labels.openebs\\.io/sts-target-affinity}" | trim | default "none" -}}
+    {{- if ne $stsTargetAffinity "none" -}}
+    {{- $stsTargetAffinity | saveAs "stsTargetAffinity" .TaskResult | noop -}}
+    {{- end -}}
+    {{- if ne .TaskResult.stsTargetAffinity "none" -}}
+    {{- printf "%s-%s" .TaskResult.stsTargetAffinity ((splitList "-" .Volume.pvc) | last) | default "none" | saveAs "sts.applicationName" .TaskResult -}}
+    {{- end -}}
 ---
 # This RunTask is meant to be run only during clone create requests.
 # However, clone & volume creation follow the same CASTemplate specifications.
@@ -265,6 +274,8 @@ spec:
   post: |
     {{- $resourceVer := jsonpath .JsonResult "{.metadata.resourceVersion}" -}}
     {{- trim $resourceVer | saveAs "creategetsc.storageClassVersion" .TaskResult | noop -}}
+    {{- $stsTargetAffinity := jsonpath .JsonResult "{.metadata.labels.openebs\\.io/sts-target-affinity}" | trim | default "none" -}}
+    {{- $stsTargetAffinity | saveAs "stsTargetAffinity" .TaskResult | noop -}}
 ---
 # runTask to create cStor target service
 apiVersion: openebs.io/v1alpha1
@@ -470,7 +481,18 @@ spec:
             {{- end }}
           {{- end}}
           serviceAccountName: {{ .Config.PVCServiceAccountName.value | default .Config.ServiceAccountName.value }}
-          {{- if ne $targetAffinityVal "none" }}
+          {{- if ne (.TaskResult.sts.applicationName | default "") "" }}
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: statefulset.kubernetes.io/pod-name
+                    operator: In
+                    values:
+                    - {{ .TaskResult.sts.applicationName }}
+                topologyKey: kubernetes.io/hostname
+          {{- else if ne $targetAffinityVal "none" }}
           affinity:
             podAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
@@ -634,13 +656,15 @@ spec:
     Calculate the replica count
     Add as many poolUid to resources as there is replica count
     */}}
-    {{- $replicaAntiAffinity:= .TaskResult.creategetpvc.replicaAntiAffinity }}
-    {{- $preferredReplicaAntiAffinity:= .TaskResult.creategetpvc.preferredReplicaAntiAffinity }}
+    {{- $hostName := .TaskResult.creategetpvc.hostName -}}
+    {{- $replicaAntiAffinity := .TaskResult.creategetpvc.replicaAntiAffinity }}
+    {{- $preferredReplicaAntiAffinity := .TaskResult.creategetpvc.preferredReplicaAntiAffinity }}
     {{- $antiAffinityLabelSelector := printf "openebs.io/replica-anti-affinity=%s" $replicaAntiAffinity | IfNotNil $replicaAntiAffinity }}
     {{- $preferredAntiAffinityLabelSelector := printf "openebs.io/preferred-replica-anti-affinity=%s" $preferredReplicaAntiAffinity | IfNotNil $preferredReplicaAntiAffinity }}
-    {{- $selectionPolicy := cspGetPolicyByLabelSelector $antiAffinityLabelSelector $preferredAntiAffinityLabelSelector }}
-    {{- $poolUids := keys .ListItems.cvolPoolList.pools }}
-    {{- $poolUids = cspFilter $poolUids $selectionPolicy | randomize }}
+    {{- $preferedScheduleOnHostAnnotationSelector := printf "volume.kubernetes.io/selected-node=%s" $hostName | IfNotNil $hostName }}
+    {{- $selectionPolicies := cspGetPolicies $antiAffinityLabelSelector $preferredAntiAffinityLabelSelector $preferedScheduleOnHostAnnotationSelector }}
+    {{- $pools :=  createCSPListFromUIDNodeMap (getMapofString .ListItems.cvolPoolNodeList "pools") }}
+    {{- $poolUids := cspFilterPoolIDs $pools $selectionPolicies | randomize }}
     {{- $replicaCount := .Config.ReplicaCount.value | int64 -}}
     {{- if lt (len $poolUids) $replicaCount -}}
     {{- printf "Not enough pools to provision replica: expected replica count %d actual count %d" $replicaCount (len $poolUids) | fail -}}
@@ -653,8 +677,8 @@ spec:
       {{- end }}
       {{- end }}
   task: |
-    {{- $replicaAntiAffinity:= .TaskResult.creategetpvc.replicaAntiAffinity -}}
-    {{- $preferredReplicaAntiAffinity:= .TaskResult.creategetpvc.preferredReplicaAntiAffinity }}
+    {{- $replicaAntiAffinity := .TaskResult.creategetpvc.replicaAntiAffinity -}}
+    {{- $preferredReplicaAntiAffinity := .TaskResult.creategetpvc.preferredReplicaAntiAffinity }}
     {{- $isClone := .Volume.isCloneEnable | default "false" -}}
     kind: CStorVolumeReplica
     apiVersion: openebs.io/v1alpha1

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Masterminds/sprig"
 	"github.com/ghodss/yaml"
 	poolselection "github.com/openebs/maya/pkg/algorithm/cstorpoolselect/v1alpha1"
+	csp "github.com/openebs/maya/pkg/cstorpool/v1alpha2"
 	v1alpha1 "github.com/openebs/maya/pkg/task/v1alpha1"
 	"github.com/openebs/maya/pkg/util"
 	kubever "github.com/openebs/maya/pkg/version/kubernetes"
@@ -794,6 +795,7 @@ func runtaskFuncs() (f template.FuncMap) {
 		"splitListTrim":      splitListTrim,
 		"randomize":          randomize,
 		"IfNotNil":           ifNotNil,
+		"getMapofString":     util.GetNestedMap,
 	}
 }
 
@@ -810,6 +812,10 @@ func allCustomFuncs() template.FuncMap {
 	}
 	ver := kubever.TemplateFunctions()
 	for k, v := range ver {
+		f[k] = v
+	}
+	sp := csp.TemplateFunctions()
+	for k, v := range sp {
 		f[k] = v
 	}
 	ps := poolselection.TemplateFunctions()


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**Why we need it**:
Users want to deploy applications using StatefulSet with application replication factor "> 1" and volume replication factor "= 1", provided that the OpenEBS volumes' target and replica related resources have an affinity with the application. This means that, for a given OpenEBS volume, Target and replica related to that volume should be scheduled on the same node where the application resides.

**What this PR does**:
This commit adds support for cstor target and replica affinity to an instance of StatefulSet application.
This feature can be enabled by using either of the following approach:

### Approach 1: 
_NOTE: This approach requires change to StatefulSet spec_

- Add **`openebs.io/sts-target-affinity: <.metadata.name of STS>`**  label in StatefulSet spec to following:
  - `spec.selector.matchLabels` &
  - `spec.template.labels` 
- Set `volumeBindingMode` to **`WaitForFirstConsumer`** in StorageClass that is referred to by the claimTemplates of this StatefulSet

```yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: test-application
  labels:
    app: test-application
spec:
  serviceName: test-application
  replicas: 1
  selector:
    matchLabels:
      app: test-application
      openebs.io/sts-target-affinity: test-application
  template:
    metadata:
      labels:
        app: test-application
        openebs.io/sts-target-affinity: test-application
    spec:
      containers:
      - name: test-application
        image: ubuntu
        imagePullPolicy: IfNotPresent
        command:
          - sleep
          - infinity
        volumeMounts:
        - name: test-application
          mountPath: /test-application
  volumeClaimTemplates:
  - metadata:
      name: test-application
    spec:
      accessModes: [ "ReadWriteOnce" ]
      storageClassName: cstor-without-sts
      resources:
        requests:
          storage: 1Gi
---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: cstor-sts
  annotations:
    openebs.io/cas-type: cstor
    cas.openebs.io/config: |
      - name: ReplicaCount
        value: "1"
      - name: StoragePoolClaim
        value: "cstor-sparse-pool" 
provisioner: openebs.io/provisioner-iscsi
volumeBindingMode: WaitForFirstConsumer
```

### Approach 2: 
_NOTE: This approach requires a new StorageClass per StatefulSet application_
_NOTE: This approach is useful when user/tool does not have control over the StatefulSet spec._

- Add **`openebs.io/sts-target-affinity: <.metadata.name of STS>`** label in StorageClass to following:
  - `metadata.labels`
- Set `volumeBindingMode` to **`WaitForFirstConsumer`** in StorageClass

```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: cstor-sts
  labels:
    openebs.io/sts-target-affinity: test-application # name of StatefulSet application
  annotations:
    openebs.io/cas-type: cstor
    cas.openebs.io/config: |
      - name: ReplicaCount
        value: "1"
      - name: StoragePoolClaim
        value: "cstor-sparse-pool" 
provisioner: openebs.io/provisioner-iscsi
volumeBindingMode: WaitForFirstConsumer
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # https://github.com/openebs/openebs/issues/2429

**Special notes for your reviewer**:

**Checklist:**
- [x] Fixes #https://github.com/openebs/openebs/issues/2429
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [x] Labelled this PR & related issue with `requires-upgrade` tag
- [x] PR messages has upgrade related information
- [x] Commit has unit tests
- [ ] Commit has integration tests