### PR TITLE
fix(runtask): fix storagepool runtask to have ownerreference to csp

### DIFF
--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -53,7 +53,7 @@ spec:
     value: {{env "OPENEBS_SERVICE_ACCOUNT"}}
   # PoolResourceRequests allow you to specify resource requests that need to be available
   # before scheduling the containers. If not specified, the default is to use the limits
-  # from PoolResourceLimits or the default requests set in the cluster. 
+  # from PoolResourceLimits or the default requests set in the cluster.
   - name: PoolResourceRequests
     value: "none"
   # PoolResourceLimits allow you to set the limits on memory and cpu for pool pods
@@ -366,9 +366,9 @@ spec:
       - apiVersion: openebs.io/v1alpha1
         blockOwnerDeletion: true
         controller: true
-        kind: Deployment
-        name: {{ .TaskResult.putcstorpooldeployment.objectName }}
-        uid: {{ .TaskResult.putcstorpooldeployment.objectUID }}
+        kind: StoragePoolClaim
+        name: {{.Storagepool.owner}}
+        uid: {{ .TaskResult.getspc.objectUID }}
     spec:
       disks:
         diskList:

--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -366,9 +366,9 @@ spec:
       - apiVersion: openebs.io/v1alpha1
         blockOwnerDeletion: true
         controller: true
-        kind: StoragePoolClaim
-        name: {{.Storagepool.owner}}
-        uid: {{ .TaskResult.getspc.objectUID }}
+        kind: CStorPool
+        name: {{ .TaskResult.putcstorpoolcr.objectName }}
+        uid: {{ .TaskResult.putcstorpoolcr.objectUID }}
     spec:
       disks:
         diskList:


### PR DESCRIPTION
Signed-off-by: mittachaitu <mittachaitu@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does**:
This PR fixes storagepool runtask to point ownerreference to corresponding csp. 
Below note is from kubernetes docs:
```
Note: Cross-namespace owner references is disallowed by design. This means: 1) Namespace-scoped dependents can only specify owners in the same namespace, and owners that are cluster-scoped. 2) Cluster-scoped dependents can only specify cluster-scoped owners, but not namespace-scoped owners.
```
https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #https://github.com/openebs/openebs/issues/2527

**Special notes for your reviewer**:
It requires a change in openebs-operator.yaml(https://github.com/openebs/openebs/pull/2528)
**Checklist:**
- [ ] Fixes #https://github.com/openebs/openebs/issues/2527
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests