### PR TITLE
enhance(travis): update kubernetes version to 1.13 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,13 @@ sudo: required
 dist: xenial
 #group: edge
 env:
-- CHANGE_MINIKUBE_NONE_USER=true
+  global:
+    - CHANGE_MINIKUBE_NONE_USER=true
+    - MINIKUBE_WANTUPDATENOTIFICATION=false
+    - MINIKUBE_WANTREPORTERRORPROMPT=false
+    - MINIKUBE_HOME=$HOME
+    - CHANGE_MINIKUBE_NONE_USER=true
+    - KUBECONFIG=$HOME/.kube/config
 services:
   - docker
 language: go
@@ -18,12 +24,13 @@ install:
   - make format
 before_script:
   # Download kubectl, which is a requirement for using minikube.
-  - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+  - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.13.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
   # Download minikube.
-  - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.28.2/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-  - sudo minikube start --vm-driver=none --bootstrapper=localkube --kubernetes-version=v1.10.0 --extra-config=apiserver.Authorization.Mode=RBAC --feature-gates=MountPropagation=false
-  # Fix the kubectl context, as it's often stale.
-  - minikube update-context
+  - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.35.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+  - mkdir -p $HOME/.kube $HOME/.minikube
+  - touch $KUBECONFIG
+  - sudo minikube start --vm-driver=none --kubernetes-version=v1.13.0
+  - "sudo chown -R travis: /home/travis/.minikube/"
   # Wait for Kubernetes to be up and ready.
   - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
   # Download and initialize helm.
@@ -34,6 +41,9 @@ before_script:
   #- helm init
 script:
   - kubectl cluster-info
+   # Verify kube-addon-manager.
+   # kube-addon-manager is responsible for managing other kubernetes components, such as kube-dns, dashboard, storage-provisioner..
+  - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lcomponent=kube-addon-manager -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-addon-manager to be available"; kubectl get pods --all-namespaces; done
   - kubectl get deployment
   - ./buildscripts/travis-build.sh
   - ./ci/travis-ci.sh


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

```sh
 sudo minikube start --vm-driver=none --kubernetes-version=v1.13.0
o   minikube v0.35.0 on linux (amd64)
>   Configuring local host environment ...
!   The 'none' driver provides limited isolation and may reduce system security and reliability.
!   For more information, see:
-   https://github.com/kubernetes/minikube/blob/master/docs/vmdriver-none.md
>   Creating none VM (CPUs=2, Memory=2048MB, Disk=20000MB) ...
-   "minikube" IP address is 10.20.3.20
-   Configuring Docker as the container runtime ...
-   Preparing Kubernetes environment ...
@   Downloading kubeadm v1.13.0
@   Downloading kubelet v1.13.0
-   Pulling images required by Kubernetes v1.13.0 ...
-   Launching Kubernetes v1.13.0 using kubeadm ... 
:   Waiting for pods: apiserver proxy etcd scheduler controller addon-manager dns
-   Configuring cluster permissions ...
-   Verifying component health .....
+   kubectl is now configured to use "minikube"
=   Done! Thank you for using minikube!
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests