### PR TITLE
fix(travis): update image tag to 0.9.x-ci for travis test

### DIFF
--- a/ci/travis-ci.sh
+++ b/ci/travis-ci.sh
@@ -17,7 +17,7 @@
 #./ci/helm_install_openebs.sh
 # global env vars to be used in test scripts
 export CI_BRANCH="v0.9.x"
-export CI_TAG="ci"
+export CI_TAG="v0.9.x-ci"
 export MAYACTL="$GOPATH/src/github.com/openebs/maya/bin/maya/mayactl"
 
 ./ci/build-maya.sh
@@ -25,10 +25,10 @@ rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 
 curl https://raw.githubusercontent.com/openebs/openebs/master/k8s/ci/test-script.sh > test-script.sh
 
-# append mayactl tests to this script 
+# append mayactl tests to this script
 cat ./ci/mayactl.sh >> ./test-script.sh
 
-# append local pv tests to this script 
+# append local pv tests to this script
 #cat ./ci/local_pv.sh >> ./test-script.sh
 
 chmod +x test-script.sh && ./test-script.sh


### PR DESCRIPTION
Change the image tag from "ci" --> "0.9.x-ci"
to be used in integration test in travis CI as openebs operator looks for 0.9.x-ci tagged based images.

If image tag is `ci` there will be no 0.9.x-ci images will be present locally and travis will pull the images from the image registry.

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [x] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests