### PR TITLE
feat(cast, statefulset): add support for statefulset in castemplate

### DIFF
--- a/pkg/client/k8s/k8s.go
+++ b/pkg/client/k8s/k8s.go
@@ -27,6 +27,7 @@ import (
 	api_oe_v1alpha1 "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	env "github.com/openebs/maya/pkg/env/v1alpha1"
 
+	api_apps_v1 "k8s.io/api/apps/v1"
 	api_apps_v1beta1 "k8s.io/api/apps/v1beta1"
 	api_batch_v1 "k8s.io/api/batch/v1"
 	api_core_v1 "k8s.io/api/core/v1"
@@ -51,6 +52,9 @@ import (
 type K8sKind string
 
 const (
+	// STSKK refers to Kubernetes StatefulSet kind
+	STSKK K8sKind = "StatefulSet"
+
 	// JobKK is a Kubernetes Job kind
 	JobKK K8sKind = "Job"
 
@@ -107,6 +111,10 @@ type K8sAPIVersion string
 const (
 	// ExtensionsV1Beta1KA is the extensions/v1beta API
 	ExtensionsV1Beta1KA K8sAPIVersion = "extensions/v1beta1"
+
+	// AppsV1KA refers to kubernetes API version
+	// apps/v1
+	AppsV1KA K8sAPIVersion = "apps/v1"
 
 	// AppsV1B1KA is the apps/v1beta1 API
 	AppsV1B1KA K8sAPIVersion = "apps/v1beta1"
@@ -849,6 +857,15 @@ func (k *K8sClient) DeleteBatchV1Job(name string) error {
 		&mach_apis_meta_v1.DeleteOptions{PropagationPolicy: &deletePropagation})
 }
 
+// DeleteAppsV1STS deletes a kubernetes StatefulSet
+// object
+func (k *K8sClient) DeleteAppsV1STS(name string) error {
+	deletePropagation := mach_apis_meta_v1.DeletePropagationForeground
+	return k.cs.AppsV1().StatefulSets(k.ns).Delete(
+		name,
+		&mach_apis_meta_v1.DeleteOptions{PropagationPolicy: &deletePropagation})
+}
+
 // TODO deprecate
 //
 // deploymentOps is a utility function that provides a instance capable of
@@ -1032,6 +1049,15 @@ func (k *K8sClient) CreateBatchV1JobAsRaw(j *api_batch_v1.Job) ([]byte, error) {
 		return nil, err
 	}
 	return json.Marshal(job)
+}
+
+// CreateAppsV1STSAsRaw creates a kubernetes StatefulSet
+func (k *K8sClient) CreateAppsV1STSAsRaw(sts *api_apps_v1.StatefulSet) ([]byte, error) {
+	s, err := k.cs.AppsV1().StatefulSets(k.ns).Create(sts)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(s)
 }
 
 // appsV1B1DeploymentOps is a utility function that provides a instance capable of

--- a/pkg/k8s/from_yaml.go
+++ b/pkg/k8s/from_yaml.go
@@ -23,11 +23,44 @@ import (
 
 	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	"github.com/openebs/maya/pkg/template"
+	api_apps_v1 "k8s.io/api/apps/v1"
 	api_apps_v1beta1 "k8s.io/api/apps/v1beta1"
 	api_batch_v1 "k8s.io/api/batch/v1"
 	api_core_v1 "k8s.io/api/core/v1"
 	api_extn_v1beta1 "k8s.io/api/extensions/v1beta1"
 )
+
+// STSYml helps generating kubernetes StatefulSet
+// object
+type STSYml struct {
+	// YmlInBytes represents a kubernetes StatefulSet
+	// in yaml format
+	YmlInBytes []byte
+}
+
+// NewSTSYml returns a new instance of STSYml
+func NewSTSYml(context, yml string, values map[string]interface{}) (*STSYml, error) {
+	b, err := template.AsTemplatedBytes(context, yml, values)
+	if err != nil {
+		return nil, err
+	}
+	return &STSYml{
+		YmlInBytes: b,
+	}, nil
+}
+
+// AsAppsV1STS returns a apps/v1 StatefulSet instance
+func (m *STSYml) AsAppsV1STS() (*api_apps_v1.StatefulSet, error) {
+	if m.YmlInBytes == nil {
+		return nil, fmt.Errorf("missing statefulset yaml")
+	}
+	sts := &api_apps_v1.StatefulSet{}
+	err := yaml.Unmarshal(m.YmlInBytes, sts)
+	if err != nil {
+		return nil, err
+	}
+	return sts, nil
+}
 
 // JobYml helps generating kubernetes Job object
 type JobYml struct {

--- a/pkg/task/identity.go
+++ b/pkg/task/identity.go
@@ -90,6 +90,10 @@ func (i taskIdentifier) isJob() bool {
 	return i.identity.Kind == string(m_k8s_client.JobKK)
 }
 
+func (i taskIdentifier) isSTS() bool {
+	return i.identity.Kind == string(m_k8s_client.STSKK)
+}
+
 func (i taskIdentifier) isService() bool {
 	return i.identity.Kind == string(m_k8s_client.ServiceKK)
 }
@@ -124,6 +128,10 @@ func (i taskIdentifier) isBatchV1() bool {
 
 func (i taskIdentifier) isAppsV1B1() bool {
 	return i.identity.APIVersion == string(m_k8s_client.AppsV1B1KA)
+}
+
+func (i taskIdentifier) isAppsV1() bool {
+	return i.identity.APIVersion == string(m_k8s_client.AppsV1KA)
 }
 
 func (i taskIdentifier) isCoreV1() bool {
@@ -180,6 +188,10 @@ func (i taskIdentifier) isExtnV1B1ReplicaSet() bool {
 
 func (i taskIdentifier) isBatchV1Job() bool {
 	return i.isBatchV1() && i.isJob()
+}
+
+func (i taskIdentifier) isAppsV1STS() bool {
+	return i.isAppsV1() && i.isSTS()
 }
 
 func (i taskIdentifier) isAppsV1B1Deploy() bool {

--- a/pkg/task/meta.go
+++ b/pkg/task/meta.go
@@ -319,6 +319,10 @@ func (m *metaTaskExecutor) isPutBatchV1Job() bool {
 	return m.identifier.isBatchV1Job() && m.isPut()
 }
 
+func (m *metaTaskExecutor) isPutAppsV1STS() bool {
+	return m.identifier.isAppsV1STS() && m.isPut()
+}
+
 func (m *metaTaskExecutor) isPatchExtnV1B1Deploy() bool {
 	return m.identifier.isExtnV1B1Deploy() && m.isPatch()
 }
@@ -397,6 +401,10 @@ func (m *metaTaskExecutor) isGetExtnV1B1Deploy() bool {
 
 func (m *metaTaskExecutor) isDeleteBatchV1Job() bool {
 	return m.identifier.isBatchV1Job() && m.isDelete()
+}
+
+func (m *metaTaskExecutor) isDeleteAppsV1STS() bool {
+	return m.identifier.isAppsV1STS() && m.isDelete()
 }
 
 func (m *metaTaskExecutor) isGetOEV1alpha1Disk() bool {


### PR DESCRIPTION
This commit adds support to create and delete a kubernetes `StatefulSet` object via `CASTemplate`.

- Kubernetes api version supported for StatefulSet is "apps/v1"
- This support enables maya to provision volumes as StatefulSet as well.

_NOTE: Till now cstor & jiva volumes make use of kubernetes Deployment as a resource to provision volumes_

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests