### PR TITLE
refact(golangci.yml) skip scopelint on unit test files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -285,6 +285,7 @@ issues:
         - errcheck
         - dupl
         - gosec
+        - scopelint
 
     # Exclude known linters from partially hard-vendored code,
     # which is impossible to exclude via "nolint" comments.


### PR DESCRIPTION
     Reasons of false positive error :
     - `name` which is a string is passed into the scope
        i.e. `t.Run(..)`
     - `mock` is passed by value to `t.Run(..)`

Signed-off-by: shubham <shubham.bajpai@mayadata.io>