### PR TITLE
feat(pool-exporter): run pool-exporter in previleged mode

### DIFF
--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -340,6 +340,8 @@ spec:
             ports:
             - containerPort: 9500
               protocol: TCP
+            securityContext:
+              privileged: true
             volumeMounts:
             - mountPath: /dev
               name: device


### PR DESCRIPTION
Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This allow pool-exporter to be run in previleged mode, it is needed since other two containers `cstor-pool` and `cstor-pool-mgmt` runs in previleged mode and uses socket path for the communication, so on some clusters which add extra layer of security such as openshift, pool-exporter was failed to establish connection with the `cstor-pool` due to permission issue.

**Checklist:**
- [x] Fixes openebs/openebs#2464
- [ ] Labelled this PR & related issue with `documentation` tag
- [x] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [x] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests