### PR TITLE
chore(maya): enable graceful shutdown of apiserver

### DIFF
--- a/cmd/maya-apiserver/app/config/config.go
+++ b/cmd/maya-apiserver/app/config/config.go
@@ -116,6 +116,7 @@ func DefaultMayaConfig() *MayaConfig {
 		Addresses:      &Addresses{},
 		AdvertiseAddrs: &AdvertiseAddrs{},
 		SyslogFacility: "LOCAL0",
+		LeaveOnTerm:    true,
 	}
 }
 


### PR DESCRIPTION
This PR will enable graceful shutdown for maya-apiserver using `SIGTERM`

Among other things, this commit helps to generate coverage reports. Maya API server binary needs to be compiled with `Testing` flags on. One can then launch a Kubernetes pod with this apiserver.test binary. Run the BDD test cases and get the coverage report. Now for this coverage report to get generated, apiserver need to exit gracefully.

Command to do a graceful shutdown:
```bash
# get the pid of maya api server
ps -aux

# terminate maya api server
kill -15 <pid>
```


Signed-off-by: Ashutosh Kumar <ashutosh.kumar@openebs.io>