### PR TITLE
chore(cherry-pick,mayactl,runtask): Removes application information from mayactl

### DIFF
--- a/cmd/mayactl/app/command/volume_info.go
+++ b/cmd/mayactl/app/command/volume_info.go
@@ -78,12 +78,6 @@ type cstorReplicaInfo struct {
 	IP         string
 }
 
-// applicationsDetails stores information about the application connected to the volume
-type applicationsDetails struct {
-	PodName      string
-	PodNamespace string
-}
-
 // NewCmdVolumeInfo displays OpenEBS Volume information.
 func NewCmdVolumeInfo() *cobra.Command {
 	cmd := &cobra.Command{
@@ -192,13 +186,6 @@ Replica Details :
 {{ printf "%s\t" $value.Name }} {{ printf "%s\t" $value.Status }} {{ printf "%s\t" $value.PoolName }} {{ $value.NodeName }} {{end}}
 `
 
-		applicationInfoTemplate = `
-Application Details:
---------------------
-Application Pod Name      : {{.PodName}}
-Application Pod Namespace : {{.PodNamespace}}
-`
-
 		portalTemplate = `
 Portal Details :
 ----------------
@@ -222,29 +209,12 @@ Replica Count     :   {{.ReplicaCount}}
 		v.GetControllerNode(),
 	}
 
-	applicationInfo := applicationsDetails{
-		PodName:      v.Volume.ObjectMeta.Annotations["openebs.io/application-pod-name"],
-		PodNamespace: v.Volume.ObjectMeta.Annotations["openebs.io/application-pod-namespace"],
-	}
-
 	tmpl, err := template.New("VolumeInfo").Parse(portalTemplate)
 	if err != nil {
 		fmt.Println("Error displaying output, found error :", err)
 		return nil
 	}
 	err = tmpl.Execute(os.Stdout, portalInfo)
-	if err != nil {
-		fmt.Println("Error displaying volume details, found error :", err)
-		return nil
-	}
-
-	tmpl, err = template.New("VolumeInfo").Parse(applicationInfoTemplate)
-	if err != nil {
-		fmt.Println("Error displaying output, found error :", err)
-		return nil
-	}
-
-	err = tmpl.Execute(os.Stdout, applicationInfo)
 	if err != nil {
 		fmt.Println("Error displaying volume details, found error :", err)
 		return nil


### PR DESCRIPTION
#### This commit contains the cherry-pick of PR https://github.com/openebs/maya/pull/1027

Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This commit removes application information from mayactl volume describe command and api server read response.
The commits that gets reverted after this PR:
https://github.com/openebs/maya/commit/cec89577a2492a0929b0cfd2588e126ab333003c
https://github.com/openebs/maya/commit/8321b6f9b5f3dd088f1f2c75c9f43629e50b39bd
https://github.com/openebs/maya/commit/0e9ae16f5ab0dd53da270f5bef6d9bb0864d4340

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/openebs/maya/issues/1028

**Special notes for your reviewer**:

**Checklist:**
- [x] Fixes https://github.com/openebs/maya/issues/1028
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests