### PR TITLE
Cherry-pick(exporter): add pool exporter yaml in runTask

### DIFF
--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -31,6 +31,10 @@ spec:
   # communicates with cstor iscsi target
   - name: CstorPoolImage
     value: {{env "OPENEBS_IO_CSTOR_POOL_IMAGE" | default "openebs/cstor-pool:latest"}}
+  # CstorPoolExporterImage is the container image that executes zpool and zfs binary
+  # to export various volume and pool metrics
+  - name: CstorPoolExporterImage
+    value: {{env "OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE" | default "openebs/m-exporter:latest"}}
   # CstorPoolMgmtImage runs cstor pool and cstor volume replica related CRUD
   # operations
   - name: CstorPoolMgmtImage
@@ -176,7 +180,7 @@ spec:
     {{- $auxResourceRequestsVal := fromYaml .Config.AuxResourceRequests.value -}}
     {{- $setAuxResourceLimits := .Config.AuxResourceLimits.value | default "none" -}}
     {{- $auxResourceLimitsVal := fromYaml .Config.AuxResourceLimits.value -}}
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1beta1
     kind: Deployment
     metadata:
       name: {{.TaskResult.putcstorpoolcr.objectName}}
@@ -186,6 +190,8 @@ spec:
         app: cstor-pool
         openebs.io/version: {{ .CAST.version }}
         openebs.io/cas-template-name: {{ .CAST.castName }}
+      annotations:
+        openebs.io/monitoring: pool_exporter_prometheus
       ownerReferences:
       - apiVersion: openebs.io/v1alpha1
         blockOwnerDeletion: true
@@ -205,6 +211,12 @@ spec:
           labels:
             app: cstor-pool
             openebs.io/storage-pool-claim: {{.Storagepool.owner}}
+            openebs.io/version: {{ .CAST.version }}
+          annotations:
+            openebs.io/monitoring: pool_exporter_prometheus
+            prometheus.io/path: /metrics
+            prometheus.io/port: "9500"
+            prometheus.io/scrape: "true"
         spec:
           serviceAccountName: {{ .Config.ServiceAccountName.value }}
           nodeSelector:
@@ -278,9 +290,6 @@ spec:
                 {{ $rKey }}: {{ $rLimit }}
               {{- end }}
               {{- end }}
-            ports:
-            - containerPort: 9500
-              protocol: TCP
             securityContext:
               privileged: true
             volumeMounts:
@@ -306,6 +315,39 @@ spec:
                   fieldPath: metadata.namespace
             - name: RESYNC_INTERVAL
               value: {{ .Config.ResyncInterval.value }}
+          - name: maya-exporter
+            image: {{ .Config.CstorPoolExporterImage.value }}
+            resources:
+              {{- if ne $setAuxResourceRequests "none" }}
+              requests:
+              {{- range $rKey, $rLimit := $auxResourceRequestsVal }}
+                {{ $rKey }}: {{ $rLimit }}
+              {{- end }}
+              {{- end }}
+              {{- if ne $setAuxResourceLimits "none" }}
+              limits:
+              {{- range $rKey, $rLimit := $auxResourceLimitsVal }}
+                {{ $rKey }}: {{ $rLimit }}
+              {{- end }}
+              {{- end }}
+            command:
+            - maya-exporter
+            args:
+            - "-e=pool"
+            ports:
+            - containerPort: 9500
+              protocol: TCP
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /dev
+              name: device
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: {{ .Config.SparseDir.value }}
+              name: sparse
+            - mountPath: /run/udev
+              name: udev
           tolerations:
           {{- if ne $isTolerations "none" }}
           {{- range $k, $v := $tolerationsVal }}


### PR DESCRIPTION
Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
add pool exporter yaml in runTask
run pool-exporter in previleged mode (#1113 )

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [x] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [x] Labelled this PR & related issue with `requires-upgrade` tag
- [x] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests