### PR TITLE
fix(webhook): ignore delete request for missing resource req name

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -130,6 +130,12 @@ func (wh *webhook) validate(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespo
 		response.Allowed = true
 		return response
 	}
+	// ignore the Delete request if requested resource doesn't exists
+	if ar.Request.Name == "" {
+		response.Allowed = true
+		return response
+	}
+
 	glog.Infof("AdmissionReview for Kind=%v, Namespace=%v Name=%v UID=%v patchOperation=%v UserInfo=%v",
 		req.Kind, req.Namespace, req.Name, req.UID, req.Operation, req.UserInfo)
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -130,7 +130,9 @@ func (wh *webhook) validate(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespo
 		response.Allowed = true
 		return response
 	}
-	// ignore the Delete request if requested resource doesn't exists
+
+	// ignore the Delete request of PVC if resource name is empty which
+	// can happen as part of cleanup process of namespace
 	if ar.Request.Name == "" {
 		response.Allowed = true
 		return response


### PR DESCRIPTION
#### why we need this PR

This fixes a bug where deleting a namespace, that doesn't have any PVC resource can trigger this validating webhook. This nil PVC resulted into a runtime error thus invalidating the validation. As a result of this invalidation, the validation is being retried that and ends up being in the same state forever.

#### What this PR does 
Request name as nil will be ignored by the webhook validation policy. In other words webhook will validate this request successfully.

fixes: openebs/openebs/issues/2431

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

**Checklist:**
- [x] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests