### PR TITLE
Cherry pick pool exporter

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -235,7 +235,7 @@ exporter-image: exporter
 	@echo "--> m-exporter image         "
 	@echo "----------------------------"
 	@cp bin/exporter/${EXPORTER} buildscripts/exporter/
-	@cd buildscripts/exporter && sudo docker build -t openebs/m-exporter:${IMAGE_TAG} --build-arg BUILD_DATE=${BUILD_DATE} .
+	@cd buildscripts/exporter && sudo docker build -t openebs/m-exporter:${IMAGE_TAG} --build-arg BUILD_DATE=${BUILD_DATE} --build-arg BASE_IMAGE=${CSTOR_BASE_IMAGE} .
 	@rm buildscripts/exporter/${EXPORTER}
 
 # Use this to build only the maya apiserver.

--- a/buildscripts/exporter/Dockerfile
+++ b/buildscripts/exporter/Dockerfile
@@ -1,12 +1,10 @@
-FROM alpine:3.6
+#openebs/cstor-base is the image that contains cstor related binaries and
+#libraries - zpool, zfs, zrepl
+#FROM openebs/cstor-base:ci
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
+
 ADD maya-exporter /usr/local/bin
-RUN apk add --no-cache \
-     iproute2 \
-     curl \
-     net-tools \
-     mii-tool \
-     procps \
-     libc6-compat
 
 ARG BUILD_DATE
 LABEL org.label-schema.name="m-exporter"

--- a/cmd/cstor-pool-mgmt/controller/common/common_test.go
+++ b/cmd/cstor-pool-mgmt/controller/common/common_test.go
@@ -117,6 +117,11 @@ func (r TestRunner) RunStdoutPipe(command string, args ...string) ([]byte, error
 	return data, nil
 }
 
+// RunCommandWithTimeoutContext is to mock Real runner exec.
+func (r TestRunner) RunCommandWithTimeoutContext(timeout time.Duration, command string, args ...string) ([]byte, error) {
+	return []byte("success"), nil
+}
+
 // TestGetterProcess is to fake get process
 func TestGetterProcess(*testing.T) {
 	if os.Getenv("poolName") != "cstor-123abc" {

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/run_replica_controller_test.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/run_replica_controller_test.go
@@ -185,6 +185,11 @@ var RunnerVar util.Runner
 
 type TestRunner struct{}
 
+// RunCommandWithTimeoutContext is to mock real runner exec with stdoutpipe.
+func (r TestRunner) RunCommandWithTimeoutContext(timeout time.Duration, command string, args ...string) ([]byte, error) {
+	return []byte("success"), nil
+}
+
 // RunCombinedOutput is to mock binaries with fake test binaries.
 func (r TestRunner) RunCombinedOutput(command string, args ...string) ([]byte, error) {
 	var cs []string

--- a/cmd/cstor-pool-mgmt/pool/pool_test.go
+++ b/cmd/cstor-pool-mgmt/pool/pool_test.go
@@ -35,6 +35,11 @@ type TestRunner struct {
 	expectedError string
 }
 
+// RunCommandWithTimeoutContext is to mock Real runner exec.
+func (r TestRunner) RunCommandWithTimeoutContext(timeout time.Duration, command string, args ...string) ([]byte, error) {
+	return []byte("success"), nil
+}
+
 // RunCombinedOutput is to mock Real runner exec.
 func (r TestRunner) RunCombinedOutput(command string, args ...string) ([]byte, error) {
 	var cs []string

--- a/cmd/cstor-pool-mgmt/volumereplica/volumereplica_test.go
+++ b/cmd/cstor-pool-mgmt/volumereplica/volumereplica_test.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/golang/glog"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
@@ -58,6 +59,11 @@ func (r TestRunner) RunCombinedOutput(command string, args ...string) ([]byte, e
 	cmd.Env = env
 	stdout, err := cmd.CombinedOutput()
 	return stdout, err
+}
+
+// RunCommandWithTimeoutContext is to mock real runner exec with stdoutpipe.
+func (r TestRunner) RunCommandWithTimeoutContext(timeout time.Duration, command string, args ...string) ([]byte, error) {
+	return []byte("success"), nil
 }
 
 // RunStdoutPipe is to mock real runner exec with stdoutpipe.

--- a/cmd/maya-exporter/app/collector/cstor_test.go
+++ b/cmd/maya-exporter/app/collector/cstor_test.go
@@ -19,11 +19,11 @@ import (
 )
 
 var (
-	SplittedResponse             = "{ \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"UpTime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\", \"RevisionCounter\":\"1000\", \"ReplicaCounter\":\"3\", \"Replicas\":[{\"Address\":\"tcp://172.18.0.3:9502\",\"Mode\":\"DEGRADED\"},{\"Address\":\"tcp://172.18.0.4:9502\",\"Mode\":\"HEALTHY\"},{\"Address\":\"tcp://172.18.0.5:9502\",\"Mode\":\"HEALTHY\"}] }"
+	SplittedResponse             = "{ \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"UpTime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\", \"RevisionCounter\":\"1000\", \"ReplicaCounter\":\"3\", \"Replicas\":[{\"Address\":\"tcp://172.18.0.3:9502\",\"Mode\":\"Degraded\"},{\"Address\":\"tcp://172.18.0.4:9502\",\"Mode\":\"Healthy\"},{\"Address\":\"tcp://172.18.0.5:9502\",\"Mode\":\"Healthy\"}] }"
 	NilCstorResponse             = "OK IOSTATS\r\n"
-	CstorResponse                = "IOSTATS  { \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"UpTime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\", \"RevisionCounter\":\"1000\", \"ReplicaCounter\":\"3\", \"Replicas\":[{\"Address\":\"tcp://172.18.0.3:9502\",\"Mode\":\"DEGRADED\"},{\"Address\":\"tcp://172.18.0.4:9502\",\"Mode\":\"HEALTHY\"},{\"Address\":\"tcp://172.18.0.5:9502\",\"Mode\":\"HEALTHY\"}] }\r\nOK IOSTATS\r\n"
-	JSONFormatedResponse         = "{ \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"UpTime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\", \"RevisionCounter\":\"1000\", \"ReplicaCounter\":\"3\", \"Replicas\":[{\"Address\":\"tcp://172.18.0.3:9502\",\"Mode\":\"DEGRADED\"},{\"Address\":\"tcp://172.18.0.4:9502\",\"Mode\":\"HEALTHY\"},{\"Address\":\"tcp://172.18.0.5:9502\",\"Mode\":\"HEALTHY\"}] }"
-	ImproperJSONFormatedResponse = `IOSTATS  { \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"UpTime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\", \"RevisionCounter\":\"1000\", \"ReplicaCounter\":\"3\", \"Replicas\":[{\"Address\":\"tcp://172.18.0.3:9502\",\"Mode\":\"DEGRADED\"},{\"Address\":\"tcp://172.18.0.4:9502\",\"Mode\":\"HEALTHY\"},{\"Address\":\"tcp://172.18.0.5:9502\",\"Mode\":\"HEALTHY\"}] }\r\nOK IOSTATS\r\n`
+	CstorResponse                = "IOSTATS  { \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"UpTime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\", \"RevisionCounter\":\"1000\", \"ReplicaCounter\":\"3\", \"Replicas\":[{\"Address\":\"tcp://172.18.0.3:9502\",\"Mode\":\"Degraded\"},{\"Address\":\"tcp://172.18.0.4:9502\",\"Mode\":\"Healthy\"},{\"Address\":\"tcp://172.18.0.5:9502\",\"Mode\":\"Healthy\"}] }\r\nOK IOSTATS\r\n"
+	JSONFormatedResponse         = "{ \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"UpTime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\", \"RevisionCounter\":\"1000\", \"ReplicaCounter\":\"3\", \"Replicas\":[{\"Address\":\"tcp://172.18.0.3:9502\",\"Mode\":\"Degraded\"},{\"Address\":\"tcp://172.18.0.4:9502\",\"Mode\":\"Healthy\"},{\"Address\":\"tcp://172.18.0.5:9502\",\"Mode\":\"Healthy\"}] }"
+	ImproperJSONFormatedResponse = `IOSTATS  { \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"UpTime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\", \"RevisionCounter\":\"1000\", \"ReplicaCounter\":\"3\", \"Replicas\":[{\"Address\":\"tcp://172.18.0.3:9502\",\"Mode\":\"Degraded\"},{\"Address\":\"tcp://172.18.0.4:9502\",\"Mode\":\"Healthy\"},{\"Address\":\"tcp://172.18.0.5:9502\",\"Mode\":\"Healthy\"}] }\r\nOK IOSTATS\r\n`
 )
 
 func fakeCstor(path string) *cstor {
@@ -214,15 +214,15 @@ func TestUnmarshal(t *testing.T) {
 				Replicas: []v1.Replica{
 					{
 						Address: "tcp://172.18.0.3:9502",
-						Mode:    "DEGRADED",
+						Mode:    "Degraded",
 					},
 					{
 						Address: "tcp://172.18.0.4:9502",
-						Mode:    "HEALTHY",
+						Mode:    "Healthy",
 					},
 					{
 						Address: "tcp://172.18.0.5:9502",
-						Mode:    "HEALTHY",
+						Mode:    "Healthy",
 					},
 				},
 			},

--- a/cmd/maya-exporter/app/collector/metrics.go
+++ b/cmd/maya-exporter/app/collector/metrics.go
@@ -46,9 +46,9 @@ type metrics struct {
 	totalWriteBytes        prometheus.Gauge
 	sizeOfVolume           prometheus.Gauge
 	volumeStatus           prometheus.Gauge
+	parseErrorCounter      prometheus.Gauge
 	connectionRetryCounter prometheus.Gauge
 	connectionErrorCounter prometheus.Gauge
-	parseErrorCounter      prometheus.Gauge
 	healthyReplicaCounter  prometheus.Gauge
 	degradedReplicaCounter prometheus.Gauge
 	totalReplicaCounter    prometheus.Gauge

--- a/cmd/maya-exporter/app/collector/metrics.go
+++ b/cmd/maya-exporter/app/collector/metrics.go
@@ -245,10 +245,12 @@ func (v *stats) getReplicaCount() {
 	)
 	for _, rep := range v.replicas {
 		switch rep.Mode {
-		case readOnly, writeOnly, degraded:
+		case readOnly, writeOnly, errored, degraded:
 			ro++
 		case readWrite, healthy:
 			rw++
+		default:
+			glog.Error("Unknown replica mode: ", rep.Mode)
 		}
 	}
 	v.degradedReplicaCount = ro

--- a/cmd/maya-exporter/app/collector/pool/metrics.go
+++ b/cmd/maya-exporter/app/collector/pool/metrics.go
@@ -1,0 +1,144 @@
+package pool
+
+import (
+	"strconv"
+
+	zpool "github.com/openebs/maya/pkg/zpool/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type metrics struct {
+	size                prometheus.Gauge
+	usedCapacity        prometheus.Gauge
+	freeCapacity        prometheus.Gauge
+	usedCapacityPercent prometheus.Gauge
+	status              *prometheus.GaugeVec
+
+	zpoolCommandErrorCounter     prometheus.Gauge
+	zpoolRejectRequestCounter    prometheus.Gauge
+	zpoolListparseErrorCounter   prometheus.Gauge
+	noPoolAvailableErrorCounter  prometheus.Gauge
+	incompleteOutputErrorCounter prometheus.Gauge
+}
+
+type statsFloat64 struct {
+	status              float64
+	size                float64
+	used                float64
+	free                float64
+	usedCapacityPercent float64
+}
+
+// List returns list of type float64 of various stats
+// NOTE: Please donot change the order, add the new stats
+// at the end of the list.
+func (s *statsFloat64) List() []float64 {
+	return []float64{
+		s.size,
+		s.used,
+		s.free,
+		s.usedCapacityPercent,
+	}
+}
+
+func parseFloat64(e string, m *metrics, ch chan<- prometheus.Metric) float64 {
+	num, err := strconv.ParseFloat(e, 64)
+	if err != nil {
+		m.zpoolListparseErrorCounter.Inc()
+	}
+	return num
+}
+
+func (s *statsFloat64) parse(stats zpool.Stats, p *pool, ch chan<- prometheus.Metric) {
+	s.size = parseFloat64(stats.Size, &p.metrics, ch)
+	s.used = parseFloat64(stats.Used, &p.metrics, ch)
+	s.free = parseFloat64(stats.Free, &p.metrics, ch)
+	s.status = zpool.Status[stats.Status]
+	s.usedCapacityPercent = parseFloat64(stats.UsedCapacityPercent, &p.metrics, ch)
+}
+
+// newMetrics initializes fields of the metrics and returns its instance
+func newMetrics() metrics {
+	return metrics{
+		size: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "pool_size",
+				Help:      "Size of pool",
+			},
+		),
+
+		status: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "pool_status",
+				Help:      `Status of pool (0, 1, 2, 3, 4, 5, 6)= {"Offline", "Online", "Degraded", "Faulted", "Removed", "Unavail", "NoPoolsAvailable"}`,
+			},
+			[]string{"pool"},
+		),
+
+		usedCapacity: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "used_pool_capacity",
+				Help:      "Capacity used by pool",
+			},
+		),
+
+		freeCapacity: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "free_pool_capacity",
+				Help:      "Free capacity in pool",
+			},
+		),
+
+		usedCapacityPercent: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "used_pool_capacity_percent",
+				Help:      "Capacity used by pool in percent",
+			},
+		),
+
+		zpoolListparseErrorCounter: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "zpool_list_parse_error_count",
+				Help:      "Total no of parsing errors",
+			},
+		),
+
+		zpoolRejectRequestCounter: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "zpool_reject_request_count",
+				Help:      "Total no of rejected requests of zpool command",
+			},
+		),
+
+		zpoolCommandErrorCounter: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "zpool_command_error",
+				Help:      "Total no of zpool command errors",
+			},
+		),
+
+		noPoolAvailableErrorCounter: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "no_pool_available_error",
+				Help:      "Total no of no pool available errors",
+			},
+		),
+
+		incompleteOutputErrorCounter: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "zpool_list_incomplete_stdout_error",
+				Help:      "Total no of incomplete stdout of zpool list command errors",
+			},
+		),
+	}
+}

--- a/cmd/maya-exporter/app/collector/pool/pool.go
+++ b/cmd/maya-exporter/app/collector/pool/pool.go
@@ -1,0 +1,173 @@
+package pool
+
+import (
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/openebs/maya/pkg/util"
+	zpool "github.com/openebs/maya/pkg/zpool/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// pool implements prometheus.Collector interface
+type pool struct {
+	sync.Mutex
+	metrics
+	request bool
+}
+
+var (
+	// runner variable is used for executing binaries
+	runner util.Runner
+)
+
+// InitVar initialize runner variable
+func InitVar() {
+	runner = util.RealRunner{}
+}
+
+// New returns new instance of pool
+func New() *pool {
+	return &pool{
+		metrics: newMetrics(),
+	}
+}
+
+func (p *pool) isRequestInProgress() bool {
+	return p.request
+}
+
+func (p *pool) setRequestToFalse() {
+	p.Lock()
+	p.request = false
+	p.Unlock()
+}
+
+// GetInitStatus run zpool binary to verify whether zpool container
+// has started.
+func (p *pool) GetInitStatus(timeout time.Duration) {
+
+	for {
+		stdout, err := zpool.Run(timeout, runner, "status")
+		if err != nil {
+			glog.Warningf("Failed to get zpool status, error: %v, pool container may be initializing,  retry after 2s", err)
+			time.Sleep(2 * time.Second)
+			continue
+		}
+		str := string(stdout)
+		if zpool.IsNotAvailable(str) {
+			glog.Warning("No pool available, pool must be creating, retry after 3s")
+			time.Sleep(3 * time.Second)
+			continue
+		}
+		glog.Info("\n", string(stdout))
+		break
+	}
+}
+
+// collectors returns the list of the collectors
+func (p *pool) collectors() []prometheus.Collector {
+	return []prometheus.Collector{
+		p.size,
+		p.status,
+		p.usedCapacity,
+		p.freeCapacity,
+		p.usedCapacityPercent,
+		p.zpoolCommandErrorCounter,
+		p.zpoolRejectRequestCounter,
+		p.zpoolListparseErrorCounter,
+		p.noPoolAvailableErrorCounter,
+		p.incompleteOutputErrorCounter,
+	}
+}
+
+// gaugeVec returns list of Gauge vectors (prometheus's type)
+// related to zpool in which values will be set.
+// NOTE: Please donot edit the order, add new metrics at the end of
+// the list
+func (p *pool) gaugeVec() []prometheus.Gauge {
+	return []prometheus.Gauge{
+		p.size,
+		p.usedCapacity,
+		p.freeCapacity,
+		p.usedCapacityPercent,
+	}
+}
+
+// Describe is implementation of Describe method of prometheus.Collector
+// interface.
+func (p *pool) Describe(ch chan<- *prometheus.Desc) {
+	for _, col := range p.collectors() {
+		col.Describe(ch)
+	}
+}
+
+func (p *pool) getZpoolStats(ch chan<- prometheus.Metric) (zpool.Stats, error) {
+	var (
+		err         error
+		stdoutZpool []byte
+		timeout     = 30 * time.Second
+		zpoolStats  = zpool.Stats{}
+	)
+
+	stdoutZpool, err = zpool.Run(timeout, runner, "list", "-Hp")
+	if err != nil {
+		p.zpoolCommandErrorCounter.Inc()
+		p.zpoolCommandErrorCounter.Collect(ch)
+		return zpoolStats, err
+	}
+
+	glog.V(2).Infof("Parse stdout of zpool list command, stdout: %v", string(stdoutZpool))
+	zpoolStats, err = zpool.ListParser(stdoutZpool)
+	if err != nil {
+		if err.Error() == string(zpool.NoPoolAvailable) {
+			p.noPoolAvailableErrorCounter.Inc()
+			p.noPoolAvailableErrorCounter.Collect(ch)
+		} else {
+			p.incompleteOutputErrorCounter.Inc()
+			p.incompleteOutputErrorCounter.Collect(ch)
+		}
+
+		return zpoolStats, err
+	}
+
+	return zpoolStats, nil
+}
+
+// Collect is implementation of prometheus's prometheus.Collector interface
+func (p *pool) Collect(ch chan<- prometheus.Metric) {
+
+	p.Lock()
+	if p.isRequestInProgress() {
+		p.zpoolRejectRequestCounter.Inc()
+		p.Unlock()
+		p.zpoolRejectRequestCounter.Collect(ch)
+		return
+	}
+
+	p.request = true
+	p.Unlock()
+
+	poolStats := statsFloat64{}
+	zpoolStats, err := p.getZpoolStats(ch)
+	if err != nil {
+		p.setRequestToFalse()
+		return
+	}
+	glog.V(2).Infof("Got zpool stats: %#v", zpoolStats)
+	poolStats.parse(zpoolStats, p, ch)
+	p.setZPoolStats(poolStats, zpoolStats.Name)
+	for _, col := range p.collectors() {
+		col.Collect(ch)
+	}
+	p.setRequestToFalse()
+}
+
+func (p *pool) setZPoolStats(stats statsFloat64, name string) {
+	items := stats.List()
+	for index, col := range p.gaugeVec() {
+		col.Set(items[index])
+	}
+	p.status.WithLabelValues(name).Set(stats.status)
+}

--- a/cmd/maya-exporter/app/collector/pool/pool_test.go
+++ b/cmd/maya-exporter/app/collector/pool/pool_test.go
@@ -1,0 +1,286 @@
+package pool
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var count int
+
+type testRunner struct {
+	stdout  []byte
+	isError bool
+}
+
+func (r testRunner) RunCombinedOutput(cmd string, args ...string) ([]byte, error) {
+	return nil, nil
+}
+
+func (r testRunner) RunStdoutPipe(cmd string, args ...string) ([]byte, error) {
+	return nil, nil
+}
+
+func (r testRunner) RunCommandWithTimeoutContext(timeout time.Duration, cmd string, args ...string) ([]byte, error) {
+	if r.isError {
+		switch count {
+		case 1:
+			count++
+			return []byte("no pools available"), nil
+		case 2:
+			return []byte("ONLINE"), nil
+		case 3:
+			count = 1
+			return nil, errors.New("some dummy error")
+		default:
+			return nil, errors.New("some dummy error")
+		}
+	}
+	return r.stdout, nil
+}
+
+func TestGetZpoolStats(t *testing.T) {
+	cases := map[string]struct {
+		run            testRunner
+		match, unmatch []*regexp.Regexp
+	}{
+		"Test0": {
+			run: testRunner{
+				stdout: []byte("cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a	1024	24	1000	-	0	0	1.00 ONLINE	-"),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_pool_size 1024`),
+				regexp.MustCompile(`openebs_pool_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a"} 1`),
+				regexp.MustCompile(`openebs_used_pool_capacity 24`),
+				regexp.MustCompile(`openebs_free_pool_capacity 1000`),
+				regexp.MustCompile(`openebs_used_pool_capacity_percent 0`),
+			},
+		},
+		"Test1": {
+			run: testRunner{
+				stdout: []byte("cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a	1024	24	1000	-	0	0	1.00 OFFLINE	-"),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_pool_size 1024`),
+				regexp.MustCompile(`openebs_pool_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a"} 0`),
+				regexp.MustCompile(`openebs_used_pool_capacity 24`),
+				regexp.MustCompile(`openebs_free_pool_capacity 1000`),
+				regexp.MustCompile(`openebs_used_pool_capacity_percent 0`),
+			},
+		},
+		"Test2": {
+			run: testRunner{
+				stdout: []byte("cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a	1024	24	1000	-	0	0	1.00 UNAVAIL	-"),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_pool_size 1024`),
+				regexp.MustCompile(`openebs_pool_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a"} 5`),
+				regexp.MustCompile(`openebs_used_pool_capacity 24`),
+				regexp.MustCompile(`openebs_free_pool_capacity 1000`),
+				regexp.MustCompile(`openebs_used_pool_capacity_percent 0`),
+			},
+		},
+		"Test3": {
+			run: testRunner{
+				stdout: []byte("cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a	1024	24	1000	-	0	0	1.00 FAULTED	-"),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_pool_size 1024`),
+				regexp.MustCompile(`openebs_pool_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a"} 3`),
+				regexp.MustCompile(`openebs_used_pool_capacity 24`),
+				regexp.MustCompile(`openebs_free_pool_capacity 1000`),
+				regexp.MustCompile(`openebs_used_pool_capacity_percent 0`),
+			},
+		},
+		"Test4": {
+			run: testRunner{
+				stdout: []byte("cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a	1024	24	1000	-	0	0	1.00 REMOVED	-"),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_pool_size 1024`),
+				regexp.MustCompile(`openebs_pool_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a"} 4`),
+				regexp.MustCompile(`openebs_used_pool_capacity 24`),
+				regexp.MustCompile(`openebs_free_pool_capacity 1000`),
+				regexp.MustCompile(`openebs_used_pool_capacity_percent 0`),
+			},
+		},
+		"Test5": {
+			run: testRunner{
+				stdout: []byte("no pools available"),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_no_pool_available_error 1`),
+			},
+		},
+		"Test6": {
+			run: testRunner{
+				stdout: []byte("cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a  1024    24  1000    -"),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_zpool_list_incomplete_stdout_error 1`),
+			},
+		},
+
+		"Test7": {
+			run: testRunner{
+				isError: true,
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_zpool_command_error 1`),
+			},
+		},
+		"Test8": {
+			run: testRunner{
+				stdout: []byte("cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a	iaueb7	aiwub	aliubv	-	0	iauwb	1.00 REMOVED	-"),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_zpool_list_parse_error_count 4`),
+			},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			runner = tt.run
+			pool := New()
+			if err := prometheus.Register(pool); err != nil {
+				t.Fatalf("collector failed to register: %s", err)
+			}
+			defer prometheus.Unregister(pool)
+
+			server := httptest.NewServer(promhttp.Handler())
+			defer server.Close()
+
+			client := http.DefaultClient
+			client.Timeout = 5 * time.Second
+			resp, err := client.Get(server.URL)
+			if err != nil {
+				t.Fatalf("unexpected failed response from prometheus: %s", err)
+			}
+			defer resp.Body.Close()
+
+			buf, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("failed reading server response: %s", err)
+			}
+
+			for _, re := range tt.match {
+				if !re.Match(buf) {
+					fmt.Println(string(buf))
+					t.Errorf("failed matching: %q", re)
+				}
+			}
+
+			for _, re := range tt.unmatch {
+				if !re.Match(buf) {
+					t.Errorf("failed unmatching: %q", re)
+				}
+			}
+		})
+	}
+}
+
+func TestGetInitStatus(t *testing.T) {
+	cases := map[string]struct {
+		run   testRunner
+		count int
+	}{
+		"Test0": {
+			run: testRunner{
+				stdout: []byte(`
+				pool: mypool
+				state: ONLINE
+				 scan: none requested
+			   config:
+
+				   NAME                                  STATE     READ WRITE CKSUM
+				   mypool                                ONLINE       0     0     0
+					 raidz1-0                            ONLINE       0     0     0
+					   /home/infinity/experiments/pool1  ONLINE       0     0     0
+					   /home/infinity/experiments/pool2  ONLINE       0     0     0
+					 raidz1-1                            ONLINE       0     0     0
+					   /home/infinity/experiments/pool3  ONLINE       0     0     0
+					   /home/infinity/experiments/pool4  ONLINE       0     0     0`),
+			},
+		},
+		"Test1": {
+			run: testRunner{
+				isError: true,
+			},
+			count: 3,
+		},
+		"Test2": {
+			run: testRunner{
+				isError: true,
+			},
+			count: 1,
+		},
+	}
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			runner = tt.run
+			pool := New()
+			count = tt.count
+			pool.GetInitStatus(1 * time.Second)
+		})
+	}
+}
+
+func TestRejectRequestCounter(t *testing.T) {
+	reqCount := 100
+	output := regexp.MustCompile(`openebs_zpool_reject_request_count\s\d+`)
+	runner = testRunner{
+		stdout: []byte("cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a	3000	23423 1341	-	0	iauwb	1.00 REMOVED	-"),
+	}
+	col := New()
+	if err := prometheus.Register(col); err != nil {
+		t.Fatalf("collector failed to register: %s", err)
+	}
+
+	server := httptest.NewServer(promhttp.Handler())
+	var body io.ReadCloser
+
+	wg := sync.WaitGroup{}
+	wg.Add(reqCount)
+	for i := 0; i < reqCount; i++ {
+		go func(server *httptest.Server) {
+			defer wg.Done()
+			client := http.DefaultClient
+			client.Timeout = 5 * time.Second
+			resp, err := client.Get(server.URL)
+			body = resp.Body
+			if err != nil {
+				t.Fatalf("unexpected failed response from prometheus: %s", err)
+			}
+		}(server)
+	}
+
+	wg.Wait()
+	defer body.Close()
+
+	buf, err := ioutil.ReadAll(body)
+	if err != nil {
+		t.Fatalf("failed reading server response: %s", err)
+	}
+
+	str := output.FindStringSubmatch(string(buf))
+	newStr := strings.Fields(str[0])
+	reqCount, _ = strconv.Atoi(newStr[1])
+	if reqCount <= 0 {
+		t.Fatalf("Failed to test reject request count, fount str: %s, buf: %s", str, string(buf))
+	}
+	prometheus.Unregister(col)
+	server.Close()
+}

--- a/cmd/maya-exporter/app/collector/types.go
+++ b/cmd/maya-exporter/app/collector/types.go
@@ -23,11 +23,12 @@ const (
 )
 
 const (
+	errored         = v1.ReplicaMode("ERR")
 	writeOnly       = v1.ReplicaMode("WO")
 	readOnly        = v1.ReplicaMode("RO")
-	degraded        = v1.ReplicaMode("DEGRADED")
+	degraded        = v1.ReplicaMode("Degraded")
 	readWrite       = v1.ReplicaMode("RW")
-	healthy         = v1.ReplicaMode("HEALTHY")
+	healthy         = v1.ReplicaMode("Healthy")
 	targetOffline   = v1.TargetMode("Offline")
 	targetDegraded  = v1.TargetMode("Degraded")
 	targetHealthy   = v1.TargetMode("Healthy")

--- a/cmd/maya-exporter/app/collector/zvol/list.go
+++ b/cmd/maya-exporter/app/collector/zvol/list.go
@@ -1,0 +1,107 @@
+package zvol
+
+import (
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	zvol "github.com/openebs/maya/pkg/zvol/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// volumeList implements prometheus.Collector interface
+type volumeList struct {
+	sync.Mutex
+	listMetrics
+	request bool
+}
+
+// NewVolumeList returns new instance of volumeList
+func NewVolumeList() *volumeList {
+	return &volumeList{
+		listMetrics: newListMetrics(),
+	}
+}
+
+func (v *volumeList) isRequestInProgress() bool {
+	return v.request
+}
+
+func (v *volumeList) setRequestToFalse() {
+	v.Lock()
+	v.request = false
+	v.Unlock()
+}
+
+// collectors returns the list of the collectors
+func (v *volumeList) collectors() []prometheus.Collector {
+	return []prometheus.Collector{
+		v.used,
+		v.available,
+		v.zfsListParseErrorCounter,
+		v.zfsListCommandErrorCounter,
+		v.zfsListRequestRejectCounter,
+	}
+}
+
+// Describe is implementation of Describe method of prometheus.Collector
+// interface.
+func (v *volumeList) Describe(ch chan<- *prometheus.Desc) {
+	for _, col := range v.collectors() {
+		col.Describe(ch)
+	}
+}
+
+func (v *volumeList) get(ch chan<- prometheus.Metric) ([]fields, error) {
+	v.Lock()
+	defer v.Unlock()
+	var timeout = 30 * time.Second
+
+	glog.V(2).Info("Run zfs list command")
+	stdout, err := zvol.Run(timeout, runner, "list", "-Hp")
+	if err != nil {
+		v.zfsListCommandErrorCounter.Inc()
+		v.zfsListCommandErrorCounter.Collect(ch)
+		return nil, err
+	}
+
+	glog.V(2).Infof("Parse stdout of zfs list command, got stdout: \n%v", string(stdout))
+	list := listParser(stdout, &v.listMetrics)
+
+	return list, nil
+}
+
+// Collect is implementation of prometheus's prometheus.Collector interface
+func (v *volumeList) Collect(ch chan<- prometheus.Metric) {
+	v.Lock()
+	if v.isRequestInProgress() {
+		v.zfsListRequestRejectCounter.Inc()
+		v.Unlock()
+		v.zfsListRequestRejectCounter.Collect(ch)
+		return
+
+	}
+
+	v.request = true
+	v.Unlock()
+
+	volumeLists, err := v.get(ch)
+	if err != nil {
+		v.setRequestToFalse()
+		return
+	}
+
+	glog.V(2).Infof("Got zfs list: %#v", volumeLists)
+	v.setListStats(volumeLists)
+	for _, col := range v.collectors() {
+		col.Collect(ch)
+	}
+	v.setRequestToFalse()
+}
+
+func (v *volumeList) setListStats(volumeLists []fields) {
+	for _, vol := range volumeLists {
+		v.used.WithLabelValues(vol.name).Set(vol.used)
+		v.available.WithLabelValues(vol.name).Set(vol.available)
+	}
+}

--- a/cmd/maya-exporter/app/collector/zvol/list_test.go
+++ b/cmd/maya-exporter/app/collector/zvol/list_test.go
@@ -1,0 +1,236 @@
+package zvol
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+func TestGetZfsList(t *testing.T) {
+	cases := map[string]struct {
+		run   testRunner
+		match []*regexp.Regexp
+	}{
+		"Test0": {
+			run: testRunner{
+				stdout: []byte(`cstor-f1ea249b-417d-11e9-9c76-42010a8001a5	238592	3000	512	/cstor-f1ea249b-417d-11e9-9c76-42010a8001a5
+				cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5	6144	3000	6144	-
+				cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone	0	3000	6144	-`),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_available_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5"} 3000`),
+				regexp.MustCompile(`openebs_available_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5"} 3000`),
+				regexp.MustCompile(`openebs_available_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone"} 3000`),
+				regexp.MustCompile(`openebs_used_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5"} 238592`),
+				regexp.MustCompile(`openebs_used_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5"} 6144`),
+				regexp.MustCompile(`openebs_used_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone"} 0`),
+			},
+		},
+		"Test1": {
+			run: testRunner{
+				stdout: []byte(`cstor-f1ea249b-417d-11e9-9c76-42010a8001a5	238592	3000	512	/cstor-f1ea249b-417d-11e9-9c76-42010a8001a5
+				cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5	3055	3000	6144	-
+				cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone	0	3000	6144	-`),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_available_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5"} 3000`),
+				regexp.MustCompile(`openebs_available_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5"} 3000`),
+				regexp.MustCompile(`openebs_available_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone"} 3000`),
+				regexp.MustCompile(`openebs_used_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5"} 238592`),
+				regexp.MustCompile(`openebs_used_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5"} 3055`),
+				regexp.MustCompile(`openebs_used_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone"} 0`),
+			},
+		},
+		"Test2": {
+			run: testRunner{
+				stdout: []byte(`cstor-f1ea249b-417d-11e9-9c76-42010a8001a5	238592	3000	512	/cstor-f1ea249b-417d-11e9-9c76-42010a8001a5
+				cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c1a68fa3-4183-11e9-9c76-42010a8001a5	6144	3000	6144	-
+				cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c1a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone	0	3000	6144	-
+				cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5	6144	3000	6144	-
+				cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone	0	3000	6144	-`),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_available_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5"} 3000`),
+				regexp.MustCompile(`openebs_available_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c1a68fa3-4183-11e9-9c76-42010a8001a5"} 3000`),
+				regexp.MustCompile(`openebs_available_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c1a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone"} 3000`),
+				regexp.MustCompile(`openebs_available_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5"} 3000`),
+				regexp.MustCompile(`openebs_available_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone"} 3000`),
+				regexp.MustCompile(`openebs_used_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5"} 238592`),
+				regexp.MustCompile(`openebs_used_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c1a68fa3-4183-11e9-9c76-42010a8001a5"} 6144`),
+				regexp.MustCompile(`openebs_used_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c1a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone"} 0`),
+				regexp.MustCompile(`openebs_used_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5"} 6144`),
+				regexp.MustCompile(`openebs_used_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone"} 0`),
+			},
+		},
+		"Test3": {
+			run: testRunner{
+				stdout: []byte(`cstor-f1ea249b-417d-11e9-9c76-42010a8001a5	238592	3000	512	/cstor-f1ea249b-417d-11e9-9c76-42010a8001a5
+				cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c3a68fa3-4183-11e9-9c76-42010a8001a5	6144	3000	6144	-
+				cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c3a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone	0	3000	6144	-
+				cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c1a68fa3-4183-11e9-9c76-42010a8001a5	6144	3000	6144	-
+				cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c1a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone	0	3000	6144	-
+				cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5	6144	3000	6144	-
+				cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone	0	3000	6144	-`),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_available_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5"} 3000`),
+				regexp.MustCompile(`openebs_available_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c3a68fa3-4183-11e9-9c76-42010a8001a5"} 3000`),
+				regexp.MustCompile(`openebs_available_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c3a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone"} 3000`),
+				regexp.MustCompile(`openebs_available_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c1a68fa3-4183-11e9-9c76-42010a8001a5"} 3000`),
+				regexp.MustCompile(`openebs_available_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c1a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone"} 3000`),
+				regexp.MustCompile(`openebs_available_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5"} 3000`),
+				regexp.MustCompile(`openebs_available_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone"} 3000`),
+				regexp.MustCompile(`openebs_used_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5"} 238592`),
+				regexp.MustCompile(`openebs_used_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c3a68fa3-4183-11e9-9c76-42010a8001a5"} 6144`),
+				regexp.MustCompile(`openebs_used_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c3a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone"} 0`),
+				regexp.MustCompile(`openebs_used_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c1a68fa3-4183-11e9-9c76-42010a8001a5"} 6144`),
+				regexp.MustCompile(`openebs_used_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c1a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone"} 0`),
+				regexp.MustCompile(`openebs_used_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5"} 6144`),
+				regexp.MustCompile(`openebs_used_size{name="cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone"} 0`),
+			},
+		},
+		"Test4": {
+			run: testRunner{
+				stdout: []byte(`cstor-f1ea249b-417d-11e9-9c76-42010a8001a5	liaub	kzjsfvn	512	/cstor-f1ea249b-417d-11e9-9c76-42010a8001a5
+						cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5	6144	3000	6144	-
+						cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone	0	3000	6144	-`),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_zfs_list_parse_error 2`),
+			},
+		},
+		"Test5": {
+			run: testRunner{
+				isError: true,
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_zfs_list_command_error 1`),
+			},
+		},
+		"Test6": {
+			run: testRunner{
+				stdout: []byte(``),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_zfs_list_parse_error 1`),
+			},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			runner = tt.run
+			vol := NewVolumeList()
+			if err := prometheus.Register(vol); err != nil {
+				t.Fatalf("collector failed to register: %s", err)
+			}
+
+			server := httptest.NewServer(promhttp.Handler())
+
+			client := http.DefaultClient
+			client.Timeout = 5 * time.Second
+			resp, err := client.Get(server.URL)
+			if err != nil {
+				t.Fatalf("unexpected failed response from prometheus: %s", err)
+			}
+			defer resp.Body.Close()
+
+			buf, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("failed reading server response: %s", err)
+			}
+
+			for _, re := range tt.match {
+				if !re.Match(buf) {
+					fmt.Println(string(buf))
+					t.Errorf("failed matching: %q", re)
+				}
+			}
+
+			prometheus.Unregister(vol)
+			server.Close()
+		})
+	}
+}
+
+func TestRejectRequestCounter(t *testing.T) {
+	cases := map[string]struct {
+		run      testRunner
+		reqCount int
+		col      prometheus.Collector
+		output   *regexp.Regexp
+	}{
+		"Test0": {
+			run: testRunner{
+				stdout: []byte(`cstor-f1ea249b-417d-11e9-9c76-42010a8001a5	238592	3000	512	/cstor-f1ea249b-417d-11e9-9c76-42010a8001a5
+				cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5	6144	3000	6144	-
+				cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone	0	3000	6144	-`),
+			},
+			reqCount: 100,
+			col:      NewVolumeList(),
+			output:   regexp.MustCompile(`openebs_zfs_list_request_reject_count\s\d+`),
+		},
+		"Test1": {
+			run: testRunner{
+				stdout: []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Rebuilding","rebuildStatus": "SNAP REBUILD INPROGRESS","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
+			},
+			reqCount: 100,
+			col:      New(),
+			output:   regexp.MustCompile(`openebs_zfs_stats_reject_request_count\s\d+`),
+		},
+	}
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			runner = tt.run
+			if err := prometheus.Register(tt.col); err != nil {
+				t.Fatalf("collector failed to register: %s", err)
+			}
+
+			server := httptest.NewServer(promhttp.Handler())
+			var body io.ReadCloser
+
+			wg := sync.WaitGroup{}
+			wg.Add(tt.reqCount)
+			for i := 0; i < tt.reqCount; i++ {
+				go func(server *httptest.Server) {
+					defer wg.Done()
+					client := http.DefaultClient
+					client.Timeout = 5 * time.Second
+					resp, err := client.Get(server.URL)
+					body = resp.Body
+					if err != nil {
+						t.Fatalf("unexpected failed response from prometheus: %s", err)
+					}
+				}(server)
+			}
+
+			wg.Wait()
+			defer body.Close()
+
+			buf, err := ioutil.ReadAll(body)
+			if err != nil {
+				t.Fatalf("failed reading server response: %s", err)
+			}
+
+			str := tt.output.FindStringSubmatch(string(buf))
+			newStr := strings.Fields(str[0])
+			reqCount, _ := strconv.Atoi(newStr[1])
+			if reqCount <= 0 {
+				t.Fatalf("Failed to test reject request count, fount str: %s, buf: %s", str, string(buf))
+			}
+			prometheus.Unregister(tt.col)
+			server.Close()
+		})
+	}
+}

--- a/cmd/maya-exporter/app/collector/zvol/metrics.go
+++ b/cmd/maya-exporter/app/collector/zvol/metrics.go
@@ -1,0 +1,302 @@
+package zvol
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type metrics struct {
+	readBytes  *prometheus.GaugeVec
+	writeBytes *prometheus.GaugeVec
+	readCount  *prometheus.GaugeVec
+	writeCount *prometheus.GaugeVec
+
+	syncCount   *prometheus.GaugeVec
+	syncLatency *prometheus.GaugeVec
+
+	readLatency  *prometheus.GaugeVec
+	writeLatency *prometheus.GaugeVec
+
+	replicaStatus *prometheus.GaugeVec
+
+	inflightIOCount   *prometheus.GaugeVec
+	dispatchedIOCount *prometheus.GaugeVec
+
+	rebuildCount       *prometheus.GaugeVec
+	rebuildBytes       *prometheus.GaugeVec
+	rebuildStatus      *prometheus.GaugeVec
+	rebuildDoneCount   *prometheus.GaugeVec
+	rebuildFailedCount *prometheus.GaugeVec
+
+	zfsCommandErrorCounter       prometheus.Gauge
+	zfsStatsParseErrorCounter    prometheus.Gauge
+	zfsStatsRejectRequestCounter prometheus.Gauge
+}
+
+type listMetrics struct {
+	used      *prometheus.GaugeVec
+	available *prometheus.GaugeVec
+
+	zfsListParseErrorCounter    prometheus.Gauge
+	zfsListCommandErrorCounter  prometheus.Gauge
+	zfsListRequestRejectCounter prometheus.Gauge
+}
+
+type fields struct {
+	name      string
+	used      float64
+	available float64
+}
+
+// newMetrics initializes fields of the metrics and returns its instance
+func newListMetrics() listMetrics {
+	return listMetrics{
+
+		used: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "used_size",
+				Help:      "Used size of pool and volume",
+			},
+			[]string{"name"},
+		),
+
+		available: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "available_size",
+				Help:      "Available size of pool and volume",
+			},
+			[]string{"name"},
+		),
+
+		zfsListParseErrorCounter: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "zfs_list_parse_error",
+				Help:      "Total no of zfs list parse errors",
+			},
+		),
+
+		zfsListCommandErrorCounter: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "zfs_list_command_error",
+				Help:      "Total no of zfs command errors",
+			},
+		),
+
+		zfsListRequestRejectCounter: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "zfs_list_request_reject_count",
+				Help:      "Total no of rejected requests of zfs list",
+			},
+		),
+	}
+}
+
+// newMetrics initializes fields of the metrics and returns its instance
+func newMetrics() metrics {
+	return metrics{
+		readBytes: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "total_read_bytes",
+				Help:      "Total read in bytes",
+			},
+			[]string{"vol", "pool"},
+		),
+
+		writeBytes: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "total_write_bytes",
+				Help:      "Total write in bytes",
+			},
+			[]string{"vol", "pool"},
+		),
+
+		readCount: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "total_read_count",
+				Help:      "Total read io count",
+			},
+			[]string{"vol", "pool"},
+		),
+
+		writeCount: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "total_write_count",
+				Help:      "Total write io count",
+			},
+			[]string{"vol", "pool"},
+		),
+
+		syncCount: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "sync_count",
+				Help:      "Total no of sync on replica",
+			},
+			[]string{"vol", "pool"},
+		),
+
+		syncLatency: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "sync_latency",
+				Help:      "Sync latency on replica",
+			},
+			[]string{"vol", "pool"},
+		),
+
+		readLatency: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "read_latency",
+				Help:      "Read latency on replica",
+			},
+			[]string{"vol", "pool"},
+		),
+
+		writeLatency: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "write_latency",
+				Help:      "Write latency on replica",
+			},
+			[]string{"vol", "pool"},
+		),
+
+		replicaStatus: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "replica_status",
+				Help:      `Status of replica (0, 1, 2, 3) = {"Offline", "Healthy", "Degraded", "Rebuilding"}`,
+			},
+			[]string{"vol", "pool"},
+		),
+
+		inflightIOCount: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "inflight_io_count",
+				Help:      "Inflight IO's count",
+			},
+			[]string{"vol", "pool"},
+		),
+
+		dispatchedIOCount: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "dispatched_io_count",
+				Help:      "Dispatched IO's count",
+			},
+			[]string{"vol", "pool"},
+		),
+
+		rebuildCount: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "rebuild_count",
+				Help:      "Rebuild count",
+			},
+			[]string{"vol", "pool"},
+		),
+
+		rebuildBytes: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "rebuild_bytes",
+				Help:      "Rebuild bytes",
+			},
+			[]string{"vol", "pool"},
+		),
+
+		rebuildStatus: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "rebuild_status",
+				Help:      `Status of rebuild on replica (0, 1, 2, 3, 4, 5, 6)= {"INIT", "DONE", "SNAP REBUILD INPROGRESS", "ACTIVE DATASET REBUILD INPROGRESS", "ERRORED", "FAILED", "UNKNOWN"}`,
+			},
+			[]string{"vol", "pool"},
+		),
+
+		rebuildDoneCount: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "total_rebuild_done",
+				Help:      "Total no of rebuild done on replica",
+			},
+			[]string{"vol", "pool"},
+		),
+
+		rebuildFailedCount: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "total_failed_rebuild",
+				Help:      "Total no of failed rebuilds on replica",
+			},
+			[]string{"vol", "pool"},
+		),
+
+		zfsCommandErrorCounter: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "zfs_command_error",
+				Help:      "Total no of zfs command errors",
+			},
+		),
+
+		zfsStatsParseErrorCounter: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "zfs_stats_parse_error_counter",
+				Help:      "Total no of zfs stats parse errors",
+			},
+		),
+
+		zfsStatsRejectRequestCounter: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "zfs_stats_reject_request_count",
+				Help:      "Total no of rejected requests of zfs stats",
+			},
+		),
+	}
+}
+
+func parseFloat64(e string, m *listMetrics) float64 {
+	num, err := strconv.ParseFloat(e, 64)
+	if err != nil {
+		m.zfsListParseErrorCounter.Inc()
+	}
+	return num
+}
+
+func listParser(stdout []byte, m *listMetrics) []fields {
+	if len(string(stdout)) == 0 {
+		m.zfsListParseErrorCounter.Inc()
+		return nil
+	}
+	list := make([]fields, 0)
+	vols := strings.Split(string(stdout), "\n")
+	for _, v := range vols {
+		f := strings.Fields(v)
+		if len(f) < 3 {
+			break
+		}
+		vol := fields{
+			name:      f[0],
+			used:      parseFloat64(f[1], m),
+			available: parseFloat64(f[2], m),
+		}
+		list = append(list, vol)
+	}
+	return list
+}

--- a/cmd/maya-exporter/app/collector/zvol/zvol.go
+++ b/cmd/maya-exporter/app/collector/zvol/zvol.go
@@ -1,0 +1,170 @@
+package zvol
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/openebs/maya/pkg/util"
+	zvol "github.com/openebs/maya/pkg/zvol/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// volume implements prometheus.Collector interface
+type volume struct {
+	sync.Mutex
+	metrics
+	request bool
+}
+
+var (
+	// runner variable is used for executing binaries
+	runner util.Runner
+)
+
+// InitVar initialize runner variable
+func InitVar() {
+	runner = util.RealRunner{}
+}
+
+// New returns new instance of pool
+func New() *volume {
+	return &volume{
+		metrics: newMetrics(),
+	}
+}
+
+func (v *volume) isRequestInProgress() bool {
+	return v.request
+}
+
+func (v *volume) setRequestToFalse() {
+	v.Lock()
+	v.request = false
+	v.Unlock()
+}
+
+// collectors returns the list of the collectors
+func (v *volume) collectors() []prometheus.Collector {
+	return []prometheus.Collector{
+		v.syncCount,
+		v.readCount,
+		v.writeCount,
+		v.readBytes,
+		v.writeBytes,
+		v.syncLatency,
+		v.readLatency,
+		v.writeLatency,
+		v.rebuildCount,
+		v.rebuildBytes,
+		v.replicaStatus,
+		v.rebuildStatus,
+		v.inflightIOCount,
+		v.rebuildDoneCount,
+		v.dispatchedIOCount,
+		v.rebuildFailedCount,
+		v.zfsCommandErrorCounter,
+		v.zfsStatsParseErrorCounter,
+		v.zfsStatsRejectRequestCounter,
+	}
+}
+
+// gaugeVec returns list of zfs Gauge vectors (prometheus's type)
+// in which values will be set.
+// NOTE: Please donot edit the order, add new metrics at the end
+// of the list
+func (v *volume) gaugeVec() []*prometheus.GaugeVec {
+	return []*prometheus.GaugeVec{
+		v.syncCount,
+		v.readCount,
+		v.writeCount,
+		v.readBytes,
+		v.writeBytes,
+		v.syncLatency,
+		v.readLatency,
+		v.writeLatency,
+		v.rebuildCount,
+		v.rebuildBytes,
+		v.inflightIOCount,
+		v.rebuildDoneCount,
+		v.dispatchedIOCount,
+		v.rebuildFailedCount,
+		v.replicaStatus,
+		v.rebuildStatus,
+	}
+}
+
+// Describe is implementation of Describe method of prometheus.Collector
+// interface.
+func (v *volume) Describe(ch chan<- *prometheus.Desc) {
+	for _, col := range v.collectors() {
+		col.Describe(ch)
+	}
+}
+
+func (v *volume) get(ch chan<- prometheus.Metric) (zvol.Stats, error) {
+	var (
+		err     error
+		stdout  []byte
+		timeout = 30 * time.Second
+		stats   = zvol.Stats{}
+	)
+
+	glog.V(2).Info("Run zfs stats command")
+	stdout, err = zvol.Run(timeout, runner, "stats")
+	if err != nil {
+		v.zfsCommandErrorCounter.Inc()
+		v.zfsCommandErrorCounter.Collect(ch)
+		return stats, err
+	}
+
+	glog.V(2).Infof("Parse stdout of zfs stats command, got stdout: %v", string(stdout))
+	stats, err = zvol.StatsParser(stdout)
+	if err != nil {
+		v.zfsStatsParseErrorCounter.Inc()
+		v.zfsStatsParseErrorCounter.Collect(ch)
+		return stats, err
+	}
+
+	return stats, nil
+}
+
+// Collect is implementation of prometheus's prometheus.Collector interface
+func (v *volume) Collect(ch chan<- prometheus.Metric) {
+	v.Lock()
+	if v.isRequestInProgress() {
+		v.zfsStatsRejectRequestCounter.Inc()
+		v.Unlock()
+		v.zfsStatsRejectRequestCounter.Collect(ch)
+		return
+
+	}
+
+	v.request = true
+	v.Unlock()
+
+	zvolStats, err := v.get(ch)
+	if err != nil {
+		v.setRequestToFalse()
+		return
+	}
+
+	glog.V(2).Infof("Got zfs stats: %#v", zvolStats)
+	v.setZVolStats(zvolStats)
+	for _, col := range v.collectors() {
+		col.Collect(ch)
+	}
+	v.setRequestToFalse()
+}
+
+func (v *volume) setZVolStats(stats zvol.Stats) {
+	for _, vol := range stats.Volumes {
+		s := strings.Split(vol.Name, "/")
+		poolName, volname := s[0], s[1]
+		items := zvol.StatsList(vol)
+		for index, col := range v.gaugeVec() {
+			col.WithLabelValues(volname, poolName).Set(items[index])
+		}
+	}
+}

--- a/cmd/maya-exporter/app/collector/zvol/zvol_test.go
+++ b/cmd/maya-exporter/app/collector/zvol/zvol_test.go
@@ -1,0 +1,264 @@
+package zvol
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var count int
+
+type testRunner struct {
+	stdout  []byte
+	isError bool
+}
+
+func (r testRunner) RunCombinedOutput(cmd string, args ...string) ([]byte, error) {
+	return nil, nil
+}
+
+func (r testRunner) RunStdoutPipe(cmd string, args ...string) ([]byte, error) {
+	return nil, nil
+}
+
+func (r testRunner) RunCommandWithTimeoutContext(timeout time.Duration, cmd string, args ...string) ([]byte, error) {
+	if r.isError {
+		return nil, errors.New("some dummy error")
+	}
+	return r.stdout, nil
+}
+
+func TestGetZfsStats(t *testing.T) {
+	cases := map[string]struct {
+		run   testRunner
+		match []*regexp.Regexp
+	}{
+		"Test0": {
+			run: testRunner{
+				stdout: []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Healthy","rebuildStatus": "DONE","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_total_read_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
+				regexp.MustCompile(`openebs_total_write_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
+				regexp.MustCompile(`openebs_total_read_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
+				regexp.MustCompile(`openebs_total_write_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
+				regexp.MustCompile(`openebs_sync_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 100`),
+				regexp.MustCompile(`openebs_sync_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 10`),
+				regexp.MustCompile(`openebs_read_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 150`),
+				regexp.MustCompile(`openebs_write_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 200`),
+				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
+				regexp.MustCompile(`openebs_inflight_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 2000`),
+				regexp.MustCompile(`openebs_dispatched_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 50`),
+				regexp.MustCompile(`openebs_rebuild_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 3`),
+				regexp.MustCompile(`openebs_rebuild_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 500`),
+				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
+			},
+		},
+		"Test1": {
+			run: testRunner{
+				stdout: []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Offline","rebuildStatus": "INIT","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 0`),
+				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 0`),
+			},
+		},
+		"Test2": {
+			run: testRunner{
+				stdout: []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Degraded","rebuildStatus": "INIT","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 2`),
+				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 0`),
+			},
+		},
+		"Test3": {
+			run: testRunner{
+				stdout: []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Rebuilding","rebuildStatus": "SNAP REBUILD INPROGRESS","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 3`),
+				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 2`),
+			},
+		},
+		"Test4": {
+			run: testRunner{
+				stdout: []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Rebuilding","rebuildStatus": "ACTIVE DATASET REBUILD INPROGRESS","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 3`),
+				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 3`),
+			},
+		},
+		"Test5": {
+			run: testRunner{
+				stdout: []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Offline","rebuildStatus": "ERRORED  ","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 0`),
+				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 4`),
+			},
+		},
+
+		"Test6": {
+			run: testRunner{
+				stdout: []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Offline","rebuildStatus": "FAILED","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 0`),
+				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 5`),
+			},
+		},
+		"Test7": {
+			run: testRunner{
+				stdout: []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Offline","rebuildStatus": "UNKNOWN","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 0`),
+				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 6`),
+			},
+		},
+		"Test8": {
+			run: testRunner{
+				isError: true,
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_zfs_command_error 1`),
+			},
+		},
+		"Test9": {
+			run: testRunner{
+				stdout: []byte(``),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_zfs_stats_parse_error_counter 1`),
+			},
+		},
+		"Test10": {
+			run: testRunner{
+				stdout: []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Healthy","rebuildStatus": "DONE","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50},{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a","status": "Healthy","rebuildStatus": "DONE","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_total_read_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
+				regexp.MustCompile(`openebs_total_read_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
+				regexp.MustCompile(`openebs_total_write_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
+				regexp.MustCompile(`openebs_total_write_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
+				regexp.MustCompile(`openebs_total_read_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
+				regexp.MustCompile(`openebs_total_read_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
+				regexp.MustCompile(`openebs_total_write_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
+				regexp.MustCompile(`openebs_total_write_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
+				regexp.MustCompile(`openebs_sync_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 100`),
+				regexp.MustCompile(`openebs_sync_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 100`),
+				regexp.MustCompile(`openebs_sync_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 10`),
+				regexp.MustCompile(`openebs_sync_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 10`),
+				regexp.MustCompile(`openebs_read_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 150`),
+				regexp.MustCompile(`openebs_read_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 150`),
+				regexp.MustCompile(`openebs_write_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 200`),
+				regexp.MustCompile(`openebs_write_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 200`),
+				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
+				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
+				regexp.MustCompile(`openebs_inflight_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 2000`),
+				regexp.MustCompile(`openebs_inflight_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 2000`),
+				regexp.MustCompile(`openebs_dispatched_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 50`),
+				regexp.MustCompile(`openebs_dispatched_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 50`),
+				regexp.MustCompile(`openebs_rebuild_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 3`),
+				regexp.MustCompile(`openebs_rebuild_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 3`),
+				regexp.MustCompile(`openebs_rebuild_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 500`),
+				regexp.MustCompile(`openebs_rebuild_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 500`),
+				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
+				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
+			},
+		},
+		"Test11": {
+			run: testRunner{
+				stdout: []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Healthy","rebuildStatus": "DONE","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50},{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a","status": "Healthy","rebuildStatus": "DONE","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50},{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a","status": "Healthy","rebuildStatus": "DONE","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
+			},
+			match: []*regexp.Regexp{
+				regexp.MustCompile(`openebs_total_read_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
+				regexp.MustCompile(`openebs_total_read_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
+				regexp.MustCompile(`openebs_total_read_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
+				regexp.MustCompile(`openebs_total_write_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
+				regexp.MustCompile(`openebs_total_write_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
+				regexp.MustCompile(`openebs_total_write_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
+				regexp.MustCompile(`openebs_total_read_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
+				regexp.MustCompile(`openebs_total_read_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
+				regexp.MustCompile(`openebs_total_read_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
+				regexp.MustCompile(`openebs_total_write_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
+				regexp.MustCompile(`openebs_total_write_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
+				regexp.MustCompile(`openebs_total_write_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
+				regexp.MustCompile(`openebs_sync_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 100`),
+				regexp.MustCompile(`openebs_sync_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 100`),
+				regexp.MustCompile(`openebs_sync_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 100`),
+				regexp.MustCompile(`openebs_sync_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 10`),
+				regexp.MustCompile(`openebs_sync_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 10`),
+				regexp.MustCompile(`openebs_sync_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 10`),
+				regexp.MustCompile(`openebs_read_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 150`),
+				regexp.MustCompile(`openebs_read_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 150`),
+				regexp.MustCompile(`openebs_read_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 150`),
+				regexp.MustCompile(`openebs_write_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 200`),
+				regexp.MustCompile(`openebs_write_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 200`),
+				regexp.MustCompile(`openebs_write_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 200`),
+				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
+				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
+				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
+				regexp.MustCompile(`openebs_inflight_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 2000`),
+				regexp.MustCompile(`openebs_inflight_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 2000`),
+				regexp.MustCompile(`openebs_inflight_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 2000`),
+				regexp.MustCompile(`openebs_dispatched_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 50`),
+				regexp.MustCompile(`openebs_dispatched_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 50`),
+				regexp.MustCompile(`openebs_dispatched_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 50`),
+				regexp.MustCompile(`openebs_rebuild_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 3`),
+				regexp.MustCompile(`openebs_rebuild_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 3`),
+				regexp.MustCompile(`openebs_rebuild_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 3`),
+				regexp.MustCompile(`openebs_rebuild_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 500`),
+				regexp.MustCompile(`openebs_rebuild_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 500`),
+				regexp.MustCompile(`openebs_rebuild_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 500`),
+				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
+				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
+				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
+			},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			runner = tt.run
+			vol := New()
+			if err := prometheus.Register(vol); err != nil {
+				t.Fatalf("collector failed to register: %s", err)
+			}
+
+			server := httptest.NewServer(promhttp.Handler())
+
+			client := http.DefaultClient
+			client.Timeout = 5 * time.Second
+			resp, err := client.Get(server.URL)
+			if err != nil {
+				t.Fatalf("unexpected failed response from prometheus: %s", err)
+			}
+			defer resp.Body.Close()
+
+			buf, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("failed reading server response: %s", err)
+			}
+
+			for _, re := range tt.match {
+				if !re.Match(buf) {
+					fmt.Println(string(buf))
+					t.Errorf("failed matching: %q", re)
+				}
+			}
+			prometheus.Unregister(vol)
+			server.Close()
+		})
+	}
+}

--- a/cmd/maya-exporter/app/command/command.go
+++ b/cmd/maya-exporter/app/command/command.go
@@ -4,9 +4,12 @@ import (
 	"errors"
 	goflag "flag"
 	"net/url"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/openebs/maya/cmd/maya-exporter/app/collector"
+	"github.com/openebs/maya/cmd/maya-exporter/app/collector/pool"
+	"github.com/openebs/maya/cmd/maya-exporter/app/collector/zvol"
 	"github.com/openebs/maya/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
@@ -99,13 +102,16 @@ func Run(cmd *cobra.Command, options *VolumeExporterOptions) error {
 	switch options.CASType {
 	case "cstor":
 		glog.Infof("Initialising maya-exporter for the cstor")
-		options.RegisterCstorStatsExporter()
+		options.RegisterCstor()
 	case "jiva":
 		glog.Infof("Initialising maya-exporter for the jiva")
-		if err := options.RegisterJivaStatsExporter(); err != nil {
+		if err := options.RegisterJiva(); err != nil {
 			glog.Fatal(err)
 			return nil
 		}
+	case "pool":
+		glog.Infof("Initialising maya-exporter for the cstor pool")
+		options.RegisterPool()
 	default:
 		return errors.New("unsupported CAS")
 	}
@@ -113,10 +119,10 @@ func Run(cmd *cobra.Command, options *VolumeExporterOptions) error {
 	return nil
 }
 
-// RegisterJivaStatsExporter parses the jiva controller URL and
-// initialises an instance of JivaStatsExporter.This returns err
+// RegisterJiva parses the jiva controller URL and
+// initialises an instance of Jiva.This returns err
 // if the URL is not correct.
-func (o *VolumeExporterOptions) RegisterJivaStatsExporter() error {
+func (o *VolumeExporterOptions) RegisterJiva() error {
 	url, err := url.ParseRequestURI(o.ControllerAddress)
 	if err != nil {
 		glog.Error(err)
@@ -129,13 +135,31 @@ func (o *VolumeExporterOptions) RegisterJivaStatsExporter() error {
 	return nil
 }
 
-// RegisterCstorStatsExporter initiates the connection with the cstor and register
+// RegisterCstor initiates the connection with the cstor and register
 // the exporter with Prometheus for collecting the metrics.This doesn't returns
 // error because that case is handled in InitiateConnection().
-func (o *VolumeExporterOptions) RegisterCstorStatsExporter() {
+func (o *VolumeExporterOptions) RegisterCstor() {
 	cstor := collector.Cstor(socketPath)
 	exporter := collector.New(cstor)
 	prometheus.MustRegister(exporter)
 	glog.Info("Registered maya exporter for cstor")
+	return
+}
+
+// RegisterPool registers pool collector which collects
+// pool level metrics
+func (o *VolumeExporterOptions) RegisterPool() {
+	pool.InitVar()
+	zvol.InitVar()
+	p := pool.New()
+	z := zvol.New()
+	l := zvol.NewVolumeList()
+
+	// Blocking call with retry timeout of 2s and context timeout of 5 sec,
+	// pool container may be starting.
+	p.GetInitStatus(5 * time.Second)
+	prometheus.MustRegister(p, z, l)
+	glog.Info("Registered maya exporter for cstor")
+
 	return
 }

--- a/cmd/maya-exporter/app/command/command_test.go
+++ b/cmd/maya-exporter/app/command/command_test.go
@@ -17,7 +17,7 @@ It can be deployed alongside the openebs volume or pool containers as sidecars.`
 	}
 )
 
-func TestRegisterJivaStatsExporter(t *testing.T) {
+func TestRegisterJiva(t *testing.T) {
 	cases := map[string]struct {
 		option *VolumeExporterOptions
 		output error
@@ -44,7 +44,7 @@ func TestRegisterJivaStatsExporter(t *testing.T) {
 
 	for name, tt := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := tt.option.RegisterJivaStatsExporter()
+			got := tt.option.RegisterJiva()
 			if !reflect.DeepEqual(got, tt.output) {
 				t.Fatalf("RegisterJivaStatsExporter() => [%v], want [%v]", got, tt.output)
 			}

--- a/cmd/maya-exporter/main.go
+++ b/cmd/maya-exporter/main.go
@@ -6,7 +6,13 @@ import (
 	"github.com/golang/glog"
 	"github.com/openebs/maya/cmd/maya-exporter/app/command"
 	mayalogger "github.com/openebs/maya/pkg/logs"
+	"github.com/openebs/maya/pkg/version"
+	"github.com/prometheus/client_golang/prometheus"
 )
+
+func init() {
+	prometheus.MustRegister(version.NewVersionCollector("maya_exporter"))
+}
 
 func main() {
 	if err := run(); err != nil {

--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -31,6 +31,10 @@ spec:
   # communicates with cstor iscsi target
   - name: CstorPoolImage
     value: {{env "OPENEBS_IO_CSTOR_POOL_IMAGE" | default "openebs/cstor-pool:latest"}}
+  # CstorPoolExporterImage is the container image that executes zpool and zfs binary
+  # to export various volume and pool metrics
+  - name: CstorPoolExporterImage
+    value: {{env "OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE" | default "openebs/m-exporter:latest"}}
   # CstorPoolMgmtImage runs cstor pool and cstor volume replica related CRUD
   # operations
   - name: CstorPoolMgmtImage
@@ -53,7 +57,7 @@ spec:
     value: {{env "OPENEBS_SERVICE_ACCOUNT"}}
   # PoolResourceRequests allow you to specify resource requests that need to be available
   # before scheduling the containers. If not specified, the default is to use the limits
-  # from PoolResourceLimits or the default requests set in the cluster. 
+  # from PoolResourceLimits or the default requests set in the cluster.
   - name: PoolResourceRequests
     value: "none"
   # PoolResourceLimits allow you to set the limits on memory and cpu for pool pods
@@ -166,7 +170,7 @@ spec:
     {{- $auxResourceRequestsVal := fromYaml .Config.AuxResourceRequests.value -}}
     {{- $setAuxResourceLimits := .Config.AuxResourceLimits.value | default "none" -}}
     {{- $auxResourceLimitsVal := fromYaml .Config.AuxResourceLimits.value -}}
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1beta1
     kind: Deployment
     metadata:
       name: {{.TaskResult.putcstorpoolcr.objectName}}
@@ -176,6 +180,15 @@ spec:
         app: cstor-pool
         openebs.io/version: {{ .CAST.version }}
         openebs.io/cas-template-name: {{ .CAST.castName }}
+      annotations:
+        openebs.io/monitoring: pool_exporter_prometheus
+      ownerReferences:
+      - apiVersion: openebs.io/v1alpha1
+        blockOwnerDeletion: true
+        controller: true
+        kind: CStorPool
+        name: {{ .TaskResult.putcstorpoolcr.objectName }}
+        uid: {{ .TaskResult.putcstorpoolcr.objectUID }}
     spec:
       strategy:
         type: Recreate
@@ -187,6 +200,11 @@ spec:
         metadata:
           labels:
             app: cstor-pool
+          annotations:
+            openebs.io/monitoring: pool_exporter_prometheus
+            prometheus.io/path: /metrics
+            prometheus.io/port: "9500"
+            prometheus.io/scrape: "true"
             openebs.io/storage-pool-claim: {{.Storagepool.owner}}
         spec:
           serviceAccountName: {{ .Config.ServiceAccountName.value }}
@@ -261,9 +279,6 @@ spec:
                 {{ $rKey }}: {{ $rLimit }}
               {{- end }}
               {{- end }}
-            ports:
-            - containerPort: 9500
-              protocol: TCP
             securityContext:
               privileged: true
             volumeMounts:
@@ -289,6 +304,37 @@ spec:
                   fieldPath: metadata.namespace
             - name: RESYNC_INTERVAL
               value: {{ .Config.ResyncInterval.value }}
+          - name: maya-exporter
+            image: {{ .Config.CstorPoolExporterImage.value }}
+            resources:
+              {{- if ne $setAuxResourceRequests "none" }}
+              requests:
+              {{- range $rKey, $rLimit := $auxResourceRequestsVal }}
+                {{ $rKey }}: {{ $rLimit }}
+              {{- end }}
+              {{- end }}
+              {{- if ne $setAuxResourceLimits "none" }}
+              limits:
+              {{- range $rKey, $rLimit := $auxResourceLimitsVal }}
+                {{ $rKey }}: {{ $rLimit }}
+              {{- end }}
+              {{- end }}
+            command:
+            - maya-exporter
+            args:
+            - "-e=pool"
+            ports:
+            - containerPort: 9500
+              protocol: TCP
+            volumeMounts:
+            - mountPath: /dev
+              name: device
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: {{ .Config.SparseDir.value }}
+              name: sparse
+            - mountPath: /run/udev
+              name: udev
           volumes:
           - name: device
             hostPath:

--- a/pkg/util/exec-run.go
+++ b/pkg/util/exec-run.go
@@ -3,6 +3,11 @@ package util
 import (
 	"io/ioutil"
 	"os/exec"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"context"
 
 	"github.com/golang/glog"
 )
@@ -12,6 +17,7 @@ import (
 type Runner interface {
 	RunCombinedOutput(string, ...string) ([]byte, error)
 	RunStdoutPipe(string, ...string) ([]byte, error)
+	RunCommandWithTimeoutContext(time.Duration, string, ...string) ([]byte, error)
 }
 
 // RealRunner is the real runner for the program that actually execs the command.
@@ -48,6 +54,25 @@ func (r RealRunner) RunStdoutPipe(command string, args ...string) ([]byte, error
 	return data, nil
 }
 
+// RunCommandWithTimeoutContext executes command provides and returns stdout
+// error. If command does not returns within given timout interval command will
+// be killed and return "Context time exceeded"
+func (r RealRunner) RunCommandWithTimeoutContext(timeout time.Duration, command string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, command, args...).CombinedOutput()
+	if err != nil {
+		select {
+		case <-ctx.Done():
+			return nil, errors.Wrapf(ctx.Err(), "Failed to run command: %v %v", command, args)
+		default:
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
 //TestRunner is used as a dummy Runner
 type TestRunner struct{}
 
@@ -58,5 +83,10 @@ func (r TestRunner) RunCombinedOutput(command string, args ...string) ([]byte, e
 
 // RunStdoutPipe is to mock real runner exec with stdoutpipe.
 func (r TestRunner) RunStdoutPipe(command string, args ...string) ([]byte, error) {
+	return []byte("success"), nil
+}
+
+// RunCommandWithTimeoutContext is to mock Real runner exec.
+func (r TestRunner) RunCommandWithTimeoutContext(timeout time.Duration, command string, args ...string) ([]byte, error) {
 	return []byte("success"), nil
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -22,6 +22,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
@@ -150,4 +152,22 @@ func GetGitCommit() string {
 
 func GetVersionDetails() string {
 	return strings.Join([]string{GetVersion(), GetGitCommit()[0:7]}, "-")
+}
+
+// NewVersionCollector returns a collector which exports metrics
+// about current version information.
+// Note: program name should be similar to maya_exporter (with
+// underscore not with dash)
+func NewVersionCollector(program string) *prometheus.GaugeVec {
+	buildInfo := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Subsystem: program,
+			Name:      "version",
+			Help:      "A metric with a constant '1' value labeled by commit and version from which maya-exporter was built.",
+		},
+		[]string{"commit", "version", "metaversion"},
+	)
+	buildInfo.WithLabelValues(GitCommit, Version, VersionMeta).Set(1)
+	return buildInfo
 }

--- a/pkg/zpool/v1alpha1/zpool.go
+++ b/pkg/zpool/v1alpha1/zpool.go
@@ -1,0 +1,96 @@
+package v1alpha1
+
+import (
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/openebs/maya/pkg/util"
+)
+
+// ZpoolStatus is pool's status
+type ZpoolStatus string
+
+const (
+	Binary                          = "zpool" // Binary represents zpool binary
+	Offline             ZpoolStatus = "OFFLINE"
+	Online              ZpoolStatus = "ONLINE"
+	Degraded            ZpoolStatus = "DEGRADED"
+	Faulted             ZpoolStatus = "FAULTED"
+	Removed             ZpoolStatus = "REMOVED"
+	Unavail             ZpoolStatus = "UNAVAIL"
+	NoPoolAvailable     ZpoolStatus = "no pools available"
+	InCompleteStdoutErr             = "Couldn't receive complete output"
+)
+
+var (
+	// Status is map of zpool status with values
+	Status = map[ZpoolStatus]float64{
+		Offline:         0,
+		Online:          1,
+		Degraded:        2,
+		Faulted:         3,
+		Removed:         4,
+		Unavail:         5,
+		NoPoolAvailable: 6,
+	}
+)
+
+// Stats is used to store the values of parsed stats
+// of zpool list -Hp command
+type Stats struct {
+	Status              ZpoolStatus // Status represents status of a Pool
+	Name                string
+	Used                string // Used size of Pools
+	Free                string // Free size of Pools
+	Size                string // Size of pool
+	UsedCapacityPercent string // Used size of pools in precent
+}
+
+// Run is wrapper over RunCommandWithTimeoutContext for running zpool commands
+func Run(timeout time.Duration, runner util.Runner, args ...string) ([]byte, error) {
+	status, err := runner.RunCommandWithTimeoutContext(timeout, Binary, args...)
+	if err != nil {
+		return nil, err
+	}
+	return status, nil
+}
+
+// IsNotAvailable checks whether any pool is availble or not.
+func IsNotAvailable(str string) bool {
+	return strings.Contains(str, string(NoPoolAvailable))
+}
+
+func isValid(stats string) ([]string, bool) {
+	statsList := strings.Fields(stats)
+	if len(statsList) < 9 {
+		return nil, false
+	}
+	return statsList, true
+}
+
+// ListParser parses output of zpool list -Hp
+// Command: zpool list -Hp
+// Output:
+// cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a	10670309376	716288	10669593088	-	0	0	1.00 ONLINE	-
+func ListParser(output []byte) (Stats, error) {
+	str := string(output)
+	if IsNotAvailable(str) {
+		return Stats{}, errors.New(string(NoPoolAvailable))
+	}
+
+	stats, ok := isValid(str)
+	if !ok {
+		return Stats{}, errors.New(InCompleteStdoutErr)
+	}
+
+	return Stats{
+		Name:                stats[0],
+		Size:                stats[1],
+		Used:                stats[2],
+		Free:                stats[3],
+		UsedCapacityPercent: stats[6],
+		Status:              ZpoolStatus(stats[8]),
+	}, nil
+}

--- a/pkg/zvol/v1alpha1/zvol.go
+++ b/pkg/zvol/v1alpha1/zvol.go
@@ -12,7 +12,7 @@ import (
 // ZVolStatus is zvol's status
 type ZVolStatus string
 
-// ZVolRebuildingStatus is zvol's rebuilding status
+// ZVolRebuildStatus is zvol's rebuilding status
 type ZVolRebuildStatus string
 
 const (

--- a/pkg/zvol/v1alpha1/zvol.go
+++ b/pkg/zvol/v1alpha1/zvol.go
@@ -1,0 +1,140 @@
+package v1alpha1
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/openebs/maya/pkg/util"
+)
+
+// ZVolStatus is zvol's status
+type ZVolStatus string
+
+// ZVolRebuildingStatus is zvol's rebuilding status
+type ZVolRebuildStatus string
+
+const (
+	// Binary represents zfs binary
+	Binary                      = "zfs"
+	StatusOffline    ZVolStatus = "Offline"
+	StatusHealthy    ZVolStatus = "Healthy"
+	StatusDegraded   ZVolStatus = "Degraded"
+	StatusRebuilding ZVolStatus = "Rebuilding"
+
+	RebuildStatusInit                    ZVolRebuildStatus = "INIT"
+	RebuildStatusDone                    ZVolRebuildStatus = "DONE"
+	RebuildStatusErrored                 ZVolRebuildStatus = "ERRORED  "
+	RebuildStatusFailed                  ZVolRebuildStatus = "FAILED"
+	RebuildStatusUnknown                 ZVolRebuildStatus = "UNKNOWN"
+	RebuildStatusInProgress              ZVolRebuildStatus = "SNAP REBUILD INPROGRESS"
+	RebuildStatusActiveDataSetInProgress ZVolRebuildStatus = "ACTIVE DATASET REBUILD INPROGRESS"
+)
+
+var (
+	// Status is mapping of the  zvol status with values
+	Status = map[ZVolStatus]float64{
+		StatusOffline:    0,
+		StatusHealthy:    1,
+		StatusDegraded:   2,
+		StatusRebuilding: 3,
+	}
+	// RebuildingStatus is mapping of rebuilding status of zvol with values
+	RebuildingStatus = map[ZVolRebuildStatus]float64{
+		RebuildStatusInit:                    0,
+		RebuildStatusDone:                    1,
+		RebuildStatusInProgress:              2,
+		RebuildStatusActiveDataSetInProgress: 3,
+		RebuildStatusErrored:                 4,
+		RebuildStatusFailed:                  5,
+		RebuildStatusUnknown:                 6,
+	}
+)
+
+// Stats represents list of volume
+type Stats struct {
+	Volumes []Volume `json:"stats"`
+}
+
+// Volume represents the volume's various stats
+type Volume struct {
+	// Name contains name of pool appened with volume name.
+	// It's of the form "<pool name>/<volume name>"
+	Name          string            `json:"name"`
+	Status        ZVolStatus        `json:"status"`        // Status of volume
+	RebuildStatus ZVolRebuildStatus `json:"rebuildStatus"` // RebuildStatus of volume
+
+	SyncCount   float64 `json:"syncCount"`   // Total Sync processed on this volume
+	ReadCount   float64 `json:"readCount"`   // Total Reads
+	WriteCount  float64 `json:"writeCount"`  // Total Writes
+	ReadBytes   float64 `json:"readByte"`    // Total Reads in bytes
+	WriteBytes  float64 `json:"writeByte"`   // Total Writes in bytes
+	SyncLatency float64 `json:"syncLatency"` // Latency involved in processing sync io's
+
+	ReadLatency        float64 `json:"readLatency"`      // Latency involved in processing read io's
+	WriteLatency       float64 `json:"writeLatency"`     // Latency involved in processing write io's
+	RebuildCount       float64 `json:"rebuildCnt"`       // Total rebuild processed
+	RebuildBytes       float64 `json:"rebuildBytes"`     // Total rebuild in bytes
+	InflightIOCount    float64 `json:"inflightIOCnt"`    // Total IO's processing currently
+	RebuildDoneCount   float64 `json:"rebuildDoneCnt"`   // Total no of rebuilds done
+	DispatchedIOCount  float64 `json:"dispatchedIOCnt"`  // Total IO's dispatched to disk
+	RebuildFailedCount float64 `json:"rebuildFailedCnt"` // Total no of failed rebuilds
+}
+
+// Run is wrapper over RunCommandWithTimeoutContext for zfs commands
+func Run(timeout time.Duration, runner util.Runner, args ...string) ([]byte, error) {
+	out, err := runner.RunCommandWithTimeoutContext(timeout, Binary, args...)
+	if err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+// StatsParser parses the json response of zfs stats command.
+func StatsParser(stdout []byte) (Stats, error) {
+	var stats = Stats{}
+	if err := json.NewDecoder(bytes.NewReader(stdout)).Decode(&stats); err != nil {
+		return stats, err
+	}
+	if isNotPresent(stats.Volumes) {
+		return stats, errors.New("Got empty pool/volume name")
+	}
+	return stats, nil
+}
+
+func isNotPresent(vol []Volume) bool {
+	if len(vol) == 0 {
+		return true
+	}
+	for _, v := range vol {
+		if v.Name == "" {
+			return true
+		}
+	}
+	return false
+}
+
+// StatsList returns the list of stats
+// NOTE: Please donot edit the order, add new stats
+// at the end of the list.
+func StatsList(v Volume) []float64 {
+	return []float64{
+		v.SyncCount,
+		v.ReadCount,
+		v.WriteCount,
+		v.ReadBytes,
+		v.WriteBytes,
+		v.SyncLatency,
+		v.ReadLatency,
+		v.WriteLatency,
+		v.RebuildCount,
+		v.RebuildBytes,
+		v.InflightIOCount,
+		v.RebuildDoneCount,
+		v.DispatchedIOCount,
+		v.RebuildFailedCount,
+		Status[v.Status],
+		RebuildingStatus[v.RebuildStatus],
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Cherry-pick commits which introduce a new feature (pool-exporter) 
- Cherry-pick  commit which fixes a bug which was setting values of exporter's time series `openebs_healthy_replica_count` and `openebs_degraded_replica_count` to 0

**Checklist:**
- [x] Fixes openebs/openebs#2420, openebs/openebs#2419, 
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests