### PR TITLE
debuggability (error package): change import path of error package in m-upgrade

### DIFF
--- a/cmd/upgrade/app/v1alpha1/executor.go
+++ b/cmd/upgrade/app/v1alpha1/executor.go
@@ -137,9 +137,7 @@ func ExecutorBuilderForConfig(cfg *apis.UpgradeConfig) *ExecutorBuilder {
 // ExecutorBuilder instance
 func (eb *ExecutorBuilder) Build() (*Executor, error) {
 	if len(eb.Errors) != 0 {
-		return nil, errors.Wrap(
-			errors.WithStack(eb.ErrorList),
-			"builder error(s) found")
+		return nil, eb.ErrorList.WithStack("failed to build executor")
 	}
 	return eb.object, nil
 }

--- a/cmd/upgrade/app/v1alpha1/executor.go
+++ b/cmd/upgrade/app/v1alpha1/executor.go
@@ -19,11 +19,11 @@ package v1alpha1
 import (
 	"os"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/upgrade/v1alpha1"
 	cast "github.com/openebs/maya/pkg/castemplate/v1alpha1"
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 	upgrade "github.com/openebs/maya/pkg/upgrade/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -48,30 +48,34 @@ type Executor struct {
 // ExecutorBuilder helps to build Executor instance
 type ExecutorBuilder struct {
 	object *Executor
-	errors []error
+	errs   *errors.ErrorList
 }
 
 // ExecutorBuilderForConfig returns an instance of ExecutorBuilder
 //It adds object in ExecutorBuilder struct with the help of config
 func ExecutorBuilderForConfig(cfg *apis.UpgradeConfig) *ExecutorBuilder {
-	executorBuilder := &ExecutorBuilder{}
+	executorBuilder := &ExecutorBuilder{
+		errs: &errors.ErrorList{
+			Errors: []error{},
+		},
+	}
 
 	selfName := os.Getenv(envSelfName)
 	if selfName == "" {
-		executorBuilder.errors = append(executorBuilder.errors,
+		executorBuilder.errs.Errors = append(executorBuilder.errs.Errors,
 			errors.Errorf("failed to instantiate executor builder: ENV {%s} not present", envSelfName))
 		return executorBuilder
 	}
 	selfNamespace := os.Getenv(envSelfNamespace)
 	if selfNamespace == "" {
-		executorBuilder.errors = append(executorBuilder.errors,
+		executorBuilder.errs.Errors = append(executorBuilder.errs.Errors,
 			errors.Errorf("failed to instantiate executor builder: ENV {%s} not present", envSelfNamespace))
 		return executorBuilder
 
 	}
 	selfUID := types.UID(os.Getenv(envSelfUID))
 	if selfUID == "" {
-		executorBuilder.errors = append(executorBuilder.errors,
+		executorBuilder.errs.Errors = append(executorBuilder.errs.Errors,
 			errors.Errorf("failed to instantiate executor builder: ENV {%s} not present", envSelfUID))
 		return executorBuilder
 
@@ -80,7 +84,7 @@ func ExecutorBuilderForConfig(cfg *apis.UpgradeConfig) *ExecutorBuilder {
 	castObj, err := cast.KubeClient().
 		Get(cfg.CASTemplate, metav1.GetOptions{})
 	if err != nil {
-		executorBuilder.errors = append(executorBuilder.errors,
+		executorBuilder.errs.Errors = append(executorBuilder.errs.Errors,
 			errors.Wrapf(err,
 				"failed to instantiate executor builder: %s", cfg))
 		return executorBuilder
@@ -108,7 +112,7 @@ func ExecutorBuilderForConfig(cfg *apis.UpgradeConfig) *ExecutorBuilder {
 			WithTasks(tasks).
 			GetOrCreate()
 		if err != nil {
-			executorBuilder.errors = append(executorBuilder.errors,
+			executorBuilder.errs.Errors = append(executorBuilder.errs.Errors,
 				errors.Wrapf(err,
 					"failed to instantiate executor builder: %s: %s", resource, cfg))
 			return executorBuilder
@@ -117,10 +121,10 @@ func ExecutorBuilderForConfig(cfg *apis.UpgradeConfig) *ExecutorBuilder {
 			WithCASTemplate(castObj).
 			WithUnitOfUpgrade(&resource).
 			WithRuntimeConfig(cfg.Data).
-			WithUpgradeResultCR(upgradeResult.Name).
+			WithUpgradeResultCR(upgradeResult.Name, upgradeResult.Namespace).
 			Build()
 		if err != nil {
-			executorBuilder.errors = append(executorBuilder.errors,
+			executorBuilder.errs.Errors = append(executorBuilder.errs.Errors,
 				errors.Wrapf(err,
 					"failed to instantiate executor builder: %s: %s", resource, cfg))
 			return executorBuilder
@@ -135,8 +139,8 @@ func ExecutorBuilderForConfig(cfg *apis.UpgradeConfig) *ExecutorBuilder {
 // Build builds a new instance of Executor with the help of
 // ExecutorBuilder instance
 func (eb *ExecutorBuilder) Build() (*Executor, error) {
-	if len(eb.errors) != 0 {
-		return nil, errors.Errorf("builder error: %s", eb.errors)
+	if len(eb.errs.Errors) != 0 {
+		return nil, errors.WithStack(errors.Wrap(eb.errs, "builder error"))
 	}
 	return eb.object, nil
 }
@@ -147,7 +151,7 @@ func (e *Executor) Execute() error {
 	for _, engine := range e.engines {
 		_, err := engine.Run()
 		if err != nil {
-			return errors.Wrapf(err, "failed to run upgrade engine")
+			return errors.Wrap(err, "failed to run upgrade engine")
 		}
 	}
 	return nil

--- a/cmd/upgrade/app/v1alpha1/result.go
+++ b/cmd/upgrade/app/v1alpha1/result.go
@@ -121,40 +121,36 @@ func (urb *UpgradeResultGetOrCreateBuilder) WithTasks(
 // validate validates UpgradeResultGetOrCreateBuilder instance
 func (urb *UpgradeResultGetOrCreateBuilder) validate() error {
 	if len(urb.ErrorList.Errors) != 0 {
-		return errors.Wrap(
-			errors.WithStack(urb.ErrorList),
-			"failed to validate: build error(s) were found")
+		return urb.ErrorList.WithStack("failed to validate upgrade result get or create")
 	}
-	validationErrs := []error{}
+	validationErrs := &errors.ErrorList{}
 	if urb.SelfName == "" {
-		validationErrs = append(validationErrs,
+		validationErrs.Errors = append(validationErrs.Errors,
 			errors.New("missing self name"))
 	}
 	if urb.SelfNamespace == "" {
-		validationErrs = append(validationErrs,
+		validationErrs.Errors = append(validationErrs.Errors,
 			errors.New("missing self namespace"))
 	}
 	if urb.SelfUID == "" {
-		validationErrs = append(validationErrs,
+		validationErrs.Errors = append(validationErrs.Errors,
 			errors.New("missing self uid"))
 	}
 	if urb.UpgradeConfig == nil {
-		validationErrs = append(validationErrs,
+		validationErrs.Errors = append(validationErrs.Errors,
 			errors.New("missing upgrade config"))
 	}
 	if urb.ResourceDetails == nil {
-		validationErrs = append(validationErrs,
+		validationErrs.Errors = append(validationErrs.Errors,
 			errors.New("missing resource details"))
 	}
 	if len(urb.Tasks) == 0 {
-		validationErrs = append(validationErrs,
+		validationErrs.Errors = append(validationErrs.Errors,
 			errors.New("missing tasks"))
 	}
-	if len(validationErrs) != 0 {
-		urb.Errors = append(urb.Errors, validationErrs...)
-		return errors.Wrap(
-			errors.WithStack(&errors.ErrorList{Errors: validationErrs}),
-			"validation error(s) found")
+	if len(validationErrs.Errors) != 0 {
+		urb.Errors = append(urb.Errors, validationErrs.Errors...)
+		return validationErrs.WithStack("failed to validate get or create upgrade result")
 	}
 	return nil
 }

--- a/cmd/upgrade/app/v1alpha1/result.go
+++ b/cmd/upgrade/app/v1alpha1/result.go
@@ -48,6 +48,7 @@ type UpgradeResult struct {
 
 // UpgradeResultGetOrCreateBuilder helps to get or create UpgradeResult instance
 type UpgradeResultGetOrCreateBuilder struct {
+	*errors.ErrorList
 	SelfName        string
 	SelfNamespace   string
 	SelfUID         types.UID
@@ -55,7 +56,6 @@ type UpgradeResultGetOrCreateBuilder struct {
 	ResourceDetails *upgrade.ResourceDetails
 	Tasks           []upgrade.UpgradeResultTask
 	UpgradeResult   *UpgradeResult
-	errs            *errors.ErrorList
 }
 
 // String implements GoStringer interface
@@ -72,9 +72,7 @@ func (urb *UpgradeResultGetOrCreateBuilder) GoString() string {
 func NewUpgradeResultGetOrCreateBuilder() *UpgradeResultGetOrCreateBuilder {
 	return &UpgradeResultGetOrCreateBuilder{
 		UpgradeResult: &UpgradeResult{},
-		errs: &errors.ErrorList{
-			Errors: []error{},
-		},
+		ErrorList:     &errors.ErrorList{},
 	}
 }
 
@@ -122,9 +120,10 @@ func (urb *UpgradeResultGetOrCreateBuilder) WithTasks(
 
 // validate validates UpgradeResultGetOrCreateBuilder instance
 func (urb *UpgradeResultGetOrCreateBuilder) validate() error {
-	if len(urb.errs.Errors) != 0 {
-		return errors.WithStack(
-			errors.Wrap(urb.errs, "failed to validate: build error(s) were found"))
+	if len(urb.ErrorList.Errors) != 0 {
+		return errors.Wrap(
+			errors.WithStack(urb.ErrorList),
+			"failed to validate: build error(s) were found")
 	}
 	validationErrs := []error{}
 	if urb.SelfName == "" {
@@ -152,9 +151,10 @@ func (urb *UpgradeResultGetOrCreateBuilder) validate() error {
 			errors.New("missing tasks"))
 	}
 	if len(validationErrs) != 0 {
-		urb.errs.Errors = append(urb.errs.Errors, validationErrs...)
-		return errors.WithStack(
-			errors.Wrap(&errors.ErrorList{Errors: validationErrs}, "validation error(s) found"))
+		urb.Errors = append(urb.Errors, validationErrs...)
+		return errors.Wrap(
+			errors.WithStack(&errors.ErrorList{Errors: validationErrs}),
+			"validation error(s) found")
 	}
 	return nil
 }

--- a/cmd/upgrade/app/v1alpha1/upgrade.go
+++ b/cmd/upgrade/app/v1alpha1/upgrade.go
@@ -20,10 +20,9 @@ import (
 	"io/ioutil"
 	"path"
 
-	"github.com/pkg/errors"
-
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/upgrade/v1alpha1"
 	stringer "github.com/openebs/maya/pkg/apis/stringer/v1alpha1"
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 	upgrade "github.com/openebs/maya/pkg/upgrade/v1alpha1"
 )
 
@@ -53,7 +52,7 @@ func (u Upgrade) GoString() string {
 func NewUpgradeForConfigPath(filePath string) (*Upgrade, error) {
 	data, err := ioutil.ReadFile(path.Clean(filePath))
 	if err != nil {
-		return nil, errors.WithMessagef(err,
+		return nil, errors.Wrapf(err,
 			"failed to initialize upgrade instance: failed to read config: %s", filePath)
 	}
 
@@ -66,7 +65,7 @@ func NewUpgradeForConfigPath(filePath string) (*Upgrade, error) {
 			"invalid resources: all resources should belong to same kind").
 		Build()
 	if err != nil {
-		return nil, errors.WithMessagef(err,
+		return nil, errors.Wrapf(err,
 			"failed to instantiate upgrade instance: config path {%s}", filePath)
 	}
 	return &Upgrade{
@@ -81,13 +80,13 @@ func (u *Upgrade) Run() error {
 	e, err := ExecutorBuilderForConfig(u.Config).
 		Build()
 	if err != nil {
-		return errors.WithMessagef(err,
+		return errors.Wrapf(err,
 			"failed to run upgrade: %s", u)
 	}
 
 	err = e.Execute()
 	if err != nil {
-		return errors.WithMessagef(err,
+		return errors.Wrapf(err,
 			"failed to run upgrade: %s", u)
 	}
 	return nil

--- a/pkg/errors/v1alpha1/types.go
+++ b/pkg/errors/v1alpha1/types.go
@@ -160,3 +160,29 @@ func (el *ErrorList) Format(s fmt.State, verb rune) {
 	fmt.Fprint(s, message)
 
 }
+
+// WithStack annotates ErrorList with a new message and
+// stack trace of caller.
+func (el *ErrorList) WithStack(message string) error {
+	if el == nil {
+		return nil
+	}
+	return &withStack{
+		stackTraceMessagePrefix,
+		Wrap(el, message),
+		callers(),
+	}
+}
+
+// WithStackf annotates ErrorList with the format specifier
+// and stack trace of caller.
+func (el *ErrorList) WithStackf(format string, args ...interface{}) error {
+	if el == nil {
+		return nil
+	}
+	return &withStack{
+		stackTraceMessagePrefix,
+		Wrapf(el, format, args...),
+		callers(),
+	}
+}

--- a/pkg/upgrade/v1alpha1/config_test.go
+++ b/pkg/upgrade/v1alpha1/config_test.go
@@ -88,9 +88,9 @@ func TestNewBuilder(t *testing.T) {
 				t.Fatalf("test %s failed, expect checks: %t but got: %t",
 					name, mock.expectChecks, b.checks != nil)
 			}
-			if (len(b.errs.Errors) == 0) != mock.expectChecks {
+			if (len(b.Errors) == 0) != mock.expectChecks {
 				t.Fatalf("test %s failed, expect errors: %t but got: %t",
-					name, mock.expectChecks, b.checks != nil)
+					name, mock.expectError, b.checks != nil)
 			}
 		})
 	}
@@ -129,9 +129,9 @@ resources:
 		mock := mock // pin it
 		t.Run(name, func(t *testing.T) {
 			b := ConfigBuilderForYaml(mock.yaml)
-			if (len(b.errs.Errors) != 0) != mock.expectError {
+			if (len(b.Errors) != 0) != mock.expectError {
 				t.Fatalf("test %s failed, expect error: %v but got: %v",
-					name, mock.expectError, len(b.errs.Errors) != 0)
+					name, mock.expectError, len(b.Errors) != 0)
 			}
 		})
 	}
@@ -170,9 +170,9 @@ resources:
 		mock := mock // pin it
 		t.Run(name, func(t *testing.T) {
 			b := ConfigBuilderForRaw(mock.raw)
-			if (len(b.errs.Errors) != 0) != mock.expectError {
+			if (len(b.Errors) != 0) != mock.expectError {
 				t.Fatalf("test %s failed, expect error: %v but got: %v",
-					name, mock.expectError, len(b.errs.Errors) != 0)
+					name, mock.expectError, len(b.Errors) != 0)
 			}
 		})
 	}
@@ -469,9 +469,9 @@ func TestBuild(t *testing.T) {
 		name := name // pin it
 		mock := mock // pin it
 		b := &ConfigBuilder{
-			Config: mock.config,
-			checks: make(map[*Predicate]string),
-			errs:   &errors.ErrorList{Errors: []error{}},
+			ErrorList: &errors.ErrorList{},
+			Config:    mock.config,
+			checks:    make(map[*Predicate]string),
 		}
 		b.AddChecks(mock.checks...)
 		_, err := b.Build()

--- a/pkg/upgrade/v1alpha1/engine.go
+++ b/pkg/upgrade/v1alpha1/engine.go
@@ -112,9 +112,7 @@ func (ceb *CASTEngineBuilder) validate() error {
 		return errors.New("missing upgrade result")
 	}
 	if len(ceb.Errors) > 0 {
-		return errors.Wrap(
-			errors.WithStack(ceb.ErrorList),
-			"build errors were found")
+		return ceb.ErrorList.WithStack("failed to build cast engine")
 	}
 	return nil
 }

--- a/pkg/upgrade/v1alpha1/engine_test.go
+++ b/pkg/upgrade/v1alpha1/engine_test.go
@@ -53,9 +53,9 @@ func TestNewCASTEngineBuilder(t *testing.T) {
 				t.Fatalf("test %s failed, expect RuntimeConfig: %t but got: %t",
 					name, mock.expectUnitOfUpgrade, len(b.RuntimeConfig) != 0)
 			}
-			if (len(b.errs.Errors) != 0) != mock.expectError {
+			if (len(b.Errors) != 0) != mock.expectError {
 				t.Fatalf("test %s failed, expect Error: %t but got: %t",
-					name, mock.expectError, len(b.errs.Errors) != 0)
+					name, mock.expectError, len(b.Errors) != 0)
 			}
 		})
 	}
@@ -157,13 +157,10 @@ func TestValidateEngineBuilder(t *testing.T) {
 	}{
 		"valid builder": {
 			&CASTEngineBuilder{
-				CASTemplate:            &apis.CASTemplate{},
-				UnitOfUpgrade:          &upgrade.ResourceDetails{},
-				UpgradeResultName:      "mock-upgrade-cju65",
-				UpgradeResultNamespace: "openebs",
-				errs: &errors.ErrorList{
-					Errors: []error{},
-				},
+				CASTemplate:   &apis.CASTemplate{},
+				UnitOfUpgrade: &upgrade.ResourceDetails{},
+				UpgradeResult: &upgrade.UpgradeResult{},
+				ErrorList:     &errors.ErrorList{},
 			},
 			false,
 		},
@@ -171,27 +168,21 @@ func TestValidateEngineBuilder(t *testing.T) {
 			&CASTEngineBuilder{
 				CASTemplate:   &apis.CASTemplate{},
 				UnitOfUpgrade: &upgrade.ResourceDetails{},
-				errs: &errors.ErrorList{
-					Errors: []error{errors.New("new error")},
-				},
+				ErrorList:     &errors.ErrorList{},
 			},
 			true,
 		},
 		"castemplate not present in builder": {
 			&CASTEngineBuilder{
 				UnitOfUpgrade: &upgrade.ResourceDetails{},
-				errs: &errors.ErrorList{
-					Errors: []error{},
-				},
+				ErrorList:     &errors.ErrorList{},
 			},
 			true,
 		},
 		"unit of upgrade not present in builder": {
 			&CASTEngineBuilder{
 				CASTemplate: &apis.CASTemplate{},
-				errs: &errors.ErrorList{
-					Errors: []error{},
-				},
+				ErrorList:   &errors.ErrorList{},
 			},
 			true,
 		},


### PR DESCRIPTION
This PR will change error package import path in `m-upgrade`.
Previously it was 
```go
import "github.com/pkg/errors"
```
now it will be
```go
import errors "github.com/openebs/maya/pkg/errors/v1alpha1"
```
Signed-off-by: Shovan Maity <shovan.maity@mayadata.io>