### PR TITLE
revert(cstor-pool, sock deletion): remove preStop hook used to delete sock file

### DIFF
--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -274,13 +274,6 @@ spec:
               postStart:
                  exec:
                     command: ["/bin/sh", "-c", "sleep 2"]
-              # Removes the sock file that is used for communication between
-              # cstor-pool and cstor-pool-mgmt containers, so that, cstor-pool-mgmt
-              # of new pool pod instance will NOT communicate with cstor-pool
-              # container of terminating pod instance.
-              preStop:
-                 exec:
-                    command: ["/bin/bash", "-c", "rm /tmp/uzfs.sock"]
           - name: cstor-pool-mgmt
             image: {{ .Config.CstorPoolMgmtImage.value }}
             resources:
@@ -370,7 +363,7 @@ spec:
               type: Directory
           - name: tmp
             hostPath:
-              # host dir {{ .Config.SparseDir.value }}/shared-<uid> is 
+              # host dir {{ .Config.SparseDir.value }}/shared-<uid> is
               # created to avoid clash if two replicas run on same node.
               path: {{ .Config.SparseDir.value }}/shared-{{.Storagepool.owner}}
               type: {{ .Config.HostPathType.value }}


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does**:
This PR deletes the preStop hook which is used to delete the unix.sock file (which is shared between the cstor-pool-mgmgt and cstor-pool) as soon as cstor-pool container deleted.

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests