### PR TITLE
fix(stringer, debuggability): remove cyclic calls in stringer package

### DIFF
--- a/pkg/apis/stringer/v1alpha1/stringer.go
+++ b/pkg/apis/stringer/v1alpha1/stringer.go
@@ -38,7 +38,7 @@ func Yaml(ctx string, obj interface{}) string {
 	}
 	b, err := yaml.Marshal(obj)
 	if err != nil {
-		return fmt.Sprintf("\n%s {%+v}", ctx, obj)
+		return fmt.Sprintf("\n%s {--failed to get details--}", ctx)
 	}
 	return fmt.Sprintf("\n%s {%s}", ctx, string(b))
 }
@@ -51,7 +51,7 @@ func JSONIndent(ctx string, obj interface{}) string {
 	}
 	b, err := json.MarshalIndent(obj, "", ".")
 	if err != nil {
-		return fmt.Sprintf("\n%s {%+v}", ctx, obj)
+		return fmt.Sprintf("\n%s {--failed to get details--}", ctx)
 	}
 	return fmt.Sprintf("\n%s %s", ctx, string(b))
 }

--- a/pkg/apis/stringer/v1alpha1/stringer.go
+++ b/pkg/apis/stringer/v1alpha1/stringer.go
@@ -34,12 +34,19 @@ import (
 // as a yaml formatted string
 func Yaml(ctx string, obj interface{}) string {
 	if obj == nil {
-		return ""
+		return fmt.Sprintf("\n%s {nil}", ctx)
 	}
+
+	str, ok := obj.(string)
+	if ok {
+		return fmt.Sprintf("\n%s {%s}", ctx, str)
+	}
+
 	b, err := yaml.Marshal(obj)
 	if err != nil {
-		return fmt.Sprintf("\n%s {--failed to get details--}", ctx)
+		return fmt.Sprintf("\n%s {nil}", ctx)
 	}
+
 	return fmt.Sprintf("\n%s {%s}", ctx, string(b))
 }
 
@@ -47,11 +54,18 @@ func Yaml(ctx string, obj interface{}) string {
 // as a json indent string
 func JSONIndent(ctx string, obj interface{}) string {
 	if obj == nil {
-		return ""
+		return fmt.Sprintf("\n%s {nil}", ctx)
 	}
+
+	str, ok := obj.(string)
+	if ok {
+		return fmt.Sprintf("\n%s {%s}", ctx, str)
+	}
+
 	b, err := json.MarshalIndent(obj, "", ".")
 	if err != nil {
-		return fmt.Sprintf("\n%s {--failed to get details--}", ctx)
+		return fmt.Sprintf("\n%s {nil}", ctx)
 	}
+
 	return fmt.Sprintf("\n%s %s", ctx, string(b))
 }

--- a/pkg/apis/stringer/v1alpha1/stringer_test.go
+++ b/pkg/apis/stringer/v1alpha1/stringer_test.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+type fakeStruct struct {
+	String string
+	Int    int
+	Bool   bool
+	Float  float64
+}
+
+func TestTypeMetaString(t *testing.T) {
+	tests := map[string]struct {
+		object              interface{}
+		expectedStringParts []string
+	}{
+		"struct as input": {
+			fakeStruct{
+				String: "fake-string",
+				Int:    123,
+				Bool:   true,
+				Float:  64.64,
+			},
+			[]string{"Int: 123", "String: fake-string", "Bool: true", "Float: 64.64"},
+		},
+		"struct pointer as input": {
+			&fakeStruct{
+				String: "fake-string",
+				Int:    123,
+				Bool:   true,
+				Float:  64.64,
+			},
+			[]string{"Int: 123", "String: fake-string", "Bool: true", "Float: 64.64"},
+		},
+		"integer as input": {
+			64,
+			[]string{"64"},
+		},
+		"integer pointer as input": {
+			func() *int {
+				i := 64
+				return &i
+			}(),
+			[]string{"64"},
+		},
+		"float as input": {
+			64.64,
+			[]string{"64.64"},
+		},
+		"float pointer as input": {
+			func() *float64 {
+				f := 64.64
+				return &f
+			}(),
+			[]string{"64.64"},
+		},
+		"bool as input": {
+			true,
+			[]string{"true"},
+		},
+		"bool pointer as input": {
+			func() *bool {
+				b := true
+				return &b
+			}(),
+			[]string{"true"},
+		},
+		"string as input": {
+			"fake-string",
+			[]string{"fake-string"},
+		},
+		"string pointer as input": {
+			func() *string {
+				s := "fake-string"
+				return &s
+			}(),
+			[]string{"fake-string"},
+		},
+		"channel as input": {
+			make(chan int),
+			[]string{"{nil}"},
+		},
+		"unsupported float64 value as input": {
+			math.Inf(1),
+			[]string{"{nil}"},
+		},
+		"nil object": {
+			nil,
+			[]string{"{nil}"},
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		t.Run(name, func(t *testing.T) {
+			ymlstr := Yaml("context", mock.object)
+			for _, expect := range mock.expectedStringParts {
+				if !strings.Contains(ymlstr, expect) {
+					t.Errorf("test '%s' failed: expected '%s' in '%s'", name, expect, ymlstr)
+				}
+			}
+		})
+	}
+}
+
+func TestJSONIndent(t *testing.T) {
+	tests := map[string]struct {
+		object              interface{}
+		expectedStringParts []string
+	}{
+		"struct as input": {
+			fakeStruct{
+				String: "fake-string",
+				Int:    123,
+				Bool:   true,
+				Float:  64.64,
+			},
+			[]string{`"Int": 123`, `"Bool": true`, `"Float": 64.64`, `"String": "fake-string"`},
+		},
+		"struct pointer as input": {
+			&fakeStruct{
+				String: "fake-string",
+				Int:    123,
+				Bool:   true,
+				Float:  64.64,
+			},
+			[]string{`"Int": 123`, `"Bool": true`, `"Float": 64.64`, `"String": "fake-string"`},
+		},
+		"integer as input": {
+			64,
+			[]string{"64"},
+		},
+		"integer pointer as input": {
+			func() *int {
+				i := 64
+				return &i
+			}(),
+			[]string{"64"},
+		},
+		"float as input": {
+			64.64,
+			[]string{"64.64"},
+		},
+		"float pointer as input": {
+			func() *float64 {
+				f := 64.64
+				return &f
+			}(),
+			[]string{"64.64"},
+		},
+		"bool as input": {
+			true,
+			[]string{"true"},
+		},
+		"bool pointer as input": {
+			func() *bool {
+				b := true
+				return &b
+			}(),
+			[]string{"true"},
+		},
+		"string as input": {
+			"fake-string",
+			[]string{"fake-string"},
+		},
+		"string pointer as input": {
+			func() *string {
+				s := "fake-string"
+				return &s
+			}(),
+			[]string{"fake-string"},
+		},
+		"channel as input": {
+			make(chan int),
+			[]string{"{nil}"},
+		},
+		"unsupported float64 value as input": {
+			math.Inf(1),
+			[]string{"{nil}"},
+		},
+		"nil object": {
+			nil,
+			[]string{"{nil}"},
+		},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		t.Run(name, func(t *testing.T) {
+			ymlstr := JSONIndent("context", mock.object)
+			for _, expect := range mock.expectedStringParts {
+				if !strings.Contains(ymlstr, expect) {
+					t.Errorf("test '%s' failed: expected '%s' in '%s'", name, expect, ymlstr)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Background
Most of the API structures in maya override `String()` & `GoString()` methods of Stringer & GoStringer interfaces. This is done to print details of the the structure while logging errors.

#### Why is this PR needed?
`String()` & `GoString()` make use of `Yaml()` to _pretty-print_ the entire instance.
However, in-case of any error during _un-marshaling_ to yaml, this instance is provided as-is to `fmt.Sprintf` as a fallback approach. However, this leads to invocation of `String()` once again since instance is an implementation of String() &/or GoString(). This results into a never ending loop causing a panic.

This commit solves above panic.

Signed-off-by: Shovan Maity <shovan.maity@mayadata.io>