### PR TITLE
enhance(cast engine): add replicaset get list delete actions

### DIFF
--- a/pkg/client/k8s/k8s.go
+++ b/pkg/client/k8s/k8s.go
@@ -1037,16 +1037,6 @@ func (k *K8sClient) DeleteExtnV1B1Deployment(name string) error {
 	})
 }
 
-// DeleteExtnV1B1ReplicaSet deletes the K8s ReplicaSet with the provided name
-func (k *K8sClient) DeleteExtnV1B1ReplicaSet(name string) error {
-	dops := k.extnV1B1ReplicaSetOps()
-	// ensure all the dependants are deleted
-	deletePropagation := mach_apis_meta_v1.DeletePropagationForeground
-	return dops.Delete(name, &mach_apis_meta_v1.DeleteOptions{
-		PropagationPolicy: &deletePropagation,
-	})
-}
-
 // CreateBatchV1JobAsRaw creates a kubernetes Job
 func (k *K8sClient) CreateBatchV1JobAsRaw(j *api_batch_v1.Job) ([]byte, error) {
 	job, err := k.cs.BatchV1().Jobs(k.ns).Create(j)

--- a/pkg/kubernetes/replicaset/v1alpha1/kubernetes.go
+++ b/pkg/kubernetes/replicaset/v1alpha1/kubernetes.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"encoding/json"
+
+	client "github.com/openebs/maya/pkg/kubernetes/client/v1alpha1"
+	extnv1beta1 "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// getClientsetFn is a typed function that
+// abstracts fetching of internal clientset
+type getClientsetFn func() (clientset *kubernetes.Clientset, err error)
+
+// getFn is a typed function that abstracts get of replicaset instances
+type getFn func(cli *kubernetes.Clientset, name, namespace string,
+	opts *metav1.GetOptions) (*extnv1beta1.ReplicaSet, error)
+
+// listFn is a typed function that abstracts get of replicaset instances
+type listFn func(cli *kubernetes.Clientset, namespace string,
+	opts *metav1.ListOptions) (*extnv1beta1.ReplicaSetList, error)
+
+// deleteFn is a typed function that abstracts get of replicaset instances
+type deleteFn func(cli *kubernetes.Clientset, name, namespace string,
+	opts *metav1.DeleteOptions) error
+
+// kubeclient enables kubernetes API operations on replicaset instance
+type kubeclient struct {
+	// clientset refers to kubernetes clientset. It is responsible to
+	// make kubernetes API calls for crud op
+	clientset *kubernetes.Clientset
+	namespace string
+
+	// functions useful during mocking
+	getClientset getClientsetFn
+	list         listFn
+	get          getFn
+	delete       deleteFn
+}
+
+// kubeclientBuildOption defines the abstraction to build a kubeclient instance
+type kubeclientBuildOption func(*kubeclient)
+
+// withDefaults sets the default options of kubeclient instance
+func (k *kubeclient) withDefaults() {
+	if k.getClientset == nil {
+		k.getClientset = func() (clients *kubernetes.Clientset, err error) {
+			config, err := client.GetConfig(client.New())
+			if err != nil {
+				return nil, err
+			}
+			return kubernetes.NewForConfig(config)
+		}
+	}
+
+	if k.get == nil {
+		k.get = func(cli *kubernetes.Clientset, name,
+			namespace string, opts *metav1.GetOptions) (
+			r *extnv1beta1.ReplicaSet, err error) {
+			r, err = cli.ExtensionsV1beta1().
+				ReplicaSets(namespace).
+				Get(name, *opts)
+			return
+		}
+	}
+
+	if k.list == nil {
+		k.list = func(cli *kubernetes.Clientset,
+			namespace string, opts *metav1.ListOptions) (
+			rl *extnv1beta1.ReplicaSetList, err error) {
+			rl, err = cli.ExtensionsV1beta1().
+				ReplicaSets(namespace).
+				List(*opts)
+			return
+		}
+	}
+
+	if k.delete == nil {
+		k.delete = func(cli *kubernetes.Clientset, name,
+			namespace string, opts *metav1.DeleteOptions) (err error) {
+			deletePropagation := metav1.DeletePropagationForeground
+			opts.PropagationPolicy = &deletePropagation
+			err = cli.ExtensionsV1beta1().
+				ReplicaSets(namespace).
+				Delete(name, opts)
+			return
+		}
+	}
+
+}
+
+// WithClientset sets the kubernetes client against the kubeclient instance
+func WithClientset(c *kubernetes.Clientset) kubeclientBuildOption {
+	return func(k *kubeclient) {
+		k.clientset = c
+	}
+}
+
+// WithNamespace set namespace in kubeclient object
+func WithNamespace(namespace string) kubeclientBuildOption {
+	return func(k *kubeclient) {
+		k.namespace = namespace
+	}
+}
+
+// KubeClient returns a new instance of kubeclient meant for deployment.
+// caller can configure it with different kubeclientBuildOption
+func KubeClient(opts ...kubeclientBuildOption) *kubeclient {
+	k := &kubeclient{}
+	for _, o := range opts {
+		o(k)
+	}
+	k.withDefaults()
+	return k
+}
+
+// getClientOrCached returns either a new
+// instance of kubernetes client or its cached copy
+func (k *kubeclient) getClientOrCached() (*kubernetes.Clientset, error) {
+	if k.clientset != nil {
+		return k.clientset, nil
+	}
+	c, err := k.getClientset()
+	if err != nil {
+		return nil, err
+	}
+	k.clientset = c
+	return k.clientset, nil
+}
+
+// Get returns deployment object for given name
+func (k *kubeclient) Get(name string) (*extnv1beta1.ReplicaSet, error) {
+	cli, err := k.getClientOrCached()
+	if err != nil {
+		return nil, err
+	}
+	return k.get(cli, name, k.namespace, &metav1.GetOptions{})
+}
+
+// GetRaw returns deployment object for given name in byte format
+func (k *kubeclient) GetRaw(name string) ([]byte, error) {
+	cli, err := k.getClientOrCached()
+	if err != nil {
+		return nil, err
+	}
+	rs, err := k.get(cli, name, k.namespace, &metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(rs)
+}
+
+// List returns deployment object for given name
+func (k *kubeclient) List(opts *metav1.ListOptions) (*extnv1beta1.ReplicaSetList, error) {
+	cli, err := k.getClientOrCached()
+	if err != nil {
+		return nil, err
+	}
+	return k.list(cli, k.namespace, opts)
+}
+
+// ListRaw returns deployment object for given name in byte format
+func (k *kubeclient) ListRaw(opts *metav1.ListOptions) ([]byte, error) {
+	cli, err := k.getClientOrCached()
+	if err != nil {
+		return nil, err
+	}
+	rsList, err := k.list(cli, k.namespace, opts)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(rsList)
+}
+
+// Delete returns deployment object for given name
+func (k *kubeclient) Delete(name string) error {
+	cli, err := k.getClientOrCached()
+	if err != nil {
+		return err
+	}
+	return k.delete(cli, name, k.namespace, &metav1.DeleteOptions{})
+}

--- a/pkg/task/meta.go
+++ b/pkg/task/meta.go
@@ -397,6 +397,10 @@ func (m *metaTaskExecutor) isListExtnV1B1Deploy() bool {
 	return m.identifier.isExtnV1B1Deploy() && m.isList()
 }
 
+func (m *metaTaskExecutor) isListExtnV1B1ReplicaSet() bool {
+	return m.identifier.isExtnV1B1ReplicaSet() && m.isList()
+}
+
 func (m *metaTaskExecutor) isListAppsV1B1Deploy() bool {
 	return m.identifier.isAppsV1B1Deploy() && m.isList()
 }
@@ -411,6 +415,10 @@ func (m *metaTaskExecutor) isGetBatchV1Job() bool {
 
 func (m *metaTaskExecutor) isGetExtnV1B1Deploy() bool {
 	return m.identifier.isExtnV1B1Deploy() && m.isGet()
+}
+
+func (m *metaTaskExecutor) isGetExtnV1B1ReplicaSet() bool {
+	return m.identifier.isExtnV1B1ReplicaSet() && m.isGet()
 }
 
 func (m *metaTaskExecutor) isDeleteBatchV1Job() bool {

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -30,6 +30,7 @@ import (
 	deploy_appsv1 "github.com/openebs/maya/pkg/kubernetes/deployment/appsv1/v1alpha1"
 	deploy_extnv1beta1 "github.com/openebs/maya/pkg/kubernetes/deployment/extnv1beta1/v1alpha1"
 	podexec "github.com/openebs/maya/pkg/kubernetes/podexec/v1alpha1"
+	replicaset "github.com/openebs/maya/pkg/kubernetes/replicaset/v1alpha1"
 	"github.com/openebs/maya/pkg/template"
 	upgrade "github.com/openebs/maya/pkg/upgrade/result/v1alpha1"
 	"github.com/openebs/maya/pkg/util"
@@ -370,6 +371,8 @@ func (m *taskExecutor) ExecuteIt() (err error) {
 		err = m.deleteExtnV1B1ReplicaSet()
 	} else if m.metaTaskExec.isGetExtnV1B1Deploy() {
 		err = m.getExtnV1B1Deployment()
+	} else if m.metaTaskExec.isGetExtnV1B1ReplicaSet() {
+		err = m.getExtnV1B1ReplicaSet()
 	} else if m.metaTaskExec.isDeleteAppsV1B1Deploy() {
 		err = m.deleteAppsV1B1Deployment()
 	} else if m.metaTaskExec.isDeleteCoreV1Service() {
@@ -791,17 +794,40 @@ func (m *taskExecutor) deleteExtnV1B1Deployment() (err error) {
 	return
 }
 
+// getExtnV1B1ReplicaSet will get the Replicaset as specified in the RunTask
+func (m *taskExecutor) getExtnV1B1ReplicaSet() (err error) {
+	client := replicaset.KubeClient(
+		replicaset.WithNamespace(m.getTaskRunNamespace()))
+
+	rs, err := client.GetRaw(m.getTaskObjectName())
+	if err != nil {
+		return
+	}
+
+	util.SetNestedField(m.templateValues, rs, string(v1alpha1.CurrentJSONResultTLP))
+	return
+}
+
 // deleteExtnV1B1ReplicaSet will delete one or more ReplicaSets as specified in
 // the RunTask
 func (m *taskExecutor) deleteExtnV1B1ReplicaSet() (err error) {
 	objectNames := strings.Split(strings.TrimSpace(m.getTaskObjectName()), ",")
+	client := replicaset.KubeClient(
+		replicaset.WithNamespace(m.getTaskRunNamespace()))
+
 	for _, name := range objectNames {
-		err = m.getK8sClient().DeleteExtnV1B1ReplicaSet(strings.TrimSpace(name))
+		err = client.Delete(strings.TrimSpace(name))
 		if err != nil {
 			return
 		}
 	}
 	return
+}
+
+func (m *taskExecutor) listExtnV1B1ReplicaSet(opt metav1.ListOptions) ([]byte, error) {
+	client := replicaset.KubeClient(
+		replicaset.WithNamespace(m.getTaskRunNamespace()))
+	return client.ListRaw(&opt)
 }
 
 // putCoreV1Service will put a Service whose specs are configured in the RunTask
@@ -1159,6 +1185,8 @@ func (m *taskExecutor) listK8sResources() (err error) {
 		op, err = kc.ListCoreV1ServiceAsRaw(opts)
 	} else if m.metaTaskExec.isListExtnV1B1Deploy() {
 		op, err = kc.ListExtnV1B1DeploymentAsRaw(opts)
+	} else if m.metaTaskExec.isListExtnV1B1ReplicaSet() {
+		op, err = m.listExtnV1B1ReplicaSet(opts)
 	} else if m.metaTaskExec.isListAppsV1B1Deploy() {
 		op, err = kc.ListAppsV1B1DeploymentAsRaw(opts)
 	} else if m.metaTaskExec.isListCoreV1PVC() {

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -796,10 +796,9 @@ func (m *taskExecutor) deleteExtnV1B1Deployment() (err error) {
 
 // getExtnV1B1ReplicaSet will get the Replicaset as specified in the RunTask
 func (m *taskExecutor) getExtnV1B1ReplicaSet() (err error) {
-	client := replicaset.KubeClient(
-		replicaset.WithNamespace(m.getTaskRunNamespace()))
-
-	rs, err := client.GetRaw(m.getTaskObjectName())
+	rs, err := replicaset.
+		KubeClient(replicaset.WithNamespace(m.getTaskRunNamespace())).
+		GetRaw(m.getTaskObjectName())
 	if err != nil {
 		return
 	}
@@ -825,9 +824,9 @@ func (m *taskExecutor) deleteExtnV1B1ReplicaSet() (err error) {
 }
 
 func (m *taskExecutor) listExtnV1B1ReplicaSet(opt metav1.ListOptions) ([]byte, error) {
-	client := replicaset.KubeClient(
-		replicaset.WithNamespace(m.getTaskRunNamespace()))
-	return client.ListRaw(&opt)
+	return replicaset.
+		KubeClient(replicaset.WithNamespace(m.getTaskRunNamespace())).
+		ListRaw(opt)
 }
 
 // putCoreV1Service will put a Service whose specs are configured in the RunTask


### PR DESCRIPTION
This PR add support for get list and delete of replicaset. Runtask related to these tasks given below -

1. get replicaset

```yaml
apiVersion: openebs.io/v1alpha1
kind: RunTask
metadata:
  name: task-getrs
  namespace: default
spec:
  meta: |
    id: getrs
    apiVersion: extensions/v1beta1
    kind: ReplicaSet
    action: get
    runNamespace: openebs
    objectName: cstor-sparse-pool-9gjf-76969fbfc9
  post: |
    {{- jsonpath .JsonResult "{.metadata.name}" | trim | saveAs "rs" .TaskResult | noop -}}
```

2. list replicaset
```yaml
apiVersion: openebs.io/v1alpha1
kind: RunTask
metadata:
  name: task-listrs
  namespace: default
spec:
  meta: |
    id: listrs
    apiVersion: extensions/v1beta1
    kind: ReplicaSet
    action: list
    runNamespace: openebs
    options: |-
      labelSelector: app=cstor-pool,openebs.io/storage-pool-claim=cstor-sparse-pool
  post: |
    {{- jsonpath .JsonResult "{range .items[*]}{@.metadata.name} {end}" | trim | replace " " "," | saveAs "listrs" .TaskResult | noop -}}
```

3. delete replicaset
```yaml
apiVersion: openebs.io/v1alpha1
kind: RunTask
metadata:
  name: task-deleters
  namespace: default
spec:
  meta: |
    id: deleters
    apiVersion: extensions/v1beta1
    kind: ReplicaSet
    action: delete
    runNamespace: openebs
    objectName: cstor-sparse-pool-9gjf-76969fbfc9,cstor-sparse-pool-9gjf-8497d75bbf
```

Signed-off-by: Shovan Maity <shovan.maity@mayadata.io>