### PR TITLE
fix(unit test): inject delays in pool-exporter's unit test

### DIFF
--- a/cmd/maya-exporter/app/collector/zvol/list_test.go
+++ b/cmd/maya-exporter/app/collector/zvol/list_test.go
@@ -173,19 +173,21 @@ func TestRejectRequestCounter(t *testing.T) {
 	}{
 		"Test0": {
 			run: testRunner{
+				injectDelay: true,
 				stdout: []byte(`cstor-f1ea249b-417d-11e9-9c76-42010a8001a5	238592	3000	512	/cstor-f1ea249b-417d-11e9-9c76-42010a8001a5
 				cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5	6144	3000	6144	-
 				cstor-f1ea249b-417d-11e9-9c76-42010a8001a5/pvc-c4a68fa3-4183-11e9-9c76-42010a8001a5_rebuild_clone	0	3000	6144	-`),
 			},
-			reqCount: 200,
+			reqCount: 20,
 			col:      NewVolumeList(),
 			output:   regexp.MustCompile(`openebs_zfs_list_request_reject_count\s\d+`),
 		},
 		"Test1": {
 			run: testRunner{
-				stdout: []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Rebuilding","rebuildStatus": "SNAP REBUILD INPROGRESS","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
+				injectDelay: true,
+				stdout:      []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Rebuilding","rebuildStatus": "SNAP REBUILD INPROGRESS","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
 			},
-			reqCount: 200,
+			reqCount: 20,
 			col:      New(),
 			output:   regexp.MustCompile(`openebs_zfs_stats_reject_request_count\s\d+`),
 		},

--- a/cmd/maya-exporter/app/collector/zvol/zvol_test.go
+++ b/cmd/maya-exporter/app/collector/zvol/zvol_test.go
@@ -17,8 +17,9 @@ import (
 var count int
 
 type testRunner struct {
-	stdout  []byte
-	isError bool
+	stdout      []byte
+	isError     bool
+	injectDelay bool
 }
 
 func (r testRunner) RunCombinedOutput(cmd string, args ...string) ([]byte, error) {
@@ -32,6 +33,10 @@ func (r testRunner) RunStdoutPipe(cmd string, args ...string) ([]byte, error) {
 func (r testRunner) RunCommandWithTimeoutContext(timeout time.Duration, cmd string, args ...string) ([]byte, error) {
 	if r.isError {
 		return nil, errors.New("some dummy error")
+	}
+	if r.injectDelay {
+		time.Sleep(50 * time.Millisecond)
+		return r.stdout, nil
 	}
 	return r.stdout, nil
 }


### PR DESCRIPTION
Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR fix the unit test by injecting delay in mock functions. The need of delay is arising since all the concurrent GET requests were being processed successfully even after increasing the no of goroutines sometimes. So injecting delays will fix issue of flaky builds.

**Special notes for your reviewer**:
It will not delay the unit test more than 1 second.

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [x] Commit has unit tests
- [ ] Commit has integration tests