### PR TITLE
debuggability(log): removes unnecessary error message and brackets

### DIFF
--- a/cmd/maya-apiserver/app/server/http.go
+++ b/cmd/maya-apiserver/app/server/http.go
@@ -373,7 +373,7 @@ func CodedErrorWrapf(code int, err error, msg string, args ...interface{}) HTTPC
 // CodedErrorWrap is used to provide HTTP error
 // Code and corresponding error
 func CodedErrorWrap(code int, err error) HTTPCodedError {
-	errMsg := fmt.Sprintf("{%+v}", err)
+	errMsg := fmt.Sprintf("%+v", err)
 	return CodedError(code, errMsg)
 }
 
@@ -381,7 +381,7 @@ func CodedErrorWrap(code int, err error) HTTPCodedError {
 // Code and corresponding error details in
 // a format decided by the caller
 func CodedErrorf(code int, msg string, args ...interface{}) HTTPCodedError {
-	errMsg := fmt.Sprintf("{%s}", msg)
+	errMsg := fmt.Sprintf("%s", msg)
 	finalMsg := fmt.Sprintf(errMsg, args...)
 	return CodedError(code, finalMsg)
 }

--- a/cmd/maya-apiserver/app/server/http_test.go
+++ b/cmd/maya-apiserver/app/server/http_test.go
@@ -357,8 +357,8 @@ func TestCodedErrorf(t *testing.T) {
 		expectedCode    int
 		expectedMessage string
 	}{
-		"401 error": {401, "%s %d", []interface{}{"unauthorized", 401}, 401, "{unauthorized 401}"},
-		"500 error": {500, "%s %d", []interface{}{"internal error", 500}, 500, "{internal error 500}"},
+		"401 error": {401, "%s %d", []interface{}{"unauthorized", 401}, 401, "unauthorized 401"},
+		"500 error": {500, "%s %d", []interface{}{"internal error", 500}, 500, "internal error 500"},
 	}
 	for name, mock := range tests {
 		mock := mock // pin it
@@ -383,10 +383,10 @@ func TestCodedErrorWrap(t *testing.T) {
 		expectedMessage string
 	}{
 		"401 error": {
-			401, fmt.Errorf("unauthorized"), 401, "{unauthorized}",
+			401, fmt.Errorf("unauthorized"), 401, "unauthorized",
 		},
 		"500 error": {
-			500, fmt.Errorf("internal error"), 500, "{internal error}",
+			500, fmt.Errorf("internal error"), 500, "internal error",
 		},
 	}
 	for name, mock := range tests {

--- a/pkg/errors/v1alpha1/types.go
+++ b/pkg/errors/v1alpha1/types.go
@@ -53,7 +53,7 @@ func (e *err) Error() string { return e.msg }
 
 // Format is implementation of Formater interface
 func (e *err) Format(s fmt.State, verb rune) {
-	message := "error(s) were found: " + e.msg
+	message := wrapErrorMessagePrefix + e.msg
 	switch verb {
 	case 'v':
 		if s.Flag('+') {
@@ -111,7 +111,7 @@ type withStack struct {
 
 // Format is implementation of Formater interface
 func (ws *withStack) Format(s fmt.State, verb rune) {
-	message := "error(s) were found: " + fmt.Sprintf("%s", ws.error)
+	message := wrapErrorMessagePrefix + fmt.Sprintf("%s", ws.error)
 	switch verb {
 	case 'v':
 		if s.Flag('+') {


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadat.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR removes unnecessary error message and brackets from the logs. 
Currently the logs have an extra error message and `{}` surrounding the entire message
```
2019/05/10 07:27:14.274444 [ERR] http: Request GET /latest/volumes/pvc-042b77bb-72f5-11e9-a678-54e1ad5e8320
{error(s) were found: failed to read volume: volume {pvc-042b77bb-72f5-11e9-a678-54e1ad5e8320} not found in namespace {default}
      github.com/openebs/maya/cmd/maya-apiserver/app/server.(*volumeAPIOpsV1alpha1).read
	/home/user/work/src/github.com/openebs/maya/cmd/maya-apiserver/app/server/volume_endpoint_v1alpha1.go:209}
I0510 07:27:14.275722       6 volume_endpoint_v1alpha1.go:77] received cas volume request: http method {POST}
I0510 07:27:14.275747       6 volume_endpoint_v1alpha1.go:130] received volume create request
W0510 07:27:14.470308       6 runner.go:166] nothing to rollback: no rollback tasks were found
2019/05/10 07:27:14.472345 [ERR] http: Request POST /latest/volumes/
{error(s) were found: unable to parse requirement: invalid label value: "“sparse-claim-auto”": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
      github.com/openebs/maya/pkg/client/k8s.(*K8sClient).ListOEV1alpha1CSPRaw
	/home/user/work/src/github.com/openebs/maya/pkg/client/k8s/k8s.go:841
  --  failed to list k8s resources
  --  failed to execute task: 
task executor {MetaExec: {}
```
As the line just before it also mentions `[ERR]` so IMO it is not required.
```
W0510 09:50:34.864273       6 runner.go:166] nothing to rollback: no rollback tasks were found
2019/05/10 09:50:34.866100 [ERR] http: Request GET /latest/volumes/pvc-0e7f3511-7309-11e9-a678-54e1ad5e8320
  --  failed to read volume: volume {pvc-0e7f3511-7309-11e9-a678-54e1ad5e8320} not found in namespace {default}
      github.com/openebs/maya/cmd/maya-apiserver/app/server.(*volumeAPIOpsV1alpha1).read
	/home/user/work/src/github.com/openebs/maya/cmd/maya-apiserver/app/server/volume_endpoint_v1alpha1.go:209
I0510 09:50:34.871688       6 volume_endpoint_v1alpha1.go:77] received cas volume request: http method {POST}
I0510 09:50:34.872906       6 volume_endpoint_v1alpha1.go:130] received volume create request
W0510 09:50:34.998771       6 runner.go:166] nothing to rollback: no rollback tasks were found
2019/05/10 09:50:35.000054 [ERR] http: Request POST /latest/volumes/
  --  unable to parse requirement: invalid label value: "“sparse-claim-auto”": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
      github.com/openebs/maya/pkg/client/k8s.(*K8sClient).ListOEV1alpha1CSPRaw
	/home/user/work/src/github.com/openebs/maya/pkg/client/k8s/k8s.go:841
  --  failed to list k8s resources
  --  failed to execute task: 
task executor {MetaExec: {}
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests