### PR TITLE
debuggability(log): remove un-required log entries

### DIFF
--- a/cmd/maya-apiserver/app/server/http_test.go
+++ b/cmd/maya-apiserver/app/server/http_test.go
@@ -357,8 +357,8 @@ func TestCodedErrorf(t *testing.T) {
 		expectedCode    int
 		expectedMessage string
 	}{
-		"401 error": {401, "%s %d", []interface{}{"unauthorized", 401}, 401, "error: {unauthorized 401}"},
-		"500 error": {500, "%s %d", []interface{}{"internal error", 500}, 500, "error: {internal error 500}"},
+		"401 error": {401, "%s %d", []interface{}{"unauthorized", 401}, 401, "{unauthorized 401}"},
+		"500 error": {500, "%s %d", []interface{}{"internal error", 500}, 500, "{internal error 500}"},
 	}
 	for name, mock := range tests {
 		mock := mock // pin it
@@ -383,10 +383,10 @@ func TestCodedErrorWrap(t *testing.T) {
 		expectedMessage string
 	}{
 		"401 error": {
-			401, fmt.Errorf("unauthorized"), 401, "error: {unauthorized}",
+			401, fmt.Errorf("unauthorized"), 401, "{unauthorized}",
 		},
 		"500 error": {
-			500, fmt.Errorf("internal error"), 500, "error: {internal error}",
+			500, fmt.Errorf("internal error"), 500, "{internal error}",
 		},
 	}
 	for name, mock := range tests {

--- a/cmd/maya-apiserver/app/server/volume_endpoint_v1alpha1.go
+++ b/cmd/maya-apiserver/app/server/volume_endpoint_v1alpha1.go
@@ -23,10 +23,10 @@ import (
 	"github.com/golang/glog"
 	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	menv "github.com/openebs/maya/pkg/env/v1alpha1"
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 	"github.com/openebs/maya/pkg/template"
 	"github.com/openebs/maya/pkg/usage"
 	"github.com/openebs/maya/pkg/volume"
-	"github.com/pkg/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -131,7 +131,7 @@ func (v *volumeAPIOpsV1alpha1) create() (*v1alpha1.CASVolume, error) {
 	vol := &v1alpha1.CASVolume{}
 	err := decodeBody(v.req, vol)
 	if err != nil {
-		return nil, CodedErrorWrapf(400, err, "failed to create volume")
+		return nil, CodedErrorWrap(400, errors.Wrap(err, "failed to create volume"))
 	}
 
 	// volume name is expected
@@ -146,12 +146,12 @@ func (v *volumeAPIOpsV1alpha1) create() (*v1alpha1.CASVolume, error) {
 
 	vOps, err := volume.NewOperation(vol)
 	if err != nil {
-		return nil, CodedErrorWrapf(400, err, "failed to create volume: failed to init volume operation: %s", vol)
+		return nil, CodedErrorWrap(400, errors.Wrapf(err, "failed to create volume: failed to init volume operation: %s", vol))
 	}
 
 	cvol, err := vOps.Create()
 	if err != nil {
-		return nil, CodedErrorWrapf(500, err, "failed to create volume: %s", vol)
+		return nil, CodedErrorWrap(500, errors.Wrapf(err, "failed to create volume: %s", vol))
 	}
 
 	glog.Infof("volume '%s' created successfully", cvol.Name)
@@ -192,15 +192,15 @@ func (v *volumeAPIOpsV1alpha1) read(volumeName string) (*v1alpha1.CASVolume, err
 
 	vOps, err := volume.NewOperation(vol)
 	if err != nil {
-		return nil, CodedErrorWrapf(400, err, "failed to read volume: failed to init volume operation: %s", vol)
+		return nil, CodedErrorWrap(400, errors.Wrapf(err, "failed to read volume: failed to init volume operation: %s", vol))
 	}
 
 	cvol, err := vOps.Read()
 	if err != nil {
 		if isNotFound(err) {
-			return nil, CodedErrorWrapf(404, err, "failed to read volume: volume '%s' not found: %s", vol.Name, vol)
+			return nil, CodedErrorWrap(404, errors.Wrapf(err, "failed to read volume: volume {%s} not found in namspace: {%s}", vol.Name, vol.Namespace))
 		}
-		return nil, CodedErrorWrapf(500, err, "failed to read volume: %s", vol)
+		return nil, CodedErrorWrap(500, errors.Wrapf(err, "failed to read volume: %s", vol))
 	}
 
 	glog.Infof("volume '%s' read successfully", cvol.Name)
@@ -234,15 +234,15 @@ func (v *volumeAPIOpsV1alpha1) delete(volumeName string) (*v1alpha1.CASVolume, e
 
 	vOps, err := volume.NewOperation(vol)
 	if err != nil {
-		return nil, CodedErrorWrapf(400, err, "failed to delete volume: failed to init volume operation: %s", vol)
+		return nil, CodedErrorWrap(400, errors.Wrapf(err, "failed to delete volume: failed to init volume operation: %s", vol))
 	}
 
 	cvol, err := vOps.Delete()
 	if err != nil {
 		if isNotFound(err) {
-			return nil, CodedErrorWrapf(404, err, "failed to delete volume: volume '%s' not found: %s", vol.Name, vol)
+			return nil, CodedErrorWrap(404, errors.Wrapf(err, "failed to delete volume: volume {%s} not found in namespace: {%s}", vol.Name, vol.Namespace))
 		}
-		return nil, CodedErrorWrapf(500, err, "failed to delete volume: %s", vol)
+		return nil, CodedErrorWrap(500, errors.Wrapf(err, "failed to delete volume: %s", vol))
 	}
 
 	glog.Infof("volume '%s' deleted successfully", cvol.Name)
@@ -269,12 +269,12 @@ func (v *volumeAPIOpsV1alpha1) list() (*v1alpha1.CASVolumeList, error) {
 
 	vOps, err := volume.NewListOperation(vols)
 	if err != nil {
-		return nil, CodedErrorWrapf(400, err, "failed to list volumes: failed to init volume operation: %s", vols)
+		return nil, CodedErrorWrap(400, errors.Wrapf(err, "failed to list volumes: failed to init volume operation: %s", vols))
 	}
 
 	cvols, err := vOps.List()
 	if err != nil {
-		return nil, CodedErrorWrapf(500, err, "failed to list volumes: %s", vols)
+		return nil, CodedErrorWrap(500, errors.Wrapf(err, "failed to list volumes: %s", vols))
 	}
 
 	glog.Infof("volumes listed successfully for namespace(s) {%s}", vols.Namespace)
@@ -314,15 +314,15 @@ func (v *volumeAPIOpsV1alpha1) readStats(volumeName string) (interface{}, error)
 
 	vOps, err := volume.NewOperation(vol)
 	if err != nil {
-		return nil, CodedErrorWrapf(400, err, "failed to read volume stats: failed to init volume operation: %s", vol)
+		return nil, CodedErrorWrap(400, errors.Wrapf(err, "failed to read volume stats: failed to init volume operation: %s", vol))
 	}
 
 	stats, err := vOps.ReadStats()
 	if err != nil {
 		if isNotFound(err) {
-			return nil, CodedErrorWrapf(404, err, "failed to read volume stats: volume not found: %s", vol)
+			return nil, CodedErrorWrap(404, errors.Wrapf(err, "failed to read volume stats: volume {%s} not found in namespace {%s}", vol.Name, vol.Namespace))
 		}
-		return nil, CodedErrorWrapf(500, err, "failed to read volume stats: %s", vol)
+		return nil, CodedErrorWrap(500, errors.Wrapf(err, "failed to read volume stats: %s", vol))
 	}
 
 	// pipelining the response

--- a/pkg/apis/openebs.io/v1alpha1/cas_volume_test.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_volume_test.go
@@ -58,7 +58,7 @@ func TestCASVolumeString(t *testing.T) {
 	}
 }
 
-func TestCASVolumeStringJSONIndent(t *testing.T) {
+func TestCASVolumeJSONIndent(t *testing.T) {
 	tests := map[string]struct {
 		context             string
 		volume              *CASVolume

--- a/pkg/castemplate/v1alpha1/cas_template_engine.go
+++ b/pkg/castemplate/v1alpha1/cas_template_engine.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 	"github.com/openebs/maya/pkg/task"
 	"github.com/openebs/maya/pkg/util"
-	"github.com/pkg/errors"
 )
 
 // UnMarshallToConfig un-marshals the provided

--- a/pkg/client/k8s/v1alpha1/unstructured.go
+++ b/pkg/client/k8s/v1alpha1/unstructured.go
@@ -37,16 +37,17 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"strings"
+
 	"github.com/ghodss/yaml"
 	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 	"github.com/openebs/maya/pkg/util"
 	"github.com/openebs/maya/pkg/version"
 	kubever "github.com/openebs/maya/pkg/version/kubernetes"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"strings"
 )
 
 // kind represents the name of the kubernetes kind
@@ -131,7 +132,7 @@ func CreateUnstructuredFromYamlBytes(raw []byte) (*unstructured.Unstructured, er
 	m := map[string]interface{}{}
 	err := yaml.Unmarshal(raw, &m)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create unstructured instance from yaml bytes")
+		return nil, errors.Wrapf(err, "failed to create unstructured instance from yaml: %s", raw)
 	}
 
 	return &unstructured.Unstructured{
@@ -217,7 +218,7 @@ func IsCASTemplate(given *unstructured.Unstructured) bool {
 	return strings.ToLower(given.GetKind()) == "castemplate"
 }
 
-// IsNameVersioned flags if the given unstructured instance name has
+// IsNameUnVersioned flags if the given unstructured instance name has
 // version as its suffix
 //
 // NOTE:

--- a/pkg/task/meta.go
+++ b/pkg/task/meta.go
@@ -169,7 +169,8 @@ type MetaTaskSpec struct {
 	RepeatWith RepeatWithResource `json:"repeatWith"`
 }
 
-type metaTaskExecutor struct {
+// MetaExecutor ...
+type MetaExecutor struct {
 	// metaTask holds the task's meta information
 	metaTask MetaTaskSpec
 	// identifier exposes a task's identity related operations
@@ -210,8 +211,8 @@ func getMetaInstances(metaTaskYml string, values map[string]interface{}) (m Meta
 	return
 }
 
-// newMetaTaskExecutor provides a new instance of metaTaskExecutor
-func newMetaTaskExecutor(metaTaskYml string, values map[string]interface{}) (*metaTaskExecutor, error) {
+// NewMetaExecutor provides a new instance of MetaExecutor
+func NewMetaExecutor(metaTaskYml string, values map[string]interface{}) (*MetaExecutor, error) {
 
 	m, i, r, err := getMetaInstances(metaTaskYml, values)
 	if err != nil {
@@ -223,7 +224,7 @@ func newMetaTaskExecutor(metaTaskYml string, values map[string]interface{}) (*me
 		return nil, err
 	}
 
-	return &metaTaskExecutor{
+	return &MetaExecutor{
 		metaTask:   m,
 		identifier: i,
 		repeater:   r,
@@ -231,39 +232,39 @@ func newMetaTaskExecutor(metaTaskYml string, values map[string]interface{}) (*me
 	}, nil
 }
 
-func (m *metaTaskExecutor) getMetaInfo() MetaTaskSpec {
+func (m *MetaExecutor) getMetaInfo() MetaTaskSpec {
 	return m.metaTask
 }
 
-func (m *metaTaskExecutor) getRepeatExecutor() repeatExecutor {
+func (m *MetaExecutor) getRepeatExecutor() repeatExecutor {
 	return m.repeater
 }
 
-func (m *metaTaskExecutor) isDisabled() bool {
+func (m *MetaExecutor) isDisabled() bool {
 	return m.metaTask.Disable
 }
 
-func (m *metaTaskExecutor) getIdentity() string {
+func (m *MetaExecutor) getIdentity() string {
 	return m.metaTask.Identity
 }
 
-func (m *metaTaskExecutor) getTaskIdentity() MetaTaskIdentity {
+func (m *MetaExecutor) getTaskIdentity() MetaTaskIdentity {
 	return m.metaTask.MetaTaskIdentity
 }
 
-func (m *metaTaskExecutor) getObjectName() string {
+func (m *MetaExecutor) getObjectName() string {
 	return m.metaTask.ObjectName
 }
 
-func (m *metaTaskExecutor) getRunNamespace() string {
+func (m *MetaExecutor) getRunNamespace() string {
 	return m.metaTask.RunNamespace
 }
 
-func (m *metaTaskExecutor) getK8sClient() *m_k8s_client.K8sClient {
+func (m *MetaExecutor) getK8sClient() *m_k8s_client.K8sClient {
 	return m.k8sClient
 }
 
-func (m *metaTaskExecutor) getRetry() (attempts int, interval time.Duration) {
+func (m *MetaExecutor) getRetry() (attempts int, interval time.Duration) {
 	retry := m.metaTask.Retry
 	// "attempts,interval" format
 	defRetry := "0,0s"
@@ -288,278 +289,278 @@ func (m *metaTaskExecutor) getRetry() (attempts int, interval time.Duration) {
 }
 
 // getListOptions unmarshall the options in yaml doc format into meta.ListOptions
-func (m *metaTaskExecutor) getListOptions() (opts mach_apis_meta_v1.ListOptions, err error) {
+func (m *MetaExecutor) getListOptions() (opts mach_apis_meta_v1.ListOptions, err error) {
 	err = yaml.Unmarshal([]byte(m.metaTask.Options), &opts)
 	return
 }
 
-func (m *metaTaskExecutor) isCommand() bool {
+func (m *MetaExecutor) isCommand() bool {
 	return m.identifier.isCommand()
 }
 
-func (m *metaTaskExecutor) isList() bool {
+func (m *MetaExecutor) isList() bool {
 	return m.metaTask.Action == ListTA
 }
 
-func (m *metaTaskExecutor) isGet() bool {
+func (m *MetaExecutor) isGet() bool {
 	return m.metaTask.Action == GetTA
 }
 
-func (m *metaTaskExecutor) isPut() bool {
+func (m *MetaExecutor) isPut() bool {
 	return m.metaTask.Action == PutTA
 }
 
-func (m *metaTaskExecutor) isDelete() bool {
+func (m *MetaExecutor) isDelete() bool {
 	return m.metaTask.Action == DeleteTA
 }
 
-func (m *metaTaskExecutor) isPatch() bool {
+func (m *MetaExecutor) isPatch() bool {
 	return m.metaTask.Action == PatchTA
 }
 
-func (m *metaTaskExecutor) isExec() bool {
+func (m *MetaExecutor) isExec() bool {
 	return m.metaTask.Action == ExecTA
 }
 
-func (m *metaTaskExecutor) isRolloutstatus() bool {
+func (m *MetaExecutor) isRolloutstatus() bool {
 	return m.metaTask.Action == RolloutstatusTA
 }
 
-func (m *metaTaskExecutor) isPutExtnV1B1Deploy() bool {
+func (m *MetaExecutor) isPutExtnV1B1Deploy() bool {
 	return m.identifier.isExtnV1B1Deploy() && m.isPut()
 }
 
-func (m *metaTaskExecutor) isPutBatchV1Job() bool {
+func (m *MetaExecutor) isPutBatchV1Job() bool {
 	return m.identifier.isBatchV1Job() && m.isPut()
 }
 
-func (m *metaTaskExecutor) isPutAppsV1STS() bool {
+func (m *MetaExecutor) isPutAppsV1STS() bool {
 	return m.identifier.isAppsV1STS() && m.isPut()
 }
 
-func (m *metaTaskExecutor) isPatchExtnV1B1Deploy() bool {
+func (m *MetaExecutor) isPatchExtnV1B1Deploy() bool {
 	return m.identifier.isExtnV1B1Deploy() && m.isPatch()
 }
 
-func (m *metaTaskExecutor) isPutAppsV1B1Deploy() bool {
+func (m *MetaExecutor) isPutAppsV1B1Deploy() bool {
 	return m.identifier.isAppsV1B1Deploy() && m.isPut()
 }
 
-func (m *metaTaskExecutor) isPatchOEV1alpha1SPC() bool {
+func (m *MetaExecutor) isPatchOEV1alpha1SPC() bool {
 	return m.identifier.isStoragePoolClaim() && m.isPatch()
 }
 
-func (m *metaTaskExecutor) isPatchOEV1alpha1CSPC() bool {
+func (m *MetaExecutor) isPatchOEV1alpha1CSPC() bool {
 	return m.identifier.isCStorPoolCluster() && m.isPatch()
 }
 
-func (m *metaTaskExecutor) isPatchAppsV1B1Deploy() bool {
+func (m *MetaExecutor) isPatchAppsV1B1Deploy() bool {
 	return m.identifier.isAppsV1B1Deploy() && m.isPatch()
 }
 
-func (m *metaTaskExecutor) isPutCoreV1Service() bool {
+func (m *MetaExecutor) isPutCoreV1Service() bool {
 	return m.identifier.isCoreV1Service() && m.isPut()
 }
 
-func (m *metaTaskExecutor) isPatchCoreV1Service() bool {
+func (m *MetaExecutor) isPatchCoreV1Service() bool {
 	return m.identifier.isCoreV1Service() && m.isPatch()
 }
 
-func (m *metaTaskExecutor) isDeleteExtnV1B1Deploy() bool {
+func (m *MetaExecutor) isDeleteExtnV1B1Deploy() bool {
 	return m.identifier.isExtnV1B1Deploy() && m.isDelete()
 }
 
-func (m *metaTaskExecutor) isDeleteExtnV1B1ReplicaSet() bool {
+func (m *MetaExecutor) isDeleteExtnV1B1ReplicaSet() bool {
 	return m.identifier.isExtnV1B1ReplicaSet() && m.isDelete()
 }
 
-func (m *metaTaskExecutor) isDeleteAppsV1B1Deploy() bool {
+func (m *MetaExecutor) isDeleteAppsV1B1Deploy() bool {
 	return m.identifier.isAppsV1B1Deploy() && m.isDelete()
 }
 
-func (m *metaTaskExecutor) isDeleteCoreV1Service() bool {
+func (m *MetaExecutor) isDeleteCoreV1Service() bool {
 	return m.identifier.isCoreV1Service() && m.isDelete()
 }
 
-func (m *metaTaskExecutor) isListCoreV1PVC() bool {
+func (m *MetaExecutor) isListCoreV1PVC() bool {
 	return m.identifier.isCoreV1PVC() && m.isList()
 }
 
-func (m *metaTaskExecutor) isListCoreV1PV() bool {
+func (m *MetaExecutor) isListCoreV1PV() bool {
 	return m.identifier.isCoreV1PV() && m.isList()
 }
 
-func (m *metaTaskExecutor) isListCoreV1Pod() bool {
+func (m *MetaExecutor) isListCoreV1Pod() bool {
 	return m.identifier.isCoreV1Pod() && m.isList()
 }
 
-func (m *metaTaskExecutor) isListCoreV1Service() bool {
+func (m *MetaExecutor) isListCoreV1Service() bool {
 	return m.identifier.isCoreV1Service() && m.isList()
 }
 
-func (m *metaTaskExecutor) isListExtnV1B1Deploy() bool {
+func (m *MetaExecutor) isListExtnV1B1Deploy() bool {
 	return m.identifier.isExtnV1B1Deploy() && m.isList()
 }
 
-func (m *metaTaskExecutor) isListExtnV1B1ReplicaSet() bool {
+func (m *MetaExecutor) isListExtnV1B1ReplicaSet() bool {
 	return m.identifier.isExtnV1B1ReplicaSet() && m.isList()
 }
 
-func (m *metaTaskExecutor) isListAppsV1B1Deploy() bool {
+func (m *MetaExecutor) isListAppsV1B1Deploy() bool {
 	return m.identifier.isAppsV1B1Deploy() && m.isList()
 }
 
-func (m *metaTaskExecutor) isGetStorageV1SC() bool {
+func (m *MetaExecutor) isGetStorageV1SC() bool {
 	return m.identifier.isStorageV1SC() && m.isGet()
 }
 
-func (m *metaTaskExecutor) isGetBatchV1Job() bool {
+func (m *MetaExecutor) isGetBatchV1Job() bool {
 	return m.identifier.isBatchV1Job() && m.isGet()
 }
 
-func (m *metaTaskExecutor) isGetExtnV1B1Deploy() bool {
+func (m *MetaExecutor) isGetExtnV1B1Deploy() bool {
 	return m.identifier.isExtnV1B1Deploy() && m.isGet()
 }
 
-func (m *metaTaskExecutor) isGetExtnV1B1ReplicaSet() bool {
+func (m *MetaExecutor) isGetExtnV1B1ReplicaSet() bool {
 	return m.identifier.isExtnV1B1ReplicaSet() && m.isGet()
 }
 
-func (m *metaTaskExecutor) isDeleteBatchV1Job() bool {
+func (m *MetaExecutor) isDeleteBatchV1Job() bool {
 	return m.identifier.isBatchV1Job() && m.isDelete()
 }
 
-func (m *metaTaskExecutor) isDeleteAppsV1STS() bool {
+func (m *MetaExecutor) isDeleteAppsV1STS() bool {
 	return m.identifier.isAppsV1STS() && m.isDelete()
 }
 
-func (m *metaTaskExecutor) isGetOEV1alpha1Disk() bool {
+func (m *MetaExecutor) isGetOEV1alpha1Disk() bool {
 	return m.identifier.isOEV1alpha1Disk() && m.isGet()
 }
 
-func (m *metaTaskExecutor) isGetOEV1alpha1SPC() bool {
+func (m *MetaExecutor) isGetOEV1alpha1SPC() bool {
 	return m.identifier.isOEV1alpha1SPC() && m.isGet()
 }
-func (m *metaTaskExecutor) isGetOEV1alpha1CSPC() bool {
+func (m *MetaExecutor) isGetOEV1alpha1CSPC() bool {
 	return m.identifier.isOEV1alpha1CSPC() && m.isGet()
 }
-func (m *metaTaskExecutor) isGetOEV1alpha1SP() bool {
+func (m *MetaExecutor) isGetOEV1alpha1SP() bool {
 	return m.identifier.isOEV1alpha1SP() && m.isGet()
 }
 
-func (m *metaTaskExecutor) isGetOEV1alpha1CSP() bool {
+func (m *MetaExecutor) isGetOEV1alpha1CSP() bool {
 	return m.identifier.isOEV1alpha1CSP() && m.isGet()
 }
 
-func (m *metaTaskExecutor) isGetOEV1alpha1UR() bool {
+func (m *MetaExecutor) isGetOEV1alpha1UR() bool {
 	return m.identifier.isOEV1alpha1UR() && m.isGet()
 }
 
-func (m *metaTaskExecutor) isGetCoreV1PVC() bool {
+func (m *MetaExecutor) isGetCoreV1PVC() bool {
 	return m.identifier.isCoreV1PVC() && m.isGet()
 }
 
-func (m *metaTaskExecutor) isGetCoreV1PV() bool {
+func (m *MetaExecutor) isGetCoreV1PV() bool {
 	return m.identifier.isCoreV1PV() && m.isGet()
 }
 
-func (m *metaTaskExecutor) isPutOEV1alpha1SP() bool {
+func (m *MetaExecutor) isPutOEV1alpha1SP() bool {
 	return m.identifier.isOEV1alpha1SP() && m.isPut()
 }
 
-func (m *metaTaskExecutor) isPutOEV1alpha1CSP() bool {
+func (m *MetaExecutor) isPutOEV1alpha1CSP() bool {
 	return m.identifier.isOEV1alpha1CSP() && m.isPut()
 }
 
-func (m *metaTaskExecutor) isPutOEV1alpha1CSV() bool {
+func (m *MetaExecutor) isPutOEV1alpha1CSV() bool {
 	return m.identifier.isOEV1alpha1CV() && m.isPut()
 }
 
-func (m *metaTaskExecutor) isPutOEV1alpha1CVR() bool {
+func (m *MetaExecutor) isPutOEV1alpha1CVR() bool {
 	return m.identifier.isOEV1alpha1CVR() && m.isPut()
 }
 
 // isPutOEV1alpha1UR returns true if RunTask.Spec.meta
 // is set with action=put and kind=UpgradeResult
-func (m *metaTaskExecutor) isPutOEV1alpha1UR() bool {
+func (m *MetaExecutor) isPutOEV1alpha1UR() bool {
 	return m.identifier.isOEV1alpha1UR() && m.isPut()
 }
 
-func (m *metaTaskExecutor) isDeleteOEV1alpha1SP() bool {
+func (m *MetaExecutor) isDeleteOEV1alpha1SP() bool {
 	return m.identifier.isOEV1alpha1SP() && m.isDelete()
 }
 
-func (m *metaTaskExecutor) isDeleteOEV1alpha1CSP() bool {
+func (m *MetaExecutor) isDeleteOEV1alpha1CSP() bool {
 	return m.identifier.isOEV1alpha1CSP() && m.isDelete()
 }
 
-func (m *metaTaskExecutor) isDeleteOEV1alpha1CSV() bool {
+func (m *MetaExecutor) isDeleteOEV1alpha1CSV() bool {
 	return m.identifier.isOEV1alpha1CV() && m.isDelete()
 }
 
-func (m *metaTaskExecutor) isDeleteOEV1alpha1CVR() bool {
+func (m *MetaExecutor) isDeleteOEV1alpha1CVR() bool {
 	return m.identifier.isOEV1alpha1CVR() && m.isDelete()
 }
 
-func (m *metaTaskExecutor) isPatchOEV1alpha1CSV() bool {
+func (m *MetaExecutor) isPatchOEV1alpha1CSV() bool {
 	return m.identifier.isOEV1alpha1CV() && m.isPatch()
 }
 
-func (m *metaTaskExecutor) isPatchOEV1alpha1CVR() bool {
+func (m *MetaExecutor) isPatchOEV1alpha1CVR() bool {
 	return m.identifier.isOEV1alpha1CVR() && m.isPatch()
 }
 
 // isPatchOEV1alpha1UR returns true if RunTask.Spec.meta
 // is set with action=patch and kind=UpgradeResult
-func (m *metaTaskExecutor) isPatchOEV1alpha1UR() bool {
+func (m *MetaExecutor) isPatchOEV1alpha1UR() bool {
 	return m.identifier.isOEV1alpha1UR() && m.isPatch()
 }
 
-func (m *metaTaskExecutor) isPatchOEV1alpha1SP() bool {
+func (m *MetaExecutor) isPatchOEV1alpha1SP() bool {
 	return m.identifier.isOEV1alpha1SP() && m.isPatch()
 }
 
-func (m *metaTaskExecutor) isPatchOEV1alpha1CSP() bool {
+func (m *MetaExecutor) isPatchOEV1alpha1CSP() bool {
 	return m.identifier.isOEV1alpha1CSP() && m.isPatch()
 }
 
-func (m *metaTaskExecutor) isListOEV1alpha1Disk() bool {
+func (m *MetaExecutor) isListOEV1alpha1Disk() bool {
 	return m.identifier.isOEV1alpha1Disk() && m.isList()
 }
 
-func (m *metaTaskExecutor) isListOEV1alpha1SP() bool {
+func (m *MetaExecutor) isListOEV1alpha1SP() bool {
 	return m.identifier.isOEV1alpha1SP() && m.isList()
 }
 
-func (m *metaTaskExecutor) isListOEV1alpha1CSP() bool {
+func (m *MetaExecutor) isListOEV1alpha1CSP() bool {
 	return m.identifier.isOEV1alpha1CSP() && m.isList()
 }
 
-func (m *metaTaskExecutor) isListOEV1alpha1CVR() bool {
+func (m *MetaExecutor) isListOEV1alpha1CVR() bool {
 	return m.identifier.isOEV1alpha1CVR() && m.isList()
 }
 
-func (m *metaTaskExecutor) isListOEV1alpha1UR() bool {
+func (m *MetaExecutor) isListOEV1alpha1UR() bool {
 	return m.identifier.isOEV1alpha1UR() && m.isList()
 }
 
-func (m *metaTaskExecutor) isListOEV1alpha1CV() bool {
+func (m *MetaExecutor) isListOEV1alpha1CV() bool {
 	return m.identifier.isOEV1alpha1CV() && m.isList()
 }
 
-func (m *metaTaskExecutor) isExecCoreV1Pod() bool {
+func (m *MetaExecutor) isExecCoreV1Pod() bool {
 	return m.identifier.isCoreV1Pod() && m.isExec()
 }
 
-func (m *metaTaskExecutor) isGetCoreV1Pod() bool {
+func (m *MetaExecutor) isGetCoreV1Pod() bool {
 	return m.identifier.isCoreV1Pod() && m.isGet()
 }
 
-func (m *metaTaskExecutor) isRolloutstatusExtnV1B1Deploy() bool {
+func (m *MetaExecutor) isRolloutstatusExtnV1B1Deploy() bool {
 	return m.identifier.isExtnV1B1Deploy() && m.isRolloutstatus()
 }
 
-func (m *metaTaskExecutor) isRolloutstatusAppsV1Deploy() bool {
+func (m *MetaExecutor) isRolloutstatusAppsV1Deploy() bool {
 	return m.identifier.isAppsV1Deploy() && m.isRolloutstatus()
 }
 
@@ -582,7 +583,7 @@ func getRollbackMetaInstances(given MetaTaskSpec, objectName string) (m MetaTask
 	return
 }
 
-// asRollbackInstance defines a metaTaskExecutor suitable for
+// asRollbackInstance defines a MetaExecutor suitable for
 // rollback operation.
 //
 // It translates a `put` action into a `delete` action
@@ -592,7 +593,7 @@ func getRollbackMetaInstances(given MetaTaskSpec, objectName string) (m MetaTask
 // NOTE:
 //  The bool return with value as `false` implies there is no
 // need for a rollback
-func (m *metaTaskExecutor) asRollbackInstance(objectName string) (*metaTaskExecutor, bool, error) {
+func (m *MetaExecutor) asRollbackInstance(objectName string) (*MetaExecutor, bool, error) {
 	// there is no rollback when task is disabled
 	// there is no rollback when original action is not put
 	if m.isDisabled() || !m.isPut() {
@@ -615,7 +616,7 @@ func (m *metaTaskExecutor) asRollbackInstance(objectName string) (*metaTaskExecu
 		return nil, true, err
 	}
 
-	return &metaTaskExecutor{
+	return &MetaExecutor{
 		metaTask:   rbSpec,
 		identifier: i,
 		k8sClient:  k,
@@ -655,9 +656,9 @@ func getRepeatMetaInstances(given MetaTaskSpec, repeatIndex int) (m MetaTaskSpec
 	return
 }
 
-// asRepeatInstance returns a new instance of metaTaskExecutor
+// asRepeatInstance returns a new instance of MetaExecutor
 // based on the provided meta task properties
-func (m *metaTaskExecutor) asRepeatInstance(repeatIndex int) (*metaTaskExecutor, error) {
+func (m *MetaExecutor) asRepeatInstance(repeatIndex int) (*MetaExecutor, error) {
 	if !m.repeater.isMetaRepeat() {
 		// old executor will suffice if repeater is not based on meta task
 		return m, nil
@@ -673,7 +674,7 @@ func (m *metaTaskExecutor) asRepeatInstance(repeatIndex int) (*metaTaskExecutor,
 		return nil, err
 	}
 
-	return &metaTaskExecutor{
+	return &MetaExecutor{
 		metaTask:   rSpec,
 		identifier: i,
 		repeater:   r,

--- a/pkg/task/meta_test.go
+++ b/pkg/task/meta_test.go
@@ -146,8 +146,10 @@ func TestNewMetaTaskExecutor(t *testing.T) {
 	}
 
 	for name, mock := range tests {
+		name := name //pin it
+		mock := mock //pin it
 		t.Run(name, func(t *testing.T) {
-			mte, err := newMetaTaskExecutor(mock.yaml, mock.values)
+			mte, err := NewMetaExecutor(mock.yaml, mock.values)
 
 			if err != nil && !mock.isErr {
 				t.Fatalf("failed to test new meta executor: expected 'no error': actual '%s'", err.Error())
@@ -209,7 +211,7 @@ action: put
 			var m MetaTaskSpec
 			yaml.Unmarshal(b, &m)
 
-			mte := &metaTaskExecutor{
+			mte := &MetaExecutor{
 				metaTask: m,
 			}
 
@@ -260,7 +262,7 @@ retry: "5,2z"
 			var m MetaTaskSpec
 			yaml.Unmarshal(b, &m)
 
-			mte := &metaTaskExecutor{
+			mte := &MetaExecutor{
 				metaTask: m,
 			}
 
@@ -307,6 +309,8 @@ objectName: {{ .objectName }}
 	}
 
 	for name, mock := range tests {
+		name := name //pin it
+		mock := mock //pin it
 		t.Run(name, func(t *testing.T) {
 			// transform the yaml with provided values
 			b, _ := template.AsTemplatedBytes("MetaTaskSpec", mock.yaml, mock.values)
@@ -315,7 +319,7 @@ objectName: {{ .objectName }}
 			var m MetaTaskSpec
 			yaml.Unmarshal(b, &m)
 
-			mte := &metaTaskExecutor{
+			mte := &MetaExecutor{
 				metaTask: m,
 			}
 
@@ -363,7 +367,7 @@ options: |-
 			var m MetaTaskSpec
 			yaml.Unmarshal(b, &m)
 
-			mte := &metaTaskExecutor{
+			mte := &MetaExecutor{
 				metaTask: m,
 			}
 
@@ -426,7 +430,7 @@ action: {{ .action }}
 			var m MetaTaskSpec
 			yaml.Unmarshal(b, &m)
 
-			mte := &metaTaskExecutor{
+			mte := &MetaExecutor{
 				metaTask: m,
 			}
 
@@ -484,7 +488,7 @@ action: {{ .action }}
 			var m MetaTaskSpec
 			yaml.Unmarshal(b, &m)
 
-			mte := &metaTaskExecutor{
+			mte := &MetaExecutor{
 				metaTask: m,
 			}
 
@@ -542,7 +546,7 @@ action: {{ .action }}
 			var m MetaTaskSpec
 			yaml.Unmarshal(b, &m)
 
-			mte := &metaTaskExecutor{
+			mte := &MetaExecutor{
 				metaTask: m,
 			}
 
@@ -600,7 +604,7 @@ action: {{ .action }}
 			var m MetaTaskSpec
 			yaml.Unmarshal(b, &m)
 
-			mte := &metaTaskExecutor{
+			mte := &MetaExecutor{
 				metaTask: m,
 			}
 
@@ -658,7 +662,7 @@ action: {{ .action }}
 			var m MetaTaskSpec
 			yaml.Unmarshal(b, &m)
 
-			mte := &metaTaskExecutor{
+			mte := &MetaExecutor{
 				metaTask: m,
 			}
 
@@ -752,7 +756,7 @@ action: {{ .action }}
 
 			i, _ := newTaskIdentifier(m.MetaTaskIdentity)
 
-			mte := &metaTaskExecutor{
+			mte := &MetaExecutor{
 				metaTask:   m,
 				identifier: i,
 			}
@@ -847,7 +851,7 @@ action: {{ .action }}
 
 			i, _ := newTaskIdentifier(m.MetaTaskIdentity)
 
-			mte := &metaTaskExecutor{
+			mte := &MetaExecutor{
 				metaTask:   m,
 				identifier: i,
 			}
@@ -942,7 +946,7 @@ action: {{ .action }}
 
 			i, _ := newTaskIdentifier(m.MetaTaskIdentity)
 
-			mte := &metaTaskExecutor{
+			mte := &MetaExecutor{
 				metaTask:   m,
 				identifier: i,
 			}
@@ -1039,7 +1043,7 @@ action: {{ .action }}
 
 			i, _ := newTaskIdentifier(m.MetaTaskIdentity)
 
-			mte := &metaTaskExecutor{
+			mte := &MetaExecutor{
 				metaTask:   m,
 				identifier: i,
 			}
@@ -1136,7 +1140,7 @@ action: {{ .action }}
 
 			i, _ := newTaskIdentifier(m.MetaTaskIdentity)
 
-			mte := &metaTaskExecutor{
+			mte := &MetaExecutor{
 				metaTask:   m,
 				identifier: i,
 			}
@@ -1233,7 +1237,7 @@ action: {{ .action }}
 
 			i, _ := newTaskIdentifier(m.MetaTaskIdentity)
 
-			mte := &metaTaskExecutor{
+			mte := &MetaExecutor{
 				metaTask:   m,
 				identifier: i,
 			}
@@ -1330,7 +1334,7 @@ action: {{ .action }}
 
 			i, _ := newTaskIdentifier(m.MetaTaskIdentity)
 
-			mte := &metaTaskExecutor{
+			mte := &MetaExecutor{
 				metaTask:   m,
 				identifier: i,
 			}
@@ -1427,7 +1431,7 @@ action: {{ .action }}
 
 			i, _ := newTaskIdentifier(m.MetaTaskIdentity)
 
-			mte := &metaTaskExecutor{
+			mte := &MetaExecutor{
 				metaTask:   m,
 				identifier: i,
 			}
@@ -1524,7 +1528,7 @@ action: {{ .action }}
 
 			i, _ := newTaskIdentifier(m.MetaTaskIdentity)
 
-			mte := &metaTaskExecutor{
+			mte := &MetaExecutor{
 				metaTask:   m,
 				identifier: i,
 			}

--- a/pkg/task/runner.go
+++ b/pkg/task/runner.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	stringer "github.com/openebs/maya/pkg/apis/stringer/v1alpha1"
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 	"github.com/openebs/maya/pkg/template"
 	"github.com/openebs/maya/pkg/util"
 )
@@ -55,7 +57,7 @@ type TaskGroupRunner struct {
 	fallbackTemplate string
 	// rollbacks is an array of task executor that need to be run in
 	// sequence in the event of any error
-	rollbacks []*taskExecutor
+	rollbacks []*executor
 }
 
 // NewTaskGroupRunner returns a new task group.
@@ -132,7 +134,7 @@ func (m *TaskGroupRunner) isTaskIDUnique(identity string) (unique bool) {
 // NOTE:
 //  This is just the planning for rollback & not actual rollback.
 // In the events of issues this planning will be useful.
-func (m *TaskGroupRunner) planForRollback(te *taskExecutor, objectName string) error {
+func (m *TaskGroupRunner) planForRollback(te *executor, objectName string) error {
 	// There are cases where multiple objects may be created due to a single
 	// RunTask. In such cases, object name will have comma separated list of
 	// object names.
@@ -190,11 +192,10 @@ func (m *TaskGroupRunner) fallback(values map[string]interface{}) (output []byte
 
 // runATask will run a task based on the task specs & template values
 func (m *TaskGroupRunner) runATask(runtask *v1alpha1.RunTask, values map[string]interface{}) (err error) {
-	te, err := newTaskExecutor(runtask, values)
+	te, err := newExecutor(runtask, values)
 	if err != nil {
 		// log with verbose details
-		glog.Errorf("failed to initialize runtask executor: name '%s': meta yaml '%s': template values in yaml '%s': template values '%+v'", runtask.Name, runtask.Spec.Meta, template.ToYaml(values), values)
-		return
+		return errors.Wrap(err, "failed to execute runtask: failed to init executor")
 	}
 
 	// check if the task ID is unique in this group
@@ -210,23 +211,15 @@ func (m *TaskGroupRunner) runATask(runtask *v1alpha1.RunTask, values map[string]
 	redactJsonResult(values)
 
 	if errExecute != nil {
-		glog.Errorf("failed to execute runtask: name '%s': meta yaml '%s': task yaml '%s': template values in yaml '%s': template values '%+v'", runtask.Name, runtask.Spec.Meta, runtask.Spec.Task, template.ToYaml(values), values)
+		return errors.Wrapf(errExecute, "failed to execute runtask: %s %s", runtask, stringer.Yaml("template values", values))
 	}
 
 	// this is planning & not the actual rollback
 	errRollback := m.planForRollback(te, util.GetNestedString(values, string(v1alpha1.TaskResultTLP), te.getTaskIdentity(), string(v1alpha1.ObjectNameTRTP)))
 	if errRollback != nil {
-		glog.Errorf("failed to plan for rollback: '%+v'", errRollback)
+		return errors.Wrapf(errRollback, "failed to plan for rollback: '%+v'", errRollback)
 	}
 
-	// err will always contain the higher priority error
-	// here errExecute > errRollback.
-	if errRollback != nil {
-		err = errRollback
-	}
-	if errExecute != nil {
-		err = errExecute
-	}
 	return
 }
 
@@ -251,15 +244,14 @@ func (m *TaskGroupRunner) runOutput(values map[string]interface{}) (output []byt
 		return
 	}
 
-	te, err := newTaskExecutor(m.outputTask, values)
+	te, err := newExecutor(m.outputTask, values)
 	if err != nil {
 		return
 	}
 
 	output, err = te.Output()
 	if err != nil {
-		// log with verbose details
-		glog.Errorf("failed to execute output task: runtask '%+v': template values in yaml '%s': template values '%+v'", m.outputTask, template.ToYaml(values), values)
+		err = errors.Wrap(err, "failed to execute output task:")
 	}
 	return
 }

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -19,14 +19,17 @@ package task
 import (
 	"encoding/json"
 	"fmt"
+
+	//"fmt"
 	"strings"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
-
+	stringer "github.com/openebs/maya/pkg/apis/stringer/v1alpha1"
 	m_k8s_client "github.com/openebs/maya/pkg/client/k8s"
 	cstorpool "github.com/openebs/maya/pkg/cstorpool/v1alpha2"
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 	m_k8s "github.com/openebs/maya/pkg/k8s"
 	deploy_appsv1 "github.com/openebs/maya/pkg/kubernetes/deployment/appsv1/v1alpha1"
 	deploy_extnv1beta1 "github.com/openebs/maya/pkg/kubernetes/deployment/extnv1beta1/v1alpha1"
@@ -46,188 +49,260 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// TaskExecutor is the interface that provides a contract method to execute
-// tasks
-type TaskExecutor interface {
+var (
+	// ErrorUnSupportedTask is used to throw error
+	// for the tasks which are not supported by
+	// the executor instance(s)
+	ErrorUnSupportedTask error = errors.New("task not supported")
+)
+
+// Executor provides the contract to execute
+// RunTasks
+type Executor interface {
 	Execute() (err error)
 }
 
-// TaskOutputExecutor is the interface that provides a contract method to
-// generate output in a pre-defined format. The output format is specified in
-// the task.
-type TaskOutputExecutor interface {
+// OutputExecutor provides the contract to
+// generate content from a RunTask's
+// specifications
+//
+// NOTE:
+//  The output format is specified in the
+// RunTask itself
+type OutputExecutor interface {
 	Output() (output []byte, err error)
 }
 
-type taskExecutor struct {
-	// templateValues will hold the values that will be applied against
-	// the task's specification (which is a go template) before this task gets
-	// executed
-	templateValues map[string]interface{}
+type executor struct {
+	// Values is applied against the
+	// task's specification (~ a go template)
+	Values map[string]interface{}
 
-	// metaTaskExec is the instance to be used to execute meta
+	// MetaExec is used to execute meta
 	// operations on this task
-	metaTaskExec *metaTaskExecutor
+	MetaExec *MetaExecutor
 
-	// runtask is the specifications that determine a task & operations associated
-	// with it
-	runtask *v1alpha1.RunTask
+	// Runtask defines a task & operations
+	// associated with it
+	Runtask *v1alpha1.RunTask
 }
 
-// newTaskExecutor returns a new instance of taskExecutor
-func newTaskExecutor(runtask *v1alpha1.RunTask, values map[string]interface{}) (*taskExecutor, error) {
-	mte, err := newMetaTaskExecutor(runtask.Spec.Meta, values)
+// newExecutor returns a new instance of
+// executor
+func newExecutor(rt *v1alpha1.RunTask, values map[string]interface{}) (*executor, error) {
+	mte, err := NewMetaExecutor(rt.Spec.Meta, values)
 	if err != nil {
-		return nil, err
+		return nil,
+			errors.Wrapf(err, "failed to init task executor: failed to init meta executor: %s %s", rt, stringer.Yaml("template values", values))
 	}
 
-	return &taskExecutor{
-		templateValues: values,
-		metaTaskExec:   mte,
-		runtask:        runtask,
+	return &executor{
+		Values:   values,
+		MetaExec: mte,
+		Runtask:  rt,
 	}, nil
 }
 
-// String provides the essential task executor details
-func (m *taskExecutor) String() string {
-	return fmt.Sprintf("task with identity '%s' and with objectname '%s'", m.getTaskIdentity(), m.getTaskObjectName())
+// String is the Stringer implementation
+// of executor
+func (m *executor) String() string {
+	return stringer.Yaml("task executor", m)
+}
+
+// GoString is the GoStringer implementation
+// of executor
+func (m *executor) GoString() string {
+	return stringer.Yaml("task executor", m)
 }
 
 // getTaskIdentity gets the task identity
-func (m *taskExecutor) getTaskIdentity() string {
-	return m.metaTaskExec.getIdentity()
+func (m *executor) getTaskIdentity() string {
+	return m.MetaExec.getIdentity()
 }
 
 // getTaskObjectName gets the task's object name
-func (m *taskExecutor) getTaskObjectName() string {
-	return m.metaTaskExec.getObjectName()
+func (m *executor) getTaskObjectName() string {
+	return m.MetaExec.getObjectName()
 }
 
-// getTaskRunNamespace gets the task's run namespace
-func (m *taskExecutor) getTaskRunNamespace() string {
-	return m.metaTaskExec.getRunNamespace()
+// getTaskRunNamespace gets the namespace where
+// RunTask should get executed
+func (m *executor) getTaskRunNamespace() string {
+	return m.MetaExec.getRunNamespace()
 }
 
 // getK8sClient gets the kubernetes client to execute this task
-func (m *taskExecutor) getK8sClient() *m_k8s_client.K8sClient {
-	return m.metaTaskExec.getK8sClient()
+func (m *executor) getK8sClient() *m_k8s_client.K8sClient {
+	return m.MetaExec.getK8sClient()
 }
 
-// Output returns the result of templating this task's yaml
+// Output returns the result of templating a
+// RunTask meant for templating only purpose
 //
-// This implements TaskOutputExecutor interface
-func (m *taskExecutor) Output() (output []byte, err error) {
-	output, err = template.AsTemplatedBytes("Output", m.runtask.Spec.Task, m.templateValues)
-	return
+// NOTE:
+//  This implements OutputExecutor interface
+func (m *executor) Output() ([]byte, error) {
+	output, err := template.AsTemplatedBytes(
+		"output",
+		m.Runtask.Spec.Task,
+		m.Values,
+	)
+	if err != nil {
+		return nil, errors.Wrapf(errors.WithStack(err), "failed to generate output: %s", m)
+	}
+	return output, nil
 }
 
-// getTaskResultNotFoundError fetches the NotFound error if any from this
-// runtask's template values
+// getNotFoundError fetches NotFound error if any; post
+// the execution of this runtask. This is extracted from
+// the updated template values
 //
 // NOTE:
-//  Logic to determine NotFound error is set at PostRunTemplateFuncs & is
-// executed during post task execution phase. NotFound error is set if specified
-// items or properties are not found. This error is set in the runtask's
-// template values.
+//  Logic to determine NotFound error is specified at
+// Post property which is executed after the task's
+// execution.
 //
 // NOTE:
-//  Below property is set with verification error if any:
+//  In case of NotFound error, template values
+// is set with NotFound error against below
+// nested key
+//
 //  .TaskResult.<taskID>.notFoundErr
-func (m *taskExecutor) getTaskResultNotFoundError() interface{} {
-	return util.GetNestedField(m.templateValues, string(v1alpha1.TaskResultTLP), m.getTaskIdentity(), string(v1alpha1.TaskResultNotFoundErrTRTP))
+func (m *executor) getNotFoundError() interface{} {
+	return util.GetNestedField(
+		m.Values,
+		string(v1alpha1.TaskResultTLP),
+		m.getTaskIdentity(),
+		string(v1alpha1.TaskResultNotFoundErrTRTP),
+	)
 }
 
-// getTaskResultVersionMismatchError fetches the VersionMismatch error if any
-// from this runtask's template values
+// getVersionMismatchError fetches VersionMismatch error
+// if any; post the execution of this runtask
 //
 // NOTE:
-//  Logic to determine VersionMismatch error is set at PostRunTemplateFuncs & is
-// executed during post task execution phase. VersionMismatch error is set if
-// task is executed for invalid version of the resource. This error is set in
-// the runtask's template values.
+//  Logic to determine VersionMismatch error is specified at
+// Post property which is executed after the task's execution.
 //
 // NOTE:
-//  Below property is set with VersionMismatch error if any:
+//  In case of VersionMismatch error, template values
+// is set with VersionMismatch error against below nested
+// key
+//
 //  .TaskResult.<taskID>.versionMismatchErr
-func (m *taskExecutor) getTaskResultVersionMismatchError() interface{} {
-	return util.GetNestedField(m.templateValues, string(v1alpha1.TaskResultTLP), m.getTaskIdentity(), string(v1alpha1.TaskResultVersionMismatchErrTRTP))
+func (m *executor) getTaskResultVersionMismatchError() interface{} {
+	return util.GetNestedField(
+		m.Values,
+		string(v1alpha1.TaskResultTLP),
+		m.getTaskIdentity(),
+		string(v1alpha1.TaskResultVersionMismatchErrTRTP),
+	)
 }
 
-// getTaskResultVerifyError fetches the verification error if any from this
-// runtask's template values
+// getVerifyError fetches the verification error if any;
+// post the execution of this runtask
 //
 // NOTE:
-//  Logic to determine Verify error is set at PostRunTemplateFuncs & is
-// executed during post task execution phase. Verify error is set if specified
-// verifications fail. This error is set in the runtask's template values.
+//  Logic to determine Verify error is specified at Post
+// property which is executed after the task's execution.
 //
 // NOTE:
-//  Below property is set with verification error if any:
+//  In case of Verify error, template values is
+// set with Verify error against below nested key
+//
 //  .TaskResult.<taskID>.verifyErr
-func (m *taskExecutor) getTaskResultVerifyError() interface{} {
-	return util.GetNestedField(m.templateValues, string(v1alpha1.TaskResultTLP), m.getTaskIdentity(), string(v1alpha1.TaskResultVerifyErrTRTP))
+func (m *executor) getVerifyError() interface{} {
+	return util.GetNestedField(
+		m.Values,
+		string(v1alpha1.TaskResultTLP),
+		m.getTaskIdentity(),
+		string(v1alpha1.TaskResultVerifyErrTRTP),
+	)
 }
 
-// resetTaskResultVerifyError resets the verification error from this runtask's
-// template values
+// resetVerifyError resets verification error if any;
+// post the execution of this runtask
 //
 // NOTE:
-//  reset here implies setting the verification err's placeholder value to nil
+//  If a runtask results in Verify error, its execution
+// can be retried by reseting Verify error
 //
-//  Below property is reset with `nil`:
+// NOTE:
+//  Reset here implies setting the verification error's
+// placeholder value to nil
+//
+//  Below property is reset with 'nil':
 //  .TaskResult.<taskID>.verifyErr
-//
-// NOTE:
-//  Verification error is set during the post task execution phase if there are
-// any verification error. This error is set in the runtask's template values.
-func (m *taskExecutor) resetTaskResultVerifyError() {
-	util.SetNestedField(m.templateValues, nil, string(v1alpha1.TaskResultTLP), m.getTaskIdentity(), string(v1alpha1.TaskResultVerifyErrTRTP))
+func (m *executor) resetTaskResultVerifyError() {
+	util.SetNestedField(
+		m.Values,
+		nil,
+		string(v1alpha1.TaskResultTLP),
+		m.getTaskIdentity(),
+		string(v1alpha1.TaskResultVerifyErrTRTP),
+	)
 }
 
-// repeatWith repeats execution of the task based on the repeatWith property
-// set in meta task specifications. The same task is executed repeatedly based
-// on the resource names set against the repeatWith property.
+// repeatWith repeats execution of the task based on
+// repeatWith property of meta task specifications.
 //
 // NOTE:
-//  Each task execution depends on the currently active repeat resource.
-func (m *taskExecutor) repeatWith() (err error) {
-	rwExec := m.metaTaskExec.getRepeatExecutor()
-	if !rwExec.isRepeat() {
-		// no need to repeat if this task is not meant to be repeated;
+//  With this property RunTask can be executed repeatedly
+// based on the resource names set against the repeatWith
+// property.
+//
+// NOTE:
+//  Each task execution depends on the current resource
+// index
+func (m *executor) repeatWith() (err error) {
+	rptExec := m.MetaExec.getRepeatExecutor()
+	if !rptExec.isRepeat() {
+		// no need to repeat if this task
+		// is not meant to be repeated;
 		// so execute once & return
 		err = m.retryOnVerificationError()
 		return
 	}
 
 	// execute the task based on each repeat
-	repeats := rwExec.len()
+	repeats := rptExec.len()
 	var (
-		rptMetaTaskExec *metaTaskExecutor
-		current         string
+		rptMetaExec *MetaExecutor
+		current     string
 	)
 
 	for idx := 0; idx < repeats; idx++ {
 		// fetch a new repeat meta task instance
-		rptMetaTaskExec, err = m.metaTaskExec.asRepeatInstance(idx)
+		rptMetaExec, err = m.MetaExec.asRepeatInstance(idx)
 		if err != nil {
-			// stop repetition on unhandled runtime errors & return
+			// stop repetition on unhandled runtime errors
+			// & return
 			return
 		}
-		// mutate the original meta task executor to this repeater instance
-		m.metaTaskExec = rptMetaTaskExec
+		// mutate the original meta task executor
+		// to this repeater instance
+		m.MetaExec = rptMetaExec
 
 		// set the currently active repeat item
-		current, err = m.metaTaskExec.repeater.getItem(idx)
+		current, err = m.MetaExec.repeater.getItem(idx)
 		if err != nil {
-			// stop repetition on unhandled runtime error & return
+			// stop repetition on unhandled runtime error
+			// & return
 			return
 		}
-		util.SetNestedField(m.templateValues, current, string(v1alpha1.ListItemsTLP), string(v1alpha1.CurrentRepeatResourceLITP))
 
-		// execute the task function... finally
+		util.SetNestedField(
+			m.Values,
+			current,
+			string(v1alpha1.ListItemsTLP),
+			string(v1alpha1.CurrentRepeatResourceLITP),
+		)
+
+		// execute the task function finally
 		err = m.retryOnVerificationError()
 		if err != nil {
-			// stop repetition on unhandled runtime error & return
+			// stop repetition on unhandled runtime error
+			// & return
 			return
 		}
 	}
@@ -235,11 +310,13 @@ func (m *taskExecutor) repeatWith() (err error) {
 	return
 }
 
-// retryOnVerificationError retries execution of the task if the task execution
-// resulted into verification error. The number of retry attempts & interval
-// between each attempt is specified in the task's meta specification.
-func (m *taskExecutor) retryOnVerificationError() (err error) {
-	retryAttempts, interval := m.metaTaskExec.getRetry()
+// retryOnVerificationError retries execution of the task
+// if the task execution resulted into verification error.
+// The number of retry attempts & interval between each
+// attempt is specified in the task's meta specification.
+func (m *executor) retryOnVerificationError() (err error) {
+	retryAttempts, interval := m.MetaExec.getRetry()
+
 	// original invocation as well as all retry attempts
 	// i == 0 implies original task execute invocation
 	// i > 0 implies a retry operation
@@ -250,22 +327,25 @@ func (m *taskExecutor) retryOnVerificationError() (err error) {
 		// execute the task function
 		err = m.ExecuteIt()
 		if err != nil {
-			// break this retry execution loop if there were any runtime errors
+			// break this retry execution loop
+			// if there were any runtime errors
 			return
 		}
 
 		// check for VerifyError if any
 		//
 		// NOTE:
-		//  VerifyError is a handled runtime error which is handled via templating
+		//  VerifyError is a handled runtime error
+		// which is set via templating
 		//
 		// NOTE:
-		//  retry is done only if VerifyError is thrown during post task
-		// execution
-		verifyErr := m.getTaskResultVerifyError()
+		//  retry is done only if VerifyError is
+		// set during post task execution
+		verifyErr := m.getVerifyError()
 		if verifyErr == nil {
-			// no need to retry if task execution was a success & there was no
-			// verification error found with the task result
+			// no need to retry if task execution was a
+			// success i.e. there was no verification error
+			// found with the task result
 			return
 		}
 
@@ -273,65 +353,86 @@ func (m *taskExecutor) retryOnVerificationError() (err error) {
 		err, _ = verifyErr.(*template.VerifyError)
 
 		if i != retryAttempts {
-			glog.Warningf("verify error was found during post runtask operations '%s': error '%+v': will retry task execution'%d'", m.getTaskIdentity(), err, i+1)
+			glog.Warningf(
+				"verify error was found for runtask {%s}: error {%s}: will retry task execution-'%d'",
+				m.getTaskIdentity(),
+				err,
+				i+1,
+			)
 
 			// will retry after the specified interval
 			time.Sleep(interval)
 		}
 	}
 
-	// return after exhausting the original invocation and all retries;
-	// verification error of the final attempt will be returned here
+	// return after exhausting the original invocation
+	// and all retries; verification error of the final
+	// attempt will be returned here
 	return
 }
 
-// Execute executes a runtask by following the directives specified in the
-// runtask's meta specifications and other conditions like presence of VerifyErr
-func (m *taskExecutor) Execute() (err error) {
-	if m.metaTaskExec.isDisabled() {
+// Execute executes a runtask by following the
+// directives specified in the runtask's meta
+// specifications
+func (m *executor) Execute() (err error) {
+	if m.MetaExec.isDisabled() {
+		// do nothing if runtask is disabled
 		return
 	}
 	return m.repeatWith()
 }
 
-// postExecuteIt executes a go template against the provided template values.
-// This is run after executing a task.
+// postExecuteIt executes a go template against
+// the provided template values. This is run
+// after executing a task.
 //
 // NOTE:
-//  This go template is a set of template functions that queries specified
-// properties from the result due to the task's execution & storing it at
-// placeholders within the **template values**. This is done to query these
-// extracted values while executing later runtasks by providing these runtasks
-// with the updated **template values**.
-func (m *taskExecutor) postExecuteIt() (err error) {
-	if m.runtask == nil || len(m.runtask.Spec.PostRun) == 0 {
-		// nothing needs to be done
+//  This go template is a set of template functions
+// that queries specified properties from the result
+// of task's execution & stores them at placeholders
+// within the **template values**. These stored values
+// can later be queried by subsequent runtasks.
+func (m *executor) postExecuteIt() (err error) {
+	if m.Runtask == nil || len(m.Runtask.Spec.PostRun) == 0 {
+		// do nothing if post specs is empty
 		return
 	}
 
 	// post runtask operation
-	_, err = template.AsTemplatedBytes("PostRun", m.runtask.Spec.PostRun, m.templateValues)
+	_, err = template.AsTemplatedBytes(
+		"PostRun",
+		m.Runtask.Spec.PostRun,
+		m.Values,
+	)
 	if err != nil {
 		// return any un-handled runtime error
 		return
 	}
 
-	// verMismatchErr is a handled runtime error. It is thrown & handled during go
-	// template execution & set is in the template values. This needs to be
-	// extracted from template values and thrown as VersionMismatchError
+	// verMismatchErr is a handled runtime error i.e.
+	// is set in template values. This needs to be
+	// extracted and thrown as VersionMismatchError
 	verMismatchErr := m.getTaskResultVersionMismatchError()
 	if verMismatchErr != nil {
-		glog.Warningf("version mismatch error during post runtask operations '%s': error '%+v'", m.getTaskIdentity(), verMismatchErr)
+		glog.Warningf(
+			"version mismatch error at runtask {%s}: error {%s}",
+			m.getTaskIdentity(),
+			verMismatchErr,
+		)
 		err, _ = verMismatchErr.(*template.VersionMismatchError)
 		return
 	}
 
-	// notFoundErr is a handled runtime error. It is thrown & handled during go
-	// template execution & set is in the template values. This needs to be
+	// notFoundErr is a handled runtime error i.e. is
+	// set is in template values. This needs to be
 	// extracted and thrown as NotFoundError
-	notFoundErr := m.getTaskResultNotFoundError()
+	notFoundErr := m.getNotFoundError()
 	if notFoundErr != nil {
-		glog.Warningf("notfound error during post runtask operations '%s': error '%+v'", m.getTaskIdentity(), notFoundErr)
+		glog.Warningf(
+			"notfound error at runtask {%s}: error {%s}",
+			m.getTaskIdentity(),
+			notFoundErr,
+		)
 		err, _ = notFoundErr.(*template.NotFoundError)
 		return
 	}
@@ -339,129 +440,128 @@ func (m *taskExecutor) postExecuteIt() (err error) {
 	return nil
 }
 
-// ExecuteIt will execute the runtask based on its meta specs & task specs
-func (m *taskExecutor) ExecuteIt() (err error) {
+// ExecuteIt will execute the runtask based on
+// its meta & task specifications
+func (m *executor) ExecuteIt() (err error) {
 	if m.getK8sClient() == nil {
-		emsg := "failed to execute task: nil k8s client: verify if run namespace was available"
-		glog.Errorf(fmt.Sprintf("%s: metatask '%+v'", emsg, m.metaTaskExec.getMetaInfo()))
-		err = fmt.Errorf("%s: task '%s'", emsg, m.getTaskIdentity())
-		return
+		return errors.Errorf("failed to execute task: nil k8s client: verify if namespace is set: %s", m)
 	}
 
 	// kind as command is a special case of task execution
-	if m.metaTaskExec.isCommand() {
+	if m.MetaExec.isCommand() {
 		return m.postExecuteIt()
 	}
 
-	if m.metaTaskExec.isRolloutstatus() {
+	if m.MetaExec.isRolloutstatus() {
 		err = m.rolloutStatus()
-	} else if m.metaTaskExec.isPutExtnV1B1Deploy() {
+	} else if m.MetaExec.isPutExtnV1B1Deploy() {
 		err = m.putExtnV1B1Deploy()
-	} else if m.metaTaskExec.isPutAppsV1B1Deploy() {
+	} else if m.MetaExec.isPutAppsV1B1Deploy() {
 		err = m.putAppsV1B1Deploy()
-	} else if m.metaTaskExec.isPatchExtnV1B1Deploy() {
+	} else if m.MetaExec.isPatchExtnV1B1Deploy() {
 		err = m.patchExtnV1B1Deploy()
-	} else if m.metaTaskExec.isPatchAppsV1B1Deploy() {
+	} else if m.MetaExec.isPatchAppsV1B1Deploy() {
 		err = m.patchAppsV1B1Deploy()
-	} else if m.metaTaskExec.isPatchOEV1alpha1SPC() {
+	} else if m.MetaExec.isPatchOEV1alpha1SPC() {
 		err = m.patchOEV1alpha1SPC()
-	} else if m.metaTaskExec.isPatchOEV1alpha1CSPC() {
+	} else if m.MetaExec.isPatchOEV1alpha1CSPC() {
 		err = m.patchOEV1alpha1CSPC()
-	} else if m.metaTaskExec.isPutCoreV1Service() {
+	} else if m.MetaExec.isPutCoreV1Service() {
 		err = m.putCoreV1Service()
-	} else if m.metaTaskExec.isPatchCoreV1Service() {
+	} else if m.MetaExec.isPatchCoreV1Service() {
 		err = m.patchCoreV1Service()
-	} else if m.metaTaskExec.isDeleteExtnV1B1Deploy() {
+	} else if m.MetaExec.isDeleteExtnV1B1Deploy() {
 		err = m.deleteExtnV1B1Deployment()
-	} else if m.metaTaskExec.isDeleteExtnV1B1ReplicaSet() {
+	} else if m.MetaExec.isDeleteExtnV1B1ReplicaSet() {
 		err = m.deleteExtnV1B1ReplicaSet()
-	} else if m.metaTaskExec.isGetExtnV1B1Deploy() {
+	} else if m.MetaExec.isGetExtnV1B1Deploy() {
 		err = m.getExtnV1B1Deployment()
-	} else if m.metaTaskExec.isGetExtnV1B1ReplicaSet() {
+	} else if m.MetaExec.isGetExtnV1B1ReplicaSet() {
 		err = m.getExtnV1B1ReplicaSet()
-	} else if m.metaTaskExec.isGetCoreV1Pod() {
+	} else if m.MetaExec.isGetCoreV1Pod() {
 		err = m.getCoreV1Pod()
-	} else if m.metaTaskExec.isDeleteAppsV1B1Deploy() {
+	} else if m.MetaExec.isDeleteAppsV1B1Deploy() {
 		err = m.deleteAppsV1B1Deployment()
-	} else if m.metaTaskExec.isDeleteCoreV1Service() {
+	} else if m.MetaExec.isDeleteCoreV1Service() {
 		err = m.deleteCoreV1Service()
-	} else if m.metaTaskExec.isGetOEV1alpha1Disk() {
+	} else if m.MetaExec.isGetOEV1alpha1Disk() {
 		err = m.getOEV1alpha1Disk()
-	} else if m.metaTaskExec.isGetOEV1alpha1SPC() {
+	} else if m.MetaExec.isGetOEV1alpha1SPC() {
 		err = m.getOEV1alpha1SPC()
-	} else if m.metaTaskExec.isGetOEV1alpha1CSPC() {
+	} else if m.MetaExec.isGetOEV1alpha1CSPC() {
 		err = m.getOEV1alpha1CSPC()
-	} else if m.metaTaskExec.isGetOEV1alpha1SP() {
+	} else if m.MetaExec.isGetOEV1alpha1SP() {
 		err = m.getOEV1alpha1SP()
-	} else if m.metaTaskExec.isGetOEV1alpha1CSP() {
+	} else if m.MetaExec.isGetOEV1alpha1CSP() {
 		err = m.getOEV1alpha1CSP()
-	} else if m.metaTaskExec.isGetOEV1alpha1UR() {
+	} else if m.MetaExec.isGetOEV1alpha1UR() {
 		err = m.getOEV1alpha1UR()
-	} else if m.metaTaskExec.isGetCoreV1PVC() {
+	} else if m.MetaExec.isGetCoreV1PVC() {
 		err = m.getCoreV1PVC()
-	} else if m.metaTaskExec.isPutOEV1alpha1CSP() {
+	} else if m.MetaExec.isPutOEV1alpha1CSP() {
 		err = m.putCStorPool()
-	} else if m.metaTaskExec.isPutOEV1alpha1SP() {
+	} else if m.MetaExec.isPutOEV1alpha1SP() {
 		err = m.putStoragePool()
-	} else if m.metaTaskExec.isPutOEV1alpha1CSV() {
+	} else if m.MetaExec.isPutOEV1alpha1CSV() {
 		err = m.putCStorVolume()
-	} else if m.metaTaskExec.isPutOEV1alpha1CVR() {
+	} else if m.MetaExec.isPutOEV1alpha1CVR() {
 		err = m.putCStorVolumeReplica()
-	} else if m.metaTaskExec.isPutOEV1alpha1UR() {
+	} else if m.MetaExec.isPutOEV1alpha1UR() {
 		err = m.putUpgradeResult()
-	} else if m.metaTaskExec.isDeleteOEV1alpha1SP() {
+	} else if m.MetaExec.isDeleteOEV1alpha1SP() {
 		err = m.deleteOEV1alpha1SP()
-	} else if m.metaTaskExec.isDeleteOEV1alpha1CSP() {
+	} else if m.MetaExec.isDeleteOEV1alpha1CSP() {
 		err = m.deleteOEV1alpha1CSP()
-	} else if m.metaTaskExec.isDeleteOEV1alpha1CSV() {
+	} else if m.MetaExec.isDeleteOEV1alpha1CSV() {
 		err = m.deleteOEV1alpha1CSV()
-	} else if m.metaTaskExec.isDeleteOEV1alpha1CVR() {
+	} else if m.MetaExec.isDeleteOEV1alpha1CVR() {
 		err = m.deleteOEV1alpha1CVR()
-	} else if m.metaTaskExec.isPatchOEV1alpha1CSV() {
+	} else if m.MetaExec.isPatchOEV1alpha1CSV() {
 		err = m.patchOEV1alpha1CSV()
-	} else if m.metaTaskExec.isPatchOEV1alpha1CVR() {
+	} else if m.MetaExec.isPatchOEV1alpha1CVR() {
 		err = m.patchOEV1alpha1CVR()
-	} else if m.metaTaskExec.isPatchOEV1alpha1UR() {
+	} else if m.MetaExec.isPatchOEV1alpha1UR() {
 		err = m.patchUpgradeResult()
-	} else if m.metaTaskExec.isPatchOEV1alpha1SP() {
+	} else if m.MetaExec.isPatchOEV1alpha1SP() {
 		err = m.patchStoragePool()
-	} else if m.metaTaskExec.isPatchOEV1alpha1CSP() {
+	} else if m.MetaExec.isPatchOEV1alpha1CSP() {
 		err = m.patchCstorPool()
-	} else if m.metaTaskExec.isList() {
+	} else if m.MetaExec.isList() {
 		err = m.listK8sResources()
-	} else if m.metaTaskExec.isGetStorageV1SC() {
+	} else if m.MetaExec.isGetStorageV1SC() {
 		err = m.getStorageV1SC()
-	} else if m.metaTaskExec.isGetCoreV1PV() {
+	} else if m.MetaExec.isGetCoreV1PV() {
 		err = m.getCoreV1PV()
-	} else if m.metaTaskExec.isDeleteBatchV1Job() {
+	} else if m.MetaExec.isDeleteBatchV1Job() {
 		err = m.deleteBatchV1Job()
-	} else if m.metaTaskExec.isGetBatchV1Job() {
+	} else if m.MetaExec.isGetBatchV1Job() {
 		err = m.getBatchV1Job()
-	} else if m.metaTaskExec.isPutBatchV1Job() {
+	} else if m.MetaExec.isPutBatchV1Job() {
 		err = m.putBatchV1Job()
-	} else if m.metaTaskExec.isPutAppsV1STS() {
+	} else if m.MetaExec.isPutAppsV1STS() {
 		err = m.putAppsV1STS()
-	} else if m.metaTaskExec.isDeleteAppsV1STS() {
+	} else if m.MetaExec.isDeleteAppsV1STS() {
 		err = m.deleteAppsV1STS()
-	} else if m.metaTaskExec.isExecCoreV1Pod() {
+	} else if m.MetaExec.isExecCoreV1Pod() {
 		err = m.execCoreV1Pod()
 	} else {
-		err = fmt.Errorf("un-supported task operation: failed to execute task: '%+v'", m.metaTaskExec.getMetaInfo())
+		err = ErrorUnSupportedTask
 	}
 
 	if err != nil {
-		return
+		return errors.Wrapf(err, "failed to execute task: %s", m)
 	}
 
 	// run the post operations after a runtask is executed
 	return m.postExecuteIt()
 }
 
-// asRollbackInstance will provide the rollback instance w.r.t this task's instance
-func (m *taskExecutor) asRollbackInstance(objectName string) (*taskExecutor, error) {
-	mte, willRollback, err := m.metaTaskExec.asRollbackInstance(objectName)
+// asRollbackInstance will provide the rollback
+// instance associated to this task's instance
+func (m *executor) asRollbackInstance(objectName string) (*executor, error) {
+	mte, willRollback, err := m.MetaExec.asRollbackInstance(objectName)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to build rollback executor for object {%s}: %v", objectName, m.MetaExec)
 	}
 
 	if !willRollback {
@@ -471,36 +571,37 @@ func (m *taskExecutor) asRollbackInstance(objectName string) (*taskExecutor, err
 
 	// Only the meta info is required for a rollback. In
 	// other words no need of task yaml template & values
-	return &taskExecutor{
-		metaTaskExec: mte,
+	return &executor{
+		MetaExec: mte,
 	}, nil
 }
 
-// asBatchV1Job generates a K8s Job object out of the embedded yaml
-func (m *taskExecutor) asBatchV1Job() (*api_batch_v1.Job, error) {
-	j, err := m_k8s.NewJobYml("BatchV1Job", m.runtask.Spec.Task, m.templateValues)
+// asBatchV1Job generates a K8s Job object
+// out of the embedded yaml
+func (m *executor) asBatchV1Job() (*api_batch_v1.Job, error) {
+	j, err := m_k8s.NewJobYml("BatchV1Job", m.Runtask.Spec.Task, m.Values)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to build job")
 	}
 	return j.AsBatchV1Job()
 }
 
 // asAppsV1STS generates a kubernetes StatefulSet api
 // instance from the yaml string specification
-func (m *taskExecutor) asAppsV1STS() (*api_apps_v1.StatefulSet, error) {
-	s, err := m_k8s.NewSTSYml("AppsV1StatefulSet", m.runtask.Spec.Task, m.templateValues)
+func (m *executor) asAppsV1STS() (*api_apps_v1.StatefulSet, error) {
+	s, err := m_k8s.NewSTSYml("AppsV1StatefulSet", m.Runtask.Spec.Task, m.Values)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to build statefulset")
 	}
 	return s.AsAppsV1STS()
 }
 
 // asAppsV1B1Deploy generates a K8s Deployment object
 // out of the embedded yaml
-func (m *taskExecutor) asAppsV1B1Deploy() (*api_apps_v1beta1.Deployment, error) {
-	d, err := m_k8s.NewDeploymentYml("AppsV1B1Deploy", m.runtask.Spec.Task, m.templateValues)
+func (m *executor) asAppsV1B1Deploy() (*api_apps_v1beta1.Deployment, error) {
+	d, err := m_k8s.NewDeploymentYml("AppsV1B1Deploy", m.Runtask.Spec.Task, m.Values)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to build deployment")
 	}
 
 	return d.AsAppsV1B1Deployment()
@@ -508,10 +609,10 @@ func (m *taskExecutor) asAppsV1B1Deploy() (*api_apps_v1beta1.Deployment, error) 
 
 // asExtnV1B1Deploy generates a K8s Deployment object
 // out of the embedded yaml
-func (m *taskExecutor) asExtnV1B1Deploy() (*api_extn_v1beta1.Deployment, error) {
-	d, err := m_k8s.NewDeploymentYml("ExtnV1B11Deploy", m.runtask.Spec.Task, m.templateValues)
+func (m *executor) asExtnV1B1Deploy() (*api_extn_v1beta1.Deployment, error) {
+	d, err := m_k8s.NewDeploymentYml("ExtnV1B11Deploy", m.Runtask.Spec.Task, m.Values)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to build deployment")
 	}
 
 	return d.AsExtnV1B1Deployment()
@@ -519,10 +620,10 @@ func (m *taskExecutor) asExtnV1B1Deploy() (*api_extn_v1beta1.Deployment, error) 
 
 // asCStorPool generates a CstorPool object
 // out of the embedded yaml
-func (m *taskExecutor) asCStorPool() (*v1alpha1.CStorPool, error) {
-	d, err := m_k8s.NewCStorPoolYml("CStorPool", m.runtask.Spec.Task, m.templateValues)
+func (m *executor) asCStorPool() (*v1alpha1.CStorPool, error) {
+	d, err := m_k8s.NewCStorPoolYml("CStorPool", m.Runtask.Spec.Task, m.Values)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to build cstorpool")
 	}
 
 	return d.AsCStorPoolYml()
@@ -530,10 +631,10 @@ func (m *taskExecutor) asCStorPool() (*v1alpha1.CStorPool, error) {
 
 // asStoragePool generates a StoragePool object
 // out of the embedded yaml
-func (m *taskExecutor) asStoragePool() (*v1alpha1.StoragePool, error) {
-	d, err := m_k8s.NewStoragePoolYml("StoragePool", m.runtask.Spec.Task, m.templateValues)
+func (m *executor) asStoragePool() (*v1alpha1.StoragePool, error) {
+	d, err := m_k8s.NewStoragePoolYml("StoragePool", m.Runtask.Spec.Task, m.Values)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to build storagepool")
 	}
 
 	return d.AsStoragePoolYml()
@@ -541,10 +642,10 @@ func (m *taskExecutor) asStoragePool() (*v1alpha1.StoragePool, error) {
 
 // asCStorVolume generates a CstorVolume object
 // out of the embedded yaml
-func (m *taskExecutor) asCStorVolume() (*v1alpha1.CStorVolume, error) {
-	d, err := m_k8s.NewCStorVolumeYml("CstorVolume", m.runtask.Spec.Task, m.templateValues)
+func (m *executor) asCStorVolume() (*v1alpha1.CStorVolume, error) {
+	d, err := m_k8s.NewCStorVolumeYml("CstorVolume", m.Runtask.Spec.Task, m.Values)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to build cstorvolume")
 	}
 
 	return d.AsCStorVolumeYml()
@@ -552,10 +653,10 @@ func (m *taskExecutor) asCStorVolume() (*v1alpha1.CStorVolume, error) {
 
 // asCstorVolumeReplica generates a CStorVolumeReplica object
 // out of the embedded yaml
-func (m *taskExecutor) asCstorVolumeReplica() (*v1alpha1.CStorVolumeReplica, error) {
-	d, err := m_k8s.NewCStorVolumeReplicaYml("CstorVolumeReplica", m.runtask.Spec.Task, m.templateValues)
+func (m *executor) asCstorVolumeReplica() (*v1alpha1.CStorVolumeReplica, error) {
+	d, err := m_k8s.NewCStorVolumeReplicaYml("CstorVolumeReplica", m.Runtask.Spec.Task, m.Values)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to build cstorvolumereplica")
 	}
 
 	return d.AsCStorVolumeReplicaYml()
@@ -563,111 +664,116 @@ func (m *taskExecutor) asCstorVolumeReplica() (*v1alpha1.CStorVolumeReplica, err
 
 // asCoreV1Svc generates a K8s Service object
 // out of the embedded yaml
-func (m *taskExecutor) asCoreV1Svc() (*api_core_v1.Service, error) {
-	s, err := m_k8s.NewServiceYml("CoreV1Svc", m.runtask.Spec.Task, m.templateValues)
+func (m *executor) asCoreV1Svc() (*api_core_v1.Service, error) {
+	s, err := m_k8s.NewServiceYml("CoreV1Svc", m.Runtask.Spec.Task, m.Values)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to build service")
 	}
 
 	return s.AsCoreV1Service()
 }
 
 // putBatchV1Job will put a Job object
-func (m *taskExecutor) putBatchV1Job() (err error) {
+func (m *executor) putBatchV1Job() error {
 	j, err := m.asBatchV1Job()
 	if err != nil {
-		return
+
+		return errors.Wrap(err, "failed to create job")
 	}
+
 	job, err := m.getK8sClient().CreateBatchV1JobAsRaw(j)
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to create job")
 	}
-	util.SetNestedField(m.templateValues, job, string(v1alpha1.CurrentJSONResultTLP))
-	return
+
+	util.SetNestedField(m.Values, job, string(v1alpha1.CurrentJSONResultTLP))
+	return nil
 }
 
 // putAppsV1STS will create a new StatefulSet
 // object in the cluster and store the response
 // in a json format
-func (m *taskExecutor) putAppsV1STS() (err error) {
+func (m *executor) putAppsV1STS() error {
 	j, err := m.asAppsV1STS()
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to create statefulset")
 	}
+
 	sts, err := m.getK8sClient().CreateAppsV1STSAsRaw(j)
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to create statefulset")
 	}
-	util.SetNestedField(m.templateValues, sts, string(v1alpha1.CurrentJSONResultTLP))
-	return
+
+	util.SetNestedField(m.Values, sts, string(v1alpha1.CurrentJSONResultTLP))
+	return nil
 }
 
 // putAppsV1B1Deploy will put (i.e. apply to a kubernetes cluster) a Deployment
 // object. The Deployment specs is configured in the RunTask.
-func (m *taskExecutor) putAppsV1B1Deploy() (err error) {
+func (m *executor) putAppsV1B1Deploy() error {
 	d, err := m.asAppsV1B1Deploy()
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to create deployment")
 	}
 
 	deploy, err := m.getK8sClient().CreateAppsV1B1DeploymentAsRaw(d)
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to create deployment")
 	}
 
-	util.SetNestedField(m.templateValues, deploy, string(v1alpha1.CurrentJSONResultTLP))
-	return
+	util.SetNestedField(m.Values, deploy, string(v1alpha1.CurrentJSONResultTLP))
+	return nil
 }
 
 // putExtnV1B1Deploy will put (i.e. apply to kubernetes cluster) a Deployment
 // whose specifications are defined in the RunTask
-func (m *taskExecutor) putExtnV1B1Deploy() (err error) {
+func (m *executor) putExtnV1B1Deploy() error {
 	d, err := m.asExtnV1B1Deploy()
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to create deployment")
 	}
 
 	deploy, err := m.getK8sClient().CreateExtnV1B1DeploymentAsRaw(d)
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to create deployment")
 	}
 
-	util.SetNestedField(m.templateValues, deploy, string(v1alpha1.CurrentJSONResultTLP))
-	return
+	util.SetNestedField(m.Values, deploy, string(v1alpha1.CurrentJSONResultTLP))
+	return nil
 }
 
 // patchSPC will patch a SPC object in a kubernetes cluster.
 // The patch specifications as configured in the RunTask
-func (m *taskExecutor) patchOEV1alpha1SPC() (err error) {
-	patch, err := asTaskPatch("patchSPC", m.runtask.Spec.Task, m.templateValues)
+func (m *executor) patchOEV1alpha1SPC() error {
+	patch, err := asTaskPatch("patchSPC", m.Runtask.Spec.Task, m.Values)
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to patch storagepoolclaim")
 	}
 
 	pe, err := newTaskPatchExecutor(patch)
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to patch storagepoolclaim")
 	}
 
 	raw, err := pe.toJson()
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to patch storagepoolclaim")
 	}
 
-	// patch the SPC
+	// patch storagepoolclaim
 	spc, err := m.getK8sClient().PatchOEV1alpha1SPCAsRaw(m.getTaskObjectName(), pe.patchType(), raw)
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to patch storagepoolclaim")
 	}
 
-	util.SetNestedField(m.templateValues, spc, string(v1alpha1.CurrentJSONResultTLP))
-	return
+	util.SetNestedField(m.Values, spc, string(v1alpha1.CurrentJSONResultTLP))
+	return nil
 }
 
 // patchOEV1alpha1CSPC will patch a CSPC object in a kubernetes cluster.
 // The patch specifications as configured in the RunTask
-func (m *taskExecutor) patchOEV1alpha1CSPC() (err error) {
-	patch, err := asTaskPatch("patchSPC", m.runtask.Spec.Task, m.templateValues)
+func (m *executor) patchOEV1alpha1CSPC() (err error) {
+	patch, err := asTaskPatch("patchSPC", m.Runtask.Spec.Task, m.Values)
 	if err != nil {
 		return
 	}
@@ -688,82 +794,103 @@ func (m *taskExecutor) patchOEV1alpha1CSPC() (err error) {
 		return
 	}
 
-	util.SetNestedField(m.templateValues, cspc, string(v1alpha1.CurrentJSONResultTLP))
+	util.SetNestedField(m.Values, cspc, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
 
 // patchOEV1alpha1CSV will patch a CStorVolume as defined in the task
-func (m *taskExecutor) patchOEV1alpha1CSV() (err error) {
-	patch, err := asTaskPatch("patchCSV", m.runtask.Spec.Task, m.templateValues)
+func (m *executor) patchOEV1alpha1CSV() error {
+	patch, err := asTaskPatch("patchCSV", m.Runtask.Spec.Task, m.Values)
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to patch cstorvolume")
 	}
+
 	pe, err := newTaskPatchExecutor(patch)
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to patch cstorvolume")
 	}
+
 	raw, err := pe.toJson()
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to patch cstorvolume")
 	}
-	// patch the CStor Volume
-	csv, err := m.getK8sClient().PatchOEV1alpha1CSV(m.getTaskObjectName(), m.getTaskRunNamespace(), pe.patchType(), raw)
+
+	// patch the cstorvolume
+	csv, err := m.getK8sClient().PatchOEV1alpha1CSV(
+		m.getTaskObjectName(),
+		m.getTaskRunNamespace(),
+		pe.patchType(),
+		raw,
+	)
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to patch cstorvolume")
 	}
-	util.SetNestedField(m.templateValues, csv, string(v1alpha1.CurrentJSONResultTLP))
-	return
+
+	util.SetNestedField(m.Values, csv, string(v1alpha1.CurrentJSONResultTLP))
+	return nil
 }
 
 // patchOEV1alpha1CVR will patch a CStorVolumeReplica as defined in the task
-func (m *taskExecutor) patchOEV1alpha1CVR() (err error) {
-	patch, err := asTaskPatch("patchCVR", m.runtask.Spec.Task, m.templateValues)
+func (m *executor) patchOEV1alpha1CVR() error {
+	patch, err := asTaskPatch("patchCVR", m.Runtask.Spec.Task, m.Values)
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to patch cstorvolumereplica")
 	}
+
 	pe, err := newTaskPatchExecutor(patch)
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to patch cstorvolumereplica")
 	}
+
 	raw, err := pe.toJson()
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to patch cstorvolumereplica")
 	}
-	// patch the CStor Volume Replica
-	cvr, err := m.getK8sClient().PatchOEV1alpha1CVR(m.getTaskObjectName(), m.getTaskRunNamespace(), pe.patchType(), raw)
+
+	// patch cstorvolumereplica
+	cvr, err := m.getK8sClient().PatchOEV1alpha1CVR(
+		m.getTaskObjectName(),
+		m.getTaskRunNamespace(),
+		pe.patchType(),
+		raw,
+	)
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to patch cstorvolumereplica")
 	}
-	util.SetNestedField(m.templateValues, cvr, string(v1alpha1.CurrentJSONResultTLP))
-	return
+
+	util.SetNestedField(m.Values, cvr, string(v1alpha1.CurrentJSONResultTLP))
+	return nil
 }
 
-// patchUpgradeResult will patch an UpgradeResult as defined in the task
-func (m *taskExecutor) patchUpgradeResult() (err error) {
+// patchUpgradeResult will patch an UpgradeResult
+// as defined in the task
+func (m *executor) patchUpgradeResult() error {
 	// build a runtask patch instance
 	patch, err := patch.
-		BuilderForRuntask("UpgradeResult", m.runtask.Spec.Task, m.templateValues).
+		BuilderForRuntask("UpgradeResult", m.Runtask.Spec.Task, m.Values).
 		AddCheckf(patch.IsValidType(), "IsValidType").
 		Build()
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to patch upgraderesult")
 	}
+
 	// patch Upgrade Result
 	p, err := upgraderesult.
 		KubeClient(upgraderesult.WithNamespace(m.getTaskRunNamespace())).
 		Patch(m.getTaskObjectName(), patch.Type, patch.Object)
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to patch upgraderesult")
 	}
-	util.SetNestedField(m.templateValues, p, string(v1alpha1.CurrentJSONResultTLP))
-	return
+
+	util.SetNestedField(m.Values, p, string(v1alpha1.CurrentJSONResultTLP))
+	return nil
 }
 
 // patchStoragePool will patch an StoragePool as defined in the task
-func (m *taskExecutor) patchStoragePool() (err error) {
+func (m *executor) patchStoragePool() (err error) {
 	// build a runtask patch instance
 	patch, err := patch.
-		BuilderForRuntask("StoragePool", m.runtask.Spec.Task, m.templateValues).
+		BuilderForRuntask("StoragePool", m.Runtask.Spec.Task, m.Values).
 		AddCheckf(patch.IsValidType(), "patch type is not valid").
 		Build()
 	if err != nil {
@@ -776,14 +903,14 @@ func (m *taskExecutor) patchStoragePool() (err error) {
 	if err != nil {
 		return
 	}
-	util.SetNestedField(m.templateValues, p, string(v1alpha1.CurrentJSONResultTLP))
+	util.SetNestedField(m.Values, p, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
 
 // patchCstorPool will patch an CstorPool as defined in the task
-func (m *taskExecutor) patchCstorPool() (err error) {
+func (m *executor) patchCstorPool() (err error) {
 	patch, err := patch.
-		BuilderForRuntask("CstorPool", m.runtask.Spec.Task, m.templateValues).
+		BuilderForRuntask("CstorPool", m.Runtask.Spec.Task, m.Values).
 		AddCheckf(patch.IsValidType(), "patch type is not valid").
 		Build()
 	if err != nil {
@@ -796,252 +923,276 @@ func (m *taskExecutor) patchCstorPool() (err error) {
 	if err != nil {
 		return
 	}
-	util.SetNestedField(m.templateValues, p, string(v1alpha1.CurrentJSONResultTLP))
+	util.SetNestedField(m.Values, p, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
 
 // patchAppsV1B1Deploy will patch a Deployment object in a kubernetes cluster.
 // The patch specifications as configured in the RunTask
-func (m *taskExecutor) patchAppsV1B1Deploy() (err error) {
+func (m *executor) patchAppsV1B1Deploy() (err error) {
 	err = fmt.Errorf("patchAppsV1B1Deploy is not implemented")
 	return
 }
 
-// patchExtnV1B1Deploy will patch a Deployment where the patch specifications
-// are configured in the RunTask
-func (m *taskExecutor) patchExtnV1B1Deploy() (err error) {
-	patch, err := asTaskPatch("ExtnV1B1DeployPatch", m.runtask.Spec.Task, m.templateValues)
+// patchExtnV1B1Deploy will patch a Deployment
+// object where patch specifications are
+// configured in the RunTask
+func (m *executor) patchExtnV1B1Deploy() error {
+	patch, err := asTaskPatch("ExtnV1B1DeployPatch", m.Runtask.Spec.Task, m.Values)
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to patch deployment")
 	}
 
 	pe, err := newTaskPatchExecutor(patch)
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to patch deployment")
 	}
 
 	raw, err := pe.toJson()
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to patch deployment")
 	}
 
 	// patch the deployment
-	deploy, err := m.getK8sClient().PatchExtnV1B1DeploymentAsRaw(m.getTaskObjectName(), pe.patchType(), raw)
+	deploy, err := m.getK8sClient().PatchExtnV1B1DeploymentAsRaw(
+		m.getTaskObjectName(),
+		pe.patchType(),
+		raw,
+	)
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to patch deployment")
 	}
 
-	util.SetNestedField(m.templateValues, deploy, string(v1alpha1.CurrentJSONResultTLP))
-	return
+	util.SetNestedField(m.Values, deploy, string(v1alpha1.CurrentJSONResultTLP))
+	return nil
 }
 
-// patchCoreV1Service will patch a Service where the patch specifications
-// are configured in the RunTask
-func (m *taskExecutor) patchCoreV1Service() (err error) {
-	patch, err := asTaskPatch("CoreV1ServicePatch", m.runtask.Spec.Task, m.templateValues)
+// patchCoreV1Service will patch a Service
+// where patch specifications are configured
+// in the RunTask
+func (m *executor) patchCoreV1Service() error {
+	patch, err := asTaskPatch("CoreV1ServicePatch", m.Runtask.Spec.Task, m.Values)
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to patch service")
 	}
+
 	pe, err := newTaskPatchExecutor(patch)
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to patch service")
 	}
+
 	raw, err := pe.toJson()
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to patch service")
 	}
-	// patch the service
-	service, err := m.getK8sClient().PatchCoreV1ServiceAsRaw(m.getTaskObjectName(), pe.patchType(), raw)
+
+	// patch service
+	service, err := m.getK8sClient().PatchCoreV1ServiceAsRaw(
+		m.getTaskObjectName(),
+		pe.patchType(),
+		raw,
+	)
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to patch service")
 	}
-	util.SetNestedField(m.templateValues, service, string(v1alpha1.CurrentJSONResultTLP))
-	return
+
+	util.SetNestedField(m.Values, service, string(v1alpha1.CurrentJSONResultTLP))
+	return nil
 }
 
-// deleteAppsV1B1Deployment will delete one or more Deployments as specified in
-// the RunTask
-func (m *taskExecutor) deleteAppsV1B1Deployment() (err error) {
+// deleteAppsV1B1Deployment will delete one or
+// more Deployments as specified in the RunTask
+func (m *executor) deleteAppsV1B1Deployment() error {
 	objectNames := strings.Split(strings.TrimSpace(m.getTaskObjectName()), ",")
 
 	for _, name := range objectNames {
-		err = m.getK8sClient().DeleteAppsV1B1Deployment(strings.TrimSpace(name))
+		err := m.getK8sClient().DeleteAppsV1B1Deployment(strings.TrimSpace(name))
 		if err != nil {
-			return
+			return errors.Wrapf(err, "failed to delete deployment {%s}", name)
 		}
 	}
 
-	return
+	return nil
 }
 
-// deleteOEV1alpha1CVR will delete one or more CStorVolumeReplica as specified in
+// deleteOEV1alpha1CVR will delete one or more
+// CStorVolumeReplica as specified in
 // the RunTask
-func (m *taskExecutor) deleteOEV1alpha1CVR() (err error) {
+func (m *executor) deleteOEV1alpha1CVR() error {
 	objectNames := strings.Split(strings.TrimSpace(m.getTaskObjectName()), ",")
 
 	for _, name := range objectNames {
-		err = m.getK8sClient().DeleteOEV1alpha1CVR(name)
+		err := m.getK8sClient().DeleteOEV1alpha1CVR(name)
 		if err != nil {
-			return
+			return errors.Wrapf(err, "failed to delete cstorvolumereplica {%s}", name)
 		}
 	}
 
-	return
+	return nil
 }
 
-// deleteExtnV1B1Deployment will delete one or more Deployments as specified in
-// the RunTask
-func (m *taskExecutor) deleteExtnV1B1Deployment() (err error) {
+// deleteExtnV1B1Deployment will delete one or
+// more Deployments as specified in the RunTask
+func (m *executor) deleteExtnV1B1Deployment() error {
 	objectNames := strings.Split(strings.TrimSpace(m.getTaskObjectName()), ",")
 
 	for _, name := range objectNames {
-		err = m.getK8sClient().DeleteExtnV1B1Deployment(strings.TrimSpace(name))
+		err := m.getK8sClient().DeleteExtnV1B1Deployment(strings.TrimSpace(name))
 		if err != nil {
-			return
+			return errors.Wrapf(err, "failed to delete deployment {%s}", name)
 		}
 	}
 
-	return
+	return nil
 }
 
-// getExtnV1B1ReplicaSet will get the Replicaset as specified in the RunTask
-func (m *taskExecutor) getExtnV1B1ReplicaSet() (err error) {
+// getExtnV1B1ReplicaSet will get the Replicaset
+// as specified in the RunTask
+func (m *executor) getExtnV1B1ReplicaSet() error {
 	rs, err := replicaset.
 		KubeClient(replicaset.WithNamespace(m.getTaskRunNamespace())).
 		GetRaw(m.getTaskObjectName())
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to get replicaset")
 	}
 
-	util.SetNestedField(m.templateValues, rs, string(v1alpha1.CurrentJSONResultTLP))
-	return
+	util.SetNestedField(m.Values, rs, string(v1alpha1.CurrentJSONResultTLP))
+	return nil
 }
 
-// deleteExtnV1B1ReplicaSet will delete one or more ReplicaSets as specified in
-// the RunTask
-func (m *taskExecutor) deleteExtnV1B1ReplicaSet() (err error) {
+// deleteExtnV1B1ReplicaSet will delete one or
+// more ReplicaSets as specified in the RunTask
+func (m *executor) deleteExtnV1B1ReplicaSet() error {
 	objectNames := strings.Split(strings.TrimSpace(m.getTaskObjectName()), ",")
 	client := replicaset.KubeClient(
 		replicaset.WithNamespace(m.getTaskRunNamespace()))
 
 	for _, name := range objectNames {
-		err = client.Delete(strings.TrimSpace(name))
+		err := client.Delete(strings.TrimSpace(name))
 		if err != nil {
-			return
+			return errors.Wrapf(err, "failed to delete replicaset {%s}", name)
 		}
 	}
-	return
+
+	return nil
 }
 
-func (m *taskExecutor) listExtnV1B1ReplicaSet(opt metav1.ListOptions) ([]byte, error) {
+// listExtnV1B1ReplicaSet lists the replica sets
+// based on the provided list options
+func (m *executor) listExtnV1B1ReplicaSet(opt metav1.ListOptions) ([]byte, error) {
 	return replicaset.
 		KubeClient(replicaset.WithNamespace(m.getTaskRunNamespace())).
 		ListRaw(opt)
 }
 
-// putCoreV1Service will put a Service whose specs are configured in the RunTask
-func (m *taskExecutor) putCoreV1Service() (err error) {
+// putCoreV1Service will create a Service whose
+// specs are configured in the RunTask
+func (m *executor) putCoreV1Service() error {
 	s, err := m.asCoreV1Svc()
 	if err != nil {
-		return
+		return errors.Wrapf(err, "failed to create service")
 	}
 
 	svc, err := m.getK8sClient().CreateCoreV1ServiceAsRaw(s)
 	if err != nil {
-		return
+		return errors.Wrapf(err, "failed to create service")
 	}
 
-	util.SetNestedField(m.templateValues, svc, string(v1alpha1.CurrentJSONResultTLP))
-	return
+	util.SetNestedField(m.Values, svc, string(v1alpha1.CurrentJSONResultTLP))
+	return nil
 }
 
-// deleteCoreV1Service will delete one or more services as specified in
-// the RunTask
-func (m *taskExecutor) deleteCoreV1Service() (err error) {
+// deleteCoreV1Service will delete one or more
+// services as specified in the RunTask
+func (m *executor) deleteCoreV1Service() error {
 	objectNames := strings.Split(strings.TrimSpace(m.getTaskObjectName()), ",")
 
 	for _, name := range objectNames {
-		err = m.getK8sClient().DeleteCoreV1Service(strings.TrimSpace(name))
+		err := m.getK8sClient().DeleteCoreV1Service(strings.TrimSpace(name))
 		if err != nil {
-			return
+			return errors.Wrapf(err, "failed to delete service {%s}", name)
 		}
 	}
 
-	return
+	return nil
 }
 
-// getOEV1alpha1Disk() will get the Disk as specified in the RunTask
-func (m *taskExecutor) getOEV1alpha1Disk() (err error) {
+// getOEV1alpha1Disk() will get the Disk
+// as specified in the RunTask
+func (m *executor) getOEV1alpha1Disk() error {
 	disk, err := m.getK8sClient().GetOEV1alpha1DiskAsRaw(m.getTaskObjectName())
 	if err != nil {
-		return
+		return errors.Wrapf(err, "failed to get disk")
 	}
 
-	util.SetNestedField(m.templateValues, disk, string(v1alpha1.CurrentJSONResultTLP))
-	return
+	util.SetNestedField(m.Values, disk, string(v1alpha1.CurrentJSONResultTLP))
+	return nil
 }
 
-// getOEV1alpha1SPC() will get the StoragePoolClaim as specified in the RunTask
-func (m *taskExecutor) getOEV1alpha1SPC() (err error) {
+// getOEV1alpha1SPC() will get the StoragePoolClaim
+// as specified in the RunTask
+func (m *executor) getOEV1alpha1SPC() error {
 	spc, err := m.getK8sClient().GetOEV1alpha1SPCAsRaw(m.getTaskObjectName())
 	if err != nil {
-		return
+		return errors.Wrapf(err, "failed to get storagepoolclaim")
 	}
 
-	util.SetNestedField(m.templateValues, spc, string(v1alpha1.CurrentJSONResultTLP))
-	return
+	util.SetNestedField(m.Values, spc, string(v1alpha1.CurrentJSONResultTLP))
+	return nil
 }
 
 // getOEV1alpha1CSPC() will get the CStorPoolCluster as specified in the RunTask
-func (m *taskExecutor) getOEV1alpha1CSPC() (err error) {
+func (m *executor) getOEV1alpha1CSPC() (err error) {
 	cspc, err := m.getK8sClient().GetOEV1alpha1CSPCAsRaw(m.getTaskObjectName())
 	if err != nil {
 		return
 	}
 
-	util.SetNestedField(m.templateValues, cspc, string(v1alpha1.CurrentJSONResultTLP))
+	util.SetNestedField(m.Values, cspc, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
 
 // getOEV1alpha1SP will get the StoragePool as specified in the RunTask
-func (m *taskExecutor) getOEV1alpha1SP() (err error) {
+func (m *executor) getOEV1alpha1SP() (err error) {
 	sp, err := m.getK8sClient().GetOEV1alpha1SPAsRaw(m.getTaskObjectName())
 	if err != nil {
-		return
+		return errors.Wrapf(err, "failed to get storagepool")
 	}
 
-	util.SetNestedField(m.templateValues, sp, string(v1alpha1.CurrentJSONResultTLP))
-	return
+	util.SetNestedField(m.Values, sp, string(v1alpha1.CurrentJSONResultTLP))
+	return nil
 }
 
-// getOEV1alpha1SP will get the CstorPool as specified in the RunTask
-func (m *taskExecutor) getOEV1alpha1CSP() (err error) {
-	sp, err := m.getK8sClient().GetOEV1alpha1CSPAsRaw(m.getTaskObjectName())
+func (m *executor) getOEV1alpha1CSP() error {
+	csp, err := m.getK8sClient().GetOEV1alpha1CSPAsRaw(m.getTaskObjectName())
 	if err != nil {
-		return
+		return errors.Wrapf(err, "failed to get cstorstoragepool")
 	}
 
-	util.SetNestedField(m.templateValues, sp, string(v1alpha1.CurrentJSONResultTLP))
-	return
+	util.SetNestedField(m.Values, csp, string(v1alpha1.CurrentJSONResultTLP))
+	return nil
 }
 
-// getOEV1alpha1UR will get the UpgradeResult as specified in the RunTask
-func (m *taskExecutor) getOEV1alpha1UR() (err error) {
-	uc := upgraderesult.KubeClient(upgraderesult.WithNamespace(m.getTaskRunNamespace()))
-	uresult, err := uc.Get(m.getTaskObjectName(), metav1.GetOptions{})
+// getOEV1alpha1UR will get the UpgradeResult
+// as specified in the RunTask
+func (m *executor) getOEV1alpha1UR() error {
+	uresult, err := upgraderesult.
+		KubeClient(upgraderesult.WithNamespace(m.getTaskRunNamespace())).
+		Get(m.getTaskObjectName(), metav1.GetOptions{})
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to get upgraderesult")
 	}
 	ur, err := json.Marshal(uresult)
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to get upgraderesult")
 	}
-	util.SetNestedField(m.templateValues, ur, string(v1alpha1.CurrentJSONResultTLP))
-	return
+
+	util.SetNestedField(m.Values, ur, string(v1alpha1.CurrentJSONResultTLP))
+	return nil
 }
 
 // getExtnV1B1Deployment will get the Deployment as specified in the RunTask
-func (m *taskExecutor) getExtnV1B1Deployment() (err error) {
+func (m *executor) getExtnV1B1Deployment() (err error) {
 	dclient := deploy_extnv1beta1.KubeClient(
 		deploy_extnv1beta1.WithNamespace(m.getTaskRunNamespace()),
 		deploy_extnv1beta1.WithClientset(m.getK8sClient().GetKCS()))
@@ -1050,12 +1201,12 @@ func (m *taskExecutor) getExtnV1B1Deployment() (err error) {
 		return
 	}
 
-	util.SetNestedField(m.templateValues, d, string(v1alpha1.CurrentJSONResultTLP))
+	util.SetNestedField(m.Values, d, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
 
 // extnV1B1DeploymentRollOutStatus generates rollout status for a given deployment from deployment object
-func (m *taskExecutor) extnV1B1DeploymentRollOutStatus() (err error) {
+func (m *executor) extnV1B1DeploymentRollOutStatus() (err error) {
 	dclient := deploy_extnv1beta1.KubeClient(
 		deploy_extnv1beta1.WithNamespace(m.getTaskRunNamespace()),
 		deploy_extnv1beta1.WithClientset(m.getK8sClient().GetKCS()))
@@ -1064,12 +1215,12 @@ func (m *taskExecutor) extnV1B1DeploymentRollOutStatus() (err error) {
 		return
 	}
 
-	util.SetNestedField(m.templateValues, res, string(v1alpha1.CurrentJSONResultTLP))
+	util.SetNestedField(m.Values, res, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
 
 // getAppsV1DeploymentRollOutStatus generates rollout status for a given deployment from deployment object
-func (m *taskExecutor) appsV1DeploymentRollOutStatus() (err error) {
+func (m *executor) appsV1DeploymentRollOutStatus() (err error) {
 	dclient := deploy_appsv1.KubeClient(
 		deploy_appsv1.WithNamespace(m.getTaskRunNamespace()),
 		deploy_appsv1.WithClientset(m.getK8sClient().GetKCS()))
@@ -1078,55 +1229,55 @@ func (m *taskExecutor) appsV1DeploymentRollOutStatus() (err error) {
 		return
 	}
 
-	util.SetNestedField(m.templateValues, res, string(v1alpha1.CurrentJSONResultTLP))
+	util.SetNestedField(m.Values, res, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
 
 // getAppsV1Deployment will get the Deployment as specified in the RunTask
-func (m *taskExecutor) getAppsV1Deployment() (err error) {
+func (m *executor) getAppsV1Deployment() (err error) {
 	dclient := deploy_appsv1.KubeClient(
 		deploy_appsv1.WithNamespace(m.getTaskRunNamespace()),
 		deploy_appsv1.WithClientset(m.getK8sClient().GetKCS()))
 	d, err := dclient.GetRaw(m.getTaskObjectName())
 
-	util.SetNestedField(m.templateValues, d, string(v1alpha1.CurrentJSONResultTLP))
+	util.SetNestedField(m.Values, d, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
 
 // getCoreV1PVC will get the PVC as specified in the RunTask
-func (m *taskExecutor) getCoreV1PVC() (err error) {
+func (m *executor) getCoreV1PVC() (err error) {
 	pvc, err := m.getK8sClient().GetCoreV1PVCAsRaw(m.getTaskObjectName())
 	if err != nil {
 		return
 	}
 
-	util.SetNestedField(m.templateValues, pvc, string(v1alpha1.CurrentJSONResultTLP))
+	util.SetNestedField(m.Values, pvc, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
 
 // getCoreV1PV will get the PersistentVolume as specified in the RunTask
-func (m *taskExecutor) getCoreV1PV() (err error) {
+func (m *executor) getCoreV1PV() (err error) {
 	pv, err := m.getK8sClient().GetCoreV1PersistentVolumeAsRaw(m.getTaskObjectName())
 	if err != nil {
 		return
 	}
 
-	util.SetNestedField(m.templateValues, pv, string(v1alpha1.CurrentJSONResultTLP))
+	util.SetNestedField(m.Values, pv, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
 
 // getBatchV1Job will get the Job as specified in the RunTask
-func (m *taskExecutor) getBatchV1Job() (err error) {
+func (m *executor) getBatchV1Job() (err error) {
 	job, err := m.getK8sClient().GetBatchV1JobAsRaw(m.getTaskObjectName())
 	if err != nil {
 		return
 	}
-	util.SetNestedField(m.templateValues, job, string(v1alpha1.CurrentJSONResultTLP))
+	util.SetNestedField(m.Values, job, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
 
 // getCoreV1Pod will get the Pod as specified in the RunTask
-func (m *taskExecutor) getCoreV1Pod() (err error) {
+func (m *executor) getCoreV1Pod() (err error) {
 	podClient := pod.NewKubeClient(pod.WithNamespace(m.getTaskRunNamespace()))
 
 	pod, err := podClient.GetRaw(m.getTaskObjectName(), metav1.GetOptions{})
@@ -1134,12 +1285,12 @@ func (m *taskExecutor) getCoreV1Pod() (err error) {
 		return
 	}
 
-	util.SetNestedField(m.templateValues, pod, string(v1alpha1.CurrentJSONResultTLP))
+	util.SetNestedField(m.Values, pod, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
 
 // deleteBatchV1Job will delete one or more Jobs specified in the RunTask
-func (m *taskExecutor) deleteBatchV1Job() (err error) {
+func (m *executor) deleteBatchV1Job() (err error) {
 	jobs := strings.Split(strings.TrimSpace(m.getTaskObjectName()), ",")
 	for _, name := range jobs {
 		err = m.getK8sClient().DeleteBatchV1Job(strings.TrimSpace(name))
@@ -1151,7 +1302,7 @@ func (m *taskExecutor) deleteBatchV1Job() (err error) {
 }
 
 // deleteAppsV1STS will delete one or more StatefulSets
-func (m *taskExecutor) deleteAppsV1STS() (err error) {
+func (m *executor) deleteAppsV1STS() (err error) {
 	stss := strings.Split(strings.TrimSpace(m.getTaskObjectName()), ",")
 	for _, name := range stss {
 		err = m.getK8sClient().DeleteAppsV1STS(strings.TrimSpace(name))
@@ -1163,18 +1314,18 @@ func (m *taskExecutor) deleteAppsV1STS() (err error) {
 }
 
 // getStorageV1SC will get the StorageClass as specified in the RunTask
-func (m *taskExecutor) getStorageV1SC() (err error) {
+func (m *executor) getStorageV1SC() (err error) {
 	sc, err := m.getK8sClient().GetStorageV1SCAsRaw(m.getTaskObjectName())
 	if err != nil {
 		return
 	}
 
-	util.SetNestedField(m.templateValues, sc, string(v1alpha1.CurrentJSONResultTLP))
+	util.SetNestedField(m.Values, sc, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
 
 // putStoragePool will put a CStorPool as defined in the task
-func (m *taskExecutor) putStoragePool() (err error) {
+func (m *executor) putStoragePool() (err error) {
 	c, err := m.asStoragePool()
 	if err != nil {
 		return
@@ -1185,12 +1336,12 @@ func (m *taskExecutor) putStoragePool() (err error) {
 		return
 	}
 
-	util.SetNestedField(m.templateValues, storagePool, string(v1alpha1.CurrentJSONResultTLP))
+	util.SetNestedField(m.Values, storagePool, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
 
 // putCStorVolume will put a CStorVolume as defined in the task
-func (m *taskExecutor) putCStorPool() (err error) {
+func (m *executor) putCStorPool() (err error) {
 	c, err := m.asCStorPool()
 	if err != nil {
 		return
@@ -1201,12 +1352,12 @@ func (m *taskExecutor) putCStorPool() (err error) {
 		return
 	}
 
-	util.SetNestedField(m.templateValues, cstorPool, string(v1alpha1.CurrentJSONResultTLP))
+	util.SetNestedField(m.Values, cstorPool, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
 
 // putCStorVolume will put a CStorVolume as defined in the task
-func (m *taskExecutor) putCStorVolume() (err error) {
+func (m *executor) putCStorVolume() (err error) {
 	c, err := m.asCStorVolume()
 	if err != nil {
 		return
@@ -1217,12 +1368,12 @@ func (m *taskExecutor) putCStorVolume() (err error) {
 		return
 	}
 
-	util.SetNestedField(m.templateValues, cstorVolume, string(v1alpha1.CurrentJSONResultTLP))
+	util.SetNestedField(m.Values, cstorVolume, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
 
 // putCStorVolumeReplica will put a CStorVolumeReplica as defined in the task
-func (m *taskExecutor) putCStorVolumeReplica() (err error) {
+func (m *executor) putCStorVolumeReplica() (err error) {
 	d, err := m.asCstorVolumeReplica()
 	if err != nil {
 		return
@@ -1233,14 +1384,14 @@ func (m *taskExecutor) putCStorVolumeReplica() (err error) {
 		return
 	}
 
-	util.SetNestedField(m.templateValues, cstorVolumeReplica, string(v1alpha1.CurrentJSONResultTLP))
+	util.SetNestedField(m.Values, cstorVolumeReplica, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
 
 // putUpgradeResult will put an upgrade result as defined in the task
-func (m *taskExecutor) putUpgradeResult() (err error) {
+func (m *executor) putUpgradeResult() (err error) {
 	uresult, err := upgraderesult.
-		BuilderForRuntask("UpgradeResult", m.runtask.Spec.Task, m.templateValues).
+		BuilderForRuntask("UpgradeResult", m.Runtask.Spec.Task, m.Values).
 		Build()
 	if err != nil {
 		return
@@ -1251,13 +1402,13 @@ func (m *taskExecutor) putUpgradeResult() (err error) {
 	if err != nil {
 		return
 	}
-	util.SetNestedField(m.templateValues, uraw, string(v1alpha1.CurrentJSONResultTLP))
+	util.SetNestedField(m.Values, uraw, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
 
 // deleteOEV1alpha1SP will delete one or more StoragePool as specified in
 // the RunTask
-func (m *taskExecutor) deleteOEV1alpha1SP() (err error) {
+func (m *executor) deleteOEV1alpha1SP() (err error) {
 	objectNames := strings.Split(strings.TrimSpace(m.getTaskObjectName()), ",")
 
 	for _, name := range objectNames {
@@ -1272,7 +1423,7 @@ func (m *taskExecutor) deleteOEV1alpha1SP() (err error) {
 
 // deleteOEV1alpha1CSP will delete one or more CStorPool as specified in
 // the RunTask
-func (m *taskExecutor) deleteOEV1alpha1CSP() (err error) {
+func (m *executor) deleteOEV1alpha1CSP() (err error) {
 	objectNames := strings.Split(strings.TrimSpace(m.getTaskObjectName()), ",")
 
 	for _, name := range objectNames {
@@ -1287,7 +1438,7 @@ func (m *taskExecutor) deleteOEV1alpha1CSP() (err error) {
 
 // deleteOEV1alpha1CSV will delete one or more CStorVolume as specified in
 // the RunTask
-func (m *taskExecutor) deleteOEV1alpha1CSV() (err error) {
+func (m *executor) deleteOEV1alpha1CSV() (err error) {
 	objectNames := strings.Split(strings.TrimSpace(m.getTaskObjectName()), ",")
 
 	for _, name := range objectNames {
@@ -1303,8 +1454,8 @@ func (m *taskExecutor) deleteOEV1alpha1CSV() (err error) {
 // execCoreV1Pod runs given command remotely in given container of given pod
 // and post stdout and and stderr in JsonResult. You can get it using -
 // {{- jsonpath .JsonResult "{.Stdout}" | trim | saveAs "XXX" .TaskResult | noop -}}
-func (m *taskExecutor) execCoreV1Pod() (err error) {
-	podexecopts, err := podexec.WithTemplate("execCoreV1Pod", m.runtask.Spec.Task, m.templateValues).
+func (m *executor) execCoreV1Pod() (err error) {
+	podexecopts, err := podexec.WithTemplate("execCoreV1Pod", m.Runtask.Spec.Task, m.Values).
 		AsAPIPodExec()
 	if err != nil {
 		return
@@ -1315,25 +1466,25 @@ func (m *taskExecutor) execCoreV1Pod() (err error) {
 		return
 	}
 
-	util.SetNestedField(m.templateValues, result, string(v1alpha1.CurrentJSONResultTLP))
+	util.SetNestedField(m.Values, result, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
 
 // rolloutStatus generates rollout status of a given resource form it's object details
-func (m *taskExecutor) rolloutStatus() (err error) {
-	if m.metaTaskExec.isRolloutstatusExtnV1B1Deploy() {
+func (m *executor) rolloutStatus() (err error) {
+	if m.MetaExec.isRolloutstatusExtnV1B1Deploy() {
 		err = m.extnV1B1DeploymentRollOutStatus()
-	} else if m.metaTaskExec.isRolloutstatusAppsV1Deploy() {
+	} else if m.MetaExec.isRolloutstatusAppsV1Deploy() {
 		err = m.appsV1DeploymentRollOutStatus()
 	} else {
-		err = fmt.Errorf("failed to get rollout status : meta task not supported: task details '%+v'", m.metaTaskExec.getTaskIdentity())
+		err = fmt.Errorf("failed to get rollout status : meta task not supported: task details '%+v'", m.MetaExec.getTaskIdentity())
 	}
 	return
 }
 
 // listK8sResources will list resources as specified in the RunTask
-func (m *taskExecutor) listK8sResources() (err error) {
-	opts, err := m.metaTaskExec.getListOptions()
+func (m *executor) listK8sResources() (err error) {
+	opts, err := m.MetaExec.getListOptions()
 	if err != nil {
 		return
 	}
@@ -1341,34 +1492,34 @@ func (m *taskExecutor) listK8sResources() (err error) {
 	var op []byte
 	kc := m.getK8sClient()
 
-	if m.metaTaskExec.isListCoreV1Pod() {
+	if m.MetaExec.isListCoreV1Pod() {
 		op, err = kc.ListCoreV1PodAsRaw(opts)
-	} else if m.metaTaskExec.isListCoreV1Service() {
+	} else if m.MetaExec.isListCoreV1Service() {
 		op, err = kc.ListCoreV1ServiceAsRaw(opts)
-	} else if m.metaTaskExec.isListExtnV1B1Deploy() {
+	} else if m.MetaExec.isListExtnV1B1Deploy() {
 		op, err = kc.ListExtnV1B1DeploymentAsRaw(opts)
-	} else if m.metaTaskExec.isListExtnV1B1ReplicaSet() {
+	} else if m.MetaExec.isListExtnV1B1ReplicaSet() {
 		op, err = m.listExtnV1B1ReplicaSet(opts)
-	} else if m.metaTaskExec.isListAppsV1B1Deploy() {
+	} else if m.MetaExec.isListAppsV1B1Deploy() {
 		op, err = kc.ListAppsV1B1DeploymentAsRaw(opts)
-	} else if m.metaTaskExec.isListCoreV1PVC() {
+	} else if m.MetaExec.isListCoreV1PVC() {
 		op, err = kc.ListCoreV1PVCAsRaw(opts)
-	} else if m.metaTaskExec.isListCoreV1PV() {
+	} else if m.MetaExec.isListCoreV1PV() {
 		op, err = kc.ListCoreV1PVAsRaw(opts)
-	} else if m.metaTaskExec.isListOEV1alpha1Disk() {
+	} else if m.MetaExec.isListOEV1alpha1Disk() {
 		op, err = kc.ListOEV1alpha1DiskRaw(opts)
-	} else if m.metaTaskExec.isListOEV1alpha1SP() {
+	} else if m.MetaExec.isListOEV1alpha1SP() {
 		op, err = kc.ListOEV1alpha1SPRaw(opts)
-	} else if m.metaTaskExec.isListOEV1alpha1CSP() {
+	} else if m.MetaExec.isListOEV1alpha1CSP() {
 		op, err = kc.ListOEV1alpha1CSPRaw(opts)
-	} else if m.metaTaskExec.isListOEV1alpha1CVR() {
+	} else if m.MetaExec.isListOEV1alpha1CVR() {
 		op, err = kc.ListOEV1alpha1CVRRaw(opts)
-	} else if m.metaTaskExec.isListOEV1alpha1CV() {
+	} else if m.MetaExec.isListOEV1alpha1CV() {
 		op, err = kc.ListOEV1alpha1CVRaw(opts)
-	} else if m.metaTaskExec.isListOEV1alpha1UR() {
+	} else if m.MetaExec.isListOEV1alpha1UR() {
 		op, err = m.listOEV1alpha1URRaw(opts)
 	} else {
-		err = fmt.Errorf("failed to list k8s resources: meta task not supported: task details '%+v'", m.metaTaskExec.getTaskIdentity())
+		err = fmt.Errorf("failed to list k8s resources: meta task not supported: task details '%+v'", m.MetaExec.getTaskIdentity())
 	}
 
 	if err != nil {
@@ -1376,13 +1527,13 @@ func (m *taskExecutor) listK8sResources() (err error) {
 	}
 
 	// set the json doc result
-	util.SetNestedField(m.templateValues, op, string(v1alpha1.CurrentJSONResultTLP))
+	util.SetNestedField(m.Values, op, string(v1alpha1.CurrentJSONResultTLP))
 	return
 }
 
 // listOEV1alpha1URRaw fetches a list of UpgradeResults as per the
 // provided options
-func (m *taskExecutor) listOEV1alpha1URRaw(opts metav1.ListOptions) (result []byte, err error) {
+func (m *executor) listOEV1alpha1URRaw(opts metav1.ListOptions) (result []byte, err error) {
 	uc := upgraderesult.KubeClient(upgraderesult.WithNamespace(m.getTaskRunNamespace()))
 	urList, err := uc.List(opts)
 	if err != nil {

--- a/pkg/upgrade/result/v1alpha1/kubernetes.go
+++ b/pkg/upgrade/result/v1alpha1/kubernetes.go
@@ -83,16 +83,19 @@ func (k *kubeclient) withDefaults() {
 			return clientset.NewForConfig(config)
 		}
 	}
+
 	if k.list == nil {
 		k.list = func(cs *clientset.Clientset, namespace string, opts metav1.ListOptions) (*apis.UpgradeResultList, error) {
 			return cs.OpenebsV1alpha1().UpgradeResults(namespace).List(opts)
 		}
 	}
+
 	if k.get == nil {
-		k.get = func(cs *clientset.Clientset, name string, namespace string, opts metav1.GetOptions) (*apis.UpgradeResult, error) {
+		k.get = func(cs *clientset.Clientset, name, namespace string, opts metav1.GetOptions) (*apis.UpgradeResult, error) {
 			return cs.OpenebsV1alpha1().UpgradeResults(namespace).Get(name, opts)
 		}
 	}
+
 	if k.create == nil {
 		k.create = func(cs *clientset.Clientset, upgradeResultObj *apis.UpgradeResult,
 			namespace string) (*apis.UpgradeResult, error) {
@@ -101,6 +104,7 @@ func (k *kubeclient) withDefaults() {
 				Create(upgradeResultObj)
 		}
 	}
+
 	if k.patch == nil {
 		k.patch = func(cs *clientset.Clientset, name string,
 			pt types.PatchType, patchObj []byte,

--- a/pkg/volume/volume_template_engine.go
+++ b/pkg/volume/volume_template_engine.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	cast "github.com/openebs/maya/pkg/castemplate/v1alpha1"
-	"github.com/pkg/errors"
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 )
 
 // volumeEngine is capable of executing CAS volume
@@ -72,21 +72,21 @@ func NewVolumeEngine(
 	// fetch CAS config from  PersistentVolumeClaim
 	casConfPVC, err := cast.UnMarshallToConfig(casConfigPVC)
 	if err != nil {
-		err = errors.Wrapf(err, "failed to instantiate volume engine: invalid pvc cas config: %s", casConfigPVC)
+		err = errors.Wrapf(errors.WithStack(err), "failed to instantiate volume engine: invalid pvc cas config: %s", casConfigPVC)
 		return
 	}
 
 	// CAS config from StorageClass
 	casConfSC, err := cast.UnMarshallToConfig(casConfigSC)
 	if err != nil {
-		err = errors.Wrapf(err, "failed to instantiate volume engine: invalid sc cas config: %s", casConfigSC)
+		err = errors.Wrapf(errors.WithStack(err), "failed to instantiate volume engine: invalid sc cas config: %s", casConfigSC)
 		return
 	}
 
 	// make use of the generic CAS template engine
 	cEngine, err := cast.Engine(castObj, key, volumeValues)
 	if err != nil {
-		err = errors.Wrapf(err, "failed to instantiate volume engine")
+		err = errors.Wrapf(errors.WithStack(err), "failed to instantiate volume engine")
 		return
 	}
 


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Currently the logs are flooded with repeated error messages and debug messages which makes it difficult to find relevant information. This PR removes those repeated messages.

**Which issue this PR fixes** :
Earlier runtask failure log were having the pretty and inline objects both.
```
2019/04/30 09:24:04.199967 [DEBUG] http: Request /latest/meta-data/instance-id (49.668µs)
2019/04/30 09:24:04.200322 [DEBUG] http: Request /latest/volumes/ (GET)
I0430 09:24:04.200339       6 volume_endpoint_v1alpha1.go:77] received cas volume request: http method 'GET'
I0430 09:24:04.200350       6 volume_endpoint_v1alpha1.go:253] received volume list request
E0430 09:24:04.294134       6 runner.go:213] failed to execute runtask: name 'jiva-volume-list-listpv-default-0.9.0': meta yaml 'id: listlistpv
apiVersion: v1
kind: PersistentVolume
action: list
options: |-
  labelSelector: openebs.io/cas-type=jiva
': task yaml '': template values in yaml 'CAST:
  castName: jiva-volume-list-default-0.9.0
  kubeVersion: v1.14.0
  version: 0.9.0
Config: {}
JsonResult: --redacted--
ListItems:
  currentRepeatResource: runNamespace=::owner=::objectName=::options=::retry=::disable=false
  volumeList:
    default/pvc-36682d35-6b27-11e9-ad9b-e4115b455108:
      capacity: 4G, 4G
      clusterIP: 10.103.83.195
      controllerIP: 172.17.0.11
      controllerStatus: true true
      replicaIP: 172.17.0.9
      replicaStatus: "true"
    default/pvc-3e7cd37b-6b10-11e9-ad9b-e4115b455108:
      capacity: 4G, 4G
      clusterIP: 10.97.35.127
      controllerIP: 172.17.0.8
      controllerStatus: true true
      replicaIP: 172.17.0.4
      replicaStatus: "true"
TaskResult:
  listlistctrl:
    verifyErr: null
  listlistpv:
    verifyErr: null
  listlistrep:
    verifyErr: null
  listlistsvc:
    verifyErr: null
Volume:
  runNamespace: ""
': template values 'map[CAST:map[castName:jiva-volume-list-default-0.9.0 kubeVersion:v1.14.0 version:0.9.0] Config:map[] JsonResult:--redacted-- ListItems:map[currentRepeatResource:runNamespace=::owner=::objectName=::options=::retry=::disable=false volumeList:map[default/pvc-36682d35-6b27-11e9-ad9b-e4115b455108:map[capacity:4G, 4G clusterIP:10.103.83.195 controllerIP:172.17.0.11 controllerStatus:true true replicaIP:172.17.0.9 replicaStatus:true] default/pvc-3e7cd37b-6b10-11e9-ad9b-e4115b455108:map[capacity:4G, 4G clusterIP:10.97.35.127 controllerIP:172.17.0.8 controllerStatus:true true replicaIP:172.17.0.4 replicaStatus:true]]] TaskResult:map[listlistctrl:map[verifyErr:<nil>] listlistpv:map[verifyErr:<nil>] listlistrep:map[verifyErr:<nil>] listlistsvc:map[verifyErr:<nil>]] Volume:map[runNamespace:]]'
W0430 09:24:04.294195       6 runner.go:278] template: PostRunYamlTpl:2: undefined variable "$pvPairs": failed to execute runtasks
W0430 09:24:04.294206       6 runner.go:164] nothing to rollback: no rollback tasks were found
2019/04/30 09:24:04.294373 [ERR] http: Request GET /latest/volumes/, error: error: {failed to list volumes: cas template 'jiva-volume-list-default-0.9.0': template: PostRunYamlTpl:2: undefined variable "$pvPairs"}, msg: {failed to list volumes: 
casvolumelist {items: null
metadata:
  creationTimestamp: null
metalist: {}
}}
2019/04/30 09:24:04.294408 [DEBUG] http: Request /latest/volumes/ (94.085356ms)
```
Now the runtask failure only has the pretty object
```
2019/05/07 11:39:10.456545 [ERR] http: Request GET /latest/volumes/
{error(s) were found: template: PostRunYamlTpl:2: undefined variable "$pvPairs"
  --  failed to execute runtask: 
runtask {metadata:
  creationTimestamp: "2019-05-07T05:46:07Z"
  generation: 2
  labels:
    version: 0.9.0
  name: jiva-volume-list-listpv-default-0.9.0
  namespace: openebs
  resourceVersion: "48467"
  selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/runtasks/jiva-volume-list-listpv-default-0.9.0
  uid: 6916f592-708b-11e9-a966-e4115b455108
spec:
  meta: |
    id: listlistpv
    apiVersion: v1
    kind: PersistentVolume
    action: list
    options: |-
      labelSelector: openebs.io/cas-type=jiva
  post: |-
    - $pvPairs := jsonpath .JsonResult "{range .items[*]}pkey={@.metadata.name},accessModes={@.spec.accessModes[0]},storageClass={@.spec.storageClassName};{end}" | trim | default "" | splitList ";" -}}
    {{- $pvPairs | keyMap "pvList" .ListItems | noop -}}
  task: ""
} 
template values {CAST:
  castName: jiva-volume-list-default-0.9.0
  kubeVersion: v1.14.0
  version: 0.9.0
Config: {}
JsonResult: --redacted--
ListItems:
  currentRepeatResource: runNamespace=::owner=::objectName=::options=::retry=::disable=false
  volumeList:
    default/pvc-4e4c9529-708e-11e9-a966-e4115b455108:
      capacity: 5Gi
      clusterIP: 10.96.109.216
      controllerIP: 172.17.0.8
      controllerStatus: true true
      replicaIP: 172.17.0.9
      replicaStatus: "true"
TaskResult:
  listlistctrl:
    verifyErr: null
  listlistpv:
    verifyErr: null
  listlistrep:
    verifyErr: null
  listlistsvc:
    verifyErr: null
Volume:
  runNamespace: ""
}
      github.com/openebs/maya/pkg/volume.(*ListOperation).List
	/home/user/work/src/github.com/openebs/maya/pkg/volume/volume.go:422
  --  failed to list volumes: cas template 'jiva-volume-list-default-0.9.0'
  --  failed to list volumes: 
casvolumelist {items: null
metadata:
  creationTimestamp: null
metalist: {}
}}

```
 Earlier in case of volume `not found` there were two empty `CASVolume` objects
```
I0430 09:27:56.649952       6 volume_endpoint_v1alpha1.go:77] received cas volume request: http method 'GET'
I0430 09:27:56.649986       6 volume_endpoint_v1alpha1.go:162] received volume read request: pvc-36682d35-6b27-11e9-ad9b-e4115b45510
2019/04/30 09:27:56.663002 [ERR] http: Request GET /latest/volumes/pvc-36682d35-6b27-11e9-ad9b-e4115b45510, error: error: {failed to read volume: 
casvolume {cloneSpec: {}
metadata:
  creationTimestamp: null
  labels:
    openebs.io/storageclass: ""
  name: pvc-36682d35-6b27-11e9-ad9b-e4115b45510
  namespace: default
spec:
  accessMode: ""
  capacity: ""
  casType: ""
  fsType: ""
  iqn: ""
  lun: 0
  replicas: ""
  targetIP: ""
  targetPort: ""
  targetPortal: ""
status:
  Message: ""
  Phase: ""
  Reason: ""
}: persistentvolumes "pvc-36682d35-6b27-11e9-ad9b-e4115b45510" not found}, msg: {failed to read volume: volume 'pvc-36682d35-6b27-11e9-ad9b-e4115b45510' not found: 
casvolume {cloneSpec: {}
metadata:
  creationTimestamp: null
  labels:
    openebs.io/storageclass: ""
  name: pvc-36682d35-6b27-11e9-ad9b-e4115b45510
  namespace: default
spec:
  accessMode: ""
  capacity: ""
  casType: ""
  fsType: ""
  iqn: ""
  lun: 0
  replicas: ""
  targetIP: ""
  targetPort: ""
  targetPortal: ""
status:
  Message: ""
  Phase: ""
  Reason: ""
}}
```
Now there are no empty objects as they don't  provide any information and can be removed
```
2019/05/07 10:01:48.349746 [ERR] http: Request GET /latest/volumes/pvc-4e4c9529-708e-11e9-a966-e4115b45510
{error(s) were found: persistentvolumes "pvc-4e4c9529-708e-11e9-a966-e4115b45510" not found
      github.com/openebs/maya/pkg/volume.(*Operation).Read
	/home/user/work/src/github.com/openebs/maya/pkg/volume/volume.go:297
  --  failed to get PV for volume: 
casvolume {cloneSpec: {}
metadata:
  creationTimestamp: null
  labels:
    openebs.io/storageclass: ""
  name: pvc-4e4c9529-708e-11e9-a966-e4115b45510
  namespace: default
spec:
  accessMode: ""
  capacity: ""
  casType: ""
  fsType: ""
  iqn: ""
  lun: 0
  replicas: ""
  targetIP: ""
  targetPort: ""
  targetPortal: ""
status:
  Message: ""
  Phase: ""
  Reason: ""
}
  --  failed to read volume: volume {pvc-4e4c9529-708e-11e9-a966-e4115b45510} not found in namspace: {default}}

```
Also made changes to avoid printing objects in `mayactl`
```
user:my$ mayactl -m 10.105.230.47 volume list
Volume list error: error: {failed to list volumes: cas template 'jiva-volume-list-default-0.9.0': template: PostRunYamlTpl:2: undefined variable "$pvPairs"}, msg: {failed to list volumes: 
casvolumelist {items: null
metadata:
  creationTimestamp: null
metalist: {}
}}
```
which will be changed to 
```
user:my$ mayactl -m 10.105.230.47 volume list
Volume list error: error: {failed to list volumes: cas template 'jiva-volume-list-default-0.9.0': template: PostRunYamlTpl:2: undefined variable "$pvPairs"}, msg: {failed to list volumes}
```
**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests