### PR TITLE
feat(unstruct, idiomatic): add support to get dynamic clientset using KubeConfig path

### DIFF
--- a/integration-tests/artifacts/installer/v1alpha1/installer.go
+++ b/integration-tests/artifacts/installer/v1alpha1/installer.go
@@ -80,7 +80,7 @@ func (i *DefaultInstaller) UnInstall() error {
 // Verify returns the installation of resource.
 // It returns true if all the predicates passes
 func (i *DefaultInstaller) Verify() (bool, error) {
-	k := unstruct.NewKubeClient()
+	k := i.getKubeClientOrCached()
 	obj, err := k.Get(
 		i.object.GetName(),
 		unstruct.WithGetNamespace(i.object.GetNamespace()),

--- a/integration-tests/artifacts/installer/v1alpha1/installer.go
+++ b/integration-tests/artifacts/installer/v1alpha1/installer.go
@@ -30,6 +30,7 @@ import (
 type DefaultInstaller struct {
 	object     *unstructured.Unstructured
 	predicates []Predicate
+	*unstruct.Kubeclient
 }
 
 // Predicate abstracts the verification of
@@ -56,33 +57,30 @@ func (i *DefaultInstaller) GoString() string {
 	return i.String()
 }
 
+func (i *DefaultInstaller) getKubeClientOrCached() *unstruct.Kubeclient {
+	if i.Kubeclient != nil {
+		return i.Kubeclient
+	}
+	i.Kubeclient = unstruct.NewKubeClient()
+	return i.Kubeclient
+}
+
 // Install triggers the installation of resource
 // in the kubernetes cluster
 func (i *DefaultInstaller) Install() error {
-	k, err := unstruct.KubeClient()
-	if err != nil {
-		return err
-	}
-	return k.Create(i.object)
+	return i.getKubeClientOrCached().Create(i.object)
 }
 
 // UnInstall triggers deletion of resource from
 // kubernetes cluster
 func (i *DefaultInstaller) UnInstall() error {
-	k, err := unstruct.KubeClient()
-	if err != nil {
-		return err
-	}
-	return k.Delete(i.object)
+	return i.getKubeClientOrCached().Delete(i.object)
 }
 
 // Verify returns the installation of resource.
 // It returns true if all the predicates passes
 func (i *DefaultInstaller) Verify() (bool, error) {
-	k, err := unstruct.KubeClient()
-	if err != nil {
-		return false, err
-	}
+	k := unstruct.NewKubeClient()
 	obj, err := k.Get(
 		i.object.GetName(),
 		unstruct.WithGetNamespace(i.object.GetNamespace()),
@@ -114,7 +112,7 @@ func BuilderForObject(obj *unstructured.Unstructured) *Builder {
 		b.errs = append(b.errs, errors.Errorf("failed to build for object: nil unstruct instance provided"))
 		return b
 	}
-	b.installer = &DefaultInstaller{object: obj}
+	b.installer = &DefaultInstaller{object: obj, Kubeclient: nil}
 	return b
 }
 
@@ -127,7 +125,13 @@ func BuilderForYaml(yaml string) *Builder {
 		b.errs = append(b.errs, err)
 		return b
 	}
-	b.installer = &DefaultInstaller{object: obj.GetUnstructured()}
+	b.installer = &DefaultInstaller{object: obj.GetUnstructured(), Kubeclient: nil}
+	return b
+}
+
+// WithKubeClient returns a new instance of unstructured kubeclient
+func (b *Builder) WithKubeClient(opts ...unstruct.KubeclientBuildOption) *Builder {
+	b.installer.Kubeclient = unstruct.NewKubeClient(opts...)
 	return b
 }
 

--- a/pkg/unstruct/v1alpha2/kubernetes.go
+++ b/pkg/unstruct/v1alpha2/kubernetes.go
@@ -20,7 +20,8 @@ import (
 	"strings"
 
 	k8s "github.com/openebs/maya/pkg/client/k8s/v1alpha1"
-	"github.com/pkg/errors"
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
+	client "github.com/openebs/maya/pkg/kubernetes/client/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -30,6 +31,10 @@ import (
 // getClientsetFn is a typed function that
 // abstracts fetching of clientset
 type getClientsetFn func() (clientset dynamic.Interface, err error)
+
+// getClientsetFromPathFn is a typed function that
+// abstracts fetching of clientset from kubeConfigPath
+type getClientsetForPathFn func(kubeConfigPath string) (clientset dynamic.Interface, err error)
 
 // CreateFn is a typed function that abstracts
 // creating of unstructured object
@@ -63,11 +68,15 @@ type Kubeclient struct {
 	// make kubernetes API calls
 	clientset dynamic.Interface
 
+	// Kubeconfig path to get kubernetes clientset
+	kubeConfigPath string
+
 	// functions useful during mocking
-	getClientset getClientsetFn
-	create       CreateFn
-	get          GetFn
-	delete       DeleteFn
+	getClientset        getClientsetFn
+	getClientsetForPath getClientsetForPathFn
+	create              CreateFn
+	get                 GetFn
+	delete              DeleteFn
 }
 
 // KubeclientBuildOption defines the abstraction to build
@@ -75,27 +84,26 @@ type Kubeclient struct {
 type KubeclientBuildOption func(*Kubeclient)
 
 // withDefaults sets default options for Kubeclient
-func withDefaults(k *Kubeclient) error {
+func withDefaults(k *Kubeclient) {
 	if k.clientset == nil {
-		cli, err := k8s.Dynamic().Provide()
-		if err != nil {
-			return err
+		k.getClientset = func() (dynamic.Interface, error) {
+			return client.New().Dynamic()
 		}
-		k.clientset = cli
+	}
+	if k.getClientsetForPath == nil {
+		k.getClientsetForPath = func(kubeConfigPath string) (dynamic.Interface, error) {
+			return client.New(client.WithKubeConfigPath(k.kubeConfigPath)).Dynamic()
+		}
 	}
 	if k.get == nil {
 		k.get = func(
 			cli dynamic.Interface,
 			name string,
 			namespace string, opt *GetOption) (*unstructured.Unstructured, error) {
-			u, err := cli.
+			return cli.
 				Resource(opt.gvr).
 				Namespace(namespace).
 				Get(name, *opt.GetOptions, opt.subresources...)
-			if err != nil {
-				return nil, err
-			}
-			return u, nil
 		}
 	}
 	if k.create == nil {
@@ -119,7 +127,6 @@ func withDefaults(k *Kubeclient) error {
 				Delete(obj.GetName(), opt.DeleteOptions, opt.subresources...)
 		}
 	}
-	return nil
 }
 
 // WithClient sets the kubernetes client against
@@ -130,31 +137,45 @@ func WithClient(c dynamic.Interface) KubeclientBuildOption {
 	}
 }
 
-// KubeClient returns a new instance of Kubeclient meant for
+// WithKubeConfigPath sets kubeconfig path
+// against this client instance
+func WithKubeConfigPath(kubeConfigPath string) KubeclientBuildOption {
+	return func(k *Kubeclient) {
+		k.kubeConfigPath = kubeConfigPath
+	}
+}
+
+// NewKubeClient returns a new instance of Kubeclient meant for
 // catalog operations
-func KubeClient(opts ...KubeclientBuildOption) (*Kubeclient, error) {
+func NewKubeClient(opts ...KubeclientBuildOption) *Kubeclient {
 	k := &Kubeclient{}
 	for _, o := range opts {
 		o(k)
 	}
-	err := withDefaults(k)
-	if err != nil {
-		return nil, err
-	}
-	return k, nil
+	withDefaults(k)
+	return k
 }
 
-// getClientOrCached returns either a new instance
+// getClientsetPathOrDirect returns new instance of kubernetes client
+func (k *Kubeclient) getClientsetPathOrDirect() (dynamic.Interface, error) {
+	if k.kubeConfigPath != "" {
+		return k.getClientsetForPath(k.kubeConfigPath)
+	}
+	return k.getClientset()
+}
+
+// getClientsetOrCached returns either a new instance
 // of kubernetes client or its cached copy
-func (k *Kubeclient) getClientOrCached() (dynamic.Interface, error) {
+func (k *Kubeclient) getClientsetOrCached() (dynamic.Interface, error) {
 	if k.clientset != nil {
 		return k.clientset, nil
 	}
-	cli, err := k.getClientset()
+	cs, err := k.getClientsetPathOrDirect()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to get clientset")
 	}
-	k.clientset = cli
+
+	k.clientset = cs
 	return k.clientset, nil
 }
 
@@ -164,7 +185,7 @@ func (k *Kubeclient) Get(name string, opts ...GetOptionFn) (*unstructured.Unstru
 	if strings.TrimSpace(name) == "" {
 		return nil, errors.New("failed to get unstructured instance: missing name")
 	}
-	cli, err := k.getClientOrCached()
+	cli, err := k.getClientsetOrCached()
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +239,7 @@ func (k *Kubeclient) Create(u *unstructured.Unstructured, opts ...CreateOptionFn
 	if u == nil {
 		return errors.Errorf("create failed: nil unstruct instance was provided")
 	}
-	cli, err := k.getClientOrCached()
+	cli, err := k.getClientsetOrCached()
 	if err != nil {
 		return err
 	}
@@ -230,7 +251,7 @@ func (k *Kubeclient) Create(u *unstructured.Unstructured, opts ...CreateOptionFn
 // Delete deletes the unstructured instance from
 // kubernetes cluster
 func (k *Kubeclient) Delete(u *unstructured.Unstructured, opts ...DeleteOptionFn) error {
-	cli, err := k.getClientOrCached()
+	cli, err := k.getClientsetOrCached()
 	if err != nil {
 		return err
 	}

--- a/pkg/unstruct/v1alpha2/kubernetes.go
+++ b/pkg/unstruct/v1alpha2/kubernetes.go
@@ -156,8 +156,8 @@ func NewKubeClient(opts ...KubeclientBuildOption) *Kubeclient {
 	return k
 }
 
-// getClientsetPathOrDirect returns new instance of kubernetes client
-func (k *Kubeclient) getClientsetPathOrDirect() (dynamic.Interface, error) {
+// getClientsetForPathOrDirect returns new instance of kubernetes client
+func (k *Kubeclient) getClientsetForPathOrDirect() (dynamic.Interface, error) {
 	if k.kubeConfigPath != "" {
 		return k.getClientsetForPath(k.kubeConfigPath)
 	}
@@ -170,7 +170,7 @@ func (k *Kubeclient) getClientsetOrCached() (dynamic.Interface, error) {
 	if k.clientset != nil {
 		return k.clientset, nil
 	}
-	cs, err := k.getClientsetPathOrDirect()
+	cs, err := k.getClientsetForPathOrDirect()
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get clientset")
 	}

--- a/pkg/unstruct/v1alpha2/kubernetes_test.go
+++ b/pkg/unstruct/v1alpha2/kubernetes_test.go
@@ -1,0 +1,373 @@
+// Copyright © 2018-2019 The OpenEBS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha2
+
+import (
+	"testing"
+
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+func fakeGetErr(cli dynamic.Interface, name, namespace string, opts *GetOption) (*unstructured.Unstructured, error) {
+	return nil, errors.New("some error")
+}
+
+func fakeGetOk(cli dynamic.Interface, name, namespace string, opts *GetOption) (*unstructured.Unstructured, error) {
+	return &unstructured.Unstructured{}, nil
+}
+
+func fakeCreateOk(cli dynamic.Interface, obj *unstructured.Unstructured, opts *CreateOption) (*unstructured.Unstructured, error) {
+	return &unstructured.Unstructured{}, nil
+}
+
+func fakeCreateErr(cli dynamic.Interface, obj *unstructured.Unstructured, opts *CreateOption) (*unstructured.Unstructured, error) {
+	return nil, errors.New("failed to create PVC")
+}
+
+func fakeDeleteErr(cli dynamic.Interface, obj *unstructured.Unstructured, opts *DeleteOption) error {
+	return errors.New("some error")
+}
+
+func fakeDeleteOk(cli dynamic.Interface, obj *unstructured.Unstructured, opts *DeleteOption) error {
+	return nil
+}
+
+func fakeGetClientSetOk() (dynamic.Interface, error) {
+	return dynamic.NewForConfig(&rest.Config{})
+}
+
+func fakeGetClientSetNil() (dynamic.Interface, error) {
+	return nil, nil
+}
+
+func fakeGetClientSetErr() (dynamic.Interface, error) {
+	return nil, errors.New("fake-error")
+}
+
+func fakeGetClientSetForPathOk(fakeConfigPath string) (dynamic.Interface, error) {
+	return dynamic.NewForConfig(&rest.Config{})
+}
+
+func fakeGetClientSetForPathErr(fakeConfigPath string) (dynamic.Interface, error) {
+	return nil, errors.New("fake error")
+}
+
+func TestNewKubeClient(t *testing.T) {
+	tests := map[string]struct {
+		fakeKubeClientBuildOption KubeclientBuildOption
+		expectedPath              bool
+	}{
+		"T1": {WithKubeConfigPath("fake-path"), true},
+		//"T2": {nil, false},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		t.Run(name, func(t *testing.T) {
+			kubeclient := NewKubeClient(mock.fakeKubeClientBuildOption)
+			if mock.expectedPath && kubeclient.kubeConfigPath == "" {
+				t.Fatalf("test %q failed: expected kubeConfigPath not to be empty", name)
+			}
+			if !mock.expectedPath && kubeclient.kubeConfigPath != "" {
+				t.Fatalf("test %q failed: expected kubeConfigPath to be empty", name)
+			}
+		})
+	}
+}
+
+func TestWithDefaults(t *testing.T) {
+	tests := map[string]struct {
+		getClientSetFn      getClientsetFn
+		getClientsetForPath getClientsetForPathFn
+		getFn               GetFn
+		createFn            CreateFn
+		deleteFn            DeleteFn
+	}{
+		"T1": {fakeGetClientSetNil, nil, nil, nil, nil},
+		"T2": {fakeGetClientSetErr, fakeGetClientSetForPathErr, fakeGetOk, fakeCreateOk, fakeDeleteOk},
+		"T3": {fakeGetClientSetOk, fakeGetClientSetForPathOk, fakeGetOk, fakeCreateOk, fakeDeleteOk},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{
+				getClientset: mock.getClientSetFn,
+				create:       mock.createFn,
+				delete:       mock.deleteFn,
+				get:          mock.getFn,
+			}
+			withDefaults(fc)
+			if fc.get == nil {
+				t.Fatalf("test %q failed: expected fc.get not to be nil", name)
+			}
+			if fc.getClientsetForPath == nil {
+				t.Fatalf("test %q failed: expected getClientsetForPath not to be nil", name)
+			}
+			if fc.create == nil {
+				t.Fatalf("test %q failed: expected fc.create not to be nil", name)
+			}
+			if fc.delete == nil {
+				t.Fatalf("test %q failed: expected fc.delete not to be nil", name)
+			}
+			if fc.getClientset == nil {
+				t.Fatalf("test %q failed: expected fc.delete not to be nil", name)
+			}
+		})
+	}
+}
+
+func TestGetClientOrCached(t *testing.T) {
+	tests := map[string]struct {
+		getClientSet        getClientsetFn
+		getClientSetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		expectErr           bool
+	}{
+		// Positive tests
+		"Positive 1": {fakeGetClientSetNil, fakeGetClientSetForPathOk, "fake-path", false},
+		"Positive 2": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "", false},
+		"Positive 3": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "fake-path", false},
+		"Positive 4": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "", false},
+
+		// Negative tests
+		"Negative 1": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "", true},
+		"Negative 2": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "fake-path", true},
+		"Negative 3": {fakeGetClientSetErr, fakeGetClientSetForPathErr, "fake-path", true},
+		"Negative 4": {fakeGetClientSetErr, fakeGetClientSetForPathErr, "", true},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{
+				getClientset:        mock.getClientSet,
+				getClientsetForPath: mock.getClientSetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+			}
+			_, err := fc.getClientsetOrCached()
+			if mock.expectErr && err == nil {
+				t.Fatalf("test %q failed : expected error not to be nil but got %v", name, err)
+			}
+			if !mock.expectErr && err != nil {
+				t.Fatalf("test %q failed : expected error be nil but got %v", name, err)
+			}
+		})
+	}
+}
+
+func TestGetClientSetPathOrDirect(t *testing.T) {
+	tests := map[string]struct {
+		kubeConfigPath      string
+		getClientSetForPath getClientsetForPathFn
+		getClientSet        getClientsetFn
+		expectErr           bool
+	}{
+		"T1": {"fake-path", fakeGetClientSetForPathOk, fakeGetClientSetOk, false},
+		"T2": {"", fakeGetClientSetForPathOk, fakeGetClientSetOk, false},
+		"T3": {"fakepath", fakeGetClientSetForPathOk, fakeGetClientSetErr, false},
+		"T4": {"", fakeGetClientSetForPathErr, fakeGetClientSetOk, false},
+		"T5": {"fake-path", fakeGetClientSetForPathErr, fakeGetClientSetOk, true},
+		"T6": {"", fakeGetClientSetForPathOk, fakeGetClientSetErr, true},
+		"T7": {"fakepath", fakeGetClientSetForPathErr, fakeGetClientSetErr, true},
+	}
+
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{
+				getClientset:        mock.getClientSet,
+				getClientsetForPath: mock.getClientSetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+			}
+			_, err := fc.getClientsetOrCached()
+			if mock.expectErr && err == nil {
+				t.Fatalf("test %q failed : expected error not to be nil but got %v", name, err)
+			}
+			if !mock.expectErr && err != nil {
+				t.Fatalf("test %q failed : expected error be nil but got %v", name, err)
+			}
+		})
+	}
+}
+
+func TestKubernetesGet(t *testing.T) {
+	tests := map[string]struct {
+		getClientSetFn getClientsetFn
+		get            GetFn
+		name           string
+		getOptionFn    GetOptionFn
+		ExpectErr      bool
+	}{
+		"T1": {fakeGetClientSetNil, fakeGetOk, "fake-name", WithGetNamespace("fake-ns"), false},
+		"T2": {fakeGetClientSetOk, fakeGetOk, "fake-name", WithGetNamespace("fake-ns"), false},
+		// Negative casses
+		"T5": {fakeGetClientSetErr, fakeGetOk, "fake-name", nil, true},
+		"T6": {fakeGetClientSetNil, fakeGetErr, "fake-name", WithGetNamespace("fake-ns"), true},
+		"T7": {fakeGetClientSetNil, fakeGetOk, "", WithGetOption(metav1.GetOptions{}), true},
+		"T8": {fakeGetClientSetOk, fakeGetErr, "fake-name", WithGetNamespace("fake-ns"), true},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{
+				getClientset: mock.getClientSetFn,
+				get:          mock.get,
+			}
+			_, err := fc.Get(mock.name, mock.getOptionFn)
+			if mock.ExpectErr && err == nil {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.ExpectErr && err != nil {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestKubernetesDelete(t *testing.T) {
+	tests := map[string]struct {
+		getClientSetFn getClientsetFn
+		del            DeleteFn
+		unstruct       *unstructured.Unstructured
+		deleteOptionFn []DeleteOptionFn
+		ExpectErr      bool
+	}{
+		"T1": {fakeGetClientSetOk, fakeDeleteOk, &unstructured.Unstructured{}, []DeleteOptionFn{}, false},
+		"T2": {fakeGetClientSetOk, fakeDeleteOk, nil, []DeleteOptionFn{WithDeleteOption(&metav1.DeleteOptions{})}, false},
+		// Negative casses
+		"T5": {fakeGetClientSetErr, fakeDeleteOk, nil, nil, true},
+		"T6": {fakeGetClientSetNil, fakeDeleteErr, nil, []DeleteOptionFn{}, true},
+		"T7": {fakeGetClientSetOk, fakeDeleteErr, nil, nil, true},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{
+				getClientset: mock.getClientSetFn,
+				delete:       mock.del,
+			}
+			err := fc.Delete(mock.unstruct, mock.deleteOptionFn...)
+			if mock.ExpectErr && err == nil {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.ExpectErr && err != nil {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestKubernetesCreate(t *testing.T) {
+	tests := map[string]struct {
+		getClientSetFn getClientsetFn
+		create         CreateFn
+		unstruct       *unstructured.Unstructured
+		createOptionFn []CreateOptionFn
+		ExpectErr      bool
+	}{
+		"T1": {fakeGetClientSetOk, fakeCreateOk, &unstructured.Unstructured{}, []CreateOptionFn{}, false},
+		"T2": {fakeGetClientSetOk, fakeCreateOk, &unstructured.Unstructured{}, []CreateOptionFn{WithCreateOption(metav1.CreateOptions{})}, false},
+		"T3": {fakeGetClientSetNil, fakeCreateOk, &unstructured.Unstructured{}, []CreateOptionFn{WithCreateOption(metav1.CreateOptions{}), WithCreateSubResources("fake-sub")}, false},
+		// Negative casses
+		"T5": {fakeGetClientSetErr, fakeCreateOk, nil, []CreateOptionFn{}, true},
+		"T6": {fakeGetClientSetNil, fakeCreateErr, nil, []CreateOptionFn{WithCreateOption(metav1.CreateOptions{})}, true},
+		"T7": {fakeGetClientSetOk, fakeCreateErr, nil, nil, true},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{
+				getClientset: mock.getClientSetFn,
+				create:       mock.create,
+			}
+			err := fc.Create(mock.unstruct, mock.createOptionFn...)
+			if mock.ExpectErr && err == nil {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.ExpectErr && err != nil {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestKubernetesCreateAll(t *testing.T) {
+	tests := map[string]struct {
+		getClientSetFn getClientsetFn
+		create         CreateFn
+		unstruct       *unstructured.Unstructured
+		ExpectErr      bool
+	}{
+		"T1": {fakeGetClientSetOk, fakeCreateOk, &unstructured.Unstructured{}, false},
+		"T2": {fakeGetClientSetOk, fakeCreateOk, &unstructured.Unstructured{}, false},
+		"T3": {fakeGetClientSetNil, fakeCreateOk, &unstructured.Unstructured{}, false},
+		// Negative casses
+		"T5": {fakeGetClientSetErr, fakeCreateOk, nil, true},
+		"T6": {fakeGetClientSetNil, fakeCreateErr, nil, true},
+		"T7": {fakeGetClientSetOk, fakeCreateErr, nil, true},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{
+				getClientset: mock.getClientSetFn,
+				create:       mock.create,
+			}
+			errs := fc.CreateAllOrNone(mock.unstruct)
+			if mock.ExpectErr && len(errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.ExpectErr && len(errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestKubernetesDeleteAll(t *testing.T) {
+	tests := map[string]struct {
+		getClientSetFn getClientsetFn
+		del            DeleteFn
+		unstruct       *unstructured.Unstructured
+		ExpectErr      bool
+	}{
+		"T1": {fakeGetClientSetOk, fakeDeleteOk, &unstructured.Unstructured{}, false},
+		"T2": {fakeGetClientSetOk, fakeDeleteOk, nil, false},
+		"T3": {fakeGetClientSetNil, fakeDeleteOk, nil, false},
+		// Negative casses
+		"T5": {fakeGetClientSetErr, fakeDeleteOk, nil, true},
+		"T6": {fakeGetClientSetNil, fakeDeleteErr, nil, true},
+		"T7": {fakeGetClientSetOk, fakeDeleteErr, nil, true},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{
+				getClientset: mock.getClientSetFn,
+				delete:       mock.del,
+			}
+			errs := fc.DeleteAll(mock.unstruct)
+			if mock.ExpectErr && len(errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.ExpectErr && len(errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does**:
 1)  Adds the support to get the dynamic clientset using provided kubeConfig Path.
 2) Adds UT for kubernetes package(`pkg/unstruct/v1alpha2/`).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests