### PR TITLE
fix(sts): fix target pod stuck at pending state (#1124)

### DIFF
--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -494,6 +494,8 @@ spec:
                     operator: In
                     values:
                     - {{ .TaskResult.sts.applicationName }}
+                namespaces:
+                - {{ .Volume.runNamespace }}
                 topologyKey: kubernetes.io/hostname
           {{- else if ne $targetAffinityVal "none" }}
           affinity:


### PR DESCRIPTION
This commit fixes the issue of cstor target pod getting stuck at pending state when `sts-target-affinity` label is used due to missing namespace in the target deployment.

Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests