### PR TITLE
Refact(cas,runtask): refactor cstor tunnables ENV parameters

### DIFF
--- a/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
+++ b/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
@@ -154,12 +154,17 @@ func builldVolumeCreateCommand(cStorVolumeReplica *apis.CStorVolumeReplica, full
 	if !quorum {
 		quorumValue = "quorum=off"
 	}
-
-	createVolCmd = append(createVolCmd, CreateCmd,
-		"-b", "4K", "-s", "-o", "compression=on", "-o", quorumValue,
-		"-o", openebsTargetIP, "-o", openebsVolname, "-o", openebsZvolWorkers,
-		"-V", cStorVolumeReplica.Spec.Capacity, fullVolName)
-
+	if len(cStorVolumeReplica.Spec.ZvolWorkers) != 0 {
+		createVolCmd = append(createVolCmd, CreateCmd,
+			"-b", "4K", "-s", "-o", "compression=on", "-o", quorumValue,
+			"-o", openebsTargetIP, "-o", openebsVolname, "-o", openebsZvolWorkers,
+			"-V", cStorVolumeReplica.Spec.Capacity, fullVolName)
+	} else {
+		createVolCmd = append(createVolCmd, CreateCmd,
+			"-b", "4K", "-s", "-o", "compression=on", "-o", quorumValue,
+			"-o", openebsTargetIP, "-o", openebsVolname,
+			"-V", cStorVolumeReplica.Spec.Capacity, fullVolName)
+	}
 	return createVolCmd
 }
 
@@ -172,10 +177,15 @@ func builldVolumeCloneCommand(cStorVolumeReplica *apis.CStorVolumeReplica, snapN
 	// ZvolWorkers represents number of threads that executes client IOs
 	openebsZvolWorkers := "io.openebs:zvol_workers=" + cStorVolumeReplica.Spec.ZvolWorkers
 
-	cloneVolCmd = append(cloneVolCmd, CloneCmd,
-		"-o", "compression=on", "-o", openebsTargetIP, "-o", "quorum=on",
-		"-o", openebsZvolWorkers, "-o", openebsVolname, snapName, fullVolName)
-
+	if len(cStorVolumeReplica.Spec.ZvolWorkers) != 0 {
+		cloneVolCmd = append(cloneVolCmd, CloneCmd,
+			"-o", "compression=on", "-o", openebsTargetIP, "-o", "quorum=on",
+			"-o", openebsZvolWorkers, "-o", openebsVolname, snapName, fullVolName)
+	} else {
+		cloneVolCmd = append(cloneVolCmd, CloneCmd,
+			"-o", "compression=on", "-o", openebsTargetIP, "-o", "quorum=on",
+			"-o", openebsVolname, snapName, fullVolName)
+	}
 	return cloneVolCmd
 }
 

--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -422,6 +422,8 @@ spec:
     {{- $nodeSelectorVal := fromYaml .Config.TargetNodeSelector.value -}}
     {{- $hasTargetToleration := .Config.TargetTolerations.value | default "none" -}}
     {{- $targetTolerationVal := fromYaml .Config.TargetTolerations.value -}}
+    {{- $isQueueDepth := .Config.QueueDepth.value | default "" -}}
+    {{- $isLuworkers := .Config.Luworkers.value | default "" -}}
     apiVersion: apps/v1beta1
     Kind: Deployment
     metadata:
@@ -551,10 +553,14 @@ spec:
             - containerPort: 3260
               protocol: TCP
             env:
+            {{- if ne $isQueueDepth "" }}
             - name: QueueDepth
               value: {{ .Config.QueueDepth.value }}
+            {{- end }}
+            {{- if ne $isLuworkers "" }}
             - name: Luworkers
               value: {{ .Config.Luworkers.value }}
+            {{- end }}
             securityContext:
               privileged: true
             volumeMounts:


### PR DESCRIPTION

**What this PR does / why we need it**:

Commit refactor the cstor tunnables env wrt to update
1. No env will be passed to target deployment if case there
   is no cas-config tunnables present in SC
2. Use default zfs create command if zvolworkers cas-config
   not present in SC

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests