### PR TITLE
fix(makefile): add make target to delete kubernetes generated code

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -190,7 +190,14 @@ kubegen1:
 	./buildscripts/code-gen.sh ${GENS} ${OUTPUT_PKG} ${APIS_PKG} ${GROUPS_WITH_VERSIONS} --go-header-file ${BOILERPLATE_TEXT_PATH} 
 
 # code generation for custom resources
-kubegen: kubegen1 kubegen2
+kubegen: kubegendelete kubegen1 kubegen2
+
+# deletes generated code by codegen
+kubegendelete:
+	@rm -rf pkg/client/generated/clientset
+	@rm -rf pkg/client/generated/listers
+	@rm -rf pkg/client/generated/informers
+	@rm -rf pkg/client/generated/openebs.io
 
 # code generation for custom resources and protobuf
 generated_files: kubegen protobuf


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This commit adds `make kubegendelete` target for deleting generating code by kubegen and also adds a travis check for this. This will be helpful for catching PR's that introduces inconsistency for generated codes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests