### PR TITLE
feat(jiva, runtask): add patch replica runtask

### DIFF
--- a/cmd/maya-apiserver/app/server/volume_endpoint_v1alpha1.go
+++ b/cmd/maya-apiserver/app/server/volume_endpoint_v1alpha1.go
@@ -185,14 +185,14 @@ func (v *volumeAPIOpsV1alpha1) read(volumeName string) (*v1alpha1.CASVolume, err
 
 	// use StorageClass name from header if present
 	scName := strings.TrimSpace(v.req.Header.Get(string(v1alpha1.StorageClassHeaderKey)))
-	patchVal := v.req.Header.Get(string(v1alpha1.IsPatchHeaderKey))
+	patchVal := v.req.Header.Get(string(v1alpha1.CASKeyIsPatchJivaReplicaNodeAffinityHeader))
 	// add the StorageClass name to volume's labels
 	vol.Labels = map[string]string{
 		string(v1alpha1.StorageClassKey): scName,
 	}
 
 	vol.Annotations = map[string]string{
-		string(v1alpha1.IsPatchKey): patchVal,
+		string(v1alpha1.NodeAffinityReplicaJivaIsPatchKey): patchVal,
 	}
 
 	vOps, err := volume.NewOperation(vol)

--- a/cmd/maya-apiserver/app/server/volume_endpoint_v1alpha1.go
+++ b/cmd/maya-apiserver/app/server/volume_endpoint_v1alpha1.go
@@ -185,9 +185,14 @@ func (v *volumeAPIOpsV1alpha1) read(volumeName string) (*v1alpha1.CASVolume, err
 
 	// use StorageClass name from header if present
 	scName := strings.TrimSpace(v.req.Header.Get(string(v1alpha1.StorageClassHeaderKey)))
+	patchVal := v.req.Header.Get(string(v1alpha1.IsPatchHeaderKey))
 	// add the StorageClass name to volume's labels
 	vol.Labels = map[string]string{
 		string(v1alpha1.StorageClassKey): scName,
+	}
+
+	vol.Annotations = map[string]string{
+		string(v1alpha1.IsPatchKey): patchVal,
 	}
 
 	vOps, err := volume.NewOperation(vol)

--- a/pkg/apis/openebs.io/v1alpha1/cas_keys.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_keys.go
@@ -54,6 +54,12 @@ const (
 	// PersistentVolumeClaimKey is the key to fetch name of PersistentVolumeClaim
 	PersistentVolumeClaimKey CASKey = "openebs.io/persistentvolumeclaim"
 
+	// IsPatchHeaderKey is the key to fetch value of IsPatchKey
+	IsPatchHeaderKey CASKey = "ispatch"
+
+	// IsPatchKey is the key to fetch value of IsPatchKey
+	IsPatchKey CASKey = "replica.jiva.openebs.io/is-patch"
+
 	// StorageClassKey is the key to fetch name of StorageClass
 	StorageClassKey CASKey = "openebs.io/storageclass"
 

--- a/pkg/apis/openebs.io/v1alpha1/cas_keys.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_keys.go
@@ -54,11 +54,17 @@ const (
 	// PersistentVolumeClaimKey is the key to fetch name of PersistentVolumeClaim
 	PersistentVolumeClaimKey CASKey = "openebs.io/persistentvolumeclaim"
 
-	// IsPatchHeaderKey is the key to fetch value of IsPatchKey
-	IsPatchHeaderKey CASKey = "ispatch"
+	// CASKeyIsPatchJivaReplicaNodeAffinityHeader is the key to fetch value of IsPatchKey
+	// its value is "enabled".
+	CASKeyIsPatchJivaReplicaNodeAffinityHeader CASKey = "Is-Patch-Jiva-Replica-Node-Affinity"
 
-	// IsPatchKey is the key to fetch value of IsPatchKey
-	IsPatchKey CASKey = "replica.jiva.openebs.io/is-patch"
+	// NodeAffinityReplicaJivaIsPatchKey is the key to fetch value of IsPatchKey
+	// its value is "enabled".
+	NodeAffinityReplicaJivaIsPatchKey CASKey = "nodeAffinity.replica.jiva.openebs.io/is-patch"
+
+	// CASKeyIsPatchJivaReplicaNodeAffinity is the key to fetch value of IsPatchKey
+	// its value is "enabled".
+	CASKeyIsPatchJivaReplicaNodeAffinity CASKey = "isPatchJivaReplicaNodeAffinity"
 
 	// StorageClassKey is the key to fetch name of StorageClass
 	StorageClassKey CASKey = "openebs.io/storageclass"

--- a/pkg/apis/openebs.io/v1alpha1/cas_template_keys.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_template_keys.go
@@ -170,6 +170,13 @@ const (
 	// {{ .Volume.isRestoreVol }}
 	IsRestoreVolumePropertyVTP VolumeTLPProperty = "isRestoreVol"
 
+	// IsPatchVolumePropertyVTP indicates if the volume is being
+	// created with patch enabled.
+	//NOTE:
+	// The Corresponding value will be accessed as
+	// {{ .Volume.isPatch }}
+	IsPatchVolumePropertyVTP VolumeTLPProperty = "isPatch"
+
 	// StorageClassVTP is the StorageClass of the volume
 	//
 	// NOTE:

--- a/pkg/apis/openebs.io/v1alpha1/cas_template_keys.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_template_keys.go
@@ -170,13 +170,6 @@ const (
 	// {{ .Volume.isRestoreVol }}
 	IsRestoreVolumePropertyVTP VolumeTLPProperty = "isRestoreVol"
 
-	// IsPatchVolumePropertyVTP indicates if the volume is being
-	// created with patch enabled.
-	//NOTE:
-	// The Corresponding value will be accessed as
-	// {{ .Volume.isPatch }}
-	IsPatchVolumePropertyVTP VolumeTLPProperty = "isPatch"
-
 	// StorageClassVTP is the StorageClass of the volume
 	//
 	// NOTE:

--- a/pkg/templatefuncs/v1alpha1/templatefuncs.go
+++ b/pkg/templatefuncs/v1alpha1/templatefuncs.go
@@ -791,6 +791,7 @@ func runtaskFuncs() (f template.FuncMap) {
 		"keyMap":             keyMap,
 		"splitKeyMap":        splitKeyMap,
 		"splitListTrim":      splitListTrim,
+		"splitListLen":       splitListLen,
 		"randomize":          randomize,
 		"IfNotNil":           ifNotNil,
 		"getMapofString":     util.GetNestedMap,
@@ -837,6 +838,20 @@ func AllCustomFuncs() template.FuncMap {
 func splitListTrim(sep, orig string) []string {
 	processedStr := strings.TrimRight(strings.TrimLeft(orig, sep), sep)
 	return strings.Split(processedStr, sep)
+}
+
+// splitListLen split the list according to separator, then
+// returns length of the new array of strings
+//
+// NOTE:
+//  This is intended to be used as a template function
+//
+// Example:
+//  {{- $nodes =: "node1,node2" | splitListLen "," | -}}
+//
+// Above operation would assign the length of the list to nodes.
+func splitListLen(sep, orig string) int {
+	return len(splitListTrim(sep, orig))
 }
 
 // For given []string as input, randomize API returns its randomized list

--- a/pkg/templatefuncs/v1alpha1/templatefuncs.go
+++ b/pkg/templatefuncs/v1alpha1/templatefuncs.go
@@ -28,11 +28,14 @@ import (
 
 	"github.com/Masterminds/sprig"
 	"github.com/ghodss/yaml"
+	"github.com/golang/glog"
 	poolselection "github.com/openebs/maya/pkg/algorithm/cstorpoolselect/v1alpha1"
+	stringer "github.com/openebs/maya/pkg/apis/stringer/v1alpha1"
 	csp "github.com/openebs/maya/pkg/cstorpool/v1alpha2"
 	v1alpha1 "github.com/openebs/maya/pkg/task/v1alpha1"
 	"github.com/openebs/maya/pkg/util"
 	kubever "github.com/openebs/maya/pkg/version/kubernetes"
+	"github.com/pkg/errors"
 )
 
 // empty returns true if the given value has the zero value for its type.
@@ -701,6 +704,25 @@ func verifyErr(errMessage string, hasVerificationFailed bool) (err error) {
 	return
 }
 
+// debugf prints the values filled into the task results.
+// This is intented to be used for debugging purpose.
+//
+// NOTE:
+//  This is intended to be used as a go template function
+//  DONOT USE IN PRODUCTION
+
+// Example:
+// {{- debugf .TaskResult -}}
+//
+// Assumption here is .Values is of type 'map[string]interface{}'
+func debugf(msg string, args interface{}) (err error) {
+	if args == nil {
+		return errors.Errorf("[Debug (Not for production)]Failed to get debug info, got empty args, msg: %s", msg)
+	}
+	glog.Infof("[Debug (Not for production)] %s", stringer.Yaml(msg, args))
+	return nil
+}
+
 // versionMismatchErr returns VersionMismatchError if given verification flag
 // failed i.e. is true
 //
@@ -794,6 +816,7 @@ func runtaskFuncs() (f template.FuncMap) {
 		"splitListLen":       splitListLen,
 		"randomize":          randomize,
 		"IfNotNil":           ifNotNil,
+		"debugf":             debugf,
 		"getMapofString":     util.GetNestedMap,
 	}
 }

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -325,6 +325,7 @@ func (v *Operation) Read() (*v1alpha1.CASVolume, error) {
 	if err != nil {
 		return nil, errors.Wrapf(errors.WithStack(err), "failed to read volume: %s", v.volume)
 	}
+
 	casConfigSC := sc.Annotations[string(v1alpha1.CASConfigKey)]
 	// read cas volume via cas template engine
 	engine, err := NewVolumeEngine(
@@ -335,8 +336,8 @@ func (v *Operation) Read() (*v1alpha1.CASVolume, error) {
 		map[string]interface{}{
 			string(v1alpha1.OwnerVTP):        v.volume.Name,
 			string(v1alpha1.RunNamespaceVTP): v.volume.Namespace,
-			string(v1alpha1.IsPatchVolumePropertyVTP): func() string {
-				val, ok := v.volume.Annotations[string(v1alpha1.IsPatchKey)]
+			string(v1alpha1.CASKeyIsPatchJivaReplicaNodeAffinity): func() string {
+				val, ok := v.volume.Annotations[string(v1alpha1.NodeAffinityReplicaJivaIsPatchKey)]
 				if !ok {
 					return ""
 				}
@@ -344,6 +345,7 @@ func (v *Operation) Read() (*v1alpha1.CASVolume, error) {
 			}(),
 		},
 	)
+
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read volume: %s", v.volume)
 	}

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -335,6 +335,13 @@ func (v *Operation) Read() (*v1alpha1.CASVolume, error) {
 		map[string]interface{}{
 			string(v1alpha1.OwnerVTP):        v.volume.Name,
 			string(v1alpha1.RunNamespaceVTP): v.volume.Namespace,
+			string(v1alpha1.IsPatchVolumePropertyVTP): func() string {
+				val, ok := v.volume.Annotations[string(v1alpha1.IsPatchKey)]
+				if !ok {
+					return ""
+				}
+				return val
+			}(),
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

### Why is this PR needed?
This PR enables `nodeAffnity` to pin jiva replicas on their scheduled nodes. This is required since, jiva replica pods may move to other node(s) if pod gets rescheduled. Having `nodeAffnity` ensures that replica pods will never be scheduled to other nodes other than its original scheduled node. This setting will lead pending state if original schedule node(s) is no longer available. 

There are following cases when replica pods can be scheduled to other nodes without this setting:
- OOM (Out of memory)
- Doesn't have enough cpu resources
- Node is drained
- Replica deployment have been patched or edited using `kubectl patch` or `kubectl edit` commands.

### What this PR does / why we need it
This commit adds following RunTasks to `jiva-volume-create-default` CASTemplate:
- _jiva-volume-read-verifyreplicationfactor-default_
  - to verify replica's info required for patching by subsequent RunTask
- _jiva-volume-read-patchreplicadeployment-default_
  - to patch the replica deployment for `nodeAffnity`

Additionally it adds `jiva-volume-delete-default cast` as fallback RunTask so that if patch failed due to un-availability of required no of replicas, it will delete the created jiva resources.

NOTE:
- This setting will lead pending state if original schedule node(s) is no longer available
- Depends on https://github.com/openebs/external-storage/pull/93
- refer https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/nodeaffinity.md

**Checklist:**
- [ ] Fixes openebs/openebs#2493
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests