### PR TITLE
refactor(m-upgrade): Refactor owner reference fetch logic in m-upgrade

### DIFF
--- a/cmd/upgrade/app/v1alpha1/executor.go
+++ b/cmd/upgrade/app/v1alpha1/executor.go
@@ -28,10 +28,10 @@ import (
 )
 
 const (
-	// envSelfName represent name of pod in which upgrade process is running.
+	// envPodName represent name of pod in which upgrade process is running.
 	// This is required to get owner reference for upgrade result cr.
 	envPodName = "OPENEBS_IO_POD_NAME"
-	// envSelfNamespace represent namespace of pod in which upgrade process is running.
+	// envPodNamespace represent namespace of pod in which upgrade process is running.
 	// This is required to get owner reference for upgrade result cr.
 	envPodNamespace = "OPENEBS_IO_POD_NAMESPACE"
 )

--- a/pkg/client/k8s/k8s.go
+++ b/pkg/client/k8s/k8s.go
@@ -1211,10 +1211,10 @@ func (k *K8sClient) ExecCoreV1Pod(name string,
 		return
 	}
 
-	// exec output struct contaons stdout and std error
+	// exec output struct contains stdout and stderr
 	type execOutput struct {
-		Stdout string `json:"Stdout"`
-		Stderr string `json:"Stderr"`
+		Stdout string `json:"stdout"`
+		Stderr string `json:"stderr"`
 	}
 
 	op := execOutput{


### PR DESCRIPTION
- Refactors owner reference fetch logic in m-upgrade
- Change environment variable name  
- Change `jsonkey` in remote exec output

### Note to Developers:
#### This is updated config & corresponding upgrade job
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: pool-upgrade-config
  namespace: default
data:
  upgrade: |
    casTemplate: cstor-pool-081-082
    resources:
    - name: pool-c3jd
      kind: cStorpool
      namespace: openebs
    - name: pool-ji38
      kind: cStorpool
      namespace: openebs
    - name: pool-jkd4
      kind: cStorpool
      namespace: openebs
---
apiVersion: batch/v1
kind: Job
metadata:
  name: spc-cstor-sparse-pool-upgrade
spec:
  template:
    spec:
      serviceAccountName: super-admin
      containers:
      - name:  upgrade
        image: openebs/m-upgrade:ci
        volumeMounts:
        - name: config
          mountPath: /etc/config
          readOnly: true
        env:
        - name: OPENEBS_IO_POD_NAME
          valueFrom:
            fieldRef:
              fieldPath: metadata.name
        - name: OPENEBS_IO_POD_NAMESPACE
          valueFrom:
            fieldRef:
              fieldPath: metadata.namespace
      volumes:
      - name: config
        configMap:
          name: pool-upgrade-config
      restartPolicy: Never
```

#### This is updated runtask for remote exec
```yaml
apiVersion: openebs.io/v1alpha1
kind: RunTask
metadata:
  name: check-quorum
  namespace: default
spec:
  meta: |
    id: quormCheck
    apiVersion: v1
    kind: Pod
    action: exec
    runNamespace: openebs
    objectName: pool-pod-ksk2c
  task: |-
    command:
    - zfs
    - get
    - quorum
    - -H
    - cstor-dnd3k
    - -o
    - value
    container: cstor-pool-mgmt
    stdin: false
    stdout: true
    stderr: true
  post: |-
    {{- jsonpath .JsonResult "{.stdout}" | trim | saveAs "quorumCheck.stdout" .TaskResult | noop -}}
```
Signed-off-by: Shovan Maity <shovan.maity@mayadata.io>