### PR TITLE
refact(cast engine): add get castemplate support

### DIFF
--- a/pkg/castemplate/v1alpha1/kubernetes.go
+++ b/pkg/castemplate/v1alpha1/kubernetes.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"errors"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	clientset "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset"
+	client "github.com/openebs/maya/pkg/kubernetes/client/v1alpha1"
+)
+
+// getClientsetFunc is a typed function that
+// abstracts fetching internal clientset
+type getClientsetFunc func() (cs *clientset.Clientset, err error)
+
+// getFunc is a typed function that abstracts
+// getting castemplate instances
+type getFunc func(cs *clientset.Clientset, name string, opts metav1.GetOptions) (*apis.CASTemplate, error)
+
+// Kubeclient enables kubernetes API operationson castemplate instance
+type Kubeclient struct {
+	// clientset refers to openebs clientset that will be
+	// responsible to make kubernetes API calls
+	clientset *clientset.Clientset
+
+	// functions useful during mocking
+	getClientset getClientsetFunc
+	get          getFunc
+}
+
+// KubeclientBuildOption defines the abstraction
+// to build a Kubeclient instance
+type KubeclientBuildOption func(*Kubeclient)
+
+// withDefaults sets the default options of Kubeclient instance
+func (k *Kubeclient) withDefaults() {
+	if k.getClientset == nil {
+		k.getClientset = func() (cs *clientset.Clientset, err error) {
+			config, err := client.GetConfig(client.New())
+			if err != nil {
+				return nil, err
+			}
+			return clientset.NewForConfig(config)
+		}
+	}
+
+	if k.get == nil {
+		k.get = func(cs *clientset.Clientset, name string, opts metav1.GetOptions) (*apis.CASTemplate, error) {
+			return cs.OpenebsV1alpha1().CASTemplates().Get(name, opts)
+		}
+	}
+}
+
+// WithClientset sets the kubernetes clientset against
+// the kubeclient instance
+func WithClientset(c *clientset.Clientset) KubeclientBuildOption {
+	return func(k *Kubeclient) {
+		k.clientset = c
+	}
+}
+
+// KubeClient returns a new instance of kubeclient meant for
+// castemplate related operations
+func KubeClient(opts ...KubeclientBuildOption) *Kubeclient {
+	k := &Kubeclient{}
+	for _, o := range opts {
+		o(k)
+	}
+	k.withDefaults()
+	return k
+}
+
+// getClientOrCached returns either a new instance
+// of kubernetes client or its cached copy
+func (k *Kubeclient) getClientOrCached() (*clientset.Clientset, error) {
+	if k.clientset != nil {
+		return k.clientset, nil
+	}
+	c, err := k.getClientset()
+	if err != nil {
+		return nil, err
+	}
+	k.clientset = c
+	return k.clientset, nil
+}
+
+// Get returns a castemplate instance for given name
+func (k *Kubeclient) Get(name string, opts metav1.GetOptions) (*apis.CASTemplate, error) {
+	if strings.TrimSpace(name) == "" {
+		return nil, errors.New("failed to get castemplate: missing castemplate name")
+	}
+	cs, err := k.getClientOrCached()
+	if err != nil {
+		return nil, err
+	}
+	return k.get(cs, name, opts)
+}

--- a/pkg/castemplate/v1alpha1/kubernetes_test.go
+++ b/pkg/castemplate/v1alpha1/kubernetes_test.go
@@ -166,17 +166,11 @@ func TestGetClientOrCached(t *testing.T) {
 
 	for name, mock := range tests {
 		t.Run(name, func(t *testing.T) {
-			kc := KubeClient(WithClientset(mock.clientset),
-				func(getClientset getClientsetFunc) KubeclientBuildOption {
-					return func(k *Kubeclient) {
-						k.getClientset = getClientset
-					}
-				}(mock.getClientset),
-				func(get getFunc) KubeclientBuildOption {
-					return func(k *Kubeclient) {
-						k.get = get
-					}
-				}(mock.get))
+			kc := &Kubeclient{
+				clientset:    mock.clientset,
+				getClientset: mock.getClientset,
+				get:          mock.get,
+			}
 			c, err := kc.getClientOrCached()
 			if mock.expectErr && err == nil {
 				t.Fatalf("test %s failed : expected error but got %v", name, err)

--- a/pkg/castemplate/v1alpha1/kubernetes_test.go
+++ b/pkg/castemplate/v1alpha1/kubernetes_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/pkg/errors"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	clientset "github.com/openebs/maya/pkg/client/generated/clientset/internalclientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func fakeGetClientset() (cs *clientset.Clientset, err error) {
+	return &clientset.Clientset{}, nil
+}
+
+func fakeGetfn(cs *clientset.Clientset, name string,
+	opts metav1.GetOptions) (*apis.CASTemplate, error) {
+	return &apis.CASTemplate{}, nil
+}
+
+func fakeGetErrfn(cs *clientset.Clientset, name string,
+	opts metav1.GetOptions) (*apis.CASTemplate, error) {
+	return &apis.CASTemplate{}, errors.New("some error")
+}
+
+func fakeSetClientset(k *Kubeclient) {
+	k.clientset = &clientset.Clientset{}
+}
+
+func fakeSetNilClientset(k *Kubeclient) {
+	k.clientset = nil
+}
+
+func fakeGetNilErrClientSet() (clientset *clientset.Clientset, err error) {
+	return nil, nil
+}
+
+func fakeGetErrClientSet() (clientset *clientset.Clientset, err error) {
+	return nil, errors.New("Some error")
+}
+
+func fakeClientSet(k *Kubeclient) {}
+
+func TestWithDefaults(t *testing.T) {
+	tests := map[string]struct {
+		getFn              getFunc
+		getClientsetFn     getClientsetFunc
+		expectGet          bool
+		expectGetClientset bool
+	}{
+		// The current implementation of WithDefaults method can be
+		// tested using these two combinations only.
+		"When mockclient is empty": {nil, nil, false, false},
+		"When mockclient contains all of them": {fakeGetfn,
+			fakeGetClientset, false, false},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{}
+			fc.get = mock.getFn
+			fc.getClientset = mock.getClientsetFn
+
+			fc.withDefaults()
+			get := (fc.get == nil)
+			if get != mock.expectGet {
+				t.Fatalf(`test %s failed: expected non-nil fc.get
+but got %v`, name, fc.get)
+			}
+			getClientset := (fc.getClientset == nil)
+			if getClientset != mock.expectGetClientset {
+				t.Fatalf(`test %s failed: expected non-nil fc.getClientset
+but got %v`, name, fc.getClientset)
+			}
+		})
+	}
+}
+func TestWithClientset(t *testing.T) {
+	tests := map[string]struct {
+		clientSet    *clientset.Clientset
+		isKubeClient bool
+	}{
+		"Clientset is empty":     {nil, false},
+		"Clientset is not empty": {&clientset.Clientset{}, true},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			h := WithClientset(mock.clientSet)
+			fake := &Kubeclient{}
+			h(fake)
+			if mock.isKubeClient && fake.clientset == nil {
+				t.Fatalf(`test %s failed, expected non-nil fake.clientset
+but got %v`, name, fake.clientset)
+			}
+			if !mock.isKubeClient && fake.clientset != nil {
+				t.Fatalf(`test %s failed, expected nil fake.clientset
+but got %v`, name, fake.clientset)
+			}
+		})
+	}
+}
+func TestKubeClientWithClientset(t *testing.T) {
+	tests := map[string]struct {
+		expectClientSet bool
+		opts            []KubeclientBuildOption
+	}{
+		"When non-nil clientset is passed": {true,
+			[]KubeclientBuildOption{fakeSetClientset}},
+		"When two options with a non-nil clientset are passed": {true,
+			[]KubeclientBuildOption{fakeSetClientset, fakeClientSet}},
+		"When three options with a non-nil clientset are passed": {true,
+			[]KubeclientBuildOption{fakeSetClientset, fakeClientSet, fakeClientSet}},
+
+		"When nil clientset is passed": {false,
+			[]KubeclientBuildOption{fakeSetNilClientset}},
+		"When two options with a nil clientset are passed": {false,
+			[]KubeclientBuildOption{fakeSetNilClientset, fakeClientSet}},
+		"When three options with a nil clientset are passed": {false,
+			[]KubeclientBuildOption{fakeSetNilClientset, fakeClientSet, fakeClientSet}},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := KubeClient(mock.opts...)
+			if !mock.expectClientSet && c.clientset != nil {
+				t.Fatalf(`test %s failed, expected nil c.clientset
+but got %v`, name, c.clientset)
+			}
+			if mock.expectClientSet && c.clientset == nil {
+				t.Fatalf(`test %s failed expected non-nil c.clientset
+but got %v`, name, c.clientset)
+			}
+		})
+	}
+}
+
+func TestGetClientOrCached(t *testing.T) {
+	tests := map[string]struct {
+		kubeClient *Kubeclient
+		expectErr  bool
+	}{
+		// Positive tests
+		"When clientset is nil": {&Kubeclient{nil,
+			fakeGetNilErrClientSet, fakeGetfn}, false},
+		"When clientset is not nil": {&Kubeclient{&clientset.Clientset{},
+			fakeGetNilErrClientSet, fakeGetfn}, false},
+		// Negative tests
+		"When getting clientset throws error": {&Kubeclient{nil,
+			fakeGetErrClientSet, fakeGetfn}, true},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			c, err := mock.kubeClient.getClientOrCached()
+			if mock.expectErr && err == nil {
+				t.Fatalf("test %s failed : expected error but got %v", name, err)
+			}
+			if !mock.expectErr && err != nil {
+				t.Fatalf("test %s failed : expected nil error but got %v", name, err)
+			}
+			if !reflect.DeepEqual(c, mock.kubeClient.clientset) {
+				t.Fatalf(`test %s failed : expected clientset %v
+but got %v`, name, mock.kubeClient.clientset, c)
+			}
+		})
+	}
+}
+
+func TestKubernetesGet(t *testing.T) {
+	tests := map[string]struct {
+		resourceName string
+		getClientset getClientsetFunc
+		get          getFunc
+		expectErr    bool
+	}{
+		"When getting clientset throws error": {"ur1", fakeGetErrClientSet, fakeGetfn, true},
+		"When getting resource throws error":  {"ur2", fakeGetClientset, fakeGetErrfn, true},
+		"When resource name is empty string":  {"", fakeGetClientset, fakeGetfn, true},
+		"When none of them throws error":      {"ur3", fakeGetClientset, fakeGetfn, false},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			k := Kubeclient{getClientset: mock.getClientset, get: mock.get}
+			_, err := k.Get(mock.resourceName, metav1.GetOptions{})
+			if mock.expectErr && err == nil {
+				t.Fatalf("test %s failed: expected error but got %v", name, err)
+			}
+			if !mock.expectErr && err != nil {
+				t.Fatalf("test %s failed: expected nil but got %v", name, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for castemplate get operation.

Signed-off-by: Shovan Maity <shovan.maity@mayadata.io>
