### PR TITLE
Cherry-pick(jiva, runtask): add patch replica runtask (#1119)

### DIFF
--- a/cmd/maya-apiserver/app/server/volume_endpoint_v1alpha1.go
+++ b/cmd/maya-apiserver/app/server/volume_endpoint_v1alpha1.go
@@ -163,9 +163,14 @@ func (v *volumeAPIOpsV1alpha1) read(volumeName string) (*v1alpha1.CASVolume, err
 
 	// use StorageClass name from header if present
 	scName := strings.TrimSpace(v.req.Header.Get(string(v1alpha1.StorageClassHeaderKey)))
+	patchVal := v.req.Header.Get(string(v1alpha1.CASKeyIsPatchJivaReplicaNodeAffinityHeader))
 	// add the StorageClass name to volume's labels
 	vol.Labels = map[string]string{
 		string(v1alpha1.StorageClassKey): scName,
+	}
+
+	vol.Annotations = map[string]string{
+		string(v1alpha1.NodeAffinityReplicaJivaIsPatchKey): patchVal,
 	}
 
 	vOps, err := volume.NewOperation(vol)

--- a/pkg/apis/openebs.io/v1alpha1/cas_keys.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_keys.go
@@ -54,6 +54,18 @@ const (
 	// PersistentVolumeClaimKey is the key to fetch name of PersistentVolumeClaim
 	PersistentVolumeClaimKey CASKey = "openebs.io/persistentvolumeclaim"
 
+	// CASKeyIsPatchJivaReplicaNodeAffinityHeader is the key to fetch value of IsPatchKey
+	// its value is "enabled".
+	CASKeyIsPatchJivaReplicaNodeAffinityHeader CASKey = "Is-Patch-Jiva-Replica-Node-Affinity"
+
+	// NodeAffinityReplicaJivaIsPatchKey is the key to fetch value of IsPatchKey
+	// its value is "enabled".
+	NodeAffinityReplicaJivaIsPatchKey CASKey = "nodeAffinity.replica.jiva.openebs.io/is-patch"
+
+	// CASKeyIsPatchJivaReplicaNodeAffinity is the key to fetch value of IsPatchKey
+	// its value is "enabled".
+	CASKeyIsPatchJivaReplicaNodeAffinity CASKey = "isPatchJivaReplicaNodeAffinity"
+
 	// StorageClassKey is the key to fetch name of StorageClass
 	StorageClassKey CASKey = "openebs.io/storageclass"
 

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -320,6 +320,7 @@ func (v *Operation) Read() (*v1alpha1.CASVolume, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	casConfigSC := sc.Annotations[string(v1alpha1.CASConfigKey)]
 	// read cas volume via cas template engine
 	engine, err := NewVolumeEngine(
@@ -330,8 +331,16 @@ func (v *Operation) Read() (*v1alpha1.CASVolume, error) {
 		map[string]interface{}{
 			string(v1alpha1.OwnerVTP):        v.volume.Name,
 			string(v1alpha1.RunNamespaceVTP): v.volume.Namespace,
+			string(v1alpha1.CASKeyIsPatchJivaReplicaNodeAffinity): func() string {
+				val, ok := v.volume.Annotations[string(v1alpha1.NodeAffinityReplicaJivaIsPatchKey)]
+				if !ok {
+					return ""
+				}
+				return val
+			}(),
 		},
 	)
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR enables nodeAffnity to pin jiva replicas on their scheduled nodes. This is required since, jiva replica pods may move to other node(s) if pod gets rescheduled. Having nodeAffnity ensures that replica pods will never be scheduled to other nodes other than its original scheduled node. This setting will lead pending state if original schedule node(s) is no longer available.

There are following cases when replica pods can be scheduled to other nodes without this setting:

- OOM (Out of memory)
- Doesn't have enough cpu resources
- Node is drained
- Replica deployment have been patched or edited using kubectl patch or kubectl edit commands.

This commit adds following RunTasks to jiva-volume-create-default CASTemplate:

- `jiva-volume-read-verifyreplicationfactor-default` to verify replica's info required for patching by subsequent RunTask
- `jiva-volume-read-patchreplicadeployment-default` to patch the replica deployment for nodeAffinity

NOTE:

- This setting will lead pending state if original schedule node(s) is no longer available
Depends on openebs/external-storage#93
- Refer https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/nodeaffinity.md

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests