### PR TITLE
fix(exporter, cherrypick): use camel case for replica status (#959)

### DIFF
--- a/cmd/maya-exporter/app/collector/cstor_test.go
+++ b/cmd/maya-exporter/app/collector/cstor_test.go
@@ -19,11 +19,11 @@ import (
 )
 
 var (
-	SplittedResponse             = "{ \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"UpTime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\", \"RevisionCounter\":\"1000\", \"ReplicaCounter\":\"3\", \"Replicas\":[{\"Address\":\"tcp://172.18.0.3:9502\",\"Mode\":\"DEGRADED\"},{\"Address\":\"tcp://172.18.0.4:9502\",\"Mode\":\"HEALTHY\"},{\"Address\":\"tcp://172.18.0.5:9502\",\"Mode\":\"HEALTHY\"}] }"
+	SplittedResponse             = "{ \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"UpTime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\", \"RevisionCounter\":\"1000\", \"ReplicaCounter\":\"3\", \"Replicas\":[{\"Address\":\"tcp://172.18.0.3:9502\",\"Mode\":\"Degraded\"},{\"Address\":\"tcp://172.18.0.4:9502\",\"Mode\":\"Healthy\"},{\"Address\":\"tcp://172.18.0.5:9502\",\"Mode\":\"Healthy\"}] }"
 	NilCstorResponse             = "OK IOSTATS\r\n"
-	CstorResponse                = "IOSTATS  { \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"UpTime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\", \"RevisionCounter\":\"1000\", \"ReplicaCounter\":\"3\", \"Replicas\":[{\"Address\":\"tcp://172.18.0.3:9502\",\"Mode\":\"DEGRADED\"},{\"Address\":\"tcp://172.18.0.4:9502\",\"Mode\":\"HEALTHY\"},{\"Address\":\"tcp://172.18.0.5:9502\",\"Mode\":\"HEALTHY\"}] }\r\nOK IOSTATS\r\n"
-	JSONFormatedResponse         = "{ \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"UpTime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\", \"RevisionCounter\":\"1000\", \"ReplicaCounter\":\"3\", \"Replicas\":[{\"Address\":\"tcp://172.18.0.3:9502\",\"Mode\":\"DEGRADED\"},{\"Address\":\"tcp://172.18.0.4:9502\",\"Mode\":\"HEALTHY\"},{\"Address\":\"tcp://172.18.0.5:9502\",\"Mode\":\"HEALTHY\"}] }"
-	ImproperJSONFormatedResponse = `IOSTATS  { \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"UpTime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\", \"RevisionCounter\":\"1000\", \"ReplicaCounter\":\"3\", \"Replicas\":[{\"Address\":\"tcp://172.18.0.3:9502\",\"Mode\":\"DEGRADED\"},{\"Address\":\"tcp://172.18.0.4:9502\",\"Mode\":\"HEALTHY\"},{\"Address\":\"tcp://172.18.0.5:9502\",\"Mode\":\"HEALTHY\"}] }\r\nOK IOSTATS\r\n`
+	CstorResponse                = "IOSTATS  { \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"UpTime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\", \"RevisionCounter\":\"1000\", \"ReplicaCounter\":\"3\", \"Replicas\":[{\"Address\":\"tcp://172.18.0.3:9502\",\"Mode\":\"Degraded\"},{\"Address\":\"tcp://172.18.0.4:9502\",\"Mode\":\"Healthy\"},{\"Address\":\"tcp://172.18.0.5:9502\",\"Mode\":\"Healthy\"}] }\r\nOK IOSTATS\r\n"
+	JSONFormatedResponse         = "{ \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"UpTime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\", \"RevisionCounter\":\"1000\", \"ReplicaCounter\":\"3\", \"Replicas\":[{\"Address\":\"tcp://172.18.0.3:9502\",\"Mode\":\"Degraded\"},{\"Address\":\"tcp://172.18.0.4:9502\",\"Mode\":\"Healthy\"},{\"Address\":\"tcp://172.18.0.5:9502\",\"Mode\":\"Healthy\"}] }"
+	ImproperJSONFormatedResponse = `IOSTATS  { \"iqn\": \"iqn.2017-08.OpenEBS.cstor:vol1\", \"WriteIOPS\": \"0\", \"ReadIOPS\": \"0\", \"TotalWriteBytes\": \"0\", \"TotalReadBytes\": \"0\", \"Size\": \"10737418240\", \"UsedLogicalBlocks\":\"19\", \"SectorSize\":\"512\", \"UpTime\":\"20\", \"TotalReadBlockCount\":\"12\", \"TotalWriteBlockCount\":\"15\", \"TotalReadTime\":\"13\", \"TotalWriteTime\":\"132\", \"RevisionCounter\":\"1000\", \"ReplicaCounter\":\"3\", \"Replicas\":[{\"Address\":\"tcp://172.18.0.3:9502\",\"Mode\":\"Degraded\"},{\"Address\":\"tcp://172.18.0.4:9502\",\"Mode\":\"Healthy\"},{\"Address\":\"tcp://172.18.0.5:9502\",\"Mode\":\"Healthy\"}] }\r\nOK IOSTATS\r\n`
 )
 
 func fakeCstor(path string) *cstor {
@@ -214,15 +214,15 @@ func TestUnmarshal(t *testing.T) {
 				Replicas: []v1.Replica{
 					{
 						Address: "tcp://172.18.0.3:9502",
-						Mode:    "DEGRADED",
+						Mode:    "Degraded",
 					},
 					{
 						Address: "tcp://172.18.0.4:9502",
-						Mode:    "HEALTHY",
+						Mode:    "Healthy",
 					},
 					{
 						Address: "tcp://172.18.0.5:9502",
-						Mode:    "HEALTHY",
+						Mode:    "Healthy",
 					},
 				},
 			},

--- a/cmd/maya-exporter/app/collector/metrics.go
+++ b/cmd/maya-exporter/app/collector/metrics.go
@@ -245,10 +245,12 @@ func (v *stats) getReplicaCount() {
 	)
 	for _, rep := range v.replicas {
 		switch rep.Mode {
-		case readOnly, writeOnly, degraded:
+		case readOnly, writeOnly, errored, degraded:
 			ro++
 		case readWrite, healthy:
 			rw++
+		default:
+			glog.Error("Unknown replica mode: ", rep.Mode)
 		}
 	}
 	v.degradedReplicaCount = ro

--- a/cmd/maya-exporter/app/collector/types.go
+++ b/cmd/maya-exporter/app/collector/types.go
@@ -23,11 +23,12 @@ const (
 )
 
 const (
+	errored         = v1.ReplicaMode("ERR")
 	writeOnly       = v1.ReplicaMode("WO")
 	readOnly        = v1.ReplicaMode("RO")
-	degraded        = v1.ReplicaMode("DEGRADED")
+	degraded        = v1.ReplicaMode("Degraded")
 	readWrite       = v1.ReplicaMode("RW")
-	healthy         = v1.ReplicaMode("HEALTHY")
+	healthy         = v1.ReplicaMode("Healthy")
 	targetOffline   = v1.TargetMode("Offline")
 	targetDegraded  = v1.TargetMode("Degraded")
 	targetHealthy   = v1.TargetMode("Healthy")


### PR DESCRIPTION
* fix(exporter): use camel case for replica status

### How does it impact end users?
The value of following time series will show 0:
- openebs_healthy_replica_count
- openebs_degraded_replica_count

### Where is the following observed?
This can be obeserved anywhere with 0.8.1 release

### Which output is the PR referring to?
Output of maya-exporter from /metrics endpoint

Refer - https://github.com/openebs/istgt/pull/211/files

Special Instruction for the reviewer:
- Added new mode "ERR" in switch case statement, which was missing earlier for jiva volumes.

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests