### PR TITLE
chore(golangci, lint): add golangci lint aggregator

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,341 @@
+# This file contains all available 
+# configuration options
+
+# options for analysis running
+run:
+  # concurrency is the available CPU number
+  # default is 4
+  concurrency: 4
+
+  # timeout for analysis, e.g. 30s, 5m
+  # default is 1m
+  deadline: 1m
+
+  # exit code when at least one issue was found
+  # default is 1
+  issues-exit-code: 1
+
+  # include test files or not
+  # default is true
+  tests: true
+
+  # list of build tags, all linters use it
+  # Default is empty list
+  build-tags:
+    - maya-lint
+
+  # which dirs to skip i.e. they won't be analyzed;
+  # can use regexp here 
+  # e.g. generated.*, regexp is applied on full path;
+  # default value is empty list, 
+  #
+  # but next dirs are always skipped independently
+  # from this option's value
+  # examples
+  #   	vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
+  skip-dirs:
+    - pkg/client/generated/
+
+  # which files to skip yet be analyzed, but issues
+  # from them won't be reported
+  #
+  # Default value is empty list
+  skip-files:
+    - 
+
+  # by default isn't set
+  # If set we pass it to "go list -mod={option}"
+  # From "go help modules"
+  #
+  # If invoked with -mod=readonly, the go command is disallowed
+  # from the implicit automatic updating of go.mod described above.
+  # Instead, it fails when any changes to go.mod are needed. 
+  # This setting is most useful to check that go.mod does not need 
+  # updates, such as in a continuous integration and testing system.
+  #
+  # If invoked with -mod=vendor, the go command assumes that the
+  # vendor directory holds the correct copies of dependencies and 
+  # ignores the dependency descriptions in go.mod
+  #
+  # modules-download-mode: readonly|release|vendor
+  modules-download-mode:
+
+# output configuration options
+output:
+  # colored-line-number|line-number|json|tab|checkstyle|code-climate, 
+  # default is "colored-line-number"
+  format: colored-line-number
+
+  # print lines of code with issue, 
+  # default is true
+  print-issued-lines: true
+
+  # print linter name in the end of issue text, 
+  # default is true
+  print-linter-name: true
+
+
+# all available settings of specific linters
+linters-settings:
+  errcheck:
+    # report about not checking of errors in type assetions
+    # `a := b.(MyStruct)`
+    # default is false
+    check-type-assertions: false
+
+    # report about assignment of errors to blank identifier
+    # `num, _ := strconv.Atoi(numStr)`
+    # default is false
+    check-blank: false
+
+    # [deprecated] comma-separated list of pairs of the form
+    # pkg:regex
+    # the regex is used to ignore names within pkg. (default "fmt:.*").
+    # see https://github.com/kisielk/errcheck#the-deprecated-method
+    # for details
+    ignore: fmt:.*,io/ioutil:^Read.*
+
+    # path to a file containing a list of functions to exclude
+    # from checking
+    # see https://github.com/kisielk/errcheck#excluding-functions
+    # for details
+    #exclude: /path/to/file.txt
+
+  govet:
+    # report about shadowed variables
+    check-shadowing: true
+
+    # settings per analyzer
+    settings:
+      printf: # analyzer name, run `go tool vet help` to see all analyzers
+        funcs: # run `go tool vet help printf` to see available settings for `printf` analyzer
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+
+  golint:
+    # minimal confidence for issues, default is 0.8
+    min-confidence: 0.8
+
+  gofmt:
+    # simplify code: gofmt with `-s` option, true by default
+    simplify: true
+
+  goimports:
+    # put imports beginning with prefix after 3rd-party packages;
+    # it's a comma-separated list of prefixes
+    #local-prefixes: github.com/org/project
+
+  gocyclo:
+    # minimal code complexity to report, 30 by default (but we recommend 10-20)
+    min-complexity: 10
+
+  maligned:
+    # print struct with more effective memory layout or not, false by default
+    suggest-new: true
+
+  dupl:
+    # tokens count to trigger issue, 150 by default
+    threshold: 100
+
+  goconst:
+    # minimal length of string constant, 3 by default
+    min-len: 3
+    # minimal occurrences count to trigger, 3 by default
+    min-occurrences: 3
+
+  depguard:
+    list-type: blacklist
+    include-go-root: false
+    #packages:
+    # - github.com/davecgh/go-spew/spew
+
+  misspell:
+    # Correct spellings using locale preferences for US or UK.
+    # Default is to use a neutral variety of English.
+    # Setting locale to US will correct the British spelling of 
+    # 'colour' to 'color'.
+    locale: US
+    ignore-words:
+      - someword
+
+  lll:
+    # max line length, lines longer will be reported.
+    # Default is 120.
+    #
+    # '\t' is counted as 1 character by default, and can be 
+    # changed with the tab-width option
+    line-length: 80
+    # tab width in spaces. Default to 1.
+    tab-width: 1
+
+  unused:
+    # treat code as a program (not a library) and report
+    # unused exported identifiers; default is false.
+    # 
+    # XXX: if you enable this setting, unused will report a lot 
+    # of false-positives in text editors
+    #
+    # if it's called for subdir of a project it can't find funcs
+    # usages. All text editor integrations with golangci-lint 
+    # call it on a directory with the changed file.
+    check-exported: false
+
+  unparam:
+    # Inspect exported functions, default is false. Set to true 
+    # if no external program/library imports your code.
+    #
+    # XXX: if you enable this setting, unparam will report a 
+    # lot of false-positives in text editors
+    #
+    # if it's called for subdir of a project it can't find 
+    # external interfaces. All text editor integrations
+    # with golangci-lint call it on a directory with the changed file.
+    check-exported: false
+
+  nakedret:
+    # make an issue if func has more lines of code than this
+    # setting and it has naked returns; 
+    #
+    # default is 30
+    max-func-lines: 30
+
+  prealloc:
+    # XXX: we don't recommend using this linter before doing
+    # performance profiling.
+    #
+    # For most programs usage of prealloc will be a premature 
+    # optimization.
+    #
+    # Report preallocation suggestions only on simple loops 
+    # that have no returns/breaks/continues/gotos in them.
+    #
+    # True by default.
+    simple: true
+    range-loops: true # Report preallocation suggestions on range loops, true by default
+    for-loops: false # Report preallocation suggestions on for loops, false by default
+
+  gocritic:
+    # Which checks should be enabled; can't be combined 
+    # with 'disabled-checks';
+    #
+    # See https://go-critic.github.io/overview#checks-overview
+    # To check which checks are enabled 
+    # run `GL_DEBUG=gocritic golangci-lint run`
+    #
+    # By default list of stable checks is used.
+    # enabled-checks:
+    #  - 
+
+    # Which checks should be disabled; can't be combined with
+    # 'enabled-checks'
+    #
+    # default is empty
+    disabled-checks:
+      - regexpMust
+
+    # Enable multiple checks by tags,
+    # run `GL_DEBUG=gocritic golangci-lint` to see all tags and checks.
+    #
+    # Empty list by default. 
+    # See https://github.com/go-critic/go-critic#usage -> section "Tags".
+    enabled-tags:
+      - performance
+
+    settings: # settings passed to gocritic
+      captLocal: # must be valid enabled check name
+        paramsOnly: true
+      rangeValCopy:
+        sizeThreshold: 32
+
+linters:
+  enable:
+    - megacheck
+    - govet
+  enable-all: false
+  disable:
+    - maligned
+    - prealloc
+  disable-all: false
+  presets:
+    - bugs
+    - unused
+  fast: false
+
+
+issues:
+  # List of regexps of issue texts to exclude, 
+  # 
+  # empty list by default.
+  #
+  # But independently from this option we use default
+  # exclude patterns, it can be disabled by 
+  # `exclude-use-default: false`. To list all excluded by
+  # default patterns execute `golangci-lint run --help`
+  exclude:
+    - abcdef
+
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    # Exclude some linters from running on tests files.
+    - path: _test\.go
+      linters:
+        - gocyclo
+        - errcheck
+        - dupl
+        - gosec
+
+    # Exclude known linters from partially hard-vendored code,
+    # which is impossible to exclude via "nolint" comments.
+    - path: internal/hmac/
+      text: "weak cryptographic primitive"
+      linters:
+        - gosec
+
+    # Exclude some staticcheck messages
+    - linters:
+        - staticcheck
+      text: "SA9003:"
+
+    # Exclude lll issues for long lines with go:generate
+    - linters:
+        - lll
+      source: "^//go:generate "
+
+  # Independently from option `exclude` we use default exclude patterns,
+  # it can be disabled by this option. To list all
+  # excluded by default patterns execute `golangci-lint run --help`.
+  # Default value for this option is true.
+  exclude-use-default: false
+
+  # Maximum issues count per one linter
+  #
+  # Set to 0 to disable
+  # Default is 50
+  max-per-linter: 0
+
+  # Maximum count of issues with the same text.
+  #
+  # Set to 0 to disable
+  # Default is 3
+  max-same-issues: 0
+
+  # Show only new issues 
+  # if there are unstaged changes or untracked files,
+  # only those changes are analyzed, else only changes in HEAD~ 
+  # are analyzed.
+  #
+  # It's a super-useful option for integration of golangci-lint 
+  # into existing large codebase. It's not practical to fix all 
+  # existing issues at the moment of integration
+  # much better don't allow issues in new code.
+  #
+  # Default is false
+  new: true
+
+  # Show only new issues created after git revision `REV`
+  #new-from-rev: REV
+
+  # Show only new issues created in git patch with set file path.
+  #new-from-patch: path/to/patch/file


### PR DESCRIPTION
This will help `openebs/maya` maintainers to keep a tab on various linting issues, via this config file. Each github PR can report any new issues.

NOTE: _Individual developers can setup golangci individually at their IDEs to learn more on the issues reported by GolangCI._

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests