### PR TITLE
feat(upgrade): add support to build upgrade result cr.

### DIFF
--- a/pkg/kubernetes/objectmeta/v1alpha1/objectmeta.go
+++ b/pkg/kubernetes/objectmeta/v1alpha1/objectmeta.go
@@ -23,10 +23,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// Builder helps to build ObjectMeta
+type Builder struct {
+	errors []error
+	Object *ObjectMeta
+}
+
 // ObjectMeta is a wrapper over metav1.ObjectMeta
 type ObjectMeta struct {
-	Object *metav1.ObjectMeta
-	errors []error
+	ObjectMeta *metav1.ObjectMeta
 }
 
 // String implements Stringer interface
@@ -39,71 +44,73 @@ func (om ObjectMeta) GoString() string {
 	return om.String()
 }
 
-// New returns a new instance of ObjectMeta
-func New() *ObjectMeta {
-	return &ObjectMeta{
-		Object: &metav1.ObjectMeta{},
+// New returns a new instance of Builder
+func New() *Builder {
+	return &Builder{
+		Object: &ObjectMeta{
+			ObjectMeta: &metav1.ObjectMeta{},
+		},
 	}
 }
 
 // WithName adds name in ObjectMeta instance
-func (om *ObjectMeta) WithName(name string) *ObjectMeta {
-	om.Object.Name = name
-	return om
+func (b *Builder) WithName(name string) *Builder {
+	b.Object.ObjectMeta.Name = name
+	return b
 }
 
 // WithNamespace adds namespace in ObjectMeta instance
-func (om *ObjectMeta) WithNamespace(namespace string) *ObjectMeta {
-	om.Object.Namespace = namespace
-	return om
+func (b *Builder) WithNamespace(namespace string) *Builder {
+	b.Object.ObjectMeta.Namespace = namespace
+	return b
 }
 
 // WithLabels adds labels in ObjectMeta instance
-func (om *ObjectMeta) WithLabels(labels map[string]string) *ObjectMeta {
-	om.Object.Labels = labels
-	return om
+func (b *Builder) WithLabels(labels map[string]string) *Builder {
+	b.Object.ObjectMeta.Labels = labels
+	return b
 }
 
 // WithAnnotations adds annotations in ObjectMeta instance
-func (om *ObjectMeta) WithAnnotations(annotations map[string]string) *ObjectMeta {
-	om.Object.Annotations = annotations
-	return om
+func (b *Builder) WithAnnotations(annotations map[string]string) *Builder {
+	b.Object.ObjectMeta.Annotations = annotations
+	return b
 }
 
 // WithOwnerReferences owner references in ObjectMeta instance
-func (om *ObjectMeta) WithOwnerReferences(ownerReferences ...metav1.OwnerReference) *ObjectMeta {
-	om.Object.OwnerReferences = append(om.Object.OwnerReferences, ownerReferences...)
-	return om
+func (b *Builder) WithOwnerReferences(ownerReferences ...metav1.OwnerReference) *Builder {
+	b.Object.ObjectMeta.OwnerReferences = append(b.Object.ObjectMeta.OwnerReferences, ownerReferences...)
+	return b
 }
 
 // WithAPIObject sets Object property in ObjectMeta instance
-func (om *ObjectMeta) WithAPIObject(objectMeta *metav1.ObjectMeta) *ObjectMeta {
-	om.Object = objectMeta
-	return om
+func (b *Builder) WithAPIObject(objectMeta *metav1.ObjectMeta) *Builder {
+	b.Object.ObjectMeta = objectMeta
+	return b
 }
 
 // validate validates ObjectMeta instance
-func (om *ObjectMeta) validate() error {
-	if len(om.errors) != 0 {
-		return errors.Errorf("failed to validate: build errors were found: %v", om.errors)
+func (b *Builder) validate() error {
+	if len(b.errors) != 0 {
+		return errors.Errorf("failed to validate: build errors were found: %v", b.errors)
 	}
 	validationErrs := []error{}
-	if om.Object.Name == "" {
+	if b.Object.ObjectMeta.Name == "" {
 		validationErrs = append(validationErrs, errors.New("missing name"))
 	}
 	if len(validationErrs) != 0 {
-		om.errors = append(om.errors, validationErrs...)
+		b.errors = append(b.errors, validationErrs...)
 		return errors.Errorf("failed to validate: %v", validationErrs)
 	}
 	return nil
 }
 
 // Build builds a new instance of metav1.ObjectMeta
-func (om *ObjectMeta) Build() (*metav1.ObjectMeta, error) {
-	err := om.validate()
+func (b *Builder) Build() (*metav1.ObjectMeta, error) {
+	err := b.validate()
 	if err != nil {
 		return nil,
-			errors.WithMessagef(err, "failed to build ObjectMeta: %s", om)
+			errors.WithMessagef(err, "failed to build ObjectMeta: %s", b.Object)
 	}
-	return om.Object, nil
+	return b.Object.ObjectMeta, nil
 }

--- a/pkg/kubernetes/objectmeta/v1alpha1/objectmeta.go
+++ b/pkg/kubernetes/objectmeta/v1alpha1/objectmeta.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2019 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"github.com/pkg/errors"
+
+	stringer "github.com/openebs/maya/pkg/apis/stringer/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ObjectMeta is a wrapper over metav1.ObjectMeta
+type ObjectMeta struct {
+	Object *metav1.ObjectMeta
+	errors []error
+}
+
+// String implements Stringer interface
+func (om ObjectMeta) String() string {
+	return stringer.Yaml("objectmeta", om)
+}
+
+// GoString implements GoStringer interface
+func (om ObjectMeta) GoString() string {
+	return om.String()
+}
+
+// New returns a new instance of ObjectMeta
+func New() *ObjectMeta {
+	return &ObjectMeta{
+		Object: &metav1.ObjectMeta{},
+	}
+}
+
+// WithName adds name in ObjectMeta instance
+func (om *ObjectMeta) WithName(name string) *ObjectMeta {
+	om.Object.Name = name
+	return om
+}
+
+// WithNamespace adds namespace in ObjectMeta instance
+func (om *ObjectMeta) WithNamespace(namespace string) *ObjectMeta {
+	om.Object.Namespace = namespace
+	return om
+}
+
+// WithLabels adds labels in ObjectMeta instance
+func (om *ObjectMeta) WithLabels(labels map[string]string) *ObjectMeta {
+	om.Object.Labels = labels
+	return om
+}
+
+// WithAnnotations adds annotations in ObjectMeta instance
+func (om *ObjectMeta) WithAnnotations(annotations map[string]string) *ObjectMeta {
+	om.Object.Annotations = annotations
+	return om
+}
+
+// WithOwnerReferences owner references in ObjectMeta instance
+func (om *ObjectMeta) WithOwnerReferences(ownerReferences ...metav1.OwnerReference) *ObjectMeta {
+	om.Object.OwnerReferences = append(om.Object.OwnerReferences, ownerReferences...)
+	return om
+}
+
+// WithAPIObject sets Object property in ObjectMeta instance
+func (om *ObjectMeta) WithAPIObject(objectMeta *metav1.ObjectMeta) *ObjectMeta {
+	om.Object = objectMeta
+	return om
+}
+
+// validate validates ObjectMeta instance
+func (om *ObjectMeta) validate() error {
+	if len(om.errors) != 0 {
+		return errors.Errorf("failed to validate: build errors were found: %v", om.errors)
+	}
+	validationErrs := []error{}
+	if om.Object.Name == "" {
+		validationErrs = append(validationErrs, errors.New("missing name"))
+	}
+	if len(validationErrs) != 0 {
+		om.errors = append(om.errors, validationErrs...)
+		return errors.Errorf("failed to validate: %v", validationErrs)
+	}
+	return nil
+}
+
+// Build builds a new instance of metav1.ObjectMeta
+func (om *ObjectMeta) Build() (*metav1.ObjectMeta, error) {
+	err := om.validate()
+	if err != nil {
+		return nil,
+			errors.WithMessagef(err, "failed to build ObjectMeta: %s", om)
+	}
+	return om.Object, nil
+}

--- a/pkg/kubernetes/objectmeta/v1alpha1/objectmeta_test.go
+++ b/pkg/kubernetes/objectmeta/v1alpha1/objectmeta_test.go
@@ -31,12 +31,12 @@ func TestObjectMetaString(t *testing.T) {
 	}{
 		"objectmeta": {
 			ObjectMeta{
-				Object: &metav1.ObjectMeta{
+				ObjectMeta: &metav1.ObjectMeta{
 					Name:      "fake-name",
 					Namespace: "fake-namespace",
 				},
 			},
-			[]string{"Object:", "name: fake-name", "namespace: fake-namespace"},
+			[]string{"ObjectMeta:", "name: fake-name", "namespace: fake-namespace"},
 		},
 	}
 	for name, mock := range tests {
@@ -60,12 +60,12 @@ func TestObjectMetaGoString(t *testing.T) {
 	}{
 		"objectmeta": {
 			ObjectMeta{
-				Object: &metav1.ObjectMeta{
+				ObjectMeta: &metav1.ObjectMeta{
 					Name:      "fake-name",
 					Namespace: "fake-namespace",
 				},
 			},
-			[]string{"Object:", "name: fake-name", "namespace: fake-namespace"},
+			[]string{"ObjectMeta:", "name: fake-name", "namespace: fake-namespace"},
 		},
 	}
 	for name, mock := range tests {
@@ -96,9 +96,9 @@ func TestNew(t *testing.T) {
 		name := name // pin it
 		mock := mock // pin it
 		b := New()
-		if (b.Object != nil) != mock.expectObject {
+		if (b.Object.ObjectMeta != nil) != mock.expectObject {
 			t.Fatalf("test %s failed, expect object %t, but got : %t",
-				name, mock.expectObject, b.Object != nil)
+				name, mock.expectObject, b.Object.ObjectMeta != nil)
 		}
 		if (len(b.errors) != 0) != mock.expectErrs {
 			t.Fatalf("test %s failed, expect error %t, but got : %t",
@@ -124,13 +124,15 @@ func TestWithName(t *testing.T) {
 	for name, mock := range tests {
 		name := name // pin it
 		mock := mock // pin it
-		b := &ObjectMeta{
-			Object: &metav1.ObjectMeta{},
+		b := &Builder{
+			Object: &ObjectMeta{
+				ObjectMeta: &metav1.ObjectMeta{},
+			},
 		}
 		b.WithName(mock.name)
-		if b.Object.Name != mock.expectedName {
+		if b.Object.ObjectMeta.Name != mock.expectedName {
 			t.Fatalf("test %s failed, expected name %s, but got : %s",
-				name, mock.expectedName, b.Object.Name)
+				name, mock.expectedName, b.Object.ObjectMeta.Name)
 		}
 	}
 }
@@ -152,13 +154,15 @@ func TestWithNamespace(t *testing.T) {
 	for name, mock := range tests {
 		name := name // pin it
 		mock := mock // pin it
-		b := &ObjectMeta{
-			Object: &metav1.ObjectMeta{},
+		b := &Builder{
+			Object: &ObjectMeta{
+				ObjectMeta: &metav1.ObjectMeta{},
+			},
 		}
 		b.WithNamespace(mock.namespace)
-		if b.Object.Namespace != mock.expectedNamespace {
+		if b.Object.ObjectMeta.Namespace != mock.expectedNamespace {
 			t.Fatalf("test %s failed, expected namespace %s, but got : %s",
-				name, mock.expectedNamespace, b.Object.Namespace)
+				name, mock.expectedNamespace, b.Object.ObjectMeta.Namespace)
 		}
 	}
 }
@@ -182,13 +186,15 @@ func TestWithLabels(t *testing.T) {
 	for name, mock := range tests {
 		name := name // pin it
 		mock := mock // pin it
-		b := &ObjectMeta{
-			Object: &metav1.ObjectMeta{},
+		b := &Builder{
+			Object: &ObjectMeta{
+				ObjectMeta: &metav1.ObjectMeta{},
+			},
 		}
 		b.WithLabels(mock.labels)
-		if (b.Object.Labels != nil) != mock.expectlabels {
+		if (b.Object.ObjectMeta.Labels != nil) != mock.expectlabels {
 			t.Fatalf("test %s failed, expect labels %t, but got : %t",
-				name, mock.expectlabels, b.Object.Labels != nil)
+				name, mock.expectlabels, b.Object.ObjectMeta.Labels != nil)
 		}
 	}
 }
@@ -212,13 +218,15 @@ func TestWithAnnotations(t *testing.T) {
 	for name, mock := range tests {
 		name := name // pin it
 		mock := mock // pin it
-		b := &ObjectMeta{
-			Object: &metav1.ObjectMeta{},
+		b := &Builder{
+			Object: &ObjectMeta{
+				ObjectMeta: &metav1.ObjectMeta{},
+			},
 		}
 		b.WithAnnotations(mock.annotations)
-		if (b.Object.Annotations != nil) != mock.expectannotations {
+		if (b.Object.ObjectMeta.Annotations != nil) != mock.expectannotations {
 			t.Fatalf("test %s failed, expect annotation %t, but got : %t",
-				name, mock.expectannotations, b.Object.Annotations != nil)
+				name, mock.expectannotations, b.Object.ObjectMeta.Annotations != nil)
 		}
 	}
 }
@@ -242,13 +250,15 @@ func TestWithOwnerReferences(t *testing.T) {
 	for name, mock := range tests {
 		name := name // pin it
 		mock := mock // pin it
-		b := &ObjectMeta{
-			Object: &metav1.ObjectMeta{},
+		b := &Builder{
+			Object: &ObjectMeta{
+				ObjectMeta: &metav1.ObjectMeta{},
+			},
 		}
 		b.WithOwnerReferences(mock.ownerReferences...)
-		if (len(b.Object.OwnerReferences) != 0) != mock.expectOwnerReferences {
+		if (len(b.Object.ObjectMeta.OwnerReferences) != 0) != mock.expectOwnerReferences {
 			t.Fatalf("test %s failed, expect owner references %t, but got : %t",
-				name, mock.expectOwnerReferences, len(b.Object.OwnerReferences) != 0)
+				name, mock.expectOwnerReferences, len(b.Object.ObjectMeta.OwnerReferences) != 0)
 		}
 	}
 }
@@ -270,11 +280,15 @@ func TestWithAPIObject(t *testing.T) {
 	for name, mock := range tests {
 		name := name // pin it
 		mock := mock // pin it
-		b := &ObjectMeta{}
+		b := &Builder{
+			Object: &ObjectMeta{
+				ObjectMeta: &metav1.ObjectMeta{},
+			},
+		}
 		b.WithAPIObject(mock.objectMeta)
-		if (b.Object != nil) != mock.expectObjectMeta {
+		if (b.Object.ObjectMeta != nil) != mock.expectObjectMeta {
 			t.Fatalf("test %s failed, expect objectmeta %t, but got : %t",
-				name, mock.expectObjectMeta, b.Object != nil)
+				name, mock.expectObjectMeta, b.Object.ObjectMeta != nil)
 		}
 	}
 }
@@ -300,8 +314,10 @@ func TestValidate(t *testing.T) {
 	for name, mock := range tests {
 		name := name // pin it
 		mock := mock // pin it
-		b := &ObjectMeta{
-			Object: &mock.objectMeta,
+		b := &Builder{
+			Object: &ObjectMeta{
+				ObjectMeta: &mock.objectMeta,
+			},
 		}
 		err := b.validate()
 		if (err != nil) != mock.expecterr {
@@ -342,8 +358,10 @@ func TestBuild(t *testing.T) {
 	for name, mock := range tests {
 		name := name // pin it
 		mock := mock // pin it
-		b := &ObjectMeta{
-			Object: &mock.objectMeta,
+		b := &Builder{
+			Object: &ObjectMeta{
+				ObjectMeta: &mock.objectMeta,
+			},
 			errors: mock.errors,
 		}
 		_, err := b.Build()

--- a/pkg/kubernetes/objectmeta/v1alpha1/objectmeta_test.go
+++ b/pkg/kubernetes/objectmeta/v1alpha1/objectmeta_test.go
@@ -31,12 +31,12 @@ func TestObjectMetaString(t *testing.T) {
 	}{
 		"objectmeta": {
 			ObjectMeta{
-				ObjectMeta: &metav1.ObjectMeta{
+				object: &metav1.ObjectMeta{
 					Name:      "fake-name",
 					Namespace: "fake-namespace",
 				},
 			},
-			[]string{"ObjectMeta:", "name: fake-name", "namespace: fake-namespace"},
+			[]string{"name: fake-name", "namespace: fake-namespace"},
 		},
 	}
 	for name, mock := range tests {
@@ -60,12 +60,12 @@ func TestObjectMetaGoString(t *testing.T) {
 	}{
 		"objectmeta": {
 			ObjectMeta{
-				ObjectMeta: &metav1.ObjectMeta{
+				object: &metav1.ObjectMeta{
 					Name:      "fake-name",
 					Namespace: "fake-namespace",
 				},
 			},
-			[]string{"ObjectMeta:", "name: fake-name", "namespace: fake-namespace"},
+			[]string{"name: fake-name", "namespace: fake-namespace"},
 		},
 	}
 	for name, mock := range tests {
@@ -82,7 +82,7 @@ func TestObjectMetaGoString(t *testing.T) {
 	}
 }
 
-func TestNew(t *testing.T) {
+func TestNewBuilder(t *testing.T) {
 	tests := map[string]struct {
 		expectObject bool
 		expectErrs   bool
@@ -95,10 +95,10 @@ func TestNew(t *testing.T) {
 	for name, mock := range tests {
 		name := name // pin it
 		mock := mock // pin it
-		b := New()
-		if (b.Object.ObjectMeta != nil) != mock.expectObject {
+		b := NewBuilder()
+		if (b.meta.object != nil) != mock.expectObject {
 			t.Fatalf("test %s failed, expect object %t, but got : %t",
-				name, mock.expectObject, b.Object.ObjectMeta != nil)
+				name, mock.expectObject, b.meta.object != nil)
 		}
 		if (len(b.errors) != 0) != mock.expectErrs {
 			t.Fatalf("test %s failed, expect error %t, but got : %t",
@@ -125,14 +125,14 @@ func TestWithName(t *testing.T) {
 		name := name // pin it
 		mock := mock // pin it
 		b := &Builder{
-			Object: &ObjectMeta{
-				ObjectMeta: &metav1.ObjectMeta{},
+			meta: &ObjectMeta{
+				object: &metav1.ObjectMeta{},
 			},
 		}
 		b.WithName(mock.name)
-		if b.Object.ObjectMeta.Name != mock.expectedName {
+		if b.meta.object.Name != mock.expectedName {
 			t.Fatalf("test %s failed, expected name %s, but got : %s",
-				name, mock.expectedName, b.Object.ObjectMeta.Name)
+				name, mock.expectedName, b.meta.object.Name)
 		}
 	}
 }
@@ -155,14 +155,14 @@ func TestWithNamespace(t *testing.T) {
 		name := name // pin it
 		mock := mock // pin it
 		b := &Builder{
-			Object: &ObjectMeta{
-				ObjectMeta: &metav1.ObjectMeta{},
+			meta: &ObjectMeta{
+				object: &metav1.ObjectMeta{},
 			},
 		}
 		b.WithNamespace(mock.namespace)
-		if b.Object.ObjectMeta.Namespace != mock.expectedNamespace {
+		if b.meta.object.Namespace != mock.expectedNamespace {
 			t.Fatalf("test %s failed, expected namespace %s, but got : %s",
-				name, mock.expectedNamespace, b.Object.ObjectMeta.Namespace)
+				name, mock.expectedNamespace, b.meta.object.Namespace)
 		}
 	}
 }
@@ -187,14 +187,14 @@ func TestWithLabels(t *testing.T) {
 		name := name // pin it
 		mock := mock // pin it
 		b := &Builder{
-			Object: &ObjectMeta{
-				ObjectMeta: &metav1.ObjectMeta{},
+			meta: &ObjectMeta{
+				object: &metav1.ObjectMeta{},
 			},
 		}
 		b.WithLabels(mock.labels)
-		if (b.Object.ObjectMeta.Labels != nil) != mock.expectlabels {
+		if (b.meta.object.Labels != nil) != mock.expectlabels {
 			t.Fatalf("test %s failed, expect labels %t, but got : %t",
-				name, mock.expectlabels, b.Object.ObjectMeta.Labels != nil)
+				name, mock.expectlabels, b.meta.object.Labels != nil)
 		}
 	}
 }
@@ -219,14 +219,14 @@ func TestWithAnnotations(t *testing.T) {
 		name := name // pin it
 		mock := mock // pin it
 		b := &Builder{
-			Object: &ObjectMeta{
-				ObjectMeta: &metav1.ObjectMeta{},
+			meta: &ObjectMeta{
+				object: &metav1.ObjectMeta{},
 			},
 		}
 		b.WithAnnotations(mock.annotations)
-		if (b.Object.ObjectMeta.Annotations != nil) != mock.expectannotations {
+		if (b.meta.object.Annotations != nil) != mock.expectannotations {
 			t.Fatalf("test %s failed, expect annotation %t, but got : %t",
-				name, mock.expectannotations, b.Object.ObjectMeta.Annotations != nil)
+				name, mock.expectannotations, b.meta.object.Annotations != nil)
 		}
 	}
 }
@@ -251,19 +251,19 @@ func TestWithOwnerReferences(t *testing.T) {
 		name := name // pin it
 		mock := mock // pin it
 		b := &Builder{
-			Object: &ObjectMeta{
-				ObjectMeta: &metav1.ObjectMeta{},
+			meta: &ObjectMeta{
+				object: &metav1.ObjectMeta{},
 			},
 		}
 		b.WithOwnerReferences(mock.ownerReferences...)
-		if (len(b.Object.ObjectMeta.OwnerReferences) != 0) != mock.expectOwnerReferences {
+		if (len(b.meta.object.OwnerReferences) != 0) != mock.expectOwnerReferences {
 			t.Fatalf("test %s failed, expect owner references %t, but got : %t",
-				name, mock.expectOwnerReferences, len(b.Object.ObjectMeta.OwnerReferences) != 0)
+				name, mock.expectOwnerReferences, len(b.meta.object.OwnerReferences) != 0)
 		}
 	}
 }
 
-func TestWithAPIObject(t *testing.T) {
+func TestNewBuilderForAPIObject(t *testing.T) {
 	tests := map[string]struct {
 		objectMeta       *metav1.ObjectMeta
 		expectObjectMeta bool
@@ -274,21 +274,16 @@ func TestWithAPIObject(t *testing.T) {
 		},
 		"nil objectmeta present": {
 			nil,
-			false,
+			true,
 		},
 	}
 	for name, mock := range tests {
 		name := name // pin it
 		mock := mock // pin it
-		b := &Builder{
-			Object: &ObjectMeta{
-				ObjectMeta: &metav1.ObjectMeta{},
-			},
-		}
-		b.WithAPIObject(mock.objectMeta)
-		if (b.Object.ObjectMeta != nil) != mock.expectObjectMeta {
+		b := NewBuilderForAPIObject(mock.objectMeta)
+		if (b.meta.object != nil) != mock.expectObjectMeta {
 			t.Fatalf("test %s failed, expect objectmeta %t, but got : %t",
-				name, mock.expectObjectMeta, b.Object.ObjectMeta != nil)
+				name, mock.expectObjectMeta, b.meta.object != nil)
 		}
 	}
 }
@@ -315,8 +310,8 @@ func TestValidate(t *testing.T) {
 		name := name // pin it
 		mock := mock // pin it
 		b := &Builder{
-			Object: &ObjectMeta{
-				ObjectMeta: &mock.objectMeta,
+			meta: &ObjectMeta{
+				object: &mock.objectMeta,
 			},
 		}
 		err := b.validate()
@@ -359,8 +354,8 @@ func TestBuild(t *testing.T) {
 		name := name // pin it
 		mock := mock // pin it
 		b := &Builder{
-			Object: &ObjectMeta{
-				ObjectMeta: &mock.objectMeta,
+			meta: &ObjectMeta{
+				object: &mock.objectMeta,
 			},
 			errors: mock.errors,
 		}

--- a/pkg/kubernetes/objectmeta/v1alpha1/objectmeta_test.go
+++ b/pkg/kubernetes/objectmeta/v1alpha1/objectmeta_test.go
@@ -1,0 +1,355 @@
+/*
+Copyright 2019 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestObjectMetaString(t *testing.T) {
+	tests := map[string]struct {
+		object              ObjectMeta
+		expectedStringParts []string
+	}{
+		"objectmeta": {
+			ObjectMeta{
+				Object: &metav1.ObjectMeta{
+					Name:      "fake-name",
+					Namespace: "fake-namespace",
+				},
+			},
+			[]string{"Object:", "name: fake-name", "namespace: fake-namespace"},
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		t.Run(name, func(t *testing.T) {
+			ymlstr := mock.object.String()
+			for _, expect := range mock.expectedStringParts {
+				if !strings.Contains(ymlstr, expect) {
+					t.Errorf("test '%s' failed: expected '%s' in '%s'", name, expect, ymlstr)
+				}
+			}
+		})
+	}
+}
+
+func TestObjectMetaGoString(t *testing.T) {
+	tests := map[string]struct {
+		object              ObjectMeta
+		expectedStringParts []string
+	}{
+		"objectmeta": {
+			ObjectMeta{
+				Object: &metav1.ObjectMeta{
+					Name:      "fake-name",
+					Namespace: "fake-namespace",
+				},
+			},
+			[]string{"Object:", "name: fake-name", "namespace: fake-namespace"},
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		t.Run(name, func(t *testing.T) {
+			ymlstr := mock.object.GoString()
+			for _, expect := range mock.expectedStringParts {
+				if !strings.Contains(ymlstr, expect) {
+					t.Errorf("test '%s' failed: expected '%s' in '%s'", name, expect, ymlstr)
+				}
+			}
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	tests := map[string]struct {
+		expectObject bool
+		expectErrs   bool
+	}{
+		"new instance of ObjectMeta": {
+			true,
+			false,
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		b := New()
+		if (b.Object != nil) != mock.expectObject {
+			t.Fatalf("test %s failed, expect object %t, but got : %t",
+				name, mock.expectObject, b.Object != nil)
+		}
+		if (len(b.errors) != 0) != mock.expectErrs {
+			t.Fatalf("test %s failed, expect error %t, but got : %t",
+				name, mock.expectErrs, len(b.errors) != 0)
+		}
+	}
+}
+
+func TestWithName(t *testing.T) {
+	tests := map[string]struct {
+		name         string
+		expectedName string
+	}{
+		"name present": {
+			"fake-name",
+			"fake-name",
+		},
+		"empty name present": {
+			"",
+			"",
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		b := &ObjectMeta{
+			Object: &metav1.ObjectMeta{},
+		}
+		b.WithName(mock.name)
+		if b.Object.Name != mock.expectedName {
+			t.Fatalf("test %s failed, expected name %s, but got : %s",
+				name, mock.expectedName, b.Object.Name)
+		}
+	}
+}
+
+func TestWithNamespace(t *testing.T) {
+	tests := map[string]struct {
+		namespace         string
+		expectedNamespace string
+	}{
+		"namespace present": {
+			"fake-namespace",
+			"fake-namespace",
+		},
+		"empty namespace present": {
+			"",
+			"",
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		b := &ObjectMeta{
+			Object: &metav1.ObjectMeta{},
+		}
+		b.WithNamespace(mock.namespace)
+		if b.Object.Namespace != mock.expectedNamespace {
+			t.Fatalf("test %s failed, expected namespace %s, but got : %s",
+				name, mock.expectedNamespace, b.Object.Namespace)
+		}
+	}
+}
+
+func TestWithLabels(t *testing.T) {
+	tests := map[string]struct {
+		labels       map[string]string
+		expectlabels bool
+	}{
+		"label present": {
+			map[string]string{
+				"key": "value",
+			},
+			true,
+		},
+		"nil label present": {
+			nil,
+			false,
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		b := &ObjectMeta{
+			Object: &metav1.ObjectMeta{},
+		}
+		b.WithLabels(mock.labels)
+		if (b.Object.Labels != nil) != mock.expectlabels {
+			t.Fatalf("test %s failed, expect labels %t, but got : %t",
+				name, mock.expectlabels, b.Object.Labels != nil)
+		}
+	}
+}
+
+func TestWithAnnotations(t *testing.T) {
+	tests := map[string]struct {
+		annotations       map[string]string
+		expectannotations bool
+	}{
+		"annotation present": {
+			map[string]string{
+				"key": "value",
+			},
+			true,
+		},
+		"nil annotation present": {
+			nil,
+			false,
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		b := &ObjectMeta{
+			Object: &metav1.ObjectMeta{},
+		}
+		b.WithAnnotations(mock.annotations)
+		if (b.Object.Annotations != nil) != mock.expectannotations {
+			t.Fatalf("test %s failed, expect annotation %t, but got : %t",
+				name, mock.expectannotations, b.Object.Annotations != nil)
+		}
+	}
+}
+
+func TestWithOwnerReferences(t *testing.T) {
+	tests := map[string]struct {
+		ownerReferences       []metav1.OwnerReference
+		expectOwnerReferences bool
+	}{
+		"owner references present": {
+			[]metav1.OwnerReference{
+				metav1.OwnerReference{},
+			},
+			true,
+		},
+		"owner references not present": {
+			[]metav1.OwnerReference{},
+			false,
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		b := &ObjectMeta{
+			Object: &metav1.ObjectMeta{},
+		}
+		b.WithOwnerReferences(mock.ownerReferences...)
+		if (len(b.Object.OwnerReferences) != 0) != mock.expectOwnerReferences {
+			t.Fatalf("test %s failed, expect owner references %t, but got : %t",
+				name, mock.expectOwnerReferences, len(b.Object.OwnerReferences) != 0)
+		}
+	}
+}
+
+func TestWithAPIObject(t *testing.T) {
+	tests := map[string]struct {
+		objectMeta       *metav1.ObjectMeta
+		expectObjectMeta bool
+	}{
+		"valid objectmeta present": {
+			&metav1.ObjectMeta{},
+			true,
+		},
+		"nil objectmeta present": {
+			nil,
+			false,
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		b := &ObjectMeta{}
+		b.WithAPIObject(mock.objectMeta)
+		if (b.Object != nil) != mock.expectObjectMeta {
+			t.Fatalf("test %s failed, expect objectmeta %t, but got : %t",
+				name, mock.expectObjectMeta, b.Object != nil)
+		}
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := map[string]struct {
+		objectMeta metav1.ObjectMeta
+		expecterr  bool
+	}{
+		"name present": {
+			metav1.ObjectMeta{
+				Name: "fake-name",
+			},
+			false,
+		},
+		"empty name present": {
+			metav1.ObjectMeta{
+				Name: "",
+			},
+			true,
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		b := &ObjectMeta{
+			Object: &mock.objectMeta,
+		}
+		err := b.validate()
+		if (err != nil) != mock.expecterr {
+			t.Fatalf("test %s failed, expect error %t, but got : %t",
+				name, mock.expecterr, err != nil)
+		}
+	}
+}
+
+func TestBuild(t *testing.T) {
+	tests := map[string]struct {
+		objectMeta metav1.ObjectMeta
+		errors     []error
+		expecterr  bool
+	}{
+		"name present": {
+			metav1.ObjectMeta{
+				Name: "fake-name",
+			},
+			[]error{},
+			false,
+		},
+		"empty name not present": {
+			metav1.ObjectMeta{
+				Name: "",
+			},
+			[]error{},
+			true,
+		},
+		"name and error present": {
+			metav1.ObjectMeta{
+				Name: "fake-name",
+			},
+			[]error{errors.New("")},
+			true,
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		b := &ObjectMeta{
+			Object: &mock.objectMeta,
+			errors: mock.errors,
+		}
+		_, err := b.Build()
+		if (err != nil) != mock.expecterr {
+			t.Fatalf("test %s failed, expect error %t, but got : %t",
+				name, mock.expecterr, err != nil)
+		}
+	}
+}

--- a/pkg/kubernetes/ownerreference/v1alpha1/ownerreference.go
+++ b/pkg/kubernetes/ownerreference/v1alpha1/ownerreference.go
@@ -24,10 +24,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// Builder helps to build OwnerReference
+type Builder struct {
+	errors []error
+	Object *OwnerReference
+}
+
 // OwnerReference is a wrapper over metav1.OwnerReference
 type OwnerReference struct {
-	Object *metav1.OwnerReference
-	errors []error
+	OwnerReference *metav1.OwnerReference
 }
 
 // String implements Stringer interface
@@ -40,74 +45,88 @@ func (or OwnerReference) GoString() string {
 	return or.String()
 }
 
-// New returns a new instance of OwnerReference
-func New() *OwnerReference {
-	return &OwnerReference{
-		Object: &metav1.OwnerReference{},
+// New returns a new instance of Builder
+func New() *Builder {
+	return &Builder{
+		Object: &OwnerReference{
+			OwnerReference: &metav1.OwnerReference{},
+		},
 	}
 }
 
 // WithName sets name in OwnerReference instance
-func (or *OwnerReference) WithName(name string) *OwnerReference {
-	or.Object.Name = name
-	return or
+func (b *Builder) WithName(name string) *Builder {
+	b.Object.OwnerReference.Name = name
+	return b
 }
 
 // WithKind sets kind in OwnerReference instance
-func (or *OwnerReference) WithKind(kind string) *OwnerReference {
-	or.Object.Kind = kind
-	return or
+func (b *Builder) WithKind(kind string) *Builder {
+	b.Object.OwnerReference.Kind = kind
+	return b
 }
 
 // WithAPIVersion sets api version in OwnerReference instance
-func (or *OwnerReference) WithAPIVersion(apiVersion string) *OwnerReference {
-	or.Object.APIVersion = apiVersion
-	return or
+func (b *Builder) WithAPIVersion(apiVersion string) *Builder {
+	b.Object.OwnerReference.APIVersion = apiVersion
+	return b
 }
 
 // WithUID sets uid in OwnerReference instance
-func (or *OwnerReference) WithUID(uid types.UID) *OwnerReference {
-	or.Object.UID = uid
-	return or
+func (b *Builder) WithUID(uid types.UID) *Builder {
+	b.Object.OwnerReference.UID = uid
+	return b
 }
 
-// WithAPIObject sets Object property in OwnerReference instance
-func (or *OwnerReference) WithAPIObject(ownerReference *metav1.OwnerReference) *OwnerReference {
-	or.Object = ownerReference
-	return or
+// WithControllerOption sets Controller property in OwnerReference instance
+func (b *Builder) WithControllerOption(controller *bool) *Builder {
+	b.Object.OwnerReference.Controller = controller
+	return b
+}
+
+// WithBlockOwnerDeletionOption sets BlockOwnerDeletion property in OwnerReference instance
+func (b *Builder) WithBlockOwnerDeletionOption(blockOwnerDeletion *bool) *Builder {
+	b.Object.OwnerReference.BlockOwnerDeletion = blockOwnerDeletion
+	return b
+}
+
+// WithAPIObject sets OwnerReference property in OwnerReference instance
+func (b *Builder) WithAPIObject(ownerReference *metav1.OwnerReference) *Builder {
+	b.Object.OwnerReference = ownerReference
+	return b
 }
 
 // validate validates OwnerReference instance
-func (or *OwnerReference) validate() error {
-	if len(or.errors) != 0 {
-		return errors.Errorf("failed to validate: build errors were found: %v", or.errors)
+func (b *Builder) validate() error {
+	if len(b.errors) != 0 {
+		return errors.Errorf("failed to validate: build errors were found: %v", b.errors)
 	}
 	validationErrs := []error{}
-	if or.Object.Name == "" {
+	if b.Object.OwnerReference.Name == "" {
 		validationErrs = append(validationErrs, errors.New("missing name"))
 	}
-	if or.Object.Kind == "" {
+	if b.Object.OwnerReference.Kind == "" {
 		validationErrs = append(validationErrs, errors.New("missing kind"))
 	}
-	if or.Object.APIVersion == "" {
+	if b.Object.OwnerReference.APIVersion == "" {
 		validationErrs = append(validationErrs, errors.New("missing api version"))
 	}
-	if or.Object.UID == "" {
+	if b.Object.OwnerReference.UID == "" {
 		validationErrs = append(validationErrs, errors.New("missing uid"))
 	}
 	if len(validationErrs) != 0 {
-		or.errors = append(or.errors, validationErrs...)
+		b.errors = append(b.errors, validationErrs...)
 		return errors.Errorf("failed to validate: %v", validationErrs)
 	}
 	return nil
 }
 
 // Build builds a new instance of matav1.OwnerReference
-func (or *OwnerReference) Build() (*metav1.OwnerReference, error) {
-	err := or.validate()
+func (b *Builder) Build() (*metav1.OwnerReference, error) {
+	err := b.validate()
 	if err != nil {
 		return nil,
-			errors.WithMessagef(err, "failed to build OwnerReference: %s", or)
+			errors.WithMessagef(err, "failed to build OwnerReference: %s", b.Object)
 	}
-	return or.Object, nil
+	return b.Object.OwnerReference, nil
 }

--- a/pkg/kubernetes/ownerreference/v1alpha1/ownerreference.go
+++ b/pkg/kubernetes/ownerreference/v1alpha1/ownerreference.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2019 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	stringer "github.com/openebs/maya/pkg/apis/stringer/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// OwnerReference is a wrapper over metav1.OwnerReference
+type OwnerReference struct {
+	Object *metav1.OwnerReference
+	errors []error
+}
+
+// String implements Stringer interface
+func (or OwnerReference) String() string {
+	return stringer.Yaml("ownerreference", or)
+}
+
+// GoString implements GoStringer interface
+func (or OwnerReference) GoString() string {
+	return or.String()
+}
+
+// New returns a new instance of OwnerReference
+func New() *OwnerReference {
+	return &OwnerReference{
+		Object: &metav1.OwnerReference{},
+	}
+}
+
+// WithName sets name in OwnerReference instance
+func (or *OwnerReference) WithName(name string) *OwnerReference {
+	or.Object.Name = name
+	return or
+}
+
+// WithKind sets kind in OwnerReference instance
+func (or *OwnerReference) WithKind(kind string) *OwnerReference {
+	or.Object.Kind = kind
+	return or
+}
+
+// WithAPIVersion sets api version in OwnerReference instance
+func (or *OwnerReference) WithAPIVersion(apiVersion string) *OwnerReference {
+	or.Object.APIVersion = apiVersion
+	return or
+}
+
+// WithUID sets uid in OwnerReference instance
+func (or *OwnerReference) WithUID(uid types.UID) *OwnerReference {
+	or.Object.UID = uid
+	return or
+}
+
+// WithAPIObject sets Object property in OwnerReference instance
+func (or *OwnerReference) WithAPIObject(ownerReference *metav1.OwnerReference) *OwnerReference {
+	or.Object = ownerReference
+	return or
+}
+
+// validate validates OwnerReference instance
+func (or *OwnerReference) validate() error {
+	if len(or.errors) != 0 {
+		return errors.Errorf("failed to validate: build errors were found: %v", or.errors)
+	}
+	validationErrs := []error{}
+	if or.Object.Name == "" {
+		validationErrs = append(validationErrs, errors.New("missing name"))
+	}
+	if or.Object.Kind == "" {
+		validationErrs = append(validationErrs, errors.New("missing kind"))
+	}
+	if or.Object.APIVersion == "" {
+		validationErrs = append(validationErrs, errors.New("missing api version"))
+	}
+	if or.Object.UID == "" {
+		validationErrs = append(validationErrs, errors.New("missing uid"))
+	}
+	if len(validationErrs) != 0 {
+		or.errors = append(or.errors, validationErrs...)
+		return errors.Errorf("failed to validate: %v", validationErrs)
+	}
+	return nil
+}
+
+// Build builds a new instance of matav1.OwnerReference
+func (or *OwnerReference) Build() (*metav1.OwnerReference, error) {
+	err := or.validate()
+	if err != nil {
+		return nil,
+			errors.WithMessagef(err, "failed to build OwnerReference: %s", or)
+	}
+	return or.Object, nil
+}

--- a/pkg/kubernetes/ownerreference/v1alpha1/ownerreference_test.go
+++ b/pkg/kubernetes/ownerreference/v1alpha1/ownerreference_test.go
@@ -32,14 +32,14 @@ func TestOwnerReferenceString(t *testing.T) {
 	}{
 		"objectmeta": {
 			OwnerReference{
-				OwnerReference: &metav1.OwnerReference{
+				object: &metav1.OwnerReference{
 					Name:       "fake-name",
 					Kind:       "fake-kind",
 					APIVersion: "fake-apiversion",
 					UID:        "fake-uid",
 				},
 			},
-			[]string{"OwnerReference:", "name: fake-name", "kind: fake-kind",
+			[]string{"name: fake-name", "kind: fake-kind",
 				"apiVersion: fake-apiversion", "uid: fake-uid"},
 		},
 	}
@@ -64,14 +64,14 @@ func TestOwnerReferenceGoString(t *testing.T) {
 	}{
 		"objectmeta": {
 			OwnerReference{
-				OwnerReference: &metav1.OwnerReference{
+				object: &metav1.OwnerReference{
 					Name:       "fake-name",
 					Kind:       "fake-kind",
 					APIVersion: "fake-apiversion",
 					UID:        "fake-uid",
 				},
 			},
-			[]string{"OwnerReference:", "name: fake-name", "kind: fake-kind",
+			[]string{"name: fake-name", "kind: fake-kind",
 				"apiVersion: fake-apiversion", "uid: fake-uid"},
 		},
 	}
@@ -89,7 +89,7 @@ func TestOwnerReferenceGoString(t *testing.T) {
 	}
 }
 
-func TestNew(t *testing.T) {
+func TestNewBuilder(t *testing.T) {
 	tests := map[string]struct {
 		expectObject bool
 		expectErrs   bool
@@ -102,10 +102,10 @@ func TestNew(t *testing.T) {
 	for name, mock := range tests {
 		name := name // pin it
 		mock := mock // pin it
-		b := New()
-		if (b.Object.OwnerReference != nil) != mock.expectObject {
+		b := NewBuilder()
+		if (b.ownerRef.object != nil) != mock.expectObject {
 			t.Fatalf("test %s failed, expect object %t, but got : %t",
-				name, mock.expectObject, b.Object.OwnerReference != nil)
+				name, mock.expectObject, b.ownerRef.object != nil)
 		}
 		if (len(b.errors) != 0) != mock.expectErrs {
 			t.Fatalf("test %s failed, expect error %t, but got : %t",
@@ -132,14 +132,14 @@ func TestWithName(t *testing.T) {
 		name := name // pin it
 		mock := mock // pin it
 		b := &Builder{
-			Object: &OwnerReference{
-				OwnerReference: &metav1.OwnerReference{},
+			ownerRef: &OwnerReference{
+				object: &metav1.OwnerReference{},
 			},
 		}
 		b.WithName(mock.name)
-		if b.Object.OwnerReference.Name != mock.expectedName {
+		if b.ownerRef.object.Name != mock.expectedName {
 			t.Fatalf("test %s failed, expected name %s, but got : %s",
-				name, mock.expectedName, b.Object.OwnerReference.Name)
+				name, mock.expectedName, b.ownerRef.object.Name)
 		}
 	}
 }
@@ -162,14 +162,14 @@ func TestWithKind(t *testing.T) {
 		name := name // pin it
 		mock := mock // pin it
 		b := &Builder{
-			Object: &OwnerReference{
-				OwnerReference: &metav1.OwnerReference{},
+			ownerRef: &OwnerReference{
+				object: &metav1.OwnerReference{},
 			},
 		}
 		b.WithKind(mock.kind)
-		if b.Object.OwnerReference.Kind != mock.expectedKind {
+		if b.ownerRef.object.Kind != mock.expectedKind {
 			t.Fatalf("test %s failed, expected kind %s, but got : %s",
-				name, mock.expectedKind, b.Object.OwnerReference.Kind)
+				name, mock.expectedKind, b.ownerRef.object.Kind)
 		}
 	}
 }
@@ -192,14 +192,14 @@ func TestWithAPIVersion(t *testing.T) {
 		name := name // pin it
 		mock := mock // pin it
 		b := &Builder{
-			Object: &OwnerReference{
-				OwnerReference: &metav1.OwnerReference{},
+			ownerRef: &OwnerReference{
+				object: &metav1.OwnerReference{},
 			},
 		}
 		b.WithAPIVersion(mock.apiVersion)
-		if b.Object.OwnerReference.APIVersion != mock.expectedAPIVersion {
+		if b.ownerRef.object.APIVersion != mock.expectedAPIVersion {
 			t.Fatalf("test %s failed, expected apiVersion %s, but got : %s",
-				name, mock.expectedAPIVersion, b.Object.OwnerReference.APIVersion)
+				name, mock.expectedAPIVersion, b.ownerRef.object.APIVersion)
 		}
 	}
 }
@@ -222,14 +222,14 @@ func TestWithUID(t *testing.T) {
 		name := name // pin it
 		mock := mock // pin it
 		b := &Builder{
-			Object: &OwnerReference{
-				OwnerReference: &metav1.OwnerReference{},
+			ownerRef: &OwnerReference{
+				object: &metav1.OwnerReference{},
 			},
 		}
 		b.WithUID(mock.uid)
-		if b.Object.OwnerReference.UID != mock.uid {
+		if b.ownerRef.object.UID != mock.uid {
 			t.Fatalf("test %s failed, expected uid %s, but got : %s",
-				name, mock.expectedUID, b.Object.OwnerReference.UID)
+				name, mock.expectedUID, b.ownerRef.object.UID)
 		}
 	}
 }
@@ -252,14 +252,14 @@ func TestWithControllerOption(t *testing.T) {
 		name := name // pin it
 		mock := mock // pin it
 		b := &Builder{
-			Object: &OwnerReference{
-				OwnerReference: &metav1.OwnerReference{},
+			ownerRef: &OwnerReference{
+				object: &metav1.OwnerReference{},
 			},
 		}
 		b.WithControllerOption(&mock.controller)
-		if *b.Object.OwnerReference.Controller != mock.expectedController {
+		if *b.ownerRef.object.Controller != mock.expectedController {
 			t.Fatalf("test %s failed, expected controller option %t, but got : %t",
-				name, mock.expectedController, *b.Object.OwnerReference.Controller)
+				name, mock.expectedController, *b.ownerRef.object.Controller)
 		}
 	}
 }
@@ -282,14 +282,14 @@ func TestWithBlockOwnerDeletionOption(t *testing.T) {
 		name := name // pin it
 		mock := mock // pin it
 		b := &Builder{
-			Object: &OwnerReference{
-				OwnerReference: &metav1.OwnerReference{},
+			ownerRef: &OwnerReference{
+				object: &metav1.OwnerReference{},
 			},
 		}
 		b.WithBlockOwnerDeletionOption(&mock.blockOwnerDeletion)
-		if *b.Object.OwnerReference.BlockOwnerDeletion != mock.expectedBlockOwnerDeletion {
+		if *b.ownerRef.object.BlockOwnerDeletion != mock.expectedBlockOwnerDeletion {
 			t.Fatalf("test %s failed, expected BlockOwnerDeletion option %t, but got : %t",
-				name, mock.expectedBlockOwnerDeletion, *b.Object.OwnerReference.BlockOwnerDeletion)
+				name, mock.expectedBlockOwnerDeletion, *b.ownerRef.object.BlockOwnerDeletion)
 		}
 	}
 }
@@ -305,21 +305,16 @@ func TestWithAPIObject(t *testing.T) {
 		},
 		"nil ownerReference present": {
 			nil,
-			false,
+			true,
 		},
 	}
 	for name, mock := range tests {
 		name := name // pin it
 		mock := mock // pin it
-		b := &Builder{
-			Object: &OwnerReference{
-				OwnerReference: &metav1.OwnerReference{},
-			},
-		}
-		b.WithAPIObject(mock.ownerReference)
-		if (b.Object.OwnerReference != nil) != mock.expectOwnerReference {
+		b := NewBuilderForAPIObject(mock.ownerReference)
+		if (b.ownerRef.object != nil) != mock.expectOwnerReference {
 			t.Fatalf("test %s failed, expect ownerReference %t, but got : %t",
-				name, mock.expectOwnerReference, b.Object.OwnerReference != nil)
+				name, mock.expectOwnerReference, b.ownerRef.object != nil)
 		}
 	}
 }
@@ -375,8 +370,8 @@ func TestValidate(t *testing.T) {
 		name := name // pin it
 		mock := mock // pin it
 		b := &Builder{
-			Object: &OwnerReference{
-				OwnerReference: &mock.ownerReference,
+			ownerRef: &OwnerReference{
+				object: &mock.ownerReference,
 			},
 		}
 		err := b.validate()
@@ -454,8 +449,8 @@ func TestBuild(t *testing.T) {
 		name := name // pin it
 		mock := mock // pin it
 		b := &Builder{
-			Object: &OwnerReference{
-				OwnerReference: &mock.ownerReference,
+			ownerRef: &OwnerReference{
+				object: &mock.ownerReference,
 			},
 			errors: mock.errors,
 		}

--- a/pkg/kubernetes/ownerreference/v1alpha1/ownerreference_test.go
+++ b/pkg/kubernetes/ownerreference/v1alpha1/ownerreference_test.go
@@ -1,0 +1,393 @@
+/*
+Copyright 2019 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestOwnerReferenceString(t *testing.T) {
+	tests := map[string]struct {
+		object              OwnerReference
+		expectedStringParts []string
+	}{
+		"objectmeta": {
+			OwnerReference{
+				Object: &metav1.OwnerReference{
+					Name:       "fake-name",
+					Kind:       "fake-kind",
+					APIVersion: "fake-apiversion",
+					UID:        "fake-uid",
+				},
+			},
+			[]string{"Object:", "name: fake-name", "kind: fake-kind",
+				"apiVersion: fake-apiversion", "uid: fake-uid"},
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		t.Run(name, func(t *testing.T) {
+			ymlstr := mock.object.String()
+			for _, expect := range mock.expectedStringParts {
+				if !strings.Contains(ymlstr, expect) {
+					t.Errorf("test '%s' failed: expected '%s' in '%s'", name, expect, ymlstr)
+				}
+			}
+		})
+	}
+}
+
+func TestOwnerReferenceGoString(t *testing.T) {
+	tests := map[string]struct {
+		object              OwnerReference
+		expectedStringParts []string
+	}{
+		"objectmeta": {
+			OwnerReference{
+				Object: &metav1.OwnerReference{
+					Name:       "fake-name",
+					Kind:       "fake-kind",
+					APIVersion: "fake-apiversion",
+					UID:        "fake-uid",
+				},
+			},
+			[]string{"Object:", "name: fake-name", "kind: fake-kind",
+				"apiVersion: fake-apiversion", "uid: fake-uid"},
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		t.Run(name, func(t *testing.T) {
+			ymlstr := mock.object.GoString()
+			for _, expect := range mock.expectedStringParts {
+				if !strings.Contains(ymlstr, expect) {
+					t.Errorf("test '%s' failed: expected '%s' in '%s'", name, expect, ymlstr)
+				}
+			}
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	tests := map[string]struct {
+		expectObject bool
+		expectErrs   bool
+	}{
+		"new instance of OwnerReference": {
+			true,
+			false,
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		b := New()
+		if (b.Object != nil) != mock.expectObject {
+			t.Fatalf("test %s failed, expect object %t, but got : %t",
+				name, mock.expectObject, b.Object != nil)
+		}
+		if (len(b.errors) != 0) != mock.expectErrs {
+			t.Fatalf("test %s failed, expect error %t, but got : %t",
+				name, mock.expectErrs, len(b.errors) != 0)
+		}
+	}
+}
+
+func TestWithName(t *testing.T) {
+	tests := map[string]struct {
+		name         string
+		expectedName string
+	}{
+		"name present": {
+			"fake-name",
+			"fake-name",
+		},
+		"empty name present": {
+			"",
+			"",
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		b := &OwnerReference{
+			Object: &metav1.OwnerReference{},
+		}
+		b.WithName(mock.name)
+		if b.Object.Name != mock.expectedName {
+			t.Fatalf("test %s failed, expected name %s, but got : %s",
+				name, mock.expectedName, b.Object.Name)
+		}
+	}
+}
+
+func TestWithKind(t *testing.T) {
+	tests := map[string]struct {
+		kind         string
+		expectedKind string
+	}{
+		"kind present": {
+			"fake-namespace",
+			"fake-namespace",
+		},
+		"empty kind present": {
+			"",
+			"",
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		b := &OwnerReference{
+			Object: &metav1.OwnerReference{},
+		}
+		b.WithKind(mock.kind)
+		if b.Object.Kind != mock.expectedKind {
+			t.Fatalf("test %s failed, expected kind %s, but got : %s",
+				name, mock.expectedKind, b.Object.Kind)
+		}
+	}
+}
+
+func TestWithAPIVersion(t *testing.T) {
+	tests := map[string]struct {
+		apiVersion         string
+		expectedAPIVersion string
+	}{
+		"apiVersion present": {
+			"apps/v1",
+			"apps/v1",
+		},
+		"empty apiVersion present": {
+			"",
+			"",
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		b := &OwnerReference{
+			Object: &metav1.OwnerReference{},
+		}
+		b.WithAPIVersion(mock.apiVersion)
+		if b.Object.APIVersion != mock.expectedAPIVersion {
+			t.Fatalf("test %s failed, expected apiVersion %s, but got : %s",
+				name, mock.expectedAPIVersion, b.Object.APIVersion)
+		}
+	}
+}
+
+func TestWithUID(t *testing.T) {
+	tests := map[string]struct {
+		uid         types.UID
+		expectedUID types.UID
+	}{
+		"uid present": {
+			"apps/v1",
+			"apps/v1",
+		},
+		"empty uid present": {
+			"",
+			"",
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		b := &OwnerReference{
+			Object: &metav1.OwnerReference{},
+		}
+		b.WithUID(mock.uid)
+		if b.Object.UID != mock.uid {
+			t.Fatalf("test %s failed, expected uid %s, but got : %s",
+				name, mock.expectedUID, b.Object.UID)
+		}
+	}
+}
+
+func TestWithAPIObject(t *testing.T) {
+	tests := map[string]struct {
+		ownerReference       *metav1.OwnerReference
+		expectOwnerReference bool
+	}{
+		"valid ownerReference present": {
+			&metav1.OwnerReference{},
+			true,
+		},
+		"nil ownerReference present": {
+			nil,
+			false,
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		b := &OwnerReference{}
+		b.WithAPIObject(mock.ownerReference)
+		if (b.Object != nil) != mock.expectOwnerReference {
+			t.Fatalf("test %s failed, expect ownerReference %t, but got : %t",
+				name, mock.expectOwnerReference, b.Object != nil)
+		}
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := map[string]struct {
+		ownerReference metav1.OwnerReference
+		expecterr      bool
+	}{
+		"valid owner reference": {
+			metav1.OwnerReference{
+				Name:       "fake-name",
+				APIVersion: "fake-api-version",
+				Kind:       "fake-kind",
+				UID:        "fake-uid",
+			},
+			false,
+		},
+		"name not present": {
+			metav1.OwnerReference{
+				APIVersion: "fake-api-version",
+				Kind:       "fake-kind",
+				UID:        "fake-uid",
+			},
+			true,
+		},
+		"api version not present": {
+			metav1.OwnerReference{
+				Name: "fake-name",
+				Kind: "fake-kind",
+				UID:  "fake-uid",
+			},
+			true,
+		},
+		"kind not present": {
+			metav1.OwnerReference{
+				Name:       "fake-name",
+				APIVersion: "fake-api-version",
+				UID:        "fake-uid",
+			},
+			true,
+		},
+		"uid not present": {
+			metav1.OwnerReference{
+				Name:       "fake-name",
+				APIVersion: "fake-api-version",
+				Kind:       "fake-kind",
+			},
+			true,
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		b := &OwnerReference{
+			Object: &mock.ownerReference,
+		}
+		err := b.validate()
+		if (err != nil) != mock.expecterr {
+			t.Fatalf("test %s failed, expect error %t, but got : %t",
+				name, mock.expecterr, err != nil)
+		}
+	}
+}
+
+func TestBuild(t *testing.T) {
+	tests := map[string]struct {
+		ownerReference metav1.OwnerReference
+		errors         []error
+		expecterr      bool
+	}{
+		"valid owner reference": {
+			metav1.OwnerReference{
+				Name:       "fake-name",
+				APIVersion: "fake-api-version",
+				Kind:       "fake-kind",
+				UID:        "fake-uid",
+			},
+			[]error{},
+			false,
+		},
+		"valid owner reference but error present": {
+			metav1.OwnerReference{
+				Name:       "fake-name",
+				APIVersion: "fake-api-version",
+				Kind:       "fake-kind",
+				UID:        "fake-uid",
+			},
+			[]error{errors.New("")},
+			true,
+		},
+		"name not present": {
+			metav1.OwnerReference{
+				APIVersion: "fake-api-version",
+				Kind:       "fake-kind",
+				UID:        "fake-uid",
+			},
+			[]error{},
+			true,
+		},
+		"api version not present": {
+			metav1.OwnerReference{
+				Name: "fake-name",
+				Kind: "fake-kind",
+				UID:  "fake-uid",
+			},
+			[]error{},
+			true,
+		},
+		"kind not present": {
+			metav1.OwnerReference{
+				Name:       "fake-name",
+				APIVersion: "fake-api-version",
+				UID:        "fake-uid",
+			},
+			[]error{},
+			true,
+		},
+		"uid not present": {
+			metav1.OwnerReference{
+				Name:       "fake-name",
+				APIVersion: "fake-api-version",
+				Kind:       "fake-kind",
+			},
+			[]error{},
+			true,
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		b := &OwnerReference{
+			Object: &mock.ownerReference,
+			errors: mock.errors,
+		}
+		_, err := b.Build()
+		if (err != nil) != mock.expecterr {
+			t.Fatalf("test %s failed, expect error %t, but got : %t",
+				name, mock.expecterr, err != nil)
+		}
+	}
+}

--- a/pkg/kubernetes/typemeta/v1alpha1/typemeta.go
+++ b/pkg/kubernetes/typemeta/v1alpha1/typemeta.go
@@ -23,10 +23,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// Builder helps to build TypeMeta
+type Builder struct {
+	errors []error
+	Object *TypeMeta
+}
+
 // TypeMeta is a wrapper over metav1.TypeMeta
 type TypeMeta struct {
-	Object *metav1.TypeMeta
-	errors []error
+	TypeMeta *metav1.TypeMeta
 }
 
 // String implements Stringer interface
@@ -39,56 +44,58 @@ func (tm TypeMeta) GoString() string {
 	return tm.String()
 }
 
-// New returns a new instance of TypeMeta
-func New() *TypeMeta {
-	return &TypeMeta{
-		Object: &metav1.TypeMeta{},
+// New returns a new instance of Builder
+func New() *Builder {
+	return &Builder{
+		Object: &TypeMeta{
+			TypeMeta: &metav1.TypeMeta{},
+		},
 	}
 }
 
 // WithKind sets Kind property in TypeMeta instance
-func (tm *TypeMeta) WithKind(kind string) *TypeMeta {
-	tm.Object.Kind = kind
-	return tm
+func (b *Builder) WithKind(kind string) *Builder {
+	b.Object.TypeMeta.Kind = kind
+	return b
 }
 
 // WithAPIVersion sets APIVersion property in TypeMeta instance
-func (tm *TypeMeta) WithAPIVersion(apiVersion string) *TypeMeta {
-	tm.Object.APIVersion = apiVersion
-	return tm
+func (b *Builder) WithAPIVersion(apiVersion string) *Builder {
+	b.Object.TypeMeta.APIVersion = apiVersion
+	return b
 }
 
 // WithAPIObject sets Object property in TypeMeta instance
-func (tm *TypeMeta) WithAPIObject(typeMeta *metav1.TypeMeta) *TypeMeta {
-	tm.Object = typeMeta
-	return tm
+func (b *Builder) WithAPIObject(typeMeta *metav1.TypeMeta) *Builder {
+	b.Object.TypeMeta = typeMeta
+	return b
 }
 
-// validate validates typeMeta instance
-func (tm *TypeMeta) validate() error {
-	if len(tm.errors) != 0 {
-		return errors.Errorf("failed to validate: build errors were found: %v", tm.errors)
+// validate validates Builder instance
+func (b *Builder) validate() error {
+	if len(b.errors) != 0 {
+		return errors.Errorf("failed to validate: build errors were found: %v", b.errors)
 	}
 	validationErrs := []error{}
-	if tm.Object.Kind == "" {
+	if b.Object.TypeMeta.Kind == "" {
 		validationErrs = append(validationErrs, errors.New("missing kind"))
 	}
-	if tm.Object.APIVersion == "" {
+	if b.Object.TypeMeta.APIVersion == "" {
 		validationErrs = append(validationErrs, errors.New("missing API version"))
 	}
 	if len(validationErrs) != 0 {
-		tm.errors = append(tm.errors, validationErrs...)
+		b.errors = append(b.errors, validationErrs...)
 		return errors.Errorf("failed to validate: %v", validationErrs)
 	}
 	return nil
 }
 
 // Build returns a new instance of metav1.TypeMeta
-func (tm *TypeMeta) Build() (*metav1.TypeMeta, error) {
-	err := tm.validate()
+func (b *Builder) Build() (*metav1.TypeMeta, error) {
+	err := b.validate()
 	if err != nil {
 		return nil,
-			errors.WithMessagef(err, "failed to build TypeMeta: %s", tm)
+			errors.WithMessagef(err, "failed to build TypeMeta: %s", b.Object)
 	}
-	return tm.Object, nil
+	return b.Object.TypeMeta, nil
 }

--- a/pkg/kubernetes/typemeta/v1alpha1/typemeta.go
+++ b/pkg/kubernetes/typemeta/v1alpha1/typemeta.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2019 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"github.com/pkg/errors"
+
+	stringer "github.com/openebs/maya/pkg/apis/stringer/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TypeMeta is a wrapper over metav1.TypeMeta
+type TypeMeta struct {
+	Object *metav1.TypeMeta
+	errors []error
+}
+
+// String implements Stringer interface
+func (tm TypeMeta) String() string {
+	return stringer.Yaml("typemeta", tm)
+}
+
+// GoString implements GoStringer interface
+func (tm TypeMeta) GoString() string {
+	return tm.String()
+}
+
+// New returns a new instance of TypeMeta
+func New() *TypeMeta {
+	return &TypeMeta{
+		Object: &metav1.TypeMeta{},
+	}
+}
+
+// WithKind sets Kind property in TypeMeta instance
+func (tm *TypeMeta) WithKind(kind string) *TypeMeta {
+	tm.Object.Kind = kind
+	return tm
+}
+
+// WithAPIVersion sets APIVersion property in TypeMeta instance
+func (tm *TypeMeta) WithAPIVersion(apiVersion string) *TypeMeta {
+	tm.Object.APIVersion = apiVersion
+	return tm
+}
+
+// WithAPIObject sets Object property in TypeMeta instance
+func (tm *TypeMeta) WithAPIObject(typeMeta *metav1.TypeMeta) *TypeMeta {
+	tm.Object = typeMeta
+	return tm
+}
+
+// validate validates typeMeta instance
+func (tm *TypeMeta) validate() error {
+	if len(tm.errors) != 0 {
+		return errors.Errorf("failed to validate: build errors were found: %v", tm.errors)
+	}
+	validationErrs := []error{}
+	if tm.Object.Kind == "" {
+		validationErrs = append(validationErrs, errors.New("missing kind"))
+	}
+	if tm.Object.APIVersion == "" {
+		validationErrs = append(validationErrs, errors.New("missing API version"))
+	}
+	if len(validationErrs) != 0 {
+		tm.errors = append(tm.errors, validationErrs...)
+		return errors.Errorf("failed to validate: %v", validationErrs)
+	}
+	return nil
+}
+
+// Build returns a new instance of metav1.TypeMeta
+func (tm *TypeMeta) Build() (*metav1.TypeMeta, error) {
+	err := tm.validate()
+	if err != nil {
+		return nil,
+			errors.WithMessagef(err, "failed to build TypeMeta: %s", tm)
+	}
+	return tm.Object, nil
+}

--- a/pkg/kubernetes/typemeta/v1alpha1/typemeta_test.go
+++ b/pkg/kubernetes/typemeta/v1alpha1/typemeta_test.go
@@ -31,12 +31,12 @@ func TestTypeMetaString(t *testing.T) {
 	}{
 		"typemeta": {
 			TypeMeta{
-				TypeMeta: &metav1.TypeMeta{
+				object: &metav1.TypeMeta{
 					Kind:       "fake-kind",
 					APIVersion: "fake-apiversion",
 				},
 			},
-			[]string{"TypeMeta:", "kind: fake-kind", "apiVersion: fake-apiversion"},
+			[]string{"kind: fake-kind", "apiVersion: fake-apiversion"},
 		},
 	}
 	for name, mock := range tests {
@@ -60,12 +60,12 @@ func TestTypeMetaGoString(t *testing.T) {
 	}{
 		"typemeta": {
 			TypeMeta{
-				TypeMeta: &metav1.TypeMeta{
+				object: &metav1.TypeMeta{
 					Kind:       "fake-kind",
 					APIVersion: "fake-apiversion",
 				},
 			},
-			[]string{"TypeMeta:", "kind: fake-kind", "apiVersion: fake-apiversion"},
+			[]string{"kind: fake-kind", "apiVersion: fake-apiversion"},
 		},
 	}
 	for name, mock := range tests {
@@ -82,7 +82,7 @@ func TestTypeMetaGoString(t *testing.T) {
 	}
 }
 
-func TestNew(t *testing.T) {
+func TestNewBuilder(t *testing.T) {
 	tests := map[string]struct {
 		expectObject bool
 		expectErrs   bool
@@ -95,10 +95,10 @@ func TestNew(t *testing.T) {
 	for name, mock := range tests {
 		name := name // pin it
 		mock := mock // pin it
-		b := New()
-		if (b.Object != nil) != mock.expectObject {
+		b := NewBuilder()
+		if (b.meta.object != nil) != mock.expectObject {
 			t.Fatalf("test %s failed, expect object %t, but got : %t",
-				name, mock.expectObject, b.Object != nil)
+				name, mock.expectObject, b.meta.object != nil)
 		}
 		if (len(b.errors) != 0) != mock.expectErrs {
 			t.Fatalf("test %s failed, expect error %t, but got : %t",
@@ -125,14 +125,14 @@ func TestWithKind(t *testing.T) {
 		name := name // pin it
 		mock := mock // pin it
 		b := &Builder{
-			Object: &TypeMeta{
-				TypeMeta: &metav1.TypeMeta{},
+			meta: &TypeMeta{
+				object: &metav1.TypeMeta{},
 			},
 		}
 		b.WithKind(mock.kind)
-		if b.Object.TypeMeta.Kind != mock.expectedKind {
+		if b.meta.object.Kind != mock.expectedKind {
 			t.Fatalf("test %s failed, expected kind %s, but got : %s",
-				name, mock.expectedKind, b.Object.TypeMeta.Kind)
+				name, mock.expectedKind, b.meta.object.Kind)
 		}
 	}
 }
@@ -155,19 +155,19 @@ func TestWithAPIVersion(t *testing.T) {
 		name := name // pin it
 		mock := mock // pin it
 		b := &Builder{
-			Object: &TypeMeta{
-				TypeMeta: &metav1.TypeMeta{},
+			meta: &TypeMeta{
+				object: &metav1.TypeMeta{},
 			},
 		}
 		b.WithAPIVersion(mock.apiVersion)
-		if b.Object.TypeMeta.APIVersion != mock.apiVersion {
+		if b.meta.object.APIVersion != mock.apiVersion {
 			t.Fatalf("test %s failed, expected api version %s, but got : %s",
-				name, mock.apiVersion, b.Object.TypeMeta.APIVersion)
+				name, mock.apiVersion, b.meta.object.APIVersion)
 		}
 	}
 }
 
-func TestWithAPIObject(t *testing.T) {
+func TestNewBuilderForAPIObject(t *testing.T) {
 	tests := map[string]struct {
 		typeMeta       *metav1.TypeMeta
 		expectTypeMeta bool
@@ -178,21 +178,16 @@ func TestWithAPIObject(t *testing.T) {
 		},
 		"nil typemeta present": {
 			nil,
-			false,
+			true,
 		},
 	}
 	for name, mock := range tests {
 		name := name
 		mock := mock
-		b := &Builder{
-			Object: &TypeMeta{
-				TypeMeta: &metav1.TypeMeta{},
-			},
-		}
-		b.WithAPIObject(mock.typeMeta)
-		if (b.Object.TypeMeta != nil) != mock.expectTypeMeta {
+		b := NewBuilderForAPIObject(mock.typeMeta)
+		if (b.meta.object != nil) != mock.expectTypeMeta {
 			t.Fatalf("test %s failed, expect typemeta %t, but got : %t",
-				name, mock.expectTypeMeta, b.Object.TypeMeta != nil)
+				name, mock.expectTypeMeta, b.meta.object != nil)
 		}
 	}
 }
@@ -226,8 +221,8 @@ func TestValidate(t *testing.T) {
 		name := name
 		mock := mock
 		b := &Builder{
-			Object: &TypeMeta{
-				TypeMeta: &mock.typeMeta,
+			meta: &TypeMeta{
+				object: &mock.typeMeta,
 			},
 		}
 		err := b.validate()
@@ -279,8 +274,8 @@ func TestBuild(t *testing.T) {
 		name := name
 		mock := mock
 		b := &Builder{
-			Object: &TypeMeta{
-				TypeMeta: &mock.typeMeta,
+			meta: &TypeMeta{
+				object: &mock.typeMeta,
 			},
 			errors: mock.errors,
 		}

--- a/pkg/kubernetes/typemeta/v1alpha1/typemeta_test.go
+++ b/pkg/kubernetes/typemeta/v1alpha1/typemeta_test.go
@@ -1,0 +1,283 @@
+/*
+Copyright 2019 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTypeMetaString(t *testing.T) {
+	tests := map[string]struct {
+		object              TypeMeta
+		expectedStringParts []string
+	}{
+		"typemeta": {
+			TypeMeta{
+				Object: &metav1.TypeMeta{
+					Kind:       "fake-kind",
+					APIVersion: "fake-apiversion",
+				},
+			},
+			[]string{"Object:", "kind: fake-kind", "apiVersion: fake-apiversion"},
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		t.Run(name, func(t *testing.T) {
+			ymlstr := mock.object.String()
+			for _, expect := range mock.expectedStringParts {
+				if !strings.Contains(ymlstr, expect) {
+					t.Errorf("test '%s' failed: expected '%s' in '%s'", name, expect, ymlstr)
+				}
+			}
+		})
+	}
+}
+
+func TestTypeMetaGoString(t *testing.T) {
+	tests := map[string]struct {
+		object              TypeMeta
+		expectedStringParts []string
+	}{
+		"typemeta": {
+			TypeMeta{
+				Object: &metav1.TypeMeta{
+					Kind:       "fake-kind",
+					APIVersion: "fake-apiversion",
+				},
+			},
+			[]string{"Object:", "kind: fake-kind", "apiVersion: fake-apiversion"},
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		t.Run(name, func(t *testing.T) {
+			ymlstr := mock.object.GoString()
+			for _, expect := range mock.expectedStringParts {
+				if !strings.Contains(ymlstr, expect) {
+					t.Errorf("test '%s' failed: expected '%s' in '%s'", name, expect, ymlstr)
+				}
+			}
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	tests := map[string]struct {
+		expectObject bool
+		expectErrs   bool
+	}{
+		"new instance of TypeMeta": {
+			true,
+			false,
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		b := New()
+		if (b.Object != nil) != mock.expectObject {
+			t.Fatalf("test %s failed, expect object %t, but got : %t",
+				name, mock.expectObject, b.Object != nil)
+		}
+		if (len(b.errors) != 0) != mock.expectErrs {
+			t.Fatalf("test %s failed, expect error %t, but got : %t",
+				name, mock.expectErrs, len(b.errors) != 0)
+		}
+	}
+}
+
+func TestWithKind(t *testing.T) {
+	tests := map[string]struct {
+		kind         string
+		expectedKind string
+	}{
+		"kind present": {
+			"fake-kind",
+			"fake-kind",
+		},
+		"empty kind present": {
+			"",
+			"",
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		b := &TypeMeta{
+			Object: &metav1.TypeMeta{},
+		}
+		b.WithKind(mock.kind)
+		if b.Object.Kind != mock.expectedKind {
+			t.Fatalf("test %s failed, expected kind %s, but got : %s",
+				name, mock.expectedKind, b.Object.Kind)
+		}
+	}
+}
+
+func TestWithAPIVersion(t *testing.T) {
+	tests := map[string]struct {
+		apiVersion         string
+		expectedapiVersion string
+	}{
+		"api version present": {
+			"fake-apiVersion",
+			"fake-apiVersion",
+		},
+		"empty api version present": {
+			"",
+			"",
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		b := &TypeMeta{
+			Object: &metav1.TypeMeta{},
+		}
+		b.WithAPIVersion(mock.apiVersion)
+		if b.Object.APIVersion != mock.apiVersion {
+			t.Fatalf("test %s failed, expected api version %s, but got : %s",
+				name, mock.apiVersion, b.Object.APIVersion)
+		}
+	}
+}
+
+func TestWithAPIObject(t *testing.T) {
+	tests := map[string]struct {
+		typeMeta       *metav1.TypeMeta
+		expectTypeMeta bool
+	}{
+		"valid typemeta present": {
+			&metav1.TypeMeta{},
+			true,
+		},
+		"nil typemeta present": {
+			nil,
+			false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		b := &TypeMeta{
+			Object: &metav1.TypeMeta{},
+		}
+		b.WithAPIObject(mock.typeMeta)
+		if (b.Object != nil) != mock.expectTypeMeta {
+			t.Fatalf("test %s failed, expect typemeta %t, but got : %t",
+				name, mock.expectTypeMeta, b.Object != nil)
+		}
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := map[string]struct {
+		typeMeta  metav1.TypeMeta
+		expecterr bool
+	}{
+		"only kind present": {
+			metav1.TypeMeta{
+				Kind: "fake-kind",
+			},
+			true,
+		},
+		"only api version present": {
+			metav1.TypeMeta{
+				APIVersion: "fake-api-version",
+			},
+			true,
+		},
+		"kind and api version present": {
+			metav1.TypeMeta{
+				Kind:       "fake-kind",
+				APIVersion: "fake-api-version",
+			},
+			false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		b := &TypeMeta{
+			Object: &mock.typeMeta,
+		}
+		err := b.validate()
+		if (err != nil) != mock.expecterr {
+			t.Fatalf("test %s failed, expect error %t, but got : %t",
+				name, mock.expecterr, err != nil)
+		}
+	}
+}
+
+func TestBuild(t *testing.T) {
+	tests := map[string]struct {
+		typeMeta  metav1.TypeMeta
+		errors    []error
+		expecterr bool
+	}{
+		"only kind present": {
+			metav1.TypeMeta{
+				Kind: "fake-kind",
+			},
+			[]error{},
+			true,
+		},
+		"only api version present": {
+			metav1.TypeMeta{
+				APIVersion: "fake-api-version",
+			},
+			[]error{},
+			true,
+		},
+		"kind, api version and error present": {
+			metav1.TypeMeta{
+				Kind:       "fake-kind",
+				APIVersion: "fake-api-version",
+			},
+			[]error{errors.New("")},
+			true,
+		},
+		"kind and api version present": {
+			metav1.TypeMeta{
+				Kind:       "fake-kind",
+				APIVersion: "fake-api-version",
+			},
+			[]error{},
+			false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		b := &TypeMeta{
+			Object: &mock.typeMeta,
+			errors: mock.errors,
+		}
+		_, err := b.Build()
+		if (err != nil) != mock.expecterr {
+			t.Fatalf("test %s failed, expect error %t, but got : %t",
+				name, mock.expecterr, err != nil)
+		}
+	}
+}

--- a/pkg/kubernetes/typemeta/v1alpha1/typemeta_test.go
+++ b/pkg/kubernetes/typemeta/v1alpha1/typemeta_test.go
@@ -31,12 +31,12 @@ func TestTypeMetaString(t *testing.T) {
 	}{
 		"typemeta": {
 			TypeMeta{
-				Object: &metav1.TypeMeta{
+				TypeMeta: &metav1.TypeMeta{
 					Kind:       "fake-kind",
 					APIVersion: "fake-apiversion",
 				},
 			},
-			[]string{"Object:", "kind: fake-kind", "apiVersion: fake-apiversion"},
+			[]string{"TypeMeta:", "kind: fake-kind", "apiVersion: fake-apiversion"},
 		},
 	}
 	for name, mock := range tests {
@@ -60,12 +60,12 @@ func TestTypeMetaGoString(t *testing.T) {
 	}{
 		"typemeta": {
 			TypeMeta{
-				Object: &metav1.TypeMeta{
+				TypeMeta: &metav1.TypeMeta{
 					Kind:       "fake-kind",
 					APIVersion: "fake-apiversion",
 				},
 			},
-			[]string{"Object:", "kind: fake-kind", "apiVersion: fake-apiversion"},
+			[]string{"TypeMeta:", "kind: fake-kind", "apiVersion: fake-apiversion"},
 		},
 	}
 	for name, mock := range tests {
@@ -124,13 +124,15 @@ func TestWithKind(t *testing.T) {
 	for name, mock := range tests {
 		name := name // pin it
 		mock := mock // pin it
-		b := &TypeMeta{
-			Object: &metav1.TypeMeta{},
+		b := &Builder{
+			Object: &TypeMeta{
+				TypeMeta: &metav1.TypeMeta{},
+			},
 		}
 		b.WithKind(mock.kind)
-		if b.Object.Kind != mock.expectedKind {
+		if b.Object.TypeMeta.Kind != mock.expectedKind {
 			t.Fatalf("test %s failed, expected kind %s, but got : %s",
-				name, mock.expectedKind, b.Object.Kind)
+				name, mock.expectedKind, b.Object.TypeMeta.Kind)
 		}
 	}
 }
@@ -152,13 +154,15 @@ func TestWithAPIVersion(t *testing.T) {
 	for name, mock := range tests {
 		name := name // pin it
 		mock := mock // pin it
-		b := &TypeMeta{
-			Object: &metav1.TypeMeta{},
+		b := &Builder{
+			Object: &TypeMeta{
+				TypeMeta: &metav1.TypeMeta{},
+			},
 		}
 		b.WithAPIVersion(mock.apiVersion)
-		if b.Object.APIVersion != mock.apiVersion {
+		if b.Object.TypeMeta.APIVersion != mock.apiVersion {
 			t.Fatalf("test %s failed, expected api version %s, but got : %s",
-				name, mock.apiVersion, b.Object.APIVersion)
+				name, mock.apiVersion, b.Object.TypeMeta.APIVersion)
 		}
 	}
 }
@@ -180,13 +184,15 @@ func TestWithAPIObject(t *testing.T) {
 	for name, mock := range tests {
 		name := name
 		mock := mock
-		b := &TypeMeta{
-			Object: &metav1.TypeMeta{},
+		b := &Builder{
+			Object: &TypeMeta{
+				TypeMeta: &metav1.TypeMeta{},
+			},
 		}
 		b.WithAPIObject(mock.typeMeta)
-		if (b.Object != nil) != mock.expectTypeMeta {
+		if (b.Object.TypeMeta != nil) != mock.expectTypeMeta {
 			t.Fatalf("test %s failed, expect typemeta %t, but got : %t",
-				name, mock.expectTypeMeta, b.Object != nil)
+				name, mock.expectTypeMeta, b.Object.TypeMeta != nil)
 		}
 	}
 }
@@ -219,8 +225,10 @@ func TestValidate(t *testing.T) {
 	for name, mock := range tests {
 		name := name
 		mock := mock
-		b := &TypeMeta{
-			Object: &mock.typeMeta,
+		b := &Builder{
+			Object: &TypeMeta{
+				TypeMeta: &mock.typeMeta,
+			},
 		}
 		err := b.validate()
 		if (err != nil) != mock.expecterr {
@@ -270,8 +278,10 @@ func TestBuild(t *testing.T) {
 	for name, mock := range tests {
 		name := name
 		mock := mock
-		b := &TypeMeta{
-			Object: &mock.typeMeta,
+		b := &Builder{
+			Object: &TypeMeta{
+				TypeMeta: &mock.typeMeta,
+			},
 			errors: mock.errors,
 		}
 		_, err := b.Build()

--- a/pkg/upgrade/result/v1alpha1/upgraderesult.go
+++ b/pkg/upgrade/result/v1alpha1/upgraderesult.go
@@ -20,9 +20,11 @@ import (
 	"fmt"
 
 	"github.com/ghodss/yaml"
-	apis "github.com/openebs/maya/pkg/apis/openebs.io/upgrade/v1alpha1"
 	"github.com/openebs/maya/pkg/template"
 	"github.com/pkg/errors"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/upgrade/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type upgradeResult struct {
@@ -64,6 +66,33 @@ func NewBuilder() *Builder {
 		},
 		checks: make(map[*Predicate]string),
 	}
+}
+
+// WithTypeMeta adds typemeta in upgrade result instance.
+func (b *Builder) WithTypeMeta(typeMeta metav1.TypeMeta) *Builder {
+	b.object.TypeMeta = typeMeta
+	return b
+}
+
+// WithObjectMeta adds objectMeta in upgrade result instance.
+func (b *Builder) WithObjectMeta(objectMeta metav1.ObjectMeta) *Builder {
+	b.object.ObjectMeta = objectMeta
+	return b
+}
+
+// WithTasks adds tasks details in upgrade result instance.
+func (b *Builder) WithTasks(tasks ...apis.UpgradeResultTask) *Builder {
+	b.object.Tasks = append(b.object.Tasks, tasks...)
+	return b
+}
+
+// WithResultConfig adds resource details and runtime
+// config in upgrade result instance.
+func (b *Builder) WithResultConfig(resource apis.ResourceDetails,
+	data ...apis.DataItem) *Builder {
+	b.object.Config.ResourceDetails = resource
+	b.object.Config.Data = append(b.object.Config.Data, data...)
+	return b
 }
 
 // BuilderForRuntask returns a new instance


### PR DESCRIPTION
This PR add supports to build **ObjectMeta**, **TypeMeta**, **OwnerReference** and **UpgradeResult** in idiomatic maya style.