### PR TITLE
debuggability(log): removes unnecessary cas object dumps for read requests

### DIFF
--- a/cmd/maya-apiserver/app/server/volume_endpoint_v1alpha1.go
+++ b/cmd/maya-apiserver/app/server/volume_endpoint_v1alpha1.go
@@ -178,7 +178,7 @@ func (v *volumeAPIOpsV1alpha1) read(volumeName string) (*v1alpha1.CASVolume, err
 
 	// volume name is expected
 	if len(vol.Name) == 0 {
-		return nil, CodedErrorf(400, "failed to read volume: missing volume name: %s", vol)
+		return nil, CodedErrorf(400, "failed to read volume: missing volume name")
 	}
 
 	// use namespace from req headers if volume ns is still not set
@@ -202,7 +202,7 @@ func (v *volumeAPIOpsV1alpha1) read(volumeName string) (*v1alpha1.CASVolume, err
 	if err != nil {
 		return nil, CodedErrorWrap(
 			400,
-			errors.Wrapf(err, "failed to read volume: failed to init volume operation: %s", vol),
+			errors.Wrapf(err, "failed to read volume {%s}: failed to init volume operation", vol.Name),
 		)
 	}
 
@@ -214,7 +214,7 @@ func (v *volumeAPIOpsV1alpha1) read(volumeName string) (*v1alpha1.CASVolume, err
 				errors.Errorf("failed to read volume: volume {%s} not found in namespace {%s}", vol.Name, vol.Namespace),
 			)
 		}
-		return nil, CodedErrorWrap(500, errors.Wrapf(err, "failed to read volume: %s", vol))
+		return nil, CodedErrorWrap(500, errors.Wrap(err, "failed to handle volume read request"))
 	}
 
 	glog.Infof("volume '%s' read successfully", cvol.Name)


### PR DESCRIPTION
 Signed-off-by: shubham <shubham.bajpai@mayadat.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Removes unnecessary cas object dumps in read requests.

*What the logs currently look like*
```
I0515 12:14:02.137363       6 volume_endpoint_v1alpha1.go:77] received cas volume request: http method 'GET'
I0515 12:14:02.137399       6 volume_endpoint_v1alpha1.go:162] received volume read request: pvc-e57cccbf-770a-11e9-bd08-54e1ad5e8320
2019/05/15 12:14:02.243921 [ERR] http: Request GET /latest/volumes/pvc-e57cccbf-770a-11e9-bd08-54e1ad5e8320
  --  error converting YAML to JSON: yaml: mapping values are not allowed in this context
      github.com/openebs/maya/pkg/volume.NewVolumeEngine
	/home/user/work/src/github.com/openebs/maya/pkg/volume/volume_template_engine.go:82
  --  failed to instantiate volume engine: invalid sc cas config: - name: ReplicaCount:
  value: 1

  --  failed to read volume: 
casvolume {cloneSpec: {}
metadata:
  annotations:
    nodeAffinity.replica.jiva.openebs.io/is-patch: ""
  creationTimestamp: null
  labels:
    openebs.io/storageclass: jiva-1r
  name: pvc-e57cccbf-770a-11e9-bd08-54e1ad5e8320
  namespace: default
spec:
  accessMode: ""
  capacity: ""
  casType: ""
  fsType: ""
  iqn: ""
  lun: 0
  replicas: ""
  targetIP: ""
  targetPort: ""
  targetPortal: ""
status:
  Message: ""
  Phase: ""
  Reason: ""
}
  --  failed to read volume: 
casvolume {cloneSpec: {}
metadata:
  annotations:
    nodeAffinity.replica.jiva.openebs.io/is-patch: ""
  creationTimestamp: null
  labels:
    openebs.io/storageclass: jiva-1r
  name: pvc-e57cccbf-770a-11e9-bd08-54e1ad5e8320
  namespace: default
spec:
  accessMode: ""
  capacity: ""
  casType: ""
  fsType: ""
  iqn: ""
  lun: 0
  replicas: ""
  targetIP: ""
  targetPort: ""
  targetPortal: ""
status:
  Message: ""
  Phase: ""
  Reason: ""
}
```
*What it should look like*
Instead for wrapping empty objects we can wrap some text related to the action which encountered the error.
```
I0515 12:49:17.168378       7 volume_endpoint_v1alpha1.go:77] received cas volume request: http method {GET}
I0515 12:49:17.168503       7 volume_endpoint_v1alpha1.go:165] received volume read request: pvc-d3ed8517-770f-11e9-bd08-54e1ad5e8320
2019/05/16 06:00:19.025146 [ERR] http: Request GET /latest/volumes/pvc-e20cbe28-779f-11e9-9440-54e1ad5e8320
  --  error converting YAML to JSON: yaml: mapping values are not allowed in this context
      github.com/openebs/maya/pkg/volume.NewVolumeEngine
	/home/user/work/src/github.com/openebs/maya/pkg/volume/volume_template_engine.go:82
  --  failed to instantiate volume engine: invalid sc cas config: - name: ReplicaCount:
  value: 1

  --  failed to read volume {pvc-e20cbe28-779f-11e9-9440-54e1ad5e8320}
  --  failed to handle volume read request

```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests