### PR TITLE
tests(cstorpool): add flag to take kubeconfigpath

### DIFF
--- a/pkg/cstorpool/v1alpha3/kubernetes.go
+++ b/pkg/cstorpool/v1alpha3/kubernetes.go
@@ -18,6 +18,7 @@ package v1alpha3
 
 import (
 	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -90,8 +91,8 @@ func WithKubeClient(c *clientset.Clientset) KubeclientBuildOption {
 	}
 }
 
-// WithFlag sets the client using the kubeconfig path
-func (k *Kubeclient) WithFlag(kubeconfig string) (*Kubeclient, error) {
+// WithKubeConfigPath sets the client using the kubeconfig path
+func (k *Kubeclient) WithKubeConfigPath(kubeconfig string) (*Kubeclient, error) {
 	cfg, err := getClusterConfig(kubeconfig)
 	if err != nil {
 		return nil, fmt.Errorf("Error building kubeconfig: %s", err.Error())

--- a/pkg/storagepoolclaim/v1alpha1/kubernetes.go
+++ b/pkg/storagepoolclaim/v1alpha1/kubernetes.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -116,8 +117,8 @@ func WithKubeClient(c *clientset.Clientset) KubeclientBuildOption {
 	}
 }
 
-// WithFlag sets the client using the kubeconfig path
-func (k *Kubeclient) WithFlag(kubeconfig string) (*Kubeclient, error) {
+// WithKubeConfigPath sets the client using the kubeconfig path
+func (k *Kubeclient) WithKubeConfigPath(kubeconfig string) (*Kubeclient, error) {
 	cfg, err := getClusterConfig(kubeconfig)
 	if err != nil {
 		return nil, fmt.Errorf("Error building kubeconfig: %s", err.Error())

--- a/pkg/storagepoolclaim/v1alpha1/kubernetes.go
+++ b/pkg/storagepoolclaim/v1alpha1/kubernetes.go
@@ -17,13 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"fmt"
-
+	client "github.com/openebs/maya/pkg/kubernetes/client/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-
-	kclient "github.com/openebs/maya/pkg/kubernetes/client/v1alpha1"
 
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	clientset "github.com/openebs/maya/pkg/client/generated/clientset/versioned"
@@ -32,6 +27,10 @@ import (
 // getClientsetFn is a typed function that
 // abstracts fetching of internal clientset
 type getClientsetFn func() (clientset *clientset.Clientset, err error)
+
+// getClientsetFromPathFn is a typed function that
+// abstracts fetching of clientset from kubeConfigPath
+type getClientsetForPathFn func(kubeConfigPath string) (clientset *clientset.Clientset, err error)
 
 // listFn is a typed function that abstracts
 // listing of cstor pool
@@ -53,25 +52,38 @@ type Kubeclient struct {
 	// make kubernetes API calls
 	clientset *clientset.Clientset
 
+	// kubeconfig path to get kubernetes clientset
+	kubeConfigPath string
+
 	// functions useful during mocking
-	getClientset getClientsetFn
-	list         listFn
-	get          getFn
-	create       createFn
-	del          deleteFn
-	update       updateFn
+	getClientset        getClientsetFn
+	getClientsetForPath getClientsetForPathFn
+	list                listFn
+	get                 getFn
+	create              createFn
+	del                 deleteFn
+	update              updateFn
 }
 
 // KubeclientBuildOption defines the abstraction
 // to build a kubeclient instance
 type KubeclientBuildOption func(*Kubeclient)
 
-// WithDefaults sets the default options
+// withDefaults sets the default options
 // of kubeclient instance
-func (k *Kubeclient) WithDefaults() {
+func (k *Kubeclient) withDefaults() {
 	if k.getClientset == nil {
 		k.getClientset = func() (clients *clientset.Clientset, err error) {
-			config, err := kclient.New().Config()
+			config, err := client.New().GetConfigForPathOrDirect()
+			if err != nil {
+				return nil, err
+			}
+			return clientset.NewForConfig(config)
+		}
+	}
+	if k.getClientsetForPath == nil {
+		k.getClientsetForPath = func(kubeConfigPath string) (clients *clientset.Clientset, err error) {
+			config, err := client.New(client.WithKubeConfigPath(kubeConfigPath)).GetConfigForPathOrDirect()
 			if err != nil {
 				return nil, err
 			}
@@ -109,6 +121,17 @@ func (k *Kubeclient) WithDefaults() {
 	}
 }
 
+// NewKubeClient returns a new instance of kubeclient meant for
+// cstor volume replica operations
+func NewKubeClient(opts ...KubeclientBuildOption) *Kubeclient {
+	k := &Kubeclient{}
+	for _, o := range opts {
+		o(k)
+	}
+	k.withDefaults()
+	return k
+}
+
 // WithKubeClient sets the kubernetes client against
 // the kubeclient instance
 func WithKubeClient(c *clientset.Clientset) KubeclientBuildOption {
@@ -117,39 +140,19 @@ func WithKubeClient(c *clientset.Clientset) KubeclientBuildOption {
 	}
 }
 
-// WithKubeConfigPath sets the client using the kubeconfig path
-func (k *Kubeclient) WithKubeConfigPath(kubeconfig string) (*Kubeclient, error) {
-	cfg, err := getClusterConfig(kubeconfig)
-	if err != nil {
-		return nil, fmt.Errorf("Error building kubeconfig: %s", err.Error())
+// WithKubeConfigPath sets the kubeConfig path
+// against client instance
+func WithKubeConfigPath(path string) KubeclientBuildOption {
+	return func(k *Kubeclient) {
+		k.kubeConfigPath = path
 	}
-
-	// Building OpenEBS Clientset
-	openebsClient, err := clientset.NewForConfig(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("Error building openebs clientset: %s", err.Error())
-	}
-	k.clientset = openebsClient
-	return k, nil
 }
 
-func getClusterConfig(kubeconfig string) (*rest.Config, error) {
-	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
-	if err != nil {
-		return nil, fmt.Errorf("Error building kubeconfig: %s", err.Error())
+func (k *Kubeclient) getClientsetForPathOrDirect() (*clientset.Clientset, error) {
+	if k.kubeConfigPath != "" {
+		return k.getClientsetForPath(k.kubeConfigPath)
 	}
-	return cfg, err
-}
-
-// KubeClient returns a new instance of kubeclient meant for
-// cstor volume replica operations
-func KubeClient(opts ...KubeclientBuildOption) *Kubeclient {
-	k := &Kubeclient{}
-	for _, o := range opts {
-		o(k)
-	}
-	k.WithDefaults()
-	return k
+	return k.getClientset()
 }
 
 // getClientOrCached returns either a new instance
@@ -158,7 +161,7 @@ func (k *Kubeclient) getClientOrCached() (*clientset.Clientset, error) {
 	if k.clientset != nil {
 		return k.clientset, nil
 	}
-	c, err := k.getClientset()
+	c, err := k.getClientsetForPathOrDirect()
 	if err != nil {
 		return nil, err
 	}

--- a/tests/cstor-pool/cstor_integration_test.go
+++ b/tests/cstor-pool/cstor_integration_test.go
@@ -17,12 +17,14 @@ limitations under the License.
 package cstorpoolit
 
 import (
+	"flag"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	csp "github.com/openebs/maya/pkg/cstorpool/v1alpha3"
 	spc "github.com/openebs/maya/pkg/storagepoolclaim/v1alpha1"
-	"time"
 
 	//	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,8 +33,11 @@ import (
 )
 
 const (
-	KubeConfigPath = "/home/ashutosh/.kube/config"
-	MaxRetry       = 30
+	MaxRetry = 30
+)
+
+var (
+	kubeConfigPath string
 )
 
 // operations encapsulates various kubernetes object client set for operations.
@@ -47,6 +52,10 @@ func TestIntegrationCstorPool(t *testing.T) {
 	RegisterFailHandler(Fail)
 	// RunSpecs runs all the test cases in the suite.
 	RunSpecs(t, "Cstor pool integration test suite")
+}
+
+func init() {
+	flag.StringVar(&kubeConfigPath, "kubeconfig", "", "path to kubeconfig to invoke kubernetes API calls")
 }
 
 var _ = Describe("STRIPED SPARSE SPC", func() {
@@ -300,7 +309,7 @@ var _ = Describe("RAIDZ2 SPARSE SPC", func() {
 })
 
 var _ = AfterSuite(func() {
-	spcClient, err := spc.KubeClient().WithFlag(KubeConfigPath)
+	spcClient, err := spc.KubeClient().WithFlag(kubeConfigPath)
 	Expect(err).To(BeNil())
 	spcList, err := spcClient.List(metav1.ListOptions{})
 	Expect(err).To(BeNil())
@@ -327,14 +336,14 @@ var clientBuilderFuncList = []clientBuilderFunc{
 }
 
 func (ops *operations) newCspClient() *operations {
-	newCspClient, err := csp.KubeClient().WithFlag(KubeConfigPath)
+	newCspClient, err := csp.KubeClient().WithFlag(kubeConfigPath)
 	Expect(err).To(BeNil())
 	ops.cspClient = newCspClient
 	return ops
 }
 
 func (ops *operations) newSpcClient() *operations {
-	newSpcClient, err := spc.KubeClient().WithFlag(KubeConfigPath)
+	newSpcClient, err := spc.KubeClient().WithFlag(kubeConfigPath)
 	Expect(err).To(BeNil())
 	ops.spcClient = newSpcClient
 	return ops

--- a/tests/cstor-pool/cstor_integration_test.go
+++ b/tests/cstor-pool/cstor_integration_test.go
@@ -309,7 +309,7 @@ var _ = Describe("RAIDZ2 SPARSE SPC", func() {
 })
 
 var _ = AfterSuite(func() {
-	spcClient, err := spc.KubeClient().WithFlag(kubeConfigPath)
+	spcClient, err := spc.KubeClient().WithKubeConfigPath(kubeConfigPath)
 	Expect(err).To(BeNil())
 	spcList, err := spcClient.List(metav1.ListOptions{})
 	Expect(err).To(BeNil())
@@ -336,14 +336,14 @@ var clientBuilderFuncList = []clientBuilderFunc{
 }
 
 func (ops *operations) newCspClient() *operations {
-	newCspClient, err := csp.KubeClient().WithFlag(kubeConfigPath)
+	newCspClient, err := csp.KubeClient().WithKubeConfigPath(kubeConfigPath)
 	Expect(err).To(BeNil())
 	ops.cspClient = newCspClient
 	return ops
 }
 
 func (ops *operations) newSpcClient() *operations {
-	newSpcClient, err := spc.KubeClient().WithFlag(kubeConfigPath)
+	newSpcClient, err := spc.KubeClient().WithKubeConfigPath(kubeConfigPath)
 	Expect(err).To(BeNil())
 	ops.spcClient = newSpcClient
 	return ops

--- a/tests/cstor-pool/cstor_integration_test.go
+++ b/tests/cstor-pool/cstor_integration_test.go
@@ -309,8 +309,8 @@ var _ = Describe("RAIDZ2 SPARSE SPC", func() {
 })
 
 var _ = AfterSuite(func() {
-	spcClient, err := spc.KubeClient().WithKubeConfigPath(kubeConfigPath)
-	Expect(err).To(BeNil())
+	spcClient := spc.NewKubeClient(spc.WithKubeConfigPath(kubeConfigPath))
+
 	spcList, err := spcClient.List(metav1.ListOptions{})
 	Expect(err).To(BeNil())
 	for _, spc := range spcList.Items {
@@ -343,8 +343,7 @@ func (ops *operations) newCspClient() *operations {
 }
 
 func (ops *operations) newSpcClient() *operations {
-	newSpcClient, err := spc.KubeClient().WithKubeConfigPath(kubeConfigPath)
-	Expect(err).To(BeNil())
+	newSpcClient := spc.NewKubeClient(spc.WithKubeConfigPath(kubeConfigPath))
 	ops.spcClient = newSpcClient
 	return ops
 }


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Adds the `kubeconfig` flag to take the KubeConfigPath while running the bdd.

Use the below command to run the test

`ginkgo -v -- -kubeconfig=/path/to/kubeconfig`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests