### PR TITLE
enhance(sc, idiomatic): add volumebinding mode in storageclass

### DIFF
--- a/pkg/kubernetes/storageclass/v1alpha1/build.go
+++ b/pkg/kubernetes/storageclass/v1alpha1/build.go
@@ -68,3 +68,21 @@ func (b *Builder) Build() (*storagev1.StorageClass, error) {
 	}
 	return b.sc.object, nil
 }
+
+// WithVolumeBindingMode sets the volume binding mode of storageclass with
+// provided argument.
+// VolumeBindingMode indicates how PersistentVolumeClaims should be bound.
+// VolumeBindingImmediate indicates that PersistentVolumeClaims should be
+// immediately provisioned and bound. This is the default mode.
+// VolumeBindingWaitForFirstConsumer indicates that PersistentVolumeClaims
+// should not be provisioned and bound until the first Pod is created that
+// references the PeristentVolumeClaim.  The volume provisioning and
+// binding will occur during Pod scheduing.
+func (b *Builder) WithVolumeBindingMode(bindingMode storagev1.VolumeBindingMode) *Builder {
+	if bindingMode == "" {
+		b.errs = append(b.errs, errors.New("failed to build storageclass: missing volume binding mode"))
+		return b
+	}
+	b.sc.object.VolumeBindingMode = &bindingMode
+	return b
+}

--- a/pkg/kubernetes/storageclass/v1alpha1/build_test.go
+++ b/pkg/kubernetes/storageclass/v1alpha1/build_test.go
@@ -114,3 +114,40 @@ func TestBuilderWithProvisioner(t *testing.T) {
 		})
 	}
 }
+
+func TestBuilderWithVolumeBind(t *testing.T) {
+	tests := map[string]struct {
+		bindmode  storagev1.VolumeBindingMode
+		builder   *Builder
+		expectErr bool
+	}{
+		"Test SC with immediate binding mode": {
+			bindmode:  storagev1.VolumeBindingImmediate,
+			builder:   &Builder{sc: &StorageClass{object: &storagev1.StorageClass{}}},
+			expectErr: false,
+		},
+		"Test SC with waitforconsumer binding mode": {
+			bindmode:  storagev1.VolumeBindingWaitForFirstConsumer,
+			builder:   &Builder{sc: &StorageClass{object: &storagev1.StorageClass{}}},
+			expectErr: false,
+		},
+
+		"Test SC with nil binding mode": {
+			bindmode:  "",
+			builder:   &Builder{sc: &StorageClass{object: &storagev1.StorageClass{}}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithVolumeBindingMode(mock.bindmode)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `WithVolumeBindingMode` as a build option to set specific volume binding mode against a SC.

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [x] Commit has unit tests
- [ ] Commit has integration tests