### PR TITLE
[Cherry-pick] enhance(travis) Exit running tests when images aren't built (#877)

### DIFF
--- a/ci/build-maya.sh
+++ b/ci/build-maya.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+echo "*****************************Retagging images and setting up env***************************"
+#Images from this repo are always tagged as ci
+#The downloaded operator file will may contain a non-ci tag name
+# depending on when and from where it is being downloaded. For ex:
+# - during the release time, the image tags can be versioned like 0.7.0-RC..
+# - from a branch, the image tags can be the branch names like v0.7.x-ci
+
+set -e
+# If any of the images aren't present the script will exit returning
+# a non zero exit code, which will result in a build failure.
+if [ ${CI_TAG} != "ci" ]; then
+  sudo docker tag openebs/m-apiserver:ci openebs/m-apiserver:${CI_TAG}
+  sudo docker tag openebs/m-exporter:ci openebs/m-exporter:${CI_TAG}
+  sudo docker tag openebs/cstor-pool-mgmt:ci openebs/cstor-pool-mgmt:${CI_TAG}
+  sudo docker tag openebs/cstor-volume-mgmt:ci openebs/cstor-volume-mgmt:${CI_TAG}
+fi
+
+#Tag the images with quay.io, since the operator can either have quay or docker images
+sudo docker tag openebs/m-apiserver:ci quay.io/openebs/m-apiserver:${CI_TAG}
+sudo docker tag openebs/m-exporter:ci quay.io/openebs/m-exporter:${CI_TAG}
+sudo docker tag openebs/cstor-pool-mgmt:ci quay.io/openebs/cstor-pool-mgmt:${CI_TAG}
+sudo docker tag openebs/cstor-volume-mgmt:ci quay.io/openebs/cstor-volume-mgmt:${CI_TAG}
+
+## install iscsi pkg
+echo "Installing iscsi packages"
+sudo apt-get install open-iscsi
+sudo service iscsid start
+sudo service iscsid status
+echo "Installation complete"

--- a/ci/travis-ci.sh
+++ b/ci/travis-ci.sh
@@ -18,6 +18,8 @@
 ./ci/install_openebs.sh
 rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 
-#./ci/test_mayactl.sh
-./ci/setup_env.sh
+curl https://raw.githubusercontent.com/openebs/openebs/master/k8s/ci/test-script.sh > test-script.sh
+# append local tests to this script
+cat ./ci/mayactl.sh >> ./test-script.sh
+chmod +x test-script.sh && ./test-script.sh
 rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi


### PR DESCRIPTION
This PR is an alternative take to skip running integration tests when
there are build/UT errors.

It is possible that the image doesn't exist, in that case the `docker
tag` command will fail and return a non-zero return code, which will
stop the build.

fixes: https://github.com/openebs/openebs/issues/2320

Signed-off-by: Harsh Vardhan <harsh.vardhan@mayadata.io>
 Conflicts:
	ci/build-maya.sh
	ci/travis-ci.sh

**Checklist:**
- [x] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests