### PR TITLE
fix(cstor-pool, sock): delete sock file before deleting for cstor-pool container

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
@@ -124,6 +124,7 @@ func (c *CStorPoolController) cStorPoolEventHandler(operation common.QueueOperat
 		status, err := c.getPoolStatus(cStorPoolGot)
 		return status, err
 	}
+	glog.Errorf("Please handle cStorPool '%s' event on '%s'", string(operation), string(cStorPoolGot.ObjectMeta.Name))
 	return string(apis.CStorPoolStatusInvalid), nil
 }
 
@@ -356,7 +357,7 @@ func IsEmptyStatus(cStorPool *apis.CStorPool) bool {
 		glog.Infof("cStorPool empty status: %v", string(cStorPool.ObjectMeta.UID))
 		return true
 	}
-	glog.Infof("Not empty status: %v", string(cStorPool.ObjectMeta.UID))
+	glog.Infof("Not empty status: %v, %v phase: %v", string(cStorPool.ObjectMeta.Name), string(cStorPool.ObjectMeta.UID), cStorPool.Status.Phase)
 	return false
 }
 
@@ -366,7 +367,7 @@ func IsPendingStatus(cStorPool *apis.CStorPool) bool {
 		glog.Infof("cStorPool pending: %v", string(cStorPool.ObjectMeta.UID))
 		return true
 	}
-	glog.V(4).Infof("Not pending status: %v", string(cStorPool.ObjectMeta.UID))
+	glog.V(4).Infof("Not pending status: %v Phase: '%s'", string(cStorPool.ObjectMeta.UID), cStorPool.Status.Phase)
 	return false
 }
 

--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
@@ -124,7 +124,7 @@ func (c *CStorPoolController) cStorPoolEventHandler(operation common.QueueOperat
 		status, err := c.getPoolStatus(cStorPoolGot)
 		return status, err
 	}
-	glog.Errorf("Please handle cStorPool '%s' event on '%s'", string(operation), string(cStorPoolGot.ObjectMeta.Name))
+	glog.Errorf("ignored event '%s' for cstor pool '%s'", string(operation), string(cStorPoolGot.ObjectMeta.Name))
 	return string(apis.CStorPoolStatusInvalid), nil
 }
 
@@ -357,7 +357,7 @@ func IsEmptyStatus(cStorPool *apis.CStorPool) bool {
 		glog.Infof("cStorPool empty status: %v", string(cStorPool.ObjectMeta.UID))
 		return true
 	}
-	glog.Infof("Not empty status: %v, %v phase: %v", string(cStorPool.ObjectMeta.Name), string(cStorPool.ObjectMeta.UID), cStorPool.Status.Phase)
+	glog.Infof("cstor pool '%s': uid '%s': phase '%s': is_empty_status: false", string(cStorPool.ObjectMeta.Name), string(cStorPool.ObjectMeta.UID), cStorPool.Status.Phase)
 	return false
 }
 
@@ -367,7 +367,7 @@ func IsPendingStatus(cStorPool *apis.CStorPool) bool {
 		glog.Infof("cStorPool pending: %v", string(cStorPool.ObjectMeta.UID))
 		return true
 	}
-	glog.V(4).Infof("Not pending status: %v Phase: '%s'", string(cStorPool.ObjectMeta.UID), cStorPool.Status.Phase)
+	glog.V(4).Infof("cstor pool '%s': uid '%s': phase '%s': is_pending_status: false", string(cStorPool.ObjectMeta.Name), string(cStorPool.ObjectMeta.UID), cStorPool.Status.Phase)
 	return false
 }
 

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -132,15 +132,21 @@ func (c *CStorVolumeReplicaController) cVREventHandler(operation common.QueueOpe
 			return string(apis.CVRStatusDeletionFailed), err
 		}
 		return "", nil
+	case common.QOpModify:
+		fallthrough
 	case common.QOpSync:
-		glog.Infof("Synchronizing CstorVolumeReplica status for volume %s", cVR.ObjectMeta.Name)
+		if operation == common.QOpModify {
+			glog.Infof("Synchronizing CstorVolumeReplica status for volume: %s", cVR.ObjectMeta.Name)
+		} else if operation == common.QOpSync {
+			glog.Infof("Modify event for CstorVolumeReplica volume: %s", cVR.ObjectMeta.Name)
+		}
 		status, err := c.getCVRStatus(cVR)
 		if err != nil {
 			glog.Errorf("Unable to get volume status:%s", err.Error())
 		}
 		return status, err
 	}
-	glog.Warningf("No matching event handlers for cvr %s", cVR.ObjectMeta.Name)
+	glog.Warningf("No matching event handlers, please handle '%s' event fot cvr '%s'", operation, cVR.ObjectMeta.Name)
 	return string(apis.CVRStatusInvalid), nil
 }
 
@@ -159,13 +165,6 @@ func (c *CStorVolumeReplicaController) cVRAddEventHandler(cVR *apis.CStorVolumeR
 		}
 	} else {
 		common.SyncResources.Mux.Unlock()
-	}
-	// If volumereplica is already present.
-	existingvol, _ := volumereplica.GetVolumes()
-	if common.CheckIfPresent(existingvol, fullVolName) {
-		glog.Warningf("CStorVolumeReplica %v is already present", string(cVR.GetUID()))
-		c.recorder.Event(cVR, corev1.EventTypeWarning, string(common.AlreadyPresent), string(common.MessageResourceAlreadyPresent))
-		return string(apis.CVRStatusErrorDuplicate), nil
 	}
 
 	// Setting quorum to true for newly creating Volumes.
@@ -252,7 +251,7 @@ func IsOnlineStatus(cVR *apis.CStorVolumeReplica) bool {
 		glog.Infof("cVR Healthy status: %v", string(cVR.ObjectMeta.UID))
 		return true
 	}
-	glog.Infof("Not Healthy status: %v", string(cVR.ObjectMeta.UID))
+	glog.Infof("Not Healthy status: %v, %v phase: %v", string(cVR.ObjectMeta.Name), string(cVR.ObjectMeta.UID), cVR.Status.Phase)
 	return false
 }
 
@@ -262,7 +261,7 @@ func IsEmptyStatus(cVR *apis.CStorVolumeReplica) bool {
 		glog.Infof("cVR empty status: %v", string(cVR.ObjectMeta.UID))
 		return true
 	}
-	glog.Infof("Not empty status: %v", string(cVR.ObjectMeta.UID))
+	glog.Infof("Not empty status: %v, %v phase: %v", string(cVR.ObjectMeta.Name), string(cVR.ObjectMeta.UID), cVR.Status.Phase)
 	return false
 }
 

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/new_replica_controller.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/new_replica_controller.go
@@ -118,6 +118,8 @@ func NewCStorVolumeReplicaController(
 			// For New request phase of cVR will be empty
 			// ToDO: Need to have an annotation in CSP and CVR which will state
 			// about recreation events.
+			// For every restart of the cstor-pool-mgmt container replica
+			// watcher will get add event
 			if IsEmptyStatus(cVR) {
 				cVR.Status.Phase = apis.CVRStatusInit
 			} else {

--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -274,6 +274,10 @@ spec:
               postStart:
                  exec:
                     command: ["/bin/sh", "-c", "sleep 2"]
+              # Removes the sock file that is used for communication between
+              # cstor-pool and cstor-pool-mgmt containers, so that, cstor-pool-mgmt
+              # of new pool pod instance will NOT communicate with cstor-pool
+              # container of terminating pod instance.
               preStop:
                  exec:
                     command: ["/bin/bash", "-c", "rm /tmp/uzfs.sock"]

--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -141,7 +141,7 @@ spec:
         controller: true
         kind: StoragePoolClaim
         name: {{.Storagepool.owner}}
-        uid: {{ .TaskResult.getspc.objectUID }} 
+        uid: {{ .TaskResult.getspc.objectUID }}
     spec:
       disks:
         diskList:
@@ -274,6 +274,9 @@ spec:
               postStart:
                  exec:
                     command: ["/bin/sh", "-c", "sleep 2"]
+              preStop:
+                 exec:
+                    command: ["/bin/bash", "-c", "rm /tmp/uzfs.sock"]
           - name: cstor-pool-mgmt
             image: {{ .Config.CstorPoolMgmtImage.value }}
             resources:
@@ -406,7 +409,7 @@ spec:
         controller: true
         kind: Deployment
         name: {{ .TaskResult.putcstorpooldeployment.objectName }}
-        uid: {{ .TaskResult.putcstorpooldeployment.objectUID }}  
+        uid: {{ .TaskResult.putcstorpooldeployment.objectUID }}
     spec:
       disks:
         diskList:


### PR DESCRIPTION
### What this PR does:
This PR deletes the unix.sock file (_which is shared between the cstor-pool-mgmgt and cstor-pool_). This is deleted during cstor-pool container deletion phase via a preStop hook.

(https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/)
In other words, before triggering `kill` of cstor-pool container, kubernetes will execute this preStop hook.

### Why we need it
This fix avoids `RPC` between cstor-pool-mgmt container of a new pod and cstor-pool container of the terminating pod i.e. old pod.

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #https://github.com/openebs/openebs/issues/2447

**Special notes for your reviewer**:
Per every restart of the pool pod or cstor-pool-mgmt phase of the corresponding, cVR Phase is set to `Recreate` need to update as per review comments.

**Checklist:**
- [x] Fixes #openebs/openebs#2447
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [x] Labelled this PR & related issue with `requires-upgrade` tag
- [x] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests