### PR TITLE
feat(patch, upgrade-result): add patch and create support for upgrade result custom resource

### DIFF
--- a/pkg/kubernetes/patch/v1alpha1/patch.go
+++ b/pkg/kubernetes/patch/v1alpha1/patch.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"encoding/json"
+
+	"github.com/ghodss/yaml"
+	"github.com/openebs/maya/pkg/template"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// TaskPatchType is a custom type that holds the patch type
+type TaskPatchType string
+
+const (
+	// JsonTPT refers to a generic json patch type that is understood
+	// by Kubernetes API as well
+	JsonTPT TaskPatchType = "json"
+	// MergeTPT refers to a generic json merge patch type that is
+	// understood by Kubernetes API as well
+	MergeTPT TaskPatchType = "merge"
+	// StrategicTPT refers to a patch type that is understood
+	// by Kubernetes API only
+	StrategicTPT TaskPatchType = "strategic"
+)
+
+var taskPatchTypes = map[TaskPatchType]types.PatchType{
+	JsonTPT:      types.JSONPatchType,
+	MergeTPT:     types.MergePatchType,
+	StrategicTPT: types.StrategicMergePatchType,
+}
+
+// Patch will consist of patch that gets applied
+// against a particular resource
+type Patch struct {
+	// Type determines the type of patch to be applied
+	Type types.PatchType `json:"type"`
+	// object determines the actual patch object
+	Object []byte `json:"object"`
+}
+
+type builder struct {
+	patch  *Patch
+	checks []Predicate
+	errors []error
+}
+
+// Predicate abstracts conditional logic w.r.t the patch instance
+//
+// NOTE:
+// Predicate is a functional approach versus traditional approach to mix
+// conditions such as *if-else* within blocks of business logic
+//
+// NOTE:
+// Predicate approach enables clear separation of conditionals from
+// imperatives i.e. actions that form the business logic
+type Predicate func(*Patch) (message string, ok bool)
+
+// predicateFailedError returns the provided predicate as an error
+func predicateFailedError(message string) error {
+	return errors.Errorf("predicatefailed: %s", message)
+}
+
+// Builder returns a new instance of builder
+func Builder() *builder {
+	return &builder{
+		patch: &Patch{},
+	}
+}
+
+// BuilderForObject returns a new instance of builder
+// when a patch obj and patch type is given
+func BuilderForObject(Type types.PatchType, obj []byte) *builder {
+	return &builder{
+		patch: &Patch{
+			Type:   Type,
+			Object: obj,
+		},
+	}
+}
+
+// BuilderForRuntask returns a new instance of builder
+// for runtask when a runtask patch yaml is given
+func BuilderForRuntask(context, yml string, values map[string]interface{}) *builder {
+	type taskPatch struct {
+		// Type determines the type of patch to be applied
+		Type TaskPatchType `json:"type"`
+		// Specs determines the actual patch object
+		Specs string `json:"pspec"`
+	}
+	t := &taskPatch{}
+	b := &builder{}
+	p, err := template.AsTemplatedBytes(context, yml, values)
+	if err != nil {
+		b.errors = append(b.errors, err)
+		return b
+	}
+	// unmarshall into taskPatch
+	err = yaml.Unmarshal(p, t)
+	if err != nil {
+		b.errors = append(b.errors, err)
+		return b
+	}
+	b.patch = &Patch{
+		Type:   (taskPatchType(t.Type)),
+		Object: []byte(t.Specs),
+	}
+	return b
+}
+
+// validate will run checks against patch instance
+func (b *builder) validate() error {
+	for _, c := range b.checks {
+		if m, ok := c(b.patch); !ok {
+			b.errors = append(b.errors, predicateFailedError(m))
+		}
+	}
+	if len(b.errors) == 0 {
+		return nil
+	}
+	return errors.New("patch validation failed")
+}
+
+// Build returns the final instance of patch
+func (b *builder) Build() (*Patch, error) {
+	err := b.validate()
+	if err != nil {
+		return nil, err
+	}
+	return b.patch, nil
+}
+
+// AddCheck adds the predicate as a condition to be validated against the
+// patch instance
+func (b *builder) AddCheck(p Predicate) *builder {
+	b.checks = append(b.checks, p)
+	return b
+}
+
+// AddChecks adds the provided predicates as conditions to be validated against
+// the patch instance
+func (b *builder) AddChecks(p []Predicate) *builder {
+	for _, check := range p {
+		b.AddCheck(check)
+	}
+	return b
+}
+
+// ToJSON converts the patch in yaml document format to corresponding
+// json document
+func (p *Patch) ToJSON() ([]byte, error) {
+	m := map[string]interface{}{}
+	err := yaml.Unmarshal(p.Object, &m)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(m)
+}
+
+// IsValidPatchType returns true if provided patch
+// type is one of the valid patch types
+func IsValidPatchType() Predicate {
+	return func(p *Patch) (string, bool) {
+		if p.Type == types.JSONPatchType || p.Type == types.MergePatchType ||
+			p.Type == types.StrategicMergePatchType {
+			return "Valid patch Type", true
+		}
+		return "Invalid patch type", false
+	}
+}
+
+// taskPatchType maps the runtask patch type to
+// kubernetes patch type
+func taskPatchType(tpt TaskPatchType) types.PatchType {
+	return taskPatchTypes[tpt]
+}

--- a/pkg/kubernetes/patch/v1alpha1/patch.go
+++ b/pkg/kubernetes/patch/v1alpha1/patch.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/ghodss/yaml"
 	"github.com/openebs/maya/pkg/template"
@@ -25,26 +26,30 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// TaskPatchType is a custom type that holds the patch type
-type TaskPatchType string
+// PatchType is a custom type that holds the patch type
+type PatchType string
 
 const (
-	// JsonTPT refers to a generic json patch type that is understood
+	// PatchTypeJSON refers to a generic json patch type that is understood
 	// by Kubernetes API as well
-	JsonTPT TaskPatchType = "json"
-	// MergeTPT refers to a generic json merge patch type that is
+	PatchTypeJSON PatchType = "json"
+	// PatchTypeMerge refers to a generic json merge patch type that is
 	// understood by Kubernetes API as well
-	MergeTPT TaskPatchType = "merge"
-	// StrategicTPT refers to a patch type that is understood
+	PatchTypeMerge PatchType = "merge"
+	// PatchTypeStrategic refers to a patch type that is understood
 	// by Kubernetes API only
-	StrategicTPT TaskPatchType = "strategic"
+	PatchTypeStrategic PatchType = "strategic"
 )
 
-var taskPatchTypes = map[TaskPatchType]types.PatchType{
-	JsonTPT:      types.JSONPatchType,
-	MergeTPT:     types.MergePatchType,
-	StrategicTPT: types.StrategicMergePatchType,
+// kubePatchTypes map task patch types
+// to k8s patch types
+var kubePatchTypes = map[PatchType]types.PatchType{
+	PatchTypeJSON:      types.JSONPatchType,
+	PatchTypeMerge:     types.MergePatchType,
+	PatchTypeStrategic: types.StrategicMergePatchType,
 }
+
+var predicatesInfo = map[*Predicate]string{}
 
 // Patch will consist of patch that gets applied
 // against a particular resource
@@ -55,9 +60,20 @@ type Patch struct {
 	Object []byte `json:"object"`
 }
 
-type builder struct {
+// GoString provides the essential Patch struct details
+func (p *Patch) GoString() string {
+	return fmt.Sprintf("Patch{Type: %s}", p.Type)
+}
+
+// String provides the essential Patch details
+func (p *Patch) String() string {
+	return fmt.Sprintf("patch with type '%s'", p.Type)
+}
+
+// Builder returns a new instance of builder
+type Builder struct {
 	patch  *Patch
-	checks []Predicate
+	checks []*Predicate
 	errors []error
 }
 
@@ -70,24 +86,24 @@ type builder struct {
 // NOTE:
 // Predicate approach enables clear separation of conditionals from
 // imperatives i.e. actions that form the business logic
-type Predicate func(*Patch) (message string, ok bool)
+type Predicate func(*Patch) bool
 
 // predicateFailedError returns the provided predicate as an error
 func predicateFailedError(message string) error {
 	return errors.Errorf("predicatefailed: %s", message)
 }
 
-// Builder returns a new instance of builder
-func Builder() *builder {
-	return &builder{
+// NewBuilder returns a new instance of builder
+func NewBuilder() *Builder {
+	return &Builder{
 		patch: &Patch{},
 	}
 }
 
 // BuilderForObject returns a new instance of builder
 // when a patch obj and patch type is given
-func BuilderForObject(Type types.PatchType, obj []byte) *builder {
-	return &builder{
+func BuilderForObject(Type types.PatchType, obj []byte) *Builder {
+	return &Builder{
 		patch: &Patch{
 			Type:   Type,
 			Object: obj,
@@ -97,16 +113,19 @@ func BuilderForObject(Type types.PatchType, obj []byte) *builder {
 
 // BuilderForRuntask returns a new instance of builder
 // for runtask when a runtask patch yaml is given
-func BuilderForRuntask(context, yml string, values map[string]interface{}) *builder {
-	type taskPatch struct {
+func BuilderForRuntask(context, templateYaml string,
+	templateValues map[string]interface{}) *Builder {
+	// runTaskPatch reflects a runtask having
+	// patch action
+	type runTaskPatch struct {
 		// Type determines the type of patch to be applied
-		Type TaskPatchType `json:"type"`
-		// Specs determines the actual patch object
-		Specs string `json:"pspec"`
+		Type PatchType `json:"type"`
+		// Spec determines the actual patch object
+		Spec string `json:"pspec"`
 	}
-	t := &taskPatch{}
-	b := &builder{}
-	p, err := template.AsTemplatedBytes(context, yml, values)
+	t := &runTaskPatch{}
+	b := &Builder{}
+	p, err := template.AsTemplatedBytes(context, templateYaml, templateValues)
 	if err != nil {
 		b.errors = append(b.errors, err)
 		return b
@@ -118,27 +137,31 @@ func BuilderForRuntask(context, yml string, values map[string]interface{}) *buil
 		return b
 	}
 	b.patch = &Patch{
-		Type:   (taskPatchType(t.Type)),
-		Object: []byte(t.Specs),
+		Type:   kubePatchTypes[t.Type],
+		Object: []byte(t.Spec),
 	}
 	return b
 }
 
 // validate will run checks against patch instance
-func (b *builder) validate() error {
+func (b *Builder) validate() error {
 	for _, c := range b.checks {
-		if m, ok := c(b.patch); !ok {
-			b.errors = append(b.errors, predicateFailedError(m))
+		if ok := (*c)(b.patch); !ok {
+			b.errors = append(b.errors,
+				errors.Errorf("predicatefailed: %s", predicatesInfo[c]))
 		}
 	}
 	if len(b.errors) == 0 {
 		return nil
 	}
-	return errors.New("patch validation failed")
+	return errors.Errorf("patch validation failed: %v", b.errors)
 }
 
 // Build returns the final instance of patch
-func (b *builder) Build() (*Patch, error) {
+func (b *Builder) Build() (*Patch, error) {
+	if len(b.errors) != 0 {
+		return nil, errors.Errorf("%v", b.errors)
+	}
 	err := b.validate()
 	if err != nil {
 		return nil, err
@@ -148,22 +171,22 @@ func (b *builder) Build() (*Patch, error) {
 
 // AddCheck adds the predicate as a condition to be validated against the
 // patch instance
-func (b *builder) AddCheck(p Predicate) *builder {
-	b.checks = append(b.checks, p)
+func (b *Builder) AddCheck(p Predicate, predicateInfo string) *Builder {
+	predicatesInfo[&p] = predicateInfo
+	b.checks = append(b.checks, &p)
 	return b
 }
 
 // AddChecks adds the provided predicates as conditions to be validated against
 // the patch instance
-func (b *builder) AddChecks(p []Predicate) *builder {
-	for _, check := range p {
-		b.AddCheck(check)
+func (b *Builder) AddChecks(predicates ...Predicate) *Builder {
+	for _, check := range predicates {
+		b.AddCheck(check, "")
 	}
 	return b
 }
 
-// ToJSON converts the patch in yaml document format to corresponding
-// json document
+// ToJSON converts the patch to json format
 func (p *Patch) ToJSON() ([]byte, error) {
 	m := map[string]interface{}{}
 	err := yaml.Unmarshal(p.Object, &m)
@@ -173,20 +196,26 @@ func (p *Patch) ToJSON() ([]byte, error) {
 	return json.Marshal(m)
 }
 
-// IsValidPatchType returns true if provided patch
-// type is one of the valid patch types
-func IsValidPatchType() Predicate {
-	return func(p *Patch) (string, bool) {
-		if p.Type == types.JSONPatchType || p.Type == types.MergePatchType ||
-			p.Type == types.StrategicMergePatchType {
-			return "Valid patch Type", true
-		}
-		return "Invalid patch type", false
+// JSON builds and returns JSON format of the patch object
+func (b *Builder) JSON() ([]byte, error) {
+	p, err := b.Build()
+	if err != nil {
+		return nil, err
+	}
+	return p.ToJSON()
+}
+
+// IsValidType returns a predicate for
+// checking valid patch type
+func IsValidType() Predicate {
+	return func(p *Patch) bool {
+		return p.IsValidType()
 	}
 }
 
-// taskPatchType maps the runtask patch type to
-// kubernetes patch type
-func taskPatchType(tpt TaskPatchType) types.PatchType {
-	return taskPatchTypes[tpt]
+// IsValidType returns true if provided patch
+// type is one of the valid patch types
+func (p *Patch) IsValidType() bool {
+	return p.Type == types.JSONPatchType || p.Type == types.MergePatchType ||
+		p.Type == types.StrategicMergePatchType
 }

--- a/pkg/kubernetes/patch/v1alpha1/patch_test.go
+++ b/pkg/kubernetes/patch/v1alpha1/patch_test.go
@@ -1,0 +1,122 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func fakePredicate() Predicate {
+	return func(p *Patch) bool {
+		return true
+	}
+}
+
+func TestNewBuilder(t *testing.T) {
+	tests := map[string]struct {
+		expectPatch  bool
+		expectChecks bool
+	}{
+		"call NewBuilder": {
+			true, true,
+		},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			b := NewBuilder()
+			patch := (b.patch != nil)
+			if patch != mock.expectPatch {
+				t.Fatalf("test %s failed, expected non-nil patch but got : %+v",
+					name, b.patch)
+			}
+			checks := (b.checks != nil)
+			if checks != mock.expectChecks {
+				t.Fatalf("test %s failed, expected non-nil checks but got : %+v",
+					name, b.checks)
+			}
+		})
+	}
+}
+
+func TestBuilderForObject(t *testing.T) {
+	tests := map[string]struct {
+		inputType    types.PatchType
+		inputObject  []byte
+		expectedType types.PatchType
+		expectedObj  []byte
+		expectChecks bool
+	}{
+		"call BuilderForObject with patch type and patch object": {
+			"application/json-patch+json",
+			[]byte("abc"),
+			"application/json-patch+json",
+			[]byte("abc"),
+			true,
+		},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			b := BuilderForObject(mock.inputType, mock.inputObject)
+			gotType := b.patch.Type
+			gotObject := b.patch.Object
+			if gotType != mock.expectedType {
+				t.Fatalf("test %s failed, expected type %+v but got : %+v",
+					name, mock.expectedType, gotType)
+			}
+			if string(gotObject) != string(mock.expectedObj) {
+				t.Fatalf("test %s failed, expected obj %s but got : %s",
+					name, string(mock.expectedObj), string(gotObject))
+			}
+			checks := (b.checks != nil)
+			if checks != mock.expectChecks {
+				t.Fatalf("test %s failed, expected non-nil checks but got : %+v",
+					name, b.checks)
+			}
+		})
+	}
+}
+
+func TestIsValidType(t *testing.T) {
+	tests := map[string]struct {
+		patch          *Patch
+		expectedOutput bool
+	}{
+		"Patch with type application/json-patch+json": {
+			&Patch{Type: "application/json-patch+json"},
+			true,
+		},
+		"Patch with type json": {
+			&Patch{Type: "json"},
+			false,
+		},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			isValid := mock.patch.IsValidType()
+			if isValid != mock.expectedOutput {
+				t.Fatalf("test %s failed, expected %+v but got : %+v",
+					name, mock.expectedOutput, isValid)
+			}
+		})
+	}
+}
+
+func TestAddCheck(t *testing.T) {
+	tests := map[string]struct {
+		input                Predicate
+		expectedChecksLength int
+	}{
+		"When a predicate is given": {
+			fakePredicate(), 1,
+		},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			b := NewBuilder().AddCheck(mock.input)
+			if len(b.checks) != mock.expectedChecksLength {
+				t.Fatalf("test %s failed, expected checks length %+v but got : %+v",
+					name, mock.expectedChecksLength, len(b.checks))
+			}
+		})
+	}
+}

--- a/pkg/kubernetes/patch/v1alpha1/patch_test.go
+++ b/pkg/kubernetes/patch/v1alpha1/patch_test.go
@@ -24,15 +24,13 @@ func TestNewBuilder(t *testing.T) {
 	for name, mock := range tests {
 		t.Run(name, func(t *testing.T) {
 			b := NewBuilder()
-			patch := (b.patch != nil)
-			if patch != mock.expectPatch {
-				t.Fatalf("test %s failed, expected non-nil patch but got : %+v",
-					name, b.patch)
+			if (b.patch != nil) != mock.expectPatch {
+				t.Fatalf("test %s failed, expect patch: %t but got: %t",
+					name, mock.expectPatch, b.patch != nil)
 			}
-			checks := (b.checks != nil)
-			if checks != mock.expectChecks {
-				t.Fatalf("test %s failed, expected non-nil checks but got : %+v",
-					name, b.checks)
+			if (b.checks != nil) != mock.expectChecks {
+				t.Fatalf("test %s failed, expect checks: %t but got: %t",
+					name, mock.expectChecks, b.checks != nil)
 			}
 		})
 	}
@@ -107,7 +105,12 @@ func TestAddCheck(t *testing.T) {
 		expectedChecksLength int
 	}{
 		"When a predicate is given": {
-			fakePredicate(), 1,
+			fakePredicate(),
+			1,
+		},
+		"When nil is given": {
+			nil,
+			0,
 		},
 	}
 	for name, mock := range tests {

--- a/pkg/task/meta.go
+++ b/pkg/task/meta.go
@@ -460,6 +460,8 @@ func (m *metaTaskExecutor) isPutOEV1alpha1CVR() bool {
 	return m.identifier.isOEV1alpha1CVR() && m.isPut()
 }
 
+// isPutOEV1alpha1UR returns true if put operation is
+// defined for upgradeResult
 func (m *metaTaskExecutor) isPutOEV1alpha1UR() bool {
 	return m.identifier.isOEV1alpha1UR() && m.isPut()
 }
@@ -488,6 +490,8 @@ func (m *metaTaskExecutor) isPatchOEV1alpha1CVR() bool {
 	return m.identifier.isOEV1alpha1CVR() && m.isPatch()
 }
 
+// isPatchOEV1alpha1UR returns true if patch operation is
+// defined for upgradeResult
 func (m *metaTaskExecutor) isPatchOEV1alpha1UR() bool {
 	return m.identifier.isOEV1alpha1UR() && m.isPatch()
 }

--- a/pkg/task/meta.go
+++ b/pkg/task/meta.go
@@ -460,8 +460,8 @@ func (m *metaTaskExecutor) isPutOEV1alpha1CVR() bool {
 	return m.identifier.isOEV1alpha1CVR() && m.isPut()
 }
 
-// isPutOEV1alpha1UR returns true if put operation is
-// defined for upgradeResult
+// isPutOEV1alpha1UR returns true if RunTask.Spec.meta
+// is set with action=put and kind=UpgradeResult
 func (m *metaTaskExecutor) isPutOEV1alpha1UR() bool {
 	return m.identifier.isOEV1alpha1UR() && m.isPut()
 }
@@ -490,8 +490,8 @@ func (m *metaTaskExecutor) isPatchOEV1alpha1CVR() bool {
 	return m.identifier.isOEV1alpha1CVR() && m.isPatch()
 }
 
-// isPatchOEV1alpha1UR returns true if patch operation is
-// defined for upgradeResult
+// isPatchOEV1alpha1UR returns true if RunTask.Spec.meta
+// is set with action=patch and kind=UpgradeResult
 func (m *metaTaskExecutor) isPatchOEV1alpha1UR() bool {
 	return m.identifier.isOEV1alpha1UR() && m.isPatch()
 }

--- a/pkg/task/meta.go
+++ b/pkg/task/meta.go
@@ -460,6 +460,10 @@ func (m *metaTaskExecutor) isPutOEV1alpha1CVR() bool {
 	return m.identifier.isOEV1alpha1CVR() && m.isPut()
 }
 
+func (m *metaTaskExecutor) isPutOEV1alpha1UR() bool {
+	return m.identifier.isOEV1alpha1UR() && m.isPut()
+}
+
 func (m *metaTaskExecutor) isDeleteOEV1alpha1SP() bool {
 	return m.identifier.isOEV1alpha1SP() && m.isDelete()
 }

--- a/pkg/task/meta.go
+++ b/pkg/task/meta.go
@@ -484,6 +484,10 @@ func (m *metaTaskExecutor) isPatchOEV1alpha1CVR() bool {
 	return m.identifier.isOEV1alpha1CVR() && m.isPatch()
 }
 
+func (m *metaTaskExecutor) isPatchOEV1alpha1UR() bool {
+	return m.identifier.isOEV1alpha1UR() && m.isPatch()
+}
+
 func (m *metaTaskExecutor) isListOEV1alpha1Disk() bool {
 	return m.identifier.isOEV1alpha1Disk() && m.isList()
 }

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -697,19 +697,15 @@ func (m *taskExecutor) patchUpgradeResult() (err error) {
 	// build a runtask patch instance
 	patch, err := patch.
 		BuilderForRuntask("UpgradeResult", m.runtask.Spec.Task, m.templateValues).
-		AddCheck(patch.IsValidType(), "IsValidType").
+		AddCheckf(patch.IsValidType(), "IsValidType").
 		Build()
-	if err != nil {
-		return
-	}
-	raw, err := patch.ToJSON()
 	if err != nil {
 		return
 	}
 	// patch Upgrade Result
 	p, err := upgraderesult.
 		KubeClient(upgraderesult.WithNamespace(m.getTaskRunNamespace())).
-		Patch(m.getTaskObjectName(), patch.Type, raw)
+		Patch(m.getTaskObjectName(), patch.Type, patch.Object)
 	if err != nil {
 		return
 	}

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -393,6 +393,8 @@ func (m *taskExecutor) ExecuteIt() (err error) {
 		err = m.putCStorVolume()
 	} else if m.metaTaskExec.isPutOEV1alpha1CVR() {
 		err = m.putCStorVolumeReplica()
+	} else if m.metaTaskExec.isPutOEV1alpha1UR() {
+		err = m.putUpgradeResult()
 	} else if m.metaTaskExec.isDeleteOEV1alpha1SP() {
 		err = m.deleteOEV1alpha1SP()
 	} else if m.metaTaskExec.isDeleteOEV1alpha1CSP() {
@@ -1089,6 +1091,19 @@ func (m *taskExecutor) putCStorVolumeReplica() (err error) {
 	}
 
 	util.SetNestedField(m.templateValues, cstorVolumeReplica, string(v1alpha1.CurrentJSONResultTLP))
+	return
+}
+
+// putUpgradeResult will put an upgrade result as defined in the task
+func (m *taskExecutor) putUpgradeResult() (err error) {
+	uresult, err := upgrade.BuilderForRuntask("UpgradeResult", m.runtask.Spec.Task, m.templateValues).Build()
+	uc := upgrade.KubeClient(upgrade.WithNamespace(m.getTaskRunNamespace()))
+	// put Upgrade Result
+	ur, err := uc.CreateAsRaw(uresult)
+	if err != nil {
+		return
+	}
+	util.SetNestedField(m.templateValues, ur, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
 

--- a/pkg/upgrade/result/v1alpha1/kubernetes.go
+++ b/pkg/upgrade/result/v1alpha1/kubernetes.go
@@ -186,6 +186,9 @@ func (k *kubeclient) Create(upgradeResultObj *apis.UpgradeResult) (*apis.Upgrade
 // Patch returns the patched upgrade result instance
 func (k *kubeclient) Patch(name string, pt types.PatchType,
 	patchObj []byte) (*apis.UpgradeResult, error) {
+	if strings.TrimSpace(name) == "" {
+		return nil, errors.New("failed to patch upgrade result: missing upgradeResult name")
+	}
 	cs, err := k.getClientOrCached()
 	if err != nil {
 		return nil, err

--- a/pkg/upgrade/result/v1alpha1/kubernetes.go
+++ b/pkg/upgrade/result/v1alpha1/kubernetes.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 
@@ -172,6 +173,16 @@ func (k *kubeclient) Get(name string, opts metav1.GetOptions) (*apis.UpgradeResu
 		return nil, err
 	}
 	return k.get(cs, name, k.namespace, opts)
+}
+
+// Create creates an upgrade result instance
+// and returns raw upgradeResult instance
+func (k *kubeclient) CreateAsRaw(upgradeResultObj *apis.UpgradeResult) ([]byte, error) {
+	ur, err := k.Create(upgradeResultObj)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(ur)
 }
 
 // Create creates an upgrade result instance in kubernetes cluster

--- a/pkg/upgrade/result/v1alpha1/kubernetes.go
+++ b/pkg/upgrade/result/v1alpha1/kubernetes.go
@@ -175,9 +175,9 @@ func (k *kubeclient) Get(name string, opts metav1.GetOptions) (*apis.UpgradeResu
 	return k.get(cs, name, k.namespace, opts)
 }
 
-// Create creates an upgrade result instance
+// CreateRaw creates an upgrade result instance
 // and returns raw upgradeResult instance
-func (k *kubeclient) CreateAsRaw(upgradeResultObj *apis.UpgradeResult) ([]byte, error) {
+func (k *kubeclient) CreateRaw(upgradeResultObj *apis.UpgradeResult) ([]byte, error) {
 	ur, err := k.Create(upgradeResultObj)
 	if err != nil {
 		return nil, err

--- a/pkg/upgrade/result/v1alpha1/kubernetes_test.go
+++ b/pkg/upgrade/result/v1alpha1/kubernetes_test.go
@@ -63,7 +63,7 @@ func fakeCreateErr(cs *clientset.Clientset, upgradeResultObj *apis.UpgradeResult
 	return &apis.UpgradeResult{}, errors.New("some error")
 }
 
-func fakePatch(cs *clientset.Clientset, name string, pt types.PatchType, patchObj []byte,
+func fakePatchOk(cs *clientset.Clientset, name string, pt types.PatchType, patchObj []byte,
 	namespace string) (*apis.UpgradeResult, error) {
 	return &apis.UpgradeResult{}, nil
 }
@@ -90,7 +90,7 @@ func TestWithDefaults(t *testing.T) {
 		// tested using these two combinations only.
 		"When mockclient is empty": {nil, nil, nil, nil, nil, false, false, false, false, false},
 		"When mockclient contains all of them": {fakeListfn, fakeGetfn,
-			fakeGetClientset, fakeCreateOk, fakePatch, false, false, false, false, false},
+			fakeGetClientset, fakeCreateOk, fakePatchOk, false, false, false, false, false},
 	}
 
 	for name, mock := range tests {
@@ -218,12 +218,12 @@ func TestGetClientOrCached(t *testing.T) {
 	}{
 		// Positive tests
 		"When clientset is nil": {&kubeclient{nil, "default",
-			fakeGetNilErrClientSet, fakeListfn, fakeGetfn, fakeCreateOk, fakePatch}, false},
+			fakeGetNilErrClientSet, fakeListfn, fakeGetfn, fakeCreateOk, fakePatchOk}, false},
 		"When clientset is not nil": {&kubeclient{&clientset.Clientset{},
-			"", fakeGetNilErrClientSet, fakeListfn, fakeGetfn, fakeCreateOk, fakePatch}, false},
+			"", fakeGetNilErrClientSet, fakeListfn, fakeGetfn, fakeCreateOk, fakePatchOk}, false},
 		// Negative tests
 		"When getting clientset throws error": {&kubeclient{nil, "",
-			fakeGetErrClientSet, fakeListfn, fakeGetfn, fakeCreateOk, fakePatch}, true},
+			fakeGetErrClientSet, fakeListfn, fakeGetfn, fakeCreateOk, fakePatchOk}, true},
 	}
 
 	for name, mock := range tests {
@@ -342,7 +342,7 @@ func TestKubernetesPatch(t *testing.T) {
 		"When get clientset throws error": {
 			"ur1", "application/merge-patch+json", []byte{},
 			fakeGetErrClientSet,
-			fakePatch,
+			fakePatchOk,
 			true},
 		"When patch resource throws error": {
 			"ur2", "application/json-patch+json", []byte{},
@@ -352,17 +352,17 @@ func TestKubernetesPatch(t *testing.T) {
 		"When patch object name is empty string": {
 			"", "application/merge-patch+json", nil,
 			fakeGetClientset,
-			fakePatch,
+			fakePatchOk,
 			true},
 		"When patch object is nil": {
 			"ur3", "application/merge-patch+json", nil,
 			fakeGetClientset,
-			fakePatch,
+			fakePatchOk,
 			false},
 		"When non-empty patch obj is given": {
 			"ur5", "application/strategic-merge-patch+json", []byte(patchObjStr),
 			fakeGetClientset,
-			fakePatch,
+			fakePatchOk,
 			false},
 	}
 

--- a/pkg/upgrade/result/v1alpha1/kubernetes_test.go
+++ b/pkg/upgrade/result/v1alpha1/kubernetes_test.go
@@ -303,16 +303,30 @@ func TestKubernetesCreate(t *testing.T) {
 		create           createFunc
 		expectErr        bool
 	}{
-		"When getting clientset throws error": {&apis.UpgradeResult{},
-			fakeGetErrClientSet, fakeCreateOk, true},
-		"When creating resource throws error": {&apis.UpgradeResult{},
-			fakeGetClientset, fakeCreateErr, true},
-		"When upgradeResult object is nil": {nil, fakeGetClientset,
-			fakeCreateOk, false},
-		"When an empty upgradeResult struct is given": {&apis.UpgradeResult{},
-			fakeGetClientset, fakeCreateOk, false},
-		"When non-empty upgradeResult struct is given": {upgradeResultObject,
-			fakeGetClientset, fakeCreateOk, false},
+		"When getting clientset throws error": {
+			&apis.UpgradeResult{},
+			fakeGetErrClientSet,
+			fakeCreateOk, true},
+		"When creating resource throws error": {
+			&apis.UpgradeResult{},
+			fakeGetClientset,
+			fakeCreateErr,
+			true},
+		"When upgradeResult object is nil": {
+			nil,
+			fakeGetClientset,
+			fakeCreateOk,
+			false},
+		"When an empty upgradeResult struct is given": {
+			&apis.UpgradeResult{},
+			fakeGetClientset,
+			fakeCreateOk,
+			false},
+		"When non-empty upgradeResult struct is given": {
+			upgradeResultObject,
+			fakeGetClientset,
+			fakeCreateOk,
+			false},
 	}
 
 	for name, mock := range tests {

--- a/pkg/upgrade/result/v1alpha1/upgraderesult_test.go
+++ b/pkg/upgrade/result/v1alpha1/upgraderesult_test.go
@@ -26,15 +26,13 @@ func TestNewBuilder(t *testing.T) {
 	for name, mock := range tests {
 		t.Run(name, func(t *testing.T) {
 			b := NewBuilder()
-			upgradeResult := (b.upgradeResult != nil)
-			if upgradeResult != mock.expectUpgradeResult {
-				t.Fatalf("test %s failed, expected non-nil upgraderesult but got : %+v",
-					name, b.upgradeResult)
+			if (b.upgradeResult != nil) != mock.expectUpgradeResult {
+				t.Fatalf("test %s failed, expect upgraderesult: %t but got: %t",
+					name, mock.expectUpgradeResult, b.upgradeResult != nil)
 			}
-			checks := (b.checks != nil)
-			if checks != mock.expectChecks {
-				t.Fatalf("test %s failed, expected non-nil checks but got : %+v",
-					name, b.checks)
+			if (b.checks != nil) != mock.expectChecks {
+				t.Fatalf("test %s failed, expect checks: %t but got: %t",
+					name, mock.expectChecks, b.checks != nil)
 			}
 		})
 	}

--- a/pkg/upgrade/result/v1alpha1/upgraderesult_test.go
+++ b/pkg/upgrade/result/v1alpha1/upgraderesult_test.go
@@ -16,18 +16,18 @@ func TestWithAPIList(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "upgradeResultList1"}}}}
 	tests := map[string]struct {
 		inputURList    *apis.UpgradeResultList
-		expectedOutput *upgradeResultList
+		expectedOutput *UpgradeResultList
 	}{
 		"empty upgrade result list": {&apis.UpgradeResultList{},
-			&upgradeResultList{}},
-		"using nil input": {nil, &upgradeResultList{}},
+			&UpgradeResultList{}},
+		"using nil input": {nil, &UpgradeResultList{}},
 		"non-empty upgrade result list": {&apis.UpgradeResultList{Items: inputURItems},
-			&upgradeResultList{items: outputURItems}},
+			&UpgradeResultList{items: outputURItems}},
 	}
 
 	for name, mock := range tests {
 		t.Run(name, func(t *testing.T) {
-			b := ListBuilder().WithAPIList(mock.inputURList)
+			b := NewListBuilder().WithAPIList(mock.inputURList)
 			if len(b.list.items) != len(mock.expectedOutput.items) {
 				t.Fatalf("test %s failed, expected len: %d got: %d",
 					name, len(mock.expectedOutput.items), len(b.list.items))
@@ -47,18 +47,18 @@ func TestList(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "upgradeResultList1"}}}}
 	tests := map[string]struct {
 		inputURList    *apis.UpgradeResultList
-		expectedOutput *upgradeResultList
+		expectedOutput *UpgradeResultList
 	}{
 		"empty upgrade result list": {&apis.UpgradeResultList{},
-			&upgradeResultList{}},
-		"using nil input": {nil, &upgradeResultList{}},
+			&UpgradeResultList{}},
+		"using nil input": {nil, &UpgradeResultList{}},
 		"non-empty upgrade result list": {&apis.UpgradeResultList{Items: inputURItems},
-			&upgradeResultList{items: outputURItems}},
+			&UpgradeResultList{items: outputURItems}},
 	}
 
 	for name, mock := range tests {
 		t.Run(name, func(t *testing.T) {
-			b := ListBuilder().WithAPIList(mock.inputURList).List()
+			b := NewListBuilder().WithAPIList(mock.inputURList).List()
 			if len(b.items) != len(mock.expectedOutput.items) {
 				t.Fatalf("test %s failed, expected len: %d got: %d",
 					name, len(mock.expectedOutput.items), len(b.items))

--- a/pkg/upgrade/result/v1alpha1/upgraderesult_test.go
+++ b/pkg/upgrade/result/v1alpha1/upgraderesult_test.go
@@ -9,6 +9,152 @@ import (
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/upgrade/v1alpha1"
 )
 
+func fakePredicate() Predicate {
+	return func(p *upgradeResult) bool {
+		return true
+	}
+}
+func TestNewBuilder(t *testing.T) {
+	tests := map[string]struct {
+		expectUpgradeResult bool
+		expectChecks        bool
+	}{
+		"call NewBuilder": {
+			true, true,
+		},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			b := NewBuilder()
+			upgradeResult := (b.upgradeResult != nil)
+			if upgradeResult != mock.expectUpgradeResult {
+				t.Fatalf("test %s failed, expected non-nil upgraderesult but got : %+v",
+					name, b.upgradeResult)
+			}
+			checks := (b.checks != nil)
+			if checks != mock.expectChecks {
+				t.Fatalf("test %s failed, expected non-nil checks but got : %+v",
+					name, b.checks)
+			}
+		})
+	}
+}
+func TestBuilderForRuntask(t *testing.T) {
+	var tv map[string]interface{}
+	validYaml :=
+		`
+apiVersion: openebs.io/v1alpha1
+config:
+kind: UpgradeResult
+metadata:
+   name: test-pr-abc12345
+   namespace: default
+status:
+  actualCount: 1
+  desiredCount: 2
+  failedCount: 1
+  resource:
+    apiVersion: v1
+    kind: Persistent Volume
+    name: pv-1
+    namespace: default
+    postState:
+      lastTransitionTime: 2019-03-12T06:59:46Z
+      message: CStor volume Replica "cvr-1" is healthy after upgrade.
+      status: Healthy
+    preState:
+      lastTransitionTime: 2019-03-12T06:59:46Z
+      message: CStor volume Replica "cvr-1" is healthy.
+      status: Healthy
+  subResources:
+  - apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: target-deploy-abc
+    namespace: openebs
+    postState:
+      lastTransitionTime: null
+      message: ""
+      status: ""
+    preState:
+      lastTransitionTime: null
+      message: ""
+      status: ""
+tasks:
+- endTime: null
+  lastError: ""
+  lastTransitionTime: 2019-03-12T07:50:41Z
+  message: Deployment "target-deploy-abc" has been successfully patched.
+  name: patch-target-deploy
+  retries: 0
+  startTime: null
+  status: completed
+- endTime: null
+  lastError: ""
+  lastTransitionTime: 2019-03-12T07:59:40Z
+  message: ""
+  name: patch-cvr
+  retries: 0
+  startTime: null
+  status: CStor volume replica "cvr-1" has been successfully patched.
+`
+	invalidYaml :=
+		`apiVersion: openebs.io/v1alpha1
+    config:
+    kind:
+    UpgradeResult
+    metadata:
+       name: test-pr-abc12345
+       namespace: default
+    status:
+      actualCount: 1
+      desiredCount: 2
+      failedCount: 1
+      `
+
+	tests := map[string]struct {
+		context           string
+		templateYaml      string
+		templateValues    map[string]interface{}
+		expectedErrLength int
+	}{
+		"When all the correct inputs are given": {
+			"ur1", validYaml, tv, 0,
+		},
+		"When invalid yaml is given": {
+			"ur1", invalidYaml, tv, 1,
+		},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			b := BuilderForRuntask(mock.context, mock.templateYaml, mock.templateValues)
+			if len(b.errors) != mock.expectedErrLength {
+				t.Fatalf("test %s failed, expected error length %+v, but got : %+v error:%+v",
+					name, mock.expectedErrLength, len(b.errors), b.errors)
+			}
+		})
+	}
+}
+
+func TestAddCheck(t *testing.T) {
+	tests := map[string]struct {
+		input                Predicate
+		expectedChecksLength int
+	}{
+		"When a predicate is given": {
+			fakePredicate(), 1,
+		},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			b := NewBuilder().AddCheck(mock.input)
+			if len(b.checks) != mock.expectedChecksLength {
+				t.Fatalf("test %s failed, expected checks length %+v but got : %+v",
+					name, mock.expectedChecksLength, len(b.checks))
+			}
+		})
+	}
+}
+
 func TestWithAPIList(t *testing.T) {
 	inputURItems := []apis.UpgradeResult{apis.UpgradeResult{
 		ObjectMeta: metav1.ObjectMeta{Name: "upgradeResultList1"}}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds a package for **patch** at pkg/kubernetes/patch/v1alpha1 which contains the basic builder functions to be called to patch a CR using runtask.
It will also add **patch** and **create** support for upgrade result cr in runtask.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests

Signed-off-by: sagarkrsd <sagar.kumar@openebs.io>