### PR TITLE
feat(clientset, idiomatic): add support to get clientset using KubeConfig path

### DIFF
--- a/pkg/kubernetes/client/v1alpha1/client.go
+++ b/pkg/kubernetes/client/v1alpha1/client.go
@@ -66,7 +66,7 @@ func GetConfig(c *Client) (*rest.Config, error) {
 	if c == nil {
 		return nil, errors.New("failed to get kubernetes config: nil client was provided")
 	}
-	return c.getConfigPathOrDirect()
+	return c.getConfigForPathOrDirect()
 }
 
 // getKubeMasterIPFunc provides the abstraction to get
@@ -178,7 +178,7 @@ func WithKubeConfigPath(kubeConfigPath string) OptionFunc {
 
 // Clientset returns a new instance of kubernetes clientset
 func (c *Client) Clientset() (*kubernetes.Clientset, error) {
-	config, err := c.getConfigPathOrDirect()
+	config, err := c.getConfigForPathOrDirect()
 	if err != nil {
 		return nil, errors.Wrapf(err,
 			"failed to get kubernetes clientset: failed to get kubernetes config: IsInCluster {%t}: KubeConfigPath {%s}",
@@ -211,7 +211,7 @@ func (c *Client) ConfigForPath(kubeConfigPath string) (config *rest.Config, err 
 	return c.buildConfigFromFlags("", kubeConfigPath)
 }
 
-func (c *Client) getConfigPathOrDirect() (config *rest.Config, err error) {
+func (c *Client) getConfigForPathOrDirect() (config *rest.Config, err error) {
 	if c.KubeConfigPath != "" {
 		return c.ConfigForPath(c.KubeConfigPath)
 	}
@@ -235,7 +235,7 @@ func (c *Client) getConfigFromENV() (config *rest.Config, err error) {
 // Dynamic returns a kubernetes dynamic client capable of invoking operations
 // against kubernetes resources
 func (c *Client) Dynamic() (dynamic.Interface, error) {
-	config, err := c.getConfigPathOrDirect()
+	config, err := c.getConfigForPathOrDirect()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get dynamic client")
 	}

--- a/pkg/kubernetes/client/v1alpha1/client_test.go
+++ b/pkg/kubernetes/client/v1alpha1/client_test.go
@@ -248,3 +248,30 @@ func TestDynamic(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigForPath(t *testing.T) {
+	tests := map[string]struct {
+		kubeConfigPath    string
+		getConfigFromPath buildConfigFromFlagsFunc
+		isErr             bool
+	}{
+		"T1": {"", fakeBuildConfigFromFlagsErr, true},
+		"T2": {"fake-path", fakeBuildConfigFromFlagsOk, false},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock // pin It
+		t.Run(name, func(t *testing.T) {
+			c := &Client{
+				KubeConfigPath:       mock.kubeConfigPath,
+				buildConfigFromFlags: mock.getConfigFromPath,
+			}
+			_, err := c.ConfigForPath()
+			if mock.isErr && err == nil {
+				t.Fatalf("test '%s' failed: expected error actual no error", name)
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("test '%s' failed: expected no error but got '%v'", name, err)
+			}
+		})
+	}
+}

--- a/pkg/kubernetes/client/v1alpha1/client_test.go
+++ b/pkg/kubernetes/client/v1alpha1/client_test.go
@@ -158,6 +158,40 @@ func TestGetConfigFromENV(t *testing.T) {
 	}
 }
 
+func TestGetConfigFromPathOrDirect(t *testing.T) {
+	tests := map[string]struct {
+		kubeConfigPath     string
+		getConfigFromFlags buildConfigFromFlagsFunc
+		getInClusterConfig getInClusterConfigFunc
+		isErr              bool
+	}{
+		"T1": {"", fakeBuildConfigFromFlagsErr, fakeInClusterConfigOk, false},
+		"T2": {"fake-path", fakeBuildConfigFromFlagsOk, fakeInClusterConfigErr, false},
+		"T3": {"fake-path", fakeBuildConfigFromFlagsErr, fakeInClusterConfigOk, true},
+		"T4": {"", fakeBuildConfigFromFlagsOk, fakeInClusterConfigErr, true},
+		"T5": {"fake-path", fakeBuildConfigFromFlagsErr, fakeInClusterConfigErr, true},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock // pin It
+		t.Run(name, func(t *testing.T) {
+			c := &Client{
+				KubeConfigPath:       mock.kubeConfigPath,
+				buildConfigFromFlags: mock.getConfigFromFlags,
+				getInClusterConfig:   mock.getInClusterConfig,
+				getKubeMasterIP:      fakeGetKubeMasterIPNil,
+				getKubeConfigPath:    fakeGetKubeConfigPathNil,
+			}
+			_, err := c.getConfigPathOrDirect()
+			if mock.isErr && err == nil {
+				t.Fatalf("test '%s' failed: expected error actual no error", name)
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("test '%s' failed: expected no error actual '%s'", name, err)
+			}
+		})
+	}
+}
+
 func TestClientset(t *testing.T) {
 	tests := map[string]struct {
 		isInCluster            bool
@@ -169,9 +203,9 @@ func TestClientset(t *testing.T) {
 		getKubernetesClientset getKubernetesClientsetFunc
 		isErr                  bool
 	}{
-		"t10": {true, "fakePath", fakeInClusterConfigOk, nil, nil, nil, fakeGetClientsetOk, false},
+		"t10": {true, "", fakeInClusterConfigOk, nil, nil, nil, fakeGetClientsetOk, false},
 		"t11": {true, "", fakeInClusterConfigOk, nil, nil, nil, fakeGetClientsetErr, true},
-		"t12": {true, "fakePath", fakeInClusterConfigErr, nil, nil, nil, fakeGetClientsetOk, true},
+		"t12": {true, "", fakeInClusterConfigErr, nil, nil, nil, fakeGetClientsetOk, true},
 
 		"t21": {false, "", nil, fakeGetKubeMasterIPOk, fakeGetKubeConfigPathNil, fakeBuildConfigFromFlagsOk, fakeGetClientsetOk, false},
 		"t22": {false, "", nil, fakeGetKubeMasterIPNil, fakeGetKubeConfigPathOk, fakeBuildConfigFromFlagsOk, fakeGetClientsetOk, false},
@@ -265,7 +299,7 @@ func TestConfigForPath(t *testing.T) {
 				KubeConfigPath:       mock.kubeConfigPath,
 				buildConfigFromFlags: mock.getConfigFromPath,
 			}
-			_, err := c.ConfigForPath()
+			_, err := c.ConfigForPath(mock.kubeConfigPath)
 			if mock.isErr && err == nil {
 				t.Fatalf("test '%s' failed: expected error actual no error", name)
 			}

--- a/pkg/kubernetes/client/v1alpha1/client_test.go
+++ b/pkg/kubernetes/client/v1alpha1/client_test.go
@@ -181,7 +181,7 @@ func TestGetConfigFromPathOrDirect(t *testing.T) {
 				getKubeMasterIP:      fakeGetKubeMasterIPNil,
 				getKubeConfigPath:    fakeGetKubeConfigPathNil,
 			}
-			_, err := c.getConfigPathOrDirect()
+			_, err := c.getConfigForPathOrDirect()
 			if mock.isErr && err == nil {
 				t.Fatalf("test '%s' failed: expected error actual no error", name)
 			}

--- a/pkg/kubernetes/node/v1alpha1/kubernetes.go
+++ b/pkg/kubernetes/node/v1alpha1/kubernetes.go
@@ -90,7 +90,7 @@ func NewKubeClient(opts ...KubeClientBuildOption) *Kubeclient {
 	return k
 }
 
-func (k *Kubeclient) getClientsetPathOrDirect() (*kubernetes.Clientset, error) {
+func (k *Kubeclient) getClientsetForPathOrDirect() (*kubernetes.Clientset, error) {
 	if k.kubeConfigPath != "" {
 		return k.getClientsetForPath(k.kubeConfigPath)
 	}
@@ -104,7 +104,7 @@ func (k *Kubeclient) getClientsetOrCached() (*kubernetes.Clientset, error) {
 		return k.clientset, nil
 	}
 
-	cs, err := k.getClientsetPathOrDirect()
+	cs, err := k.getClientsetForPathOrDirect()
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get clientset")
 	}

--- a/pkg/kubernetes/node/v1alpha1/kubernetes_test.go
+++ b/pkg/kubernetes/node/v1alpha1/kubernetes_test.go
@@ -103,7 +103,7 @@ func TestWithDefaultsForClientSetPath(t *testing.T) {
 	}
 }
 
-func TestGetClientSetPathOrDirect(t *testing.T) {
+func TestGetClientSetForPathOrDirect(t *testing.T) {
 	tests := map[string]struct {
 		getClientSet        getClientsetFn
 		getClientSetForPath getClientsetForPathFn
@@ -131,7 +131,7 @@ func TestGetClientSetPathOrDirect(t *testing.T) {
 				getClientsetForPath: mock.getClientSetForPath,
 				kubeConfigPath:      mock.kubeConfigPath,
 			}
-			_, err := fc.getClientsetOrCached()
+			_, err := fc.getClientsetForPathOrDirect()
 			if mock.isErr && err == nil {
 				t.Fatalf("test %q failed : expected error not to be nil but got %v", name, err)
 			}

--- a/pkg/kubernetes/node/v1alpha1/kubernetes_test.go
+++ b/pkg/kubernetes/node/v1alpha1/kubernetes_test.go
@@ -15,7 +15,6 @@
 package v1alpha1
 
 import (
-	"reflect"
 	"testing"
 
 	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
@@ -24,45 +23,61 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 )
 
-func fakeGetClientsetOk(fakeConfigPath string) (cli *clientset.Clientset, err error) {
+func fakeGetClientSetOk() (cli *clientset.Clientset, err error) {
 	return &clientset.Clientset{}, nil
 }
 
-func fakeListfnOk(cli *clientset.Clientset, opts metav1.ListOptions) (*corev1.NodeList, error) {
+func fakeListOk(cli *clientset.Clientset, opts metav1.ListOptions) (*corev1.NodeList, error) {
 	return &corev1.NodeList{}, nil
 }
 
 func fakeListErr(cli *clientset.Clientset, opts metav1.ListOptions) (*corev1.NodeList, error) {
-	return nil, errors.New("some error")
+	return nil, errors.New("fake error")
 }
 
-func fakeGetClientSetNil(fakeConfigPath string) (clientset *clientset.Clientset, err error) {
+func fakeGetClientSetNil() (clientset *clientset.Clientset, err error) {
 	return nil, nil
 }
 
-func fakeGetClientSetErr(fakeConfigPath string) (clientset *clientset.Clientset, err error) {
-	return nil, errors.New("Some error")
+func fakeGetClientSetErr() (clientset *clientset.Clientset, err error) {
+	return nil, errors.New("fake error")
+}
+
+func fakeGetClientSetForPathOk(fakeConfigPath string) (cli *clientset.Clientset, err error) {
+	return &clientset.Clientset{}, nil
+}
+
+func fakeGetClientSetForPathErr(fakeConfigPath string) (cli *clientset.Clientset, err error) {
+	return nil, errors.New("fake error")
 }
 
 func TestWithDefaultOptions(t *testing.T) {
 	tests := map[string]struct {
-		KubeClient *Kubeclient
+		getClientSet        getClientsetFn
+		getClientSetForPath getClientsetForPathFn
+		list                listFn
 	}{
-		"When both listFn and getClientsetFn are error": {&Kubeclient{nil, "fake-path", fakeGetClientSetErr, fakeListErr}},
-		"When both listFn and getClientsetFn are nil":   {&Kubeclient{}},
-		"When listFn nil":                       {&Kubeclient{nil, "fake-Path", fakeGetClientsetOk, nil}},
-		"When getClientsetFn nil":               {&Kubeclient{nil, "fake-path", nil, fakeListfnOk}},
-		"When getClientsetFn and listFn are ok": {&Kubeclient{nil, "fake-path", fakeGetClientsetOk, fakeListfnOk}},
+		"T1": {fakeGetClientSetErr, fakeGetClientSetForPathErr, fakeListErr},
+		"T2": {nil, nil, nil},
+		"T3": {fakeGetClientSetOk, fakeGetClientSetForPathOk, nil},
 	}
 	for name, mock := range tests {
 		name := name // pin it
 		mock := mock // pin it
 		t.Run(name, func(t *testing.T) {
-			mock.KubeClient.withDefaults()
-			if mock.KubeClient.getClientset == nil {
-				t.Fatalf("test %q failed: expected getClientset not to be empty", name)
+			fc := Kubeclient{
+				getClientset:        mock.getClientSet,
+				getClientsetForPath: mock.getClientSetForPath,
+				list:                mock.list,
 			}
-			if mock.KubeClient.list == nil {
+			fc.withDefaults()
+			if fc.getClientset == nil {
+				t.Fatalf("test %q failed: expected getClientset not to be nil", name)
+			}
+			if fc.getClientsetForPath == nil {
+				t.Fatalf("test %q failed: expected getClientset not to be nil", name)
+			}
+			if fc.list == nil {
 				t.Fatalf("test %q failed: expected list not to be empty", name)
 			}
 		})
@@ -71,27 +86,39 @@ func TestWithDefaultOptions(t *testing.T) {
 
 func TestGetClientOrCached(t *testing.T) {
 	tests := map[string]struct {
-		expectErr  bool
-		KubeClient *Kubeclient
+		getClientSet        getClientsetFn
+		getClientSetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		expectErr           bool
 	}{
 		// Positive tests
-		"Positive 1": {false, &Kubeclient{nil, "fake-path", fakeGetClientSetNil, fakeListfnOk}},
-		"Positive 2": {false, &Kubeclient{&clientset.Clientset{}, "fake-path", fakeGetClientSetNil, fakeListfnOk}},
+		"Positive 1": {fakeGetClientSetNil, fakeGetClientSetForPathOk, "fake-path", false},
+		"Positive 2": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "", false},
+		"Positive 3": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "fake-path", false},
+		"Positive 4": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "", false},
 
 		// Negative tests
-		"Negative 1": {true, &Kubeclient{nil, "fake-path", fakeGetClientSetErr, fakeListfnOk}},
+		"Negative 1": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "", true},
+		"Negative 2": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "fake-path", true},
+		"Negative 3": {fakeGetClientSetErr, fakeGetClientSetForPathErr, "fake-path", true},
+		"Negative 4": {fakeGetClientSetErr, fakeGetClientSetForPathErr, "", true},
 	}
 
 	for name, mock := range tests {
 		name := name // pin it
 		mock := mock // pin it
 		t.Run(name, func(t *testing.T) {
-			c, err := mock.KubeClient.getClientOrCached()
+			fc := &Kubeclient{
+				getClientset:        mock.getClientSet,
+				getClientsetForPath: mock.getClientSetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+			}
+			_, err := fc.getClientOrCached()
 			if mock.expectErr && err == nil {
 				t.Fatalf("test %q failed : expected error not to be nil but got %v", name, err)
 			}
-			if !reflect.DeepEqual(c, mock.KubeClient.clientset) {
-				t.Fatalf("test %q failed : expected clientset %v but got %v", name, mock.KubeClient.clientset, c)
+			if !mock.expectErr && err != nil {
+				t.Fatalf("test %q failed : expected error be nil but got %v", name, err)
 			}
 		})
 	}
@@ -99,25 +126,40 @@ func TestGetClientOrCached(t *testing.T) {
 
 func TestKubenetesNodeList(t *testing.T) {
 	tests := map[string]struct {
-		getClientset getClientsetFn
-		list         listFn
-		expectErr    bool
+		getClientset        getClientsetFn
+		getClientSetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		list                listFn
+		expectedErr         bool
 	}{
-		"Test 1": {fakeGetClientSetErr, fakeListfnOk, true},
-		"Test 2": {fakeGetClientsetOk, fakeListfnOk, false},
-		"Test 3": {fakeGetClientsetOk, fakeListErr, true},
+		// Positive tests
+		"Positive 1": {fakeGetClientSetNil, fakeGetClientSetForPathOk, "fake-path", fakeListOk, false},
+		"Positive 2": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "", fakeListOk, false},
+		"Positive 3": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "fake-path", fakeListOk, false},
+		"Positive 4": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "", fakeListOk, false},
+
+		// Negative tests
+		"Negative 1": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "", fakeListOk, true},
+		"Negative 2": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "fake-path", fakeListOk, true},
+		"Negative 3": {fakeGetClientSetErr, fakeGetClientSetForPathErr, "fake-path", fakeListOk, true},
+		"Negative 4": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "", fakeListErr, true},
 	}
 
 	for name, mock := range tests {
 		name := name // pin it
 		mock := mock // pin it
 		t.Run(name, func(t *testing.T) {
-			k := Kubeclient{getClientset: mock.getClientset, list: mock.list}
-			_, err := k.List(metav1.ListOptions{})
-			if mock.expectErr && err == nil {
+			fc := &Kubeclient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientSetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+				list:                mock.list,
+			}
+			_, err := fc.List(metav1.ListOptions{})
+			if mock.expectedErr && err == nil {
 				t.Fatalf("Test %q failed: expected error not to be nil", name)
 			}
-			if !mock.expectErr && err != nil {
+			if !mock.expectedErr && err != nil {
 				t.Fatalf("Test %q failed: expected error to be nil", name)
 			}
 		})

--- a/pkg/kubernetes/node/v1alpha1/kubernetes_test.go
+++ b/pkg/kubernetes/node/v1alpha1/kubernetes_test.go
@@ -53,22 +53,20 @@ func fakeGetClientSetForPathErr(fakeConfigPath string) (cli *clientset.Clientset
 
 func TestWithDefaultOptions(t *testing.T) {
 	tests := map[string]struct {
-		getClientSet        getClientsetFn
-		getClientSetForPath getClientsetForPathFn
-		list                listFn
+		getClientSet getClientsetFn
+		list         listFn
 	}{
-		"T1": {fakeGetClientSetErr, fakeGetClientSetForPathErr, fakeListErr},
-		"T2": {nil, nil, nil},
-		"T3": {fakeGetClientSetOk, fakeGetClientSetForPathOk, nil},
+		"T1": {fakeGetClientSetErr, fakeListErr},
+		"T2": {nil, nil},
+		"T3": {fakeGetClientSetOk, nil},
 	}
 	for name, mock := range tests {
 		name := name // pin it
 		mock := mock // pin it
 		t.Run(name, func(t *testing.T) {
 			fc := Kubeclient{
-				getClientset:        mock.getClientSet,
-				getClientsetForPath: mock.getClientSetForPath,
-				list:                mock.list,
+				getClientset: mock.getClientSet,
+				list:         mock.list,
 			}
 			fc.withDefaults()
 			if fc.getClientset == nil {
@@ -79,6 +77,66 @@ func TestWithDefaultOptions(t *testing.T) {
 			}
 			if fc.list == nil {
 				t.Fatalf("test %q failed: expected list not to be empty", name)
+			}
+		})
+	}
+}
+
+func TestWithDefaultsForClientSetPath(t *testing.T) {
+	tests := map[string]struct {
+		getClientSetForPath getClientsetForPathFn
+	}{
+		"T1": {nil},
+		"T2": {fakeGetClientSetForPathOk},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{
+				getClientsetForPath: mock.getClientSetForPath,
+			}
+			fc.withDefaults()
+			if fc.getClientsetForPath == nil {
+				t.Fatalf("test %q failed: expected getClientsetForPath not to be nil", name)
+			}
+		})
+	}
+}
+
+func TestGetClientSetPathOrDirect(t *testing.T) {
+	tests := map[string]struct {
+		getClientSet        getClientsetFn
+		getClientSetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		isErr               bool
+	}{
+		// Positive tests
+		"Positive 1": {fakeGetClientSetNil, fakeGetClientSetForPathOk, "fake-path", false},
+		"Positive 2": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "", false},
+		"Positive 3": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "fake-path", false},
+		"Positive 4": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "", false},
+
+		// Negative tests
+		"Negative 1": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "", true},
+		"Negative 2": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "fake-path", true},
+		"Negative 3": {fakeGetClientSetErr, fakeGetClientSetForPathErr, "fake-path", true},
+		"Negative 4": {fakeGetClientSetErr, fakeGetClientSetForPathErr, "", true},
+	}
+
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{
+				getClientset:        mock.getClientSet,
+				getClientsetForPath: mock.getClientSetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+			}
+			_, err := fc.getClientsetOrCached()
+			if mock.isErr && err == nil {
+				t.Fatalf("test %q failed : expected error not to be nil but got %v", name, err)
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("test %q failed : expected error be nil but got %v", name, err)
 			}
 		})
 	}
@@ -113,7 +171,7 @@ func TestGetClientOrCached(t *testing.T) {
 				getClientsetForPath: mock.getClientSetForPath,
 				kubeConfigPath:      mock.kubeConfigPath,
 			}
-			_, err := fc.getClientOrCached()
+			_, err := fc.getClientsetOrCached()
 			if mock.expectErr && err == nil {
 				t.Fatalf("test %q failed : expected error not to be nil but got %v", name, err)
 			}

--- a/pkg/kubernetes/node/v1alpha1/kubernetes_test.go
+++ b/pkg/kubernetes/node/v1alpha1/kubernetes_test.go
@@ -18,13 +18,13 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/pkg/errors"
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 )
 
-func fakeGetClientsetOk() (cli *clientset.Clientset, err error) {
+func fakeGetClientsetOk(fakeConfigPath string) (cli *clientset.Clientset, err error) {
 	return &clientset.Clientset{}, nil
 }
 
@@ -36,11 +36,11 @@ func fakeListErr(cli *clientset.Clientset, opts metav1.ListOptions) (*corev1.Nod
 	return nil, errors.New("some error")
 }
 
-func fakeGetClientSetNil() (clientset *clientset.Clientset, err error) {
+func fakeGetClientSetNil(fakeConfigPath string) (clientset *clientset.Clientset, err error) {
 	return nil, nil
 }
 
-func fakeGetClientSetErr() (clientset *clientset.Clientset, err error) {
+func fakeGetClientSetErr(fakeConfigPath string) (clientset *clientset.Clientset, err error) {
 	return nil, errors.New("Some error")
 }
 
@@ -48,11 +48,11 @@ func TestWithDefaultOptions(t *testing.T) {
 	tests := map[string]struct {
 		KubeClient *Kubeclient
 	}{
-		"When both listFn and getClientsetFn are error": {&Kubeclient{nil, fakeGetClientSetErr, fakeListErr}},
+		"When both listFn and getClientsetFn are error": {&Kubeclient{nil, "fake-path", fakeGetClientSetErr, fakeListErr}},
 		"When both listFn and getClientsetFn are nil":   {&Kubeclient{}},
-		"When listFn nil":                       {&Kubeclient{nil, fakeGetClientsetOk, nil}},
-		"When getClientsetFn nil":               {&Kubeclient{nil, nil, fakeListfnOk}},
-		"When getClientsetFn and listFn are ok": {&Kubeclient{nil, fakeGetClientsetOk, fakeListfnOk}},
+		"When listFn nil":                       {&Kubeclient{nil, "fake-Path", fakeGetClientsetOk, nil}},
+		"When getClientsetFn nil":               {&Kubeclient{nil, "fake-path", nil, fakeListfnOk}},
+		"When getClientsetFn and listFn are ok": {&Kubeclient{nil, "fake-path", fakeGetClientsetOk, fakeListfnOk}},
 	}
 	for name, mock := range tests {
 		name := name // pin it
@@ -75,11 +75,11 @@ func TestGetClientOrCached(t *testing.T) {
 		KubeClient *Kubeclient
 	}{
 		// Positive tests
-		"Positive 1": {false, &Kubeclient{nil, fakeGetClientSetNil, fakeListfnOk}},
-		"Positive 2": {false, &Kubeclient{&clientset.Clientset{}, fakeGetClientSetNil, fakeListfnOk}},
+		"Positive 1": {false, &Kubeclient{nil, "fake-path", fakeGetClientSetNil, fakeListfnOk}},
+		"Positive 2": {false, &Kubeclient{&clientset.Clientset{}, "fake-path", fakeGetClientSetNil, fakeListfnOk}},
 
 		// Negative tests
-		"Negative 1": {true, &Kubeclient{nil, fakeGetClientSetErr, fakeListfnOk}},
+		"Negative 1": {true, &Kubeclient{nil, "fake-path", fakeGetClientSetErr, fakeListfnOk}},
 	}
 
 	for name, mock := range tests {

--- a/pkg/kubernetes/persistentvolumeclaim/v1alpha1/kubernetes.go
+++ b/pkg/kubernetes/persistentvolumeclaim/v1alpha1/kubernetes.go
@@ -158,7 +158,7 @@ func NewKubeClient(opts ...KubeclientBuildOption) *Kubeclient {
 	return k
 }
 
-func (k *Kubeclient) getClientsetPathOrDirect() (*kubernetes.Clientset, error) {
+func (k *Kubeclient) getClientsetForPathOrDirect() (*kubernetes.Clientset, error) {
 	if k.kubeConfigPath != "" {
 		return k.getClientsetForPath(k.kubeConfigPath)
 	}
@@ -172,7 +172,7 @@ func (k *Kubeclient) getClientsetOrCached() (*kubernetes.Clientset, error) {
 		return k.clientset, nil
 	}
 
-	cs, err := k.getClientsetPathOrDirect()
+	cs, err := k.getClientsetForPathOrDirect()
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get clientset")
 	}

--- a/pkg/kubernetes/persistentvolumeclaim/v1alpha1/kubernetes_test.go
+++ b/pkg/kubernetes/persistentvolumeclaim/v1alpha1/kubernetes_test.go
@@ -15,7 +15,6 @@
 package v1alpha1
 
 import (
-	"reflect"
 	"testing"
 
 	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
@@ -25,8 +24,16 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func fakeGetClientsetOk(kubeConfigPath string) (cli *kubernetes.Clientset, err error) {
+func fakeGetClientSetOk() (cli *kubernetes.Clientset, err error) {
 	return &kubernetes.Clientset{}, nil
+}
+
+func fakeGetClientSetForPathOk(fakeConfigPath string) (cli *kubernetes.Clientset, err error) {
+	return &kubernetes.Clientset{}, nil
+}
+
+func fakeGetClientSetForPathErr(fakeConfigPath string) (cli *kubernetes.Clientset, err error) {
+	return nil, errors.New("fake error")
 }
 
 func fakeGetOk(cli *kubernetes.Clientset, name, namespace string, opts metav1.GetOptions) (*corev1.PersistentVolumeClaim, error) {
@@ -57,15 +64,19 @@ func fakeSetClientset(k *Kubeclient) {
 	k.clientset = &kubernetes.Clientset{}
 }
 
+func fakeSetKubeConfigPath(k *Kubeclient) {
+	k.kubeConfigPath = "fake-path"
+}
+
 func fakeSetNilClientset(k *Kubeclient) {
 	k.clientset = nil
 }
 
-func fakeGetNilErrClientSet(kubeConfigPath string) (clientset *kubernetes.Clientset, err error) {
+func fakeGetClientSetNil() (clientset *kubernetes.Clientset, err error) {
 	return nil, nil
 }
 
-func fakeGetClientSetErr(kubeConfigPath string) (clientset *kubernetes.Clientset, err error) {
+func fakeGetClientSetErr() (clientset *kubernetes.Clientset, err error) {
 	return nil, errors.New("Some error")
 }
 
@@ -85,37 +96,41 @@ func TestWithDefaultOptions(t *testing.T) {
 	}{
 		"When all are nil": {&Kubeclient{}},
 		"When clientset is nil": {&Kubeclient{
-			clientset:     nil,
-			getClientset:  fakeGetClientsetOk,
-			list:          fakeListOk,
-			get:           fakeGetOk,
-			create:        fakeCreateFnOk,
-			del:           fakeDeleteOk,
-			delCollection: nil,
+			clientset:           nil,
+			getClientset:        fakeGetClientSetOk,
+			getClientsetForPath: fakeGetClientSetForPathOk,
+			list:                fakeListOk,
+			get:                 fakeGetOk,
+			create:              fakeCreateFnOk,
+			del:                 fakeDeleteOk,
+			delCollection:       nil,
 		}},
 		"When listFn nil": {&Kubeclient{
-			getClientset:  fakeGetClientsetOk,
-			list:          nil,
-			get:           fakeGetOk,
-			create:        fakeCreateFnOk,
-			del:           fakeDeleteOk,
-			delCollection: nil,
+			getClientset:        fakeGetClientSetOk,
+			list:                nil,
+			getClientsetForPath: fakeGetClientSetForPathErr,
+			get:                 fakeGetOk,
+			create:              fakeCreateFnOk,
+			del:                 fakeDeleteOk,
+			delCollection:       nil,
 		}},
 		"When getClientsetFn nil": {&Kubeclient{
-			getClientset:  nil,
-			list:          fakeListOk,
-			get:           fakeGetOk,
-			create:        fakeCreateFnOk,
-			del:           fakeDeleteOk,
-			delCollection: nil,
+			getClientset:        nil,
+			list:                fakeListOk,
+			get:                 fakeGetOk,
+			getClientsetForPath: fakeGetClientSetForPathOk,
+			create:              fakeCreateFnOk,
+			del:                 fakeDeleteOk,
+			delCollection:       nil,
 		}},
 		"When getFn and CreateFn are nil": {&Kubeclient{
-			getClientset:  fakeGetClientsetOk,
-			list:          fakeListOk,
-			get:           nil,
-			create:        nil,
-			del:           fakeDeleteOk,
-			delCollection: nil,
+			getClientset:        fakeGetClientSetOk,
+			list:                fakeListOk,
+			getClientsetForPath: fakeGetClientSetForPathErr,
+			get:                 nil,
+			create:              nil,
+			del:                 fakeDeleteOk,
+			delCollection:       nil,
 		}},
 	}
 	for name, mock := range tests {
@@ -125,6 +140,9 @@ func TestWithDefaultOptions(t *testing.T) {
 			mock.KubeClient.withDefaults()
 			if mock.KubeClient.getClientset == nil {
 				t.Fatalf("test %q failed: expected getClientset not to be empty", name)
+			}
+			if mock.KubeClient.getClientsetForPath == nil {
+				t.Fatalf("test %q failed: expected getClientset not to be nil", name)
 			}
 			if mock.KubeClient.list == nil {
 				t.Fatalf("test %q failed: expected list not to be empty", name)
@@ -140,6 +158,45 @@ func TestWithDefaultOptions(t *testing.T) {
 			}
 			if mock.KubeClient.delCollection == nil {
 				t.Fatalf("test %q failed: expected delCollection not to be empty", name)
+			}
+		})
+	}
+}
+
+func TestGetClientSetPathOrDirect(t *testing.T) {
+	tests := map[string]struct {
+		getClientSet        getClientsetFn
+		getClientSetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		isErr               bool
+	}{
+		// Positive tests
+		"Positive 1": {fakeGetClientSetNil, fakeGetClientSetForPathOk, "fake-path", false},
+		"Positive 2": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "", false},
+		"Positive 3": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "fake-path", false},
+		"Positive 4": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "", false},
+
+		// Negative tests
+		"Negative 1": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "", true},
+		"Negative 2": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "fake-path", true},
+		"Negative 3": {fakeGetClientSetErr, fakeGetClientSetForPathErr, "fake-path", true},
+		"Negative 4": {fakeGetClientSetErr, fakeGetClientSetForPathErr, "", true},
+	}
+
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{
+				getClientset:        mock.getClientSet,
+				getClientsetForPath: mock.getClientSetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+			}
+			_, err := fc.getClientsetOrCached()
+			if mock.isErr && err == nil {
+				t.Fatalf("test %q failed : expected error not to be nil but got %v", name, err)
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("test %q failed : expected error be nil but got %v", name, err)
 			}
 		})
 	}
@@ -172,16 +229,17 @@ func TestWithClientsetBuildOption(t *testing.T) {
 
 func TestKubeClientBuildOption(t *testing.T) {
 	tests := map[string]struct {
-		expectClientSet bool
-		opts            []KubeclientBuildOption
+		opts                   []KubeclientBuildOption
+		expectClientSet        bool
+		expectedKubeConfigPath bool
 	}{
-		"Positive 1": {true, []KubeclientBuildOption{fakeSetClientset}},
-		"Positive 2": {true, []KubeclientBuildOption{fakeSetClientset, fakeClientSet}},
-		"Positive 3": {true, []KubeclientBuildOption{fakeSetClientset, fakeClientSet, fakeClientSet}},
+		"Positive 1": {[]KubeclientBuildOption{fakeSetClientset, fakeSetKubeConfigPath}, true, true},
+		"Positive 2": {[]KubeclientBuildOption{fakeSetClientset, fakeClientSet}, true, false},
+		"Positive 3": {[]KubeclientBuildOption{fakeSetClientset, fakeClientSet, fakeClientSet}, true, false},
 
-		"Negative 1": {false, []KubeclientBuildOption{fakeSetNilClientset}},
-		"Negative 2": {false, []KubeclientBuildOption{fakeSetNilClientset, fakeClientSet}},
-		"Negative 3": {false, []KubeclientBuildOption{fakeSetNilClientset, fakeClientSet, fakeClientSet}},
+		"Negative 1": {[]KubeclientBuildOption{fakeSetNilClientset, fakeSetKubeConfigPath}, false, true},
+		"Negative 2": {[]KubeclientBuildOption{fakeSetNilClientset, fakeClientSet, fakeSetKubeConfigPath}, false, true},
+		"Negative 3": {[]KubeclientBuildOption{fakeSetNilClientset, fakeClientSet, fakeClientSet}, false, false},
 	}
 
 	for name, mock := range tests {
@@ -194,32 +252,51 @@ func TestKubeClientBuildOption(t *testing.T) {
 			if mock.expectClientSet && c.clientset == nil {
 				t.Fatalf("test %q failed expected fake.clientset not to be empty", name)
 			}
+			if mock.expectedKubeConfigPath && c.kubeConfigPath == "" {
+				t.Fatalf("test %q failed expected kubeConfigPath not to be empty", name)
+			}
+			if !mock.expectedKubeConfigPath && c.kubeConfigPath != "" {
+				t.Fatalf("test %q failed expected kubeConfigPath to be empty", name)
+			}
 		})
 	}
 }
 
 func TestGetClientOrCached(t *testing.T) {
 	tests := map[string]struct {
-		expectErr  bool
-		KubeClient *Kubeclient
+		getClientSet        getClientsetFn
+		getClientSetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		expectErr           bool
 	}{
 		// Positive tests
-		"Positive 1": {false, &Kubeclient{nil, "", "fake-path", fakeGetNilErrClientSet, fakeListOk, nil, nil, nil, nil}},
-		"Positive 2": {false, &Kubeclient{&kubernetes.Clientset{}, "", "", fakeGetNilErrClientSet, fakeListOk, nil, nil, nil, nil}},
+		"Positive 1": {fakeGetClientSetNil, fakeGetClientSetForPathOk, "fake-path", false},
+		"Positive 2": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "", false},
+		"Positive 3": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "fake-path", false},
+		"Positive 4": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "", false},
 
 		// Negative tests
-		"Negative 1": {true, &Kubeclient{nil, "", "fake-path", fakeGetClientSetErr, fakeListOk, nil, nil, nil, nil}},
+		"Negative 1": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "", true},
+		"Negative 2": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "fake-path", true},
+		"Negative 3": {fakeGetClientSetErr, fakeGetClientSetForPathErr, "fake-path", true},
+		"Negative 4": {fakeGetClientSetErr, fakeGetClientSetForPathErr, "", true},
 	}
 
 	for name, mock := range tests {
-		name, mock := name, mock
+		name := name // pin it
+		mock := mock // pin it
 		t.Run(name, func(t *testing.T) {
-			c, err := mock.KubeClient.getClientSetOrCached()
+			fc := &Kubeclient{
+				getClientset:        mock.getClientSet,
+				getClientsetForPath: mock.getClientSetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+			}
+			_, err := fc.getClientsetOrCached()
 			if mock.expectErr && err == nil {
 				t.Fatalf("test %q failed : expected error not to be nil but got %v", name, err)
 			}
-			if !reflect.DeepEqual(c, mock.KubeClient.clientset) {
-				t.Fatalf("test %q failed : expected clientset %v but got %v", name, mock.KubeClient.clientset, c)
+			if !mock.expectErr && err != nil {
+				t.Fatalf("test %q failed : expected error be nil but got %v", name, err)
 			}
 		})
 	}
@@ -227,24 +304,40 @@ func TestGetClientOrCached(t *testing.T) {
 
 func TestKubernetesPVCList(t *testing.T) {
 	tests := map[string]struct {
-		getClientset getClientsetFn
-		list         listFn
-		expectErr    bool
+		getClientset        getClientsetFn
+		getClientSetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		list                listFn
+		expectedErr         bool
 	}{
-		"Test 1": {fakeGetClientSetErr, fakeListOk, true},
-		"Test 2": {fakeGetClientsetOk, fakeListOk, false},
-		"Test 3": {fakeGetClientsetOk, fakeListErr, true},
+		// Positive tests
+		"Positive 1": {fakeGetClientSetNil, fakeGetClientSetForPathOk, "fake-path", fakeListOk, false},
+		"Positive 2": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "", fakeListOk, false},
+		"Positive 3": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "fake-path", fakeListOk, false},
+		"Positive 4": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "", fakeListOk, false},
+
+		// Negative tests
+		"Negative 1": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "", fakeListOk, true},
+		"Negative 2": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "fake-path", fakeListOk, true},
+		"Negative 3": {fakeGetClientSetErr, fakeGetClientSetForPathErr, "fake-path", fakeListOk, true},
+		"Negative 4": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "", fakeListErr, true},
 	}
 
 	for name, mock := range tests {
-		name, mock := name, mock
+		name := name // pin it
+		mock := mock // pin it
 		t.Run(name, func(t *testing.T) {
-			k := Kubeclient{getClientset: mock.getClientset, namespace: "", list: mock.list}
-			_, err := k.List(metav1.ListOptions{})
-			if mock.expectErr && err == nil {
+			fc := &Kubeclient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientSetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+				list:                mock.list,
+			}
+			_, err := fc.List(metav1.ListOptions{})
+			if mock.expectedErr && err == nil {
 				t.Fatalf("Test %q failed: expected error not to be nil", name)
 			}
-			if !mock.expectErr && err != nil {
+			if !mock.expectedErr && err != nil {
 				t.Fatalf("Test %q failed: expected error to be nil", name)
 			}
 		})
@@ -273,23 +366,34 @@ func TestWithNamespaceBuildOption(t *testing.T) {
 
 func TestKubenetesGetPVC(t *testing.T) {
 	tests := map[string]struct {
-		getClientset    getClientsetFn
-		get             getFn
-		name, namespace string
-		expectErr       bool
+		getClientset        getClientsetFn
+		getClientSetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		get                 getFn
+		podName             string
+		expectErr           bool
 	}{
-		"Test 1": {fakeGetClientSetErr, fakeGetOk, "testvol", "test-ns", true},
-		"Test 2": {fakeGetClientsetOk, fakeGetOk, "testvol", "test-ns", false},
-		"Test 3": {fakeGetClientsetOk, fakeGetErr, "testvol", "", true},
+		"Test 1": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "", fakeGetOk, "pod-1", true},
+		"Test 2": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "fake-path", fakeGetOk, "pod-1", true},
+		"Test 3": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "", fakeGetOk, "pod-2", false},
+		"Test 4": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "fp", fakeGetErr, "pod-3", true},
+		"Test 5": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "fakepath", fakeGetOk, "", true},
 	}
 
 	for name, mock := range tests {
-		name, mock := name, mock
+		name := name
+		mock := mock
 		t.Run(name, func(t *testing.T) {
-			k := Kubeclient{getClientset: mock.getClientset, get: mock.get}
-			_, err := k.Get(mock.name, metav1.GetOptions{})
+			k := &Kubeclient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientSetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+				namespace:           "",
+				get:                 mock.get,
+			}
+			_, err := k.Get(mock.podName, metav1.GetOptions{})
 			if mock.expectErr && err == nil {
-				t.Fatalf("Test %q failed: expected error not to be nil, got %v", name, err)
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
 			}
 			if !mock.expectErr && err != nil {
 				t.Fatalf("Test %q failed: expected error to be nil", name)
@@ -298,24 +402,35 @@ func TestKubenetesGetPVC(t *testing.T) {
 	}
 }
 
-func TestKubenetesDelete(t *testing.T) {
+func TestKubernetesDeletePVC(t *testing.T) {
 	tests := map[string]struct {
-		getClientset getClientsetFn
-		del          deleteFn
-		name         string
-		expectErr    bool
+		getClientset        getClientsetFn
+		getClientSetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		podName             string
+		delete              deleteFn
+		expectErr           bool
 	}{
-		"Test 1": {fakeGetClientSetErr, fakeDeleteOk, "testvol", true},
-		"Test 2": {fakeGetClientsetOk, fakeDeleteOk, "testvol", false},
-		"Test 3": {fakeGetClientsetOk, fakeDeleteErr, "testvol", true},
-		"Test 4": {fakeGetClientsetOk, fakeDeleteErr, "", true},
+		"Test 1": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "", "pod-1", fakeDeleteOk, true},
+		"Test 2": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "fake-path2", "pod-2", fakeDeleteOk, false},
+		"Test 3": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "", "pod-3", fakeDeleteErr, true},
+		"Test 4": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "fakepath", "", fakeDeleteOk, true},
+		"Test 5": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "fake-path2", "pod1", fakeDeleteOk, true},
+		"Test 6": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "fake-path2", "pod1", fakeDeleteErr, true},
 	}
 
 	for name, mock := range tests {
-		name, mock := name, mock
+		name := name
+		mock := mock
 		t.Run(name, func(t *testing.T) {
-			k := Kubeclient{getClientset: mock.getClientset, del: mock.del}
-			err := k.Delete(mock.name, &metav1.DeleteOptions{})
+			k := &Kubeclient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientSetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+				namespace:           "",
+				del:                 mock.delete,
+			}
+			err := k.Delete(mock.podName, &metav1.DeleteOptions{})
 			if mock.expectErr && err == nil {
 				t.Fatalf("Test %q failed: expected error not to be nil", name)
 			}
@@ -328,42 +443,65 @@ func TestKubenetesDelete(t *testing.T) {
 
 func TestKubernetesPVCCreate(t *testing.T) {
 	tests := map[string]struct {
-		getClientSet getClientsetFn
-		create       createFn
-		pvc          *v1.PersistentVolumeClaim
-		expectErr    bool
+		getClientSet        getClientsetFn
+		getClientSetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		create              createFn
+		pvc                 *v1.PersistentVolumeClaim
+		expectErr           bool
 	}{
-		"Negative Test 1": {
-			getClientSet: fakeGetClientSetErr,
-			create:       fakeCreateFnOk,
-			pvc:          &v1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "PVC-1"}},
-			expectErr:    true,
+		"Test 1": {
+			getClientSet:        fakeGetClientSetErr,
+			getClientSetForPath: fakeGetClientSetForPathErr,
+			kubeConfigPath:      "",
+			create:              fakeCreateFnOk,
+			pvc:                 &v1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "PVC-1"}},
+			expectErr:           true,
 		},
-		"Negative Test 2": {
-			getClientSet: fakeGetClientsetOk,
-			create:       fakeCreateFnErr,
-			pvc:          &v1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "PVC-2"}},
-			expectErr:    true,
+		"Test 2": {
+			getClientSet:        fakeGetClientSetOk,
+			getClientSetForPath: fakeGetClientSetForPathOk,
+			kubeConfigPath:      "",
+			create:              fakeCreateFnErr,
+			pvc:                 &v1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "PVC-2"}},
+			expectErr:           true,
 		},
-		"Negative Test 3": {
-			getClientSet: fakeGetClientsetOk,
-			create:       fakeCreateFnErr,
-			pvc:          nil,
-			expectErr:    true,
+		"Test 3": {
+			getClientSet:        fakeGetClientSetOk,
+			getClientSetForPath: fakeGetClientSetForPathOk,
+			kubeConfigPath:      "fake-path",
+			create:              fakeCreateFnErr,
+			pvc:                 nil,
+			expectErr:           true,
 		},
-		"Positive Test 4": {
-			getClientSet: fakeGetClientsetOk,
-			create:       fakeCreateFnOk,
-			pvc:          nil,
-			expectErr:    false,
+		"Test 4": {
+			getClientSet:        fakeGetClientSetErr,
+			getClientSetForPath: fakeGetClientSetForPathOk,
+			kubeConfigPath:      "fake-path",
+			create:              fakeCreateFnOk,
+			pvc:                 nil,
+			expectErr:           false,
+		},
+		"Test 5": {
+			getClientSet:        fakeGetClientSetOk,
+			getClientSetForPath: fakeGetClientSetForPathErr,
+			kubeConfigPath:      "fake-path",
+			create:              fakeCreateFnOk,
+			pvc:                 nil,
+			expectErr:           true,
 		},
 	}
 
 	for name, mock := range tests {
 		name, mock := name, mock
 		t.Run(name, func(t *testing.T) {
-			k := Kubeclient{getClientset: mock.getClientSet, create: mock.create}
-			_, err := k.Create(mock.pvc)
+			fc := &Kubeclient{
+				getClientset:        mock.getClientSet,
+				getClientsetForPath: mock.getClientSetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+				create:              mock.create,
+			}
+			_, err := fc.Create(mock.pvc)
 			if mock.expectErr && err == nil {
 				t.Fatalf("Test %q failed: expected error not to be nil", name)
 			}

--- a/pkg/kubernetes/persistentvolumeclaim/v1alpha1/kubernetes_test.go
+++ b/pkg/kubernetes/persistentvolumeclaim/v1alpha1/kubernetes_test.go
@@ -163,7 +163,7 @@ func TestWithDefaultOptions(t *testing.T) {
 	}
 }
 
-func TestGetClientSetPathOrDirect(t *testing.T) {
+func TestGetClientSetForPathOrDirect(t *testing.T) {
 	tests := map[string]struct {
 		getClientSet        getClientsetFn
 		getClientSetForPath getClientsetForPathFn
@@ -191,7 +191,7 @@ func TestGetClientSetPathOrDirect(t *testing.T) {
 				getClientsetForPath: mock.getClientSetForPath,
 				kubeConfigPath:      mock.kubeConfigPath,
 			}
-			_, err := fc.getClientsetOrCached()
+			_, err := fc.getClientsetForPathOrDirect()
 			if mock.isErr && err == nil {
 				t.Fatalf("test %q failed : expected error not to be nil but got %v", name, err)
 			}

--- a/pkg/kubernetes/persistentvolumeclaim/v1alpha1/kubernetes_test.go
+++ b/pkg/kubernetes/persistentvolumeclaim/v1alpha1/kubernetes_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func fakeGetClientsetOk() (cli *kubernetes.Clientset, err error) {
+func fakeGetClientsetOk(kubeConfigPath string) (cli *kubernetes.Clientset, err error) {
 	return &kubernetes.Clientset{}, nil
 }
 
@@ -61,11 +61,11 @@ func fakeSetNilClientset(k *Kubeclient) {
 	k.clientset = nil
 }
 
-func fakeGetNilErrClientSet() (clientset *kubernetes.Clientset, err error) {
+func fakeGetNilErrClientSet(kubeConfigPath string) (clientset *kubernetes.Clientset, err error) {
 	return nil, nil
 }
 
-func fakeGetClientSetErr() (clientset *kubernetes.Clientset, err error) {
+func fakeGetClientSetErr(kubeConfigPath string) (clientset *kubernetes.Clientset, err error) {
 	return nil, errors.New("Some error")
 }
 
@@ -204,11 +204,11 @@ func TestGetClientOrCached(t *testing.T) {
 		KubeClient *Kubeclient
 	}{
 		// Positive tests
-		"Positive 1": {false, &Kubeclient{nil, "", fakeGetNilErrClientSet, fakeListOk, nil, nil, nil, nil}},
-		"Positive 2": {false, &Kubeclient{&kubernetes.Clientset{}, "", fakeGetNilErrClientSet, fakeListOk, nil, nil, nil, nil}},
+		"Positive 1": {false, &Kubeclient{nil, "", "fake-path", fakeGetNilErrClientSet, fakeListOk, nil, nil, nil, nil}},
+		"Positive 2": {false, &Kubeclient{&kubernetes.Clientset{}, "", "", fakeGetNilErrClientSet, fakeListOk, nil, nil, nil, nil}},
 
 		// Negative tests
-		"Negative 1": {true, &Kubeclient{nil, "", fakeGetClientSetErr, fakeListOk, nil, nil, nil, nil}},
+		"Negative 1": {true, &Kubeclient{nil, "", "fake-path", fakeGetClientSetErr, fakeListOk, nil, nil, nil, nil}},
 	}
 
 	for name, mock := range tests {

--- a/pkg/kubernetes/pod/v1alpha1/kubernetes.go
+++ b/pkg/kubernetes/pod/v1alpha1/kubernetes.go
@@ -15,18 +15,18 @@
 package v1alpha1
 
 import (
-	"github.com/pkg/errors"
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kclient "github.com/openebs/maya/pkg/kubernetes/client/v1alpha1"
+	client "github.com/openebs/maya/pkg/kubernetes/client/v1alpha1"
 	clientset "k8s.io/client-go/kubernetes"
 )
 
 // getClientsetFn is a typed function that
 // abstracts fetching of clientset
-type getClientsetFn func() (clientset *clientset.Clientset, err error)
+type getClientsetFn func(kubeConfigPath string) (clientset *clientset.Clientset, err error)
 
 // listFn is a typed function that abstracts
 // listing of pods
@@ -51,6 +51,10 @@ type KubeClient struct {
 	// namespace holds the namespace on which
 	// KubeClient has to operate
 	namespace string
+
+	// kubeconfig path to get kubernetes clientset
+	kubeConfigPath string
+
 	// functions useful during mocking
 	getClientset getClientsetFn
 	list         listFn
@@ -66,12 +70,10 @@ type KubeClientBuildOption func(*KubeClient)
 // of KubeClient instance
 func (k *KubeClient) withDefaults() {
 	if k.getClientset == nil {
-		k.getClientset = func() (clients *clientset.Clientset, err error) {
-			config, err := kclient.New().Config()
-			if err != nil {
-				return nil, err
-			}
-			return clientset.NewForConfig(config)
+		k.getClientset = func(kubeConfigPath string) (clients *clientset.Clientset, err error) {
+			// TODO: Update after dependent PR checked in
+			//return client.New(client.WithKubeConfigPath(kubeConfigPath)).Clientset()
+			return client.New().Clientset()
 		}
 	}
 	if k.list == nil {
@@ -107,6 +109,14 @@ func WithClientSet(c *clientset.Clientset) KubeClientBuildOption {
 	}
 }
 
+// WithKubeConfigPath sets the kubeConfig path
+// against client instance
+func WithKubeConfigPath(path string) KubeClientBuildOption {
+	return func(k *KubeClient) {
+		k.kubeConfigPath = path
+	}
+}
+
 // NewKubeClient returns a new instance of KubeClient meant for
 // cstor volume replica operations
 func NewKubeClient(opts ...KubeClientBuildOption) *KubeClient {
@@ -124,7 +134,7 @@ func (k *KubeClient) getClientsetOrCached() (*clientset.Clientset, error) {
 	if k.clientset != nil {
 		return k.clientset, nil
 	}
-	c, err := k.getClientset()
+	c, err := k.getClientset(k.kubeConfigPath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get clientset")
 	}

--- a/pkg/kubernetes/pod/v1alpha1/kubernetes.go
+++ b/pkg/kubernetes/pod/v1alpha1/kubernetes.go
@@ -136,32 +136,25 @@ func NewKubeClient(opts ...KubeClientBuildOption) *KubeClient {
 	return k
 }
 
+func (k *KubeClient) getClientsetPathOrDirect() (*clientset.Clientset, error) {
+	if k.kubeConfigPath != "" {
+		return k.getClientsetForPath(k.kubeConfigPath)
+	}
+	return k.getClientset()
+}
+
 // getClientsetOrCached returns either a new instance
 // of kubernetes client or its cached copy
 func (k *KubeClient) getClientsetOrCached() (*clientset.Clientset, error) {
-	var c *clientset.Clientset
-	var err error
-
 	if k.clientset != nil {
 		return k.clientset, nil
 	}
 
-	// KubeConfigPath holds the first priority to get clientset
-	if k.kubeConfigPath != "" {
-		c, err = k.getClientsetForPath(k.kubeConfigPath)
-		if err != nil {
-			return nil, errors.Wrapf(err,
-				"failed to get clientset kubeconfigpath: %s",
-				k.kubeConfigPath)
-		}
-	} else {
-		c, err = k.getClientset()
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get clientset")
-		}
+	cs, err := k.getClientsetPathOrDirect()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get clientset")
 	}
-
-	k.clientset = c
+	k.clientset = cs
 	return k.clientset, nil
 }
 

--- a/pkg/kubernetes/pod/v1alpha1/kubernetes.go
+++ b/pkg/kubernetes/pod/v1alpha1/kubernetes.go
@@ -136,7 +136,7 @@ func NewKubeClient(opts ...KubeClientBuildOption) *KubeClient {
 	return k
 }
 
-func (k *KubeClient) getClientsetPathOrDirect() (*clientset.Clientset, error) {
+func (k *KubeClient) getClientsetForPathOrDirect() (*clientset.Clientset, error) {
 	if k.kubeConfigPath != "" {
 		return k.getClientsetForPath(k.kubeConfigPath)
 	}
@@ -150,7 +150,7 @@ func (k *KubeClient) getClientsetOrCached() (*clientset.Clientset, error) {
 		return k.clientset, nil
 	}
 
-	cs, err := k.getClientsetPathOrDirect()
+	cs, err := k.getClientsetForPathOrDirect()
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get clientset")
 	}

--- a/pkg/kubernetes/pod/v1alpha1/kubernetes_test.go
+++ b/pkg/kubernetes/pod/v1alpha1/kubernetes_test.go
@@ -25,7 +25,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 )
 
-func fakeGetClientSetOk() (cli *clientset.Clientset, err error) {
+func fakeGetClientSetOk(kubeConfigPath string) (cli *clientset.Clientset, err error) {
 	return &clientset.Clientset{}, nil
 }
 
@@ -61,11 +61,11 @@ func fakeSetNilClientset(k *KubeClient) {
 	k.clientset = nil
 }
 
-func fakeGetNilErrClientSet() (clientset *clientset.Clientset, err error) {
+func fakeGetClientSetNil(kubeConfigPath string) (clientset *clientset.Clientset, err error) {
 	return nil, nil
 }
 
-func fakeGetClientSetErr() (clientset *clientset.Clientset, err error) {
+func fakeGetClientSetErr(kubeConfigPath string) (clientset *clientset.Clientset, err error) {
 	return nil, errors.New("Some error")
 }
 
@@ -187,11 +187,11 @@ func TestGetClientOrCached(t *testing.T) {
 		expectErr  bool
 	}{
 		// Positive tests
-		"Positive 1": {&KubeClient{nil, "", fakeGetNilErrClientSet, fakeListFnOk, fakeDeleteFnOk, fakeGetFnOk}, false},
-		"Positive 2": {&KubeClient{&client.Clientset{}, "", fakeGetNilErrClientSet, fakeListFnOk, fakeDeleteFnOk, fakeGetFnOk}, false},
+		"Positive 1": {&KubeClient{nil, "", "fake-path", fakeGetClientSetNil, fakeListFnOk, fakeDeleteFnOk, fakeGetFnOk}, false},
+		"Positive 2": {&KubeClient{&client.Clientset{}, "", "", fakeGetClientSetNil, fakeListFnOk, fakeDeleteFnOk, fakeGetFnOk}, false},
 
 		// Negative tests
-		"Negative 1": {&KubeClient{nil, "", fakeGetClientSetErr, fakeListFnOk, fakeDeleteFnOk, fakeGetFnOk}, true},
+		"Negative 1": {&KubeClient{nil, "", "", fakeGetClientSetErr, fakeListFnOk, fakeDeleteFnOk, fakeGetFnOk}, true},
 	}
 
 	for name, mock := range tests {

--- a/pkg/kubernetes/pod/v1alpha1/kubernetes_test.go
+++ b/pkg/kubernetes/pod/v1alpha1/kubernetes_test.go
@@ -144,7 +144,7 @@ func TestWithDefaultsForClientSetPath(t *testing.T) {
 	}
 }
 
-func TestGetClientSetPathOrDirect(t *testing.T) {
+func TestGetClientSetForPathOrDirect(t *testing.T) {
 	tests := map[string]struct {
 		getClientSet        getClientsetFn
 		getClientSetForPath getClientsetForPathFn
@@ -172,7 +172,7 @@ func TestGetClientSetPathOrDirect(t *testing.T) {
 				getClientsetForPath: mock.getClientSetForPath,
 				kubeConfigPath:      mock.kubeConfigPath,
 			}
-			_, err := fc.getClientsetOrCached()
+			_, err := fc.getClientsetForPathOrDirect()
 			if mock.isErr && err == nil {
 				t.Fatalf("test %q failed : expected error not to be nil but got %v", name, err)
 			}

--- a/pkg/kubernetes/storageclass/v1alpha1/kubernetes.go
+++ b/pkg/kubernetes/storageclass/v1alpha1/kubernetes.go
@@ -26,7 +26,11 @@ import (
 
 // getClientsetFn is a typed function that abstracts
 // fetching an instance of kubernetes clientset
-type getClientsetFn func(kubeConfigPath string) (clientset *kubernetes.Clientset, err error)
+type getClientsetFn func() (clientset *kubernetes.Clientset, err error)
+
+// getClientsetFromPathFn is a typed function that
+// abstracts fetching of clientset from kubeConfigPath
+type getClientsetForPathFn func(kubeConfigPath string) (clientset *kubernetes.Clientset, err error)
 
 // listFn is a typed function that abstracts
 // listing of storageclasses
@@ -55,11 +59,12 @@ type Kubeclient struct {
 	kubeConfigPath string
 
 	// functions useful during mocking
-	getClientset getClientsetFn
-	list         listFn
-	get          getFn
-	create       createFn
-	del          deleteFn
+	getClientset        getClientsetFn
+	getClientsetForPath getClientsetForPathFn
+	list                listFn
+	get                 getFn
+	create              createFn
+	del                 deleteFn
 }
 
 // KubeClientBuildOption defines the abstraction
@@ -68,10 +73,13 @@ type KubeClientBuildOption func(*Kubeclient)
 
 func (k *Kubeclient) withDefaults() {
 	if k.getClientset == nil {
-		k.getClientset = func(kubeConfigPath string) (clients *kubernetes.Clientset, err error) {
-			// TODO: Update after dependent PR checked in
-			//return client.New(client.WithKubeConfigPath(kubeConfigPath)).Clientset()
+		k.getClientset = func() (clients *kubernetes.Clientset, err error) {
 			return client.New().Clientset()
+		}
+	}
+	if k.getClientsetForPath == nil {
+		k.getClientsetForPath = func(kubeConfigPath string) (clients *kubernetes.Clientset, err error) {
+			return client.New(client.WithKubeConfigPath(kubeConfigPath)).Clientset()
 		}
 	}
 	if k.list == nil {
@@ -126,12 +134,24 @@ func WithKubeConfigPath(path string) KubeClientBuildOption {
 // instance of kubernetes clientset or its
 // cached copy cached copy
 func (k *Kubeclient) getClientsetOrCached() (*kubernetes.Clientset, error) {
+	var c *kubernetes.Clientset
+	var err error
 	if k.clientset != nil {
 		return k.clientset, nil
 	}
-	c, err := k.getClientset(k.kubeConfigPath)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get clientset")
+	// KubeConfigPath holds the first priority to get clientset
+	if k.kubeConfigPath != "" {
+		c, err = k.getClientsetForPath(k.kubeConfigPath)
+		if err != nil {
+			return nil, errors.Wrapf(err,
+				"failed to get clientset kubeconfigpath: %s",
+				k.kubeConfigPath)
+		}
+	} else {
+		c, err = k.getClientset()
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get clientset")
+		}
 	}
 	k.clientset = c
 	return k.clientset, nil
@@ -157,6 +177,9 @@ func (k *Kubeclient) Get(name string, opts metav1.GetOptions) (*storagev1.Storag
 
 // Create creates and returns a storageclass instance
 func (k *Kubeclient) Create(sc *storagev1.StorageClass) (*storagev1.StorageClass, error) {
+	if sc == nil {
+		return nil, errors.New("failed to create the storageclass: missing storage class object")
+	}
 	cli, err := k.getClientsetOrCached()
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create the storageclass {%+v}", *sc)

--- a/pkg/kubernetes/storageclass/v1alpha1/kubernetes.go
+++ b/pkg/kubernetes/storageclass/v1alpha1/kubernetes.go
@@ -130,7 +130,7 @@ func WithKubeConfigPath(path string) KubeClientBuildOption {
 	}
 }
 
-func (k *Kubeclient) getClientsetPathOrDirect() (*kubernetes.Clientset, error) {
+func (k *Kubeclient) getClientsetForPathOrDirect() (*kubernetes.Clientset, error) {
 	if k.kubeConfigPath != "" {
 		return k.getClientsetForPath(k.kubeConfigPath)
 	}
@@ -145,7 +145,7 @@ func (k *Kubeclient) getClientsetOrCached() (*kubernetes.Clientset, error) {
 		return k.clientset, nil
 	}
 
-	cs, err := k.getClientsetPathOrDirect()
+	cs, err := k.getClientsetForPathOrDirect()
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get clientset")
 	}

--- a/pkg/kubernetes/storageclass/v1alpha1/kubernetes.go
+++ b/pkg/kubernetes/storageclass/v1alpha1/kubernetes.go
@@ -130,30 +130,26 @@ func WithKubeConfigPath(path string) KubeClientBuildOption {
 	}
 }
 
+func (k *Kubeclient) getClientsetPathOrDirect() (*kubernetes.Clientset, error) {
+	if k.kubeConfigPath != "" {
+		return k.getClientsetForPath(k.kubeConfigPath)
+	}
+	return k.getClientset()
+}
+
 // getClientsetOrCached returns either a new
 // instance of kubernetes clientset or its
 // cached copy cached copy
 func (k *Kubeclient) getClientsetOrCached() (*kubernetes.Clientset, error) {
-	var c *kubernetes.Clientset
-	var err error
 	if k.clientset != nil {
 		return k.clientset, nil
 	}
-	// KubeConfigPath holds the first priority to get clientset
-	if k.kubeConfigPath != "" {
-		c, err = k.getClientsetForPath(k.kubeConfigPath)
-		if err != nil {
-			return nil, errors.Wrapf(err,
-				"failed to get clientset kubeconfigpath: %s",
-				k.kubeConfigPath)
-		}
-	} else {
-		c, err = k.getClientset()
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get clientset")
-		}
+
+	cs, err := k.getClientsetPathOrDirect()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get clientset")
 	}
-	k.clientset = c
+	k.clientset = cs
 	return k.clientset, nil
 }
 

--- a/pkg/kubernetes/storageclass/v1alpha1/kubernetes_test.go
+++ b/pkg/kubernetes/storageclass/v1alpha1/kubernetes_test.go
@@ -119,7 +119,7 @@ func TestWithDefaultOptions(t *testing.T) {
 	}
 }
 
-func TestGetClientSetPathOrDirect(t *testing.T) {
+func TestGetClientSetForPathOrDirect(t *testing.T) {
 	tests := map[string]struct {
 		getClientSet        getClientsetFn
 		getClientSetForPath getClientsetForPathFn
@@ -147,7 +147,7 @@ func TestGetClientSetPathOrDirect(t *testing.T) {
 				getClientsetForPath: mock.getClientSetForPath,
 				kubeConfigPath:      mock.kubeConfigPath,
 			}
-			_, err := fc.getClientsetOrCached()
+			_, err := fc.getClientsetForPathOrDirect()
 			if mock.isErr && err == nil {
 				t.Fatalf("test %q failed : expected error not to be nil but got %v", name, err)
 			}

--- a/pkg/kubernetes/storageclass/v1alpha1/kubernetes_test.go
+++ b/pkg/kubernetes/storageclass/v1alpha1/kubernetes_test.go
@@ -26,7 +26,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 )
 
-func fakeGetClientSetOk(kubeConfigPath string) (cli *clientset.Clientset, err error) {
+func fakeGetClientSetOk() (cli *clientset.Clientset, err error) {
 	return &clientset.Clientset{}, nil
 }
 
@@ -38,11 +38,11 @@ func fakeListFnErr(cli *clientset.Clientset, opts metav1.ListOptions) (*storagev
 	return nil, errors.New("some error occured to get storageclass list")
 }
 
-func fakeGetClientSetNil(kubeConfigPath string) (clientset *clientset.Clientset, err error) {
+func fakeGetClientSetNil() (clientset *clientset.Clientset, err error) {
 	return nil, nil
 }
 
-func fakeGetClientSetErr(kubeConfigPath string) (clientset *clientset.Clientset, err error) {
+func fakeGetClientSetErr() (clientset *clientset.Clientset, err error) {
 	return nil, errors.New("Some error")
 }
 
@@ -70,6 +70,14 @@ func fakeDeleteFnOk(cli *clientset.Clientset, name string, opts *metav1.DeleteOp
 	return nil
 }
 
+func fakeGetClientSetForPathOk(fakeConfigPath string) (cli *clientset.Clientset, err error) {
+	return &clientset.Clientset{}, nil
+}
+
+func fakeGetClientSetForPathErr(fakeConfigPath string) (cli *clientset.Clientset, err error) {
+	return nil, errors.New("fake error")
+}
+
 func TestKubeClient(t *testing.T) {
 	kubeclient := NewKubeClient()
 	if reflect.DeepEqual(kubeclient, Kubeclient{}) {
@@ -79,37 +87,33 @@ func TestKubeClient(t *testing.T) {
 
 func TestWithDefaultOptions(t *testing.T) {
 	tests := map[string]struct {
-		KubeClient *Kubeclient
+		kubeClient *Kubeclient
 	}{
-		"When all getClientsetFn, listFn and getFn are error": {&Kubeclient{nil, "", fakeGetClientSetErr, fakeListFnErr, fakeGetFnErr, fakeCreateFnErr, fakeDeleteFnErr}},
-		"When all are nil":                         {&Kubeclient{}},
-		"When getClientSet is error":               {&Kubeclient{nil, "", fakeGetClientSetErr, nil, nil, nil, nil}},
-		"When ListFn is error":                     {&Kubeclient{nil, "", nil, fakeListFnErr, nil, nil, nil}},
-		"When GetFn is error":                      {&Kubeclient{nil, "", nil, nil, fakeGetFnErr, nil, nil}},
-		"When listFn and getFn are error":          {&Kubeclient{nil, "", fakeGetClientSetOk, fakeListFnErr, fakeGetFnErr, fakeCreateFnOk, fakeDeleteFnOk}},
-		"When getClientsetFn and listFn are error": {&Kubeclient{nil, "", fakeGetClientSetErr, fakeListFnErr, fakeGetFnOk, fakeCreateFnOk, fakeDeleteFnOk}},
-		"When getClientsetFn and getFn are error":  {&Kubeclient{nil, "", fakeGetClientSetErr, fakeListFnOk, fakeGetFnErr, fakeCreateFnOk, fakeDeleteFnOk}},
-		"When CreateFn and DeleteFn are error":     {&Kubeclient{nil, "", fakeGetClientSetErr, fakeListFnOk, fakeGetFnErr, fakeCreateFnErr, fakeDeleteFnErr}},
+		"T1": {&Kubeclient{}},
+		"T2": {&Kubeclient{nil, "fake-path", fakeGetClientSetOk, fakeGetClientSetForPathOk, fakeListFnOk, fakeGetFnOk, fakeCreateFnOk, fakeDeleteFnOk}},
 	}
 	for name, mock := range tests {
 		name := name
 		mock := mock
 		t.Run(name, func(t *testing.T) {
-			mock.KubeClient.withDefaults()
-			if mock.KubeClient.getClientset == nil {
+			mock.kubeClient.withDefaults()
+			if mock.kubeClient.getClientset == nil {
 				t.Fatalf("test %q failed: expected getClientset not to be empty", name)
 			}
-			if mock.KubeClient.list == nil {
+			if mock.kubeClient.list == nil {
 				t.Fatalf("test %q failed: expected list not to be empty", name)
 			}
-			if mock.KubeClient.get == nil {
+			if mock.kubeClient.get == nil {
 				t.Fatalf("test %q failed: expected get not to be emptu", name)
 			}
-			if mock.KubeClient.create == nil {
+			if mock.kubeClient.create == nil {
 				t.Fatalf("test %q failed: expected get not to be empty", name)
 			}
-			if mock.KubeClient.del == nil {
+			if mock.kubeClient.del == nil {
 				t.Fatalf("test %q failed: expected get not to be empty", name)
+			}
+			if mock.kubeClient.getClientsetForPath == nil {
+				t.Fatalf("test %q failed: expected getClientset not to be nil", name)
 			}
 		})
 	}
@@ -117,36 +121,39 @@ func TestWithDefaultOptions(t *testing.T) {
 
 func TestGetClientOrCached(t *testing.T) {
 	tests := map[string]struct {
-		KubeClient *Kubeclient
-		expectErr  bool
+		getClientSet        getClientsetFn
+		getClientSetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		expectErr           bool
 	}{
 		// Positive tests
-		"Positive 1": {
-			KubeClient: &Kubeclient{nil, "fake-path", fakeGetClientSetNil, fakeListFnOk, fakeGetFnErr, fakeCreateFnErr, fakeDeleteFnErr},
-			expectErr:  false,
-		},
-		"Positive 2": {
-			KubeClient: &Kubeclient{&clientset.Clientset{}, "fake-path", fakeGetClientSetOk, fakeListFnOk, fakeGetFnOk, fakeCreateFnOk, fakeDeleteFnOk},
-			expectErr:  false,
-		},
+		"Positive 1": {fakeGetClientSetNil, fakeGetClientSetForPathOk, "fake-path", false},
+		"Positive 2": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "", false},
+		"Positive 3": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "fake-path", false},
+		"Positive 4": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "", false},
 
 		// Negative tests
-		"Negative 1": {
-			KubeClient: &Kubeclient{nil, "fake-path", fakeGetClientSetErr, fakeListFnOk, fakeGetFnOk, nil, nil},
-			expectErr:  true,
-		},
+		"Negative 1": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "", true},
+		"Negative 2": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "fake-path", true},
+		"Negative 3": {fakeGetClientSetErr, fakeGetClientSetForPathErr, "fake-path", true},
+		"Negative 4": {fakeGetClientSetErr, fakeGetClientSetForPathErr, "", true},
 	}
 
 	for name, mock := range tests {
 		name := name // pin it
 		mock := mock // pin it
 		t.Run(name, func(t *testing.T) {
-			c, err := mock.KubeClient.getClientsetOrCached()
+			fc := &Kubeclient{
+				getClientset:        mock.getClientSet,
+				getClientsetForPath: mock.getClientSetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+			}
+			_, err := fc.getClientsetOrCached()
 			if mock.expectErr && err == nil {
 				t.Fatalf("test %q failed : expected error not to be nil but got %v", name, err)
 			}
-			if !reflect.DeepEqual(c, mock.KubeClient.clientset) {
-				t.Fatalf("test %q failed : expected clientset %v but got %v", name, mock.KubeClient.clientset, c)
+			if !mock.expectErr && err != nil {
+				t.Fatalf("test %q failed : expected error be nil but got %v", name, err)
 			}
 		})
 	}
@@ -154,28 +161,40 @@ func TestGetClientOrCached(t *testing.T) {
 
 func TestKubenetesStorageClassList(t *testing.T) {
 	tests := map[string]struct {
-		getClientset getClientsetFn
-		list         listFn
-		expectErr    bool
+		getClientset        getClientsetFn
+		getClientSetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		list                listFn
+		expectedErr         bool
 	}{
-		// Negative tests
-		"When GetClientSetErr": {fakeGetClientSetErr, fakeListFnOk, true},
-		"When ListFnErr":       {fakeGetClientSetOk, fakeListFnErr, true},
 		// Positive tests
-		"When GetClientSetNil": {fakeGetClientSetNil, fakeListFnOk, false},
-		"When both are ok":     {fakeGetClientSetOk, fakeListFnOk, false},
+		"Positive 1": {fakeGetClientSetNil, fakeGetClientSetForPathOk, "fake-path", fakeListFnOk, false},
+		"Positive 2": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "", fakeListFnOk, false},
+		"Positive 3": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "fake-path", fakeListFnOk, false},
+		"Positive 4": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "", fakeListFnOk, false},
+
+		// Negative tests
+		"Negative 1": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "", fakeListFnOk, true},
+		"Negative 2": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "fake-path", fakeListFnErr, true},
+		"Negative 3": {fakeGetClientSetErr, fakeGetClientSetForPathErr, "fake-path", fakeListFnOk, true},
+		"Negative 4": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "", fakeListFnErr, true},
 	}
 
 	for name, mock := range tests {
-		name := name
-		mock := mock
+		name := name // pin it
+		mock := mock // pin it
 		t.Run(name, func(t *testing.T) {
-			k := Kubeclient{getClientset: mock.getClientset, list: mock.list}
-			_, err := k.List(metav1.ListOptions{})
-			if mock.expectErr && err == nil {
+			fc := &Kubeclient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientSetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+				list:                mock.list,
+			}
+			_, err := fc.List(metav1.ListOptions{})
+			if mock.expectedErr && err == nil {
 				t.Fatalf("Test %q failed: expected error not to be nil", name)
 			}
-			if !mock.expectErr && err != nil {
+			if !mock.expectedErr && err != nil {
 				t.Fatalf("Test %q failed: expected error to be nil", name)
 			}
 		})
@@ -184,29 +203,40 @@ func TestKubenetesStorageClassList(t *testing.T) {
 
 func TestKubenetesStorageClassGet(t *testing.T) {
 	tests := map[string]struct {
-		getClientset getClientsetFn
-		get          getFn
-		name         string
-		expectErr    bool
+		getClientset        getClientsetFn
+		getClientSetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		get                 getFn
+		expectedErr         bool
 	}{
-		// Negative tests
-		"When GetClientSetErr": {fakeGetClientSetErr, fakeGetFnOk, "SC1", true},
-		"When GetFnErr":        {fakeGetClientSetOk, fakeGetFnErr, "SC2", true},
 		// Positive tests
-		"When GetClientSetNil": {fakeGetClientSetNil, fakeGetFnOk, "SC3", false},
-		"When both are ok":     {fakeGetClientSetOk, fakeGetFnOk, "SC4", false},
+		"Positive 1": {fakeGetClientSetNil, fakeGetClientSetForPathOk, "fake-path", fakeGetFnOk, false},
+		"Positive 2": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "", fakeGetFnOk, false},
+		"Positive 3": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "fake-path", fakeGetFnOk, false},
+		"Positive 4": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "", fakeGetFnOk, false},
+
+		// Negative tests
+		"Negative 1": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "", fakeGetFnOk, true},
+		"Negative 2": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "fake-path", fakeGetFnErr, true},
+		"Negative 3": {fakeGetClientSetErr, fakeGetClientSetForPathErr, "fake-path", fakeGetFnOk, true},
+		"Negative 4": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "", fakeGetFnErr, true},
 	}
 
 	for name, mock := range tests {
 		name := name
 		mock := mock
 		t.Run(name, func(t *testing.T) {
-			k := Kubeclient{getClientset: mock.getClientset, get: mock.get}
-			_, err := k.Get(name, metav1.GetOptions{})
-			if mock.expectErr && err == nil {
+			fc := &Kubeclient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientSetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+				get:                 mock.get,
+			}
+			_, err := fc.Get(name, metav1.GetOptions{})
+			if mock.expectedErr && err == nil {
 				t.Fatalf("Test %q failed: expected error not to be nil", name)
 			}
-			if !mock.expectErr && err != nil {
+			if !mock.expectedErr && err != nil {
 				t.Fatalf("Test %q failed: expected error to be nil", name)
 			}
 		})
@@ -215,34 +245,60 @@ func TestKubenetesStorageClassGet(t *testing.T) {
 
 func TestKubenetesStorageClassCreate(t *testing.T) {
 	tests := map[string]struct {
-		getClientSet getClientsetFn
-		create       createFn
-		sc           *storagev1.StorageClass
-		expectErr    bool
+		getClientset        getClientsetFn
+		getClientSetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		create              createFn
+		sc                  *storagev1.StorageClass
+		expectedErr         bool
 	}{
-		"Negative Test 1": {
-			getClientSet: fakeGetClientSetErr,
-			create:       fakeCreateFnOk,
-			sc:           &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "SC-1"}},
-			expectErr:    true,
+		"Test 1": {
+			getClientset:        fakeGetClientSetErr,
+			getClientSetForPath: fakeGetClientSetForPathOk,
+			kubeConfigPath:      "",
+			create:              fakeCreateFnOk,
+			sc:                  &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "SC-1"}},
+			expectedErr:         true,
 		},
-		"Negative Test 2": {
-			getClientSet: fakeGetClientSetOk,
-			create:       fakeCreateFnErr,
-			sc:           &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "SC-2"}},
-			expectErr:    true,
+		"Test 2": {
+			getClientset:        fakeGetClientSetOk,
+			getClientSetForPath: fakeGetClientSetForPathOk,
+			kubeConfigPath:      "fake-path",
+			create:              fakeCreateFnErr,
+			sc:                  &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "SC-2"}},
+			expectedErr:         true,
 		},
-		"Negative Test 3": {
-			getClientSet: fakeGetClientSetOk,
-			create:       fakeCreateFnErr,
-			sc:           nil,
-			expectErr:    true,
+		"Test 3": {
+			getClientset:        fakeGetClientSetOk,
+			getClientSetForPath: fakeGetClientSetForPathOk,
+			kubeConfigPath:      "fake-path",
+			create:              fakeCreateFnErr,
+			sc:                  nil,
+			expectedErr:         true,
 		},
-		"Positive Test 4": {
-			getClientSet: fakeGetClientSetOk,
-			create:       fakeCreateFnOk,
-			sc:           nil,
-			expectErr:    false,
+		"Test 4": {
+			getClientset:        fakeGetClientSetOk,
+			getClientSetForPath: fakeGetClientSetForPathErr,
+			kubeConfigPath:      "",
+			create:              fakeCreateFnOk,
+			sc:                  &storagev1.StorageClass{},
+			expectedErr:         false,
+		},
+		"Test 5": {
+			getClientset:        fakeGetClientSetOk,
+			getClientSetForPath: fakeGetClientSetForPathErr,
+			kubeConfigPath:      "fp",
+			create:              fakeCreateFnOk,
+			sc:                  nil,
+			expectedErr:         true,
+		},
+		"Test 6": {
+			getClientset:        fakeGetClientSetOk,
+			getClientSetForPath: fakeGetClientSetForPathErr,
+			kubeConfigPath:      "",
+			create:              fakeCreateFnOk,
+			sc:                  nil,
+			expectedErr:         true,
 		},
 	}
 
@@ -250,12 +306,17 @@ func TestKubenetesStorageClassCreate(t *testing.T) {
 		name := name
 		mock := mock
 		t.Run(name, func(t *testing.T) {
-			k := Kubeclient{getClientset: mock.getClientSet, create: mock.create}
-			_, err := k.Create(mock.sc)
-			if mock.expectErr && err == nil {
+			fc := &Kubeclient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientSetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+				create:              mock.create,
+			}
+			_, err := fc.Create(mock.sc)
+			if mock.expectedErr && err == nil {
 				t.Fatalf("Test %q failed: expected error not to be nil", name)
 			}
-			if !mock.expectErr && err != nil {
+			if !mock.expectedErr && err != nil {
 				t.Fatalf("Test %q failed: expected error to be nil", name)
 			}
 		})
@@ -264,34 +325,52 @@ func TestKubenetesStorageClassCreate(t *testing.T) {
 
 func TestKubenetesStorageClassDelete(t *testing.T) {
 	tests := map[string]struct {
-		getClientSet getClientsetFn
-		del          deleteFn
-		scName       string
-		expectErr    bool
+		getClientSet        getClientsetFn
+		getClientSetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		del                 deleteFn
+		scName              string
+		expectErr           bool
 	}{
 		"Negative Test 1": {
-			getClientSet: fakeGetClientSetErr,
-			del:          fakeDeleteFnOk,
-			scName:       "SC1",
-			expectErr:    true,
+			getClientSet:        fakeGetClientSetErr,
+			getClientSetForPath: fakeGetClientSetForPathOk,
+			kubeConfigPath:      "",
+			del:                 fakeDeleteFnOk,
+			scName:              "SC1",
+			expectErr:           true,
 		},
 		"Negative Test 2": {
-			getClientSet: fakeGetClientSetOk,
-			del:          fakeDeleteFnErr,
-			scName:       "SC2",
-			expectErr:    true,
+			getClientSet:        fakeGetClientSetOk,
+			getClientSetForPath: fakeGetClientSetForPathErr,
+			kubeConfigPath:      "",
+			del:                 fakeDeleteFnErr,
+			scName:              "SC2",
+			expectErr:           true,
 		},
 		"Negative Test 3": {
-			getClientSet: fakeGetClientSetOk,
-			del:          fakeDeleteFnErr,
-			scName:       "",
-			expectErr:    true,
+			getClientSet:        fakeGetClientSetOk,
+			getClientSetForPath: fakeGetClientSetForPathOk,
+			kubeConfigPath:      "",
+			del:                 fakeDeleteFnErr,
+			scName:              "",
+			expectErr:           true,
 		},
-		"Positive Test 4": {
-			getClientSet: fakeGetClientSetOk,
-			del:          fakeDeleteFnOk,
-			scName:       "",
-			expectErr:    false,
+		"Negative Test 4": {
+			getClientSet:        fakeGetClientSetOk,
+			getClientSetForPath: fakeGetClientSetForPathErr,
+			kubeConfigPath:      "fp",
+			del:                 fakeDeleteFnErr,
+			scName:              "",
+			expectErr:           true,
+		},
+		"Positive Test 5": {
+			getClientSet:        fakeGetClientSetOk,
+			getClientSetForPath: fakeGetClientSetForPathOk,
+			kubeConfigPath:      "",
+			del:                 fakeDeleteFnOk,
+			scName:              "",
+			expectErr:           false,
 		},
 	}
 
@@ -299,8 +378,13 @@ func TestKubenetesStorageClassDelete(t *testing.T) {
 		name := name
 		mock := mock
 		t.Run(name, func(t *testing.T) {
-			k := Kubeclient{getClientset: mock.getClientSet, del: mock.del}
-			err := k.Delete(mock.scName, &metav1.DeleteOptions{})
+			fc := &Kubeclient{
+				getClientset:        mock.getClientSet,
+				getClientsetForPath: mock.getClientSetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+				del:                 mock.del,
+			}
+			err := fc.Delete(mock.scName, &metav1.DeleteOptions{})
 			if mock.expectErr && err == nil {
 				t.Fatalf("Test %q failed: expected error not to be nil", name)
 			}


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->
**What this PR does**:
This PR adds the support to get the clientset using provided kubeConfig Path.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Dependent PR need to merge:(https://github.com/openebs/maya/pull/1120)
**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [x] Commit has unit tests
- [ ] Commit has integration tests