### PR TITLE
fix(mayactl): remove portal and iqn from volume stats

### DIFF
--- a/cmd/mayactl/app/command/volume_stats.go
+++ b/cmd/mayactl/app/command/volume_stats.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	"github.com/openebs/maya/pkg/client/mapiserver"
-	"github.com/openebs/maya/types/v1"
+	v1 "github.com/openebs/maya/types/v1"
 
 	"github.com/openebs/maya/pkg/util"
 	"github.com/spf13/cobra"
@@ -40,9 +40,7 @@ Usage: mayactl volume stats --volname <vol> [-size <size>]
 const statsTemplate = ` 
 Portal Details :
 ---------------
-IQN     :   {{.IQN}}
 Volume  :   {{.Volume}}
-Portal  :   {{.Portal}}
 Size    :   {{.Size}}
 
 Performance Stats :
@@ -146,11 +144,7 @@ func processStats(statsInitial, statsFinal map[string]v1alpha1.MetricsFamily) (s
 
 	if val, p := statsFinal["openebs_volume_uptime"]; p {
 		for _, v := range val.Label {
-			if v.Name == "iqn" {
-				stats.IQN = v.Value
-			} else if v.Name == "portal" {
-				stats.Portal = v.Value
-			} else if v.Name == "volName" {
+			if v.Name == "volName" {
 				stats.Volume = v.Value
 			} else if v.Name == "castype" {
 				stats.CASType = v.Value

--- a/cmd/mayactl/app/command/volume_stats_test.go
+++ b/cmd/mayactl/app/command/volume_stats_test.go
@@ -146,7 +146,7 @@ func TestProcessStats(t *testing.T) {
 				"openebs_size_of_volume":    v1alpha1.MetricsFamily{Gauge: v1alpha1.Gauge{Value: 5}},
 				"openebs_volume_uptime":     v1alpha1.MetricsFamily{Label: []v1alpha1.LabelItem{v1alpha1.LabelItem{Name: "castype", Value: "jiva"}, v1alpha1.LabelItem{Name: "iqn", Value: "iqn.2016-09.com.openebs.jiva:pvc-66a9a0b4-e7ef-11e8-a279-b4b686bd0cff"}, v1alpha1.LabelItem{Name: "portal", Value: "127.0.0.1"}, v1alpha1.LabelItem{Name: "volName", Value: "pvc-66a9a0b4-e7ef-11e8-a279-b4b686bd0cff"}}},
 			},
-			Output: v1alpha1.StatsJSON{IQN: "iqn.2016-09.com.openebs.jiva:pvc-66a9a0b4-e7ef-11e8-a279-b4b686bd0cff", Volume: "pvc-66a9a0b4-e7ef-11e8-a279-b4b686bd0cff", Portal: "127.0.0.1", Size: "5.000000", CASType: "jiva", ReadIOPS: 4096, WriteIOPS: 4096, ReadThroughput: 0, WriteThroughput: 0, ReadLatency: 0, WriteLatency: 0, AvgReadBlockSize: 0, AvgWriteBlockSize: 0, SectorSize: 4096, ActualUsed: 4096, LogicalSize: 1.52587890625e-05},
+			Output: v1alpha1.StatsJSON{Volume: "pvc-66a9a0b4-e7ef-11e8-a279-b4b686bd0cff", Size: "5.000000", CASType: "jiva", ReadIOPS: 4096, WriteIOPS: 4096, ReadThroughput: 0, WriteThroughput: 0, ReadLatency: 0, WriteLatency: 0, AvgReadBlockSize: 0, AvgWriteBlockSize: 0, SectorSize: 4096, ActualUsed: 4096, LogicalSize: 1.52587890625e-05},
 		},
 		"When length of stats1 is  equal to stat2": {
 			stats1: map[string]v1alpha1.MetricsFamily{
@@ -175,7 +175,7 @@ func TestProcessStats(t *testing.T) {
 				"openebs_size_of_volume":    v1alpha1.MetricsFamily{Gauge: v1alpha1.Gauge{Value: 5}},
 				"openebs_volume_uptime":     v1alpha1.MetricsFamily{Label: []v1alpha1.LabelItem{v1alpha1.LabelItem{Name: "castype", Value: "jiva"}, v1alpha1.LabelItem{Name: "iqn", Value: "iqn.2016-09.com.openebs.jiva:pvc-66a9a0b4-e7ef-11e8-a279-b4b686bd0cff"}, v1alpha1.LabelItem{Name: "portal", Value: "127.0.0.1"}, v1alpha1.LabelItem{Name: "volName", Value: "pvc-66a9a0b4-e7ef-11e8-a279-b4b686bd0cff"}}},
 			},
-			Output: v1alpha1.StatsJSON{IQN: "iqn.2016-09.com.openebs.jiva:pvc-66a9a0b4-e7ef-11e8-a279-b4b686bd0cff", Volume: "pvc-66a9a0b4-e7ef-11e8-a279-b4b686bd0cff", Portal: "127.0.0.1", Size: "5.000000", CASType: "jiva", ReadIOPS: 2048, WriteIOPS: 2048, ReadThroughput: 1.9073650038576458e-06, WriteThroughput: 1.9073650038576458e-06, ReadLatency: 9.765625e-10, WriteLatency: 9.765625e-10, AvgReadBlockSize: 0, AvgWriteBlockSize: 0, SectorSize: 4096, ActualUsed: 4096, LogicalSize: 1.52687890625e-05},
+			Output: v1alpha1.StatsJSON{Volume: "pvc-66a9a0b4-e7ef-11e8-a279-b4b686bd0cff", Size: "5.000000", CASType: "jiva", ReadIOPS: 2048, WriteIOPS: 2048, ReadThroughput: 1.9073650038576458e-06, WriteThroughput: 1.9073650038576458e-06, ReadLatency: 9.765625e-10, WriteLatency: 9.765625e-10, AvgReadBlockSize: 0, AvgWriteBlockSize: 0, SectorSize: 4096, ActualUsed: 4096, LogicalSize: 1.52687890625e-05},
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This commit removes volume and iqn information from mayactl volume stats command as these information is not comming anymore from volume exporter.

Output after this :
```
Portal Details :
---------------
Volume  :   pvc-beae53f3-5222-11e9-9f6d-b4b686bd0cff
Size    :   4.000000

Performance Stats :
--------------------
r/s      w/s      r(MB/s)      w(MB/s)      rLat(ms)      wLat(ms)
----     ----     --------     --------     ---------     ---------
0        0        0.000        0.000        0.000         0.000    

Capacity Stats :
---------------
LOGICAL(GB)      USED(GB)
------------     ---------
0.000            0.000    
```
**Special notes for your reviewer**:

**Checklist:**
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests