### PR TITLE
fix(ci): increase goroutine count to fix ci

### DIFF
--- a/cmd/maya-exporter/app/collector/pool/pool_test.go
+++ b/cmd/maya-exporter/app/collector/pool/pool_test.go
@@ -239,7 +239,7 @@ func TestGetInitStatus(t *testing.T) {
 }
 
 func TestRejectRequestCounter(t *testing.T) {
-	reqCount := 100
+	reqCount := 200
 	output := regexp.MustCompile(`openebs_zpool_reject_request_count\s\d+`)
 	runner = testRunner{
 		stdout: []byte("cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a	3000	23423 1341	-	0	iauwb	1.00 REMOVED	-"),

--- a/cmd/maya-exporter/app/collector/zvol/list_test.go
+++ b/cmd/maya-exporter/app/collector/zvol/list_test.go
@@ -177,7 +177,7 @@ func TestRejectRequestCounter(t *testing.T) {
 				cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5	6144	3000	6144	-
 				cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone	0	3000	6144	-`),
 			},
-			reqCount: 100,
+			reqCount: 200,
 			col:      NewVolumeList(),
 			output:   regexp.MustCompile(`openebs_zfs_list_request_reject_count\s\d+`),
 		},
@@ -185,7 +185,7 @@ func TestRejectRequestCounter(t *testing.T) {
 			run: testRunner{
 				stdout: []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Rebuilding","rebuildStatus": "SNAP REBUILD INPROGRESS","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
 			},
-			reqCount: 100,
+			reqCount: 200,
 			col:      New(),
 			output:   regexp.MustCompile(`openebs_zfs_stats_reject_request_count\s\d+`),
 		},


### PR DESCRIPTION
Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR fixes flaky ci by increasing the goroutine count.
100 concurrent requests were being served in 1 second successfully while unit testing sometimes that's why it was failing.

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests