### PR TITLE
feat(spc_v1beta1_schema): add poolspec in spc schema

### DIFF
--- a/pkg/apis/openebs.io/v1beta1/storage_pool_claim.go
+++ b/pkg/apis/openebs.io/v1beta1/storage_pool_claim.go
@@ -41,6 +41,7 @@ type StoragePoolClaimSpec struct {
 	MaxPools *int                       `json:"maxPools"`
 	MinPools int                        `json:"minPools"`
 	Nodes    []StoragePoolClaimNodeSpec `json:"nodes"`
+	PoolSpec CStorPoolAttr              `json:"poolSpec"`
 }
 
 // StoragePoolClaimNodeSpec is the spec for node where pool should be created.

--- a/pkg/apis/openebs.io/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/openebs.io/v1beta1/zz_generated.deepcopy.go
@@ -177,6 +177,7 @@ func (in *StoragePoolClaimSpec) DeepCopyInto(out *StoragePoolClaimSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	out.PoolSpec = in.PoolSpec
 	return
 }
 


### PR DESCRIPTION
This PR will do following:
1. Add `poolspec` in spc inside spc `spec` also so that this can be used in auto provisioning.
2. Add auto gen files for the added spec. 
Signed-off-by: Ashutosh Kumar <ashutosh.kumar@openebs.io>