### PR TITLE
feat(casconfig, perf, cstor): introduce ZvolWorkers, QueueDepth & Luworkers cstor volume config

### DIFF
--- a/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
+++ b/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
@@ -47,6 +47,7 @@ const (
 	// ZfsStatusRebuilding is the rebuilding state of zfs volume.
 	ZfsStatusRebuilding = "Rebuilding"
 )
+
 const (
 	// CStorPoolUIDKey is the key for csp object uid which is present in cvr labels.
 	CStorPoolUIDKey = "cstorpool.openebs.io/uid"
@@ -145,8 +146,9 @@ func builldVolumeCreateCommand(cStorVolumeReplica *apis.CStorVolumeReplica, full
 	var createVolCmd []string
 
 	openebsVolname := "io.openebs:volname=" + cStorVolumeReplica.ObjectMeta.Name
-
 	openebsTargetIP := "io.openebs:targetip=" + cStorVolumeReplica.Spec.TargetIP
+	// ZvolWorkers represents number of threads that executes client IOs
+	openebsZvolWorkers := "io.openebs:zvol_workers=" + cStorVolumeReplica.Spec.ZvolWorkers
 
 	quorumValue := "quorum=on"
 	if !quorum {
@@ -155,7 +157,7 @@ func builldVolumeCreateCommand(cStorVolumeReplica *apis.CStorVolumeReplica, full
 
 	createVolCmd = append(createVolCmd, CreateCmd,
 		"-b", "4K", "-s", "-o", "compression=on", "-o", quorumValue,
-		"-o", openebsTargetIP, "-o", openebsVolname,
+		"-o", openebsTargetIP, "-o", openebsVolname, "-o", openebsZvolWorkers,
 		"-V", cStorVolumeReplica.Spec.Capacity, fullVolName)
 
 	return createVolCmd
@@ -166,12 +168,13 @@ func builldVolumeCloneCommand(cStorVolumeReplica *apis.CStorVolumeReplica, snapN
 	var cloneVolCmd []string
 
 	openebsVolname := "io.openebs:volname=" + cStorVolumeReplica.ObjectMeta.Name
-
 	openebsTargetIP := "io.openebs:targetip=" + cStorVolumeReplica.Spec.TargetIP
+	// ZvolWorkers represents number of threads that executes client IOs
+	openebsZvolWorkers := "io.openebs:zvol_workers=" + cStorVolumeReplica.Spec.ZvolWorkers
 
 	cloneVolCmd = append(cloneVolCmd, CloneCmd,
 		"-o", "compression=on", "-o", openebsTargetIP, "-o", "quorum=on",
-		"-o", openebsVolname, snapName, fullVolName)
+		"-o", openebsZvolWorkers, "-o", openebsVolname, snapName, fullVolName)
 
 	return cloneVolCmd
 }

--- a/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
@@ -52,6 +52,8 @@ type CStorVolumeReplica struct {
 type CStorVolumeReplicaSpec struct {
 	TargetIP string `json:"targetIP"`
 	Capacity string `json:"capacity"`
+	// ZvolWorkers represents number of threads that executes client IOs
+	ZvolWorkers string `json:"zvolWorkers"`
 }
 
 // CStorVolumeReplicaPhase is to hold result of action.

--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -528,6 +528,11 @@ spec:
             ports:
             - containerPort: 3260
               protocol: TCP
+            env:
+            - name: QueueDepth
+              value: {{ .Config.QueueDepth.value }}
+            - name: Luworkers
+              value: {{ .Config.Luworkers.value }}
             securityContext:
               privileged: true
             volumeMounts:
@@ -656,6 +661,7 @@ spec:
     {{- $replicaAntiAffinity:= .TaskResult.creategetpvc.replicaAntiAffinity -}}
     {{- $preferredReplicaAntiAffinity:= .TaskResult.creategetpvc.preferredReplicaAntiAffinity }}
     {{- $isClone := .Volume.isCloneEnable | default "false" -}}
+    {{- $zvolWorkers := .Config.ZvolWorkers.value | default "" -}}
     kind: CStorVolumeReplica
     apiVersion: openebs.io/v1alpha1
     metadata:
@@ -694,6 +700,9 @@ spec:
     spec:
       capacity: {{ .Volume.capacity }}
       targetIP: {{ .TaskResult.cvolcreateputsvc.clusterIP }}
+      {{- if ne $zvolWorkers  "" }}
+      zvolWorkers: {{ .Config.ZvolWorkers.value }}
+      {{- end }}
     status:
       # phase would be update by appropriate target
       phase: ""


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit adds `ZvolWorkers`, `QueueDepth` and  `Luworkers` cstor volume config as CAS configuration. This can be set at StorageClass.

- `QueueDepth`: sets the **queue size at iSCSI target** which limits the ongoing IO count from client. 
  - Defaults to 32
- `Luworkers`: sets the **number of threads** that are working on above queue
  - Defaults to 6
- `ZvolWorkers`: sets **thread count at pool pod** that work on IOs received from iSCSI target of a particular volume
  - Is associated with cstor volume replica
  - Defaults to the number of cores on the machine

**Note:** _Default values will be used  in case of **invalid/None** values has been provided using config 
refer PR openebs/istgt/pull/237 and  openebs/istgt/pull/234 for more details._

### Limitations:
- These config can be only used during volume provisioning

Example:-
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-cstor-sparse-auto
  annotations:
    openebs.io/cas-type: cstor
    cas.openebs.io/config: |
      - name: StoragePoolClaim
        value: "sparse-claim-auto"
      - name: QueueDepth
        value: "20"
      - name: Luworkers
        value: "10"
      - name: ZvolWorkers
        value: "4"
provisioner: openebs.io/provisioner-iscsi
```
#### How to verify the changes:
Run below commands in target and pool pods to verify that the tunnable are set correctly 

```sh
$ kubectl exec -it pvc-ba7c9f46-40d4-11e9-b548-54e1ad0c1ccc-target-f47d6b875-w6cj6  -n openebs -- istgtcontrol iostats
{
   "iqn":"iqn.2016-09.com.openebs.cstor:pvc-ba7c9f46-40d4-11e9-b548-54e1ad0c1ccc",
   "WriteIOPS":"0",
   "QueueDepth":20,
   "Luworkers":10,
   "ReadIOPS":"0",
   "TotalWriteBytes":"0",
   "TotalReadBytes":"0",
   "Size":"4294967296",
   "UsedLogicalBlocks":"12",
   "SectorSize":"512",
   "UpTime":"28",
   "TotalReadTime":"0",
   "LUTotalReadTime":"0",
   "ReplicationTotalReadTime":"0",
   "TotalWriteTime":"0",
   "LUTotalWriteTime":"0",
   "ReplicationTotalWriteTime":"0",
   "TotalReadBlockCount":"0",
   "TotalWriteBlockCount":"0",
   "ReplicaCounter":1,
   "RevisionCounter":"10",
   "Status":"Healthy",
   "Replicas":[
      {
         "replicaId":"16178149552629799470",
         "Address":"172.17.0.6",
         "Mode":"Healthy",
         "checkpointedIOSeq":"0",
         "inflightRead":"0",
         "inflightWrite":"0",
         "inflightSync":"0",
         "quorum":"1",
         "upTime":22,
         "ReadReqTime":"0",
         "ReadRespTime":"0",
         "WriteReqTime":"0",
         "WriteRespTime":"0"
      }
   ]
}
DONE IOSTATS command

```
```
$ kubectl  exec -it sparse-claim-auto-nvh7-657fdb8587-5xp5w -c cstor-pool -n openebs -- zfs stats
 
{
   "stats":[
      {
         "name":"cstor-9d669a9a-40d4-11e9-b548-54e1ad0c1ccc\/pvc-ba7c9f46-40d4-11e9-b548-54e1ad0c1ccc",
         "status":"Healthy",
         "rebuildStatus":"DONE",
         "isIOAckSenderCreated":1,
         "isIOReceiverCreated":1,
         "runningIONum":0,
         "checkpointedIONum":0,
         "degradedCheckpointedIONum":0,
         "checkpointedTime":1551961834,
         "zvol_workers":4,
         "rebuildBytes":0,
         "rebuildCnt":1,
         "rebuildDoneCnt":1,
         "rebuildFailedCnt":0,
         "readCount":0,
         "readLatency":0,
         "readByte":0,
         "writeCount":0,
         "writeLatency":0,
         "writeByte":0,
         "syncCount":0,
         "syncLatency":0,
         "inflightIOCnt":0,
         "dispatchedIOCnt":0
      }
   ]
}
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #openebs/openebs/issues/2413

**Special notes for your reviewer**:
Default values will be used in case of invalid values
 
**Checklist:**
- [x] Fixes #<issue number>
- [x] Labelled this PR & related issue with `documentation` tag
- [x] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>