### PR TITLE
feat(bdd, upgrade) add BDD for jiva volume upgrade

### DIFF
--- a/cmd/upgrade/app/v1alpha1/result.go
+++ b/cmd/upgrade/app/v1alpha1/result.go
@@ -158,7 +158,7 @@ func (urb *UpgradeResultGetOrCreateBuilder) GetOrCreate() (
 	opts := metav1.ListOptions{
 		LabelSelector: l,
 	}
-	urList, err := upgraderesult.KubeClient().
+	urList, err := upgraderesult.NewKubeClient().
 		WithNamespace(urb.SelfNamespace).
 		List(opts)
 	if err != nil {
@@ -173,7 +173,7 @@ func (urb *UpgradeResultGetOrCreateBuilder) GetOrCreate() (
 				errors.Wrapf(err, "failed to get or create upgrade result: %s", urb)
 		}
 
-		urb.UpgradeResult.object, err = upgraderesult.KubeClient().
+		urb.UpgradeResult.object, err = upgraderesult.NewKubeClient().
 			WithNamespace(urb.SelfNamespace).
 			Create(ur)
 		if err != nil {

--- a/pkg/kubernetes/pod/v1alpha1/pod.go
+++ b/pkg/kubernetes/pod/v1alpha1/pod.go
@@ -76,6 +76,20 @@ func IsRunning() Predicate {
 	}
 }
 
+// IsCompleted retuns true if the pod is in completed
+// state
+func (p *Pod) IsCompleted() bool {
+	return p.object.Status.Phase == "Succeeded"
+}
+
+// IsCompleted is a predicate to filter out pods
+// which in completed state
+func IsCompleted() Predicate {
+	return func(p *Pod) bool {
+		return p.IsCompleted()
+	}
+}
+
 // HasLabels returns true if provided labels
 // map[key]value are present in the provided PodList
 // instance

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -920,7 +920,7 @@ func (m *executor) patchUpgradeResult() error {
 
 	// patch Upgrade Result
 	p, err := upgraderesult.
-		KubeClient().
+		NewKubeClient().
 		WithNamespace(m.getTaskRunNamespace()).
 		Patch(m.getTaskObjectName(), patch.Type, patch.Object)
 	if err != nil {
@@ -1246,7 +1246,7 @@ func (m *executor) getOEV1alpha1CSP() error {
 // as specified in the RunTask
 func (m *executor) getOEV1alpha1UR() error {
 	uresult, err := upgraderesult.
-		KubeClient().
+		NewKubeClient().
 		WithNamespace(m.getTaskRunNamespace()).
 		Get(m.getTaskObjectName(), metav1.GetOptions{})
 	if err != nil {
@@ -1499,7 +1499,7 @@ func (m *executor) putUpgradeResult() (err error) {
 		return errors.Wrap(err, "failed to create upgrade result")
 	}
 	uraw, err := upgraderesult.
-		KubeClient().
+		NewKubeClient().
 		WithNamespace(m.getTaskRunNamespace()).
 		CreateRaw(uresult)
 	if err != nil {
@@ -1646,7 +1646,7 @@ func (m *executor) listK8sResources() (err error) {
 // listOEV1alpha1URRaw fetches a list of UpgradeResults as per the
 // provided options
 func (m *executor) listOEV1alpha1URRaw(opts metav1.ListOptions) (result []byte, err error) {
-	urList, err := upgraderesult.KubeClient().
+	urList, err := upgraderesult.NewKubeClient().
 		WithNamespace(m.getTaskRunNamespace()).
 		List(opts)
 	if err != nil {

--- a/pkg/unstruct/v1alpha2/unstruct.go
+++ b/pkg/unstruct/v1alpha2/unstruct.go
@@ -26,13 +26,13 @@ import (
 
 // Unstruct holds an object of Unstructured
 type Unstruct struct {
-	object *unstructured.Unstructured
+	Object *unstructured.Unstructured
 }
 
 // GetUnstructured converts Unstruct object
 // to API's Unstructured
 func (u *Unstruct) GetUnstructured() *unstructured.Unstructured {
-	return u.object
+	return u.Object
 }
 
 // Builder enables building of an
@@ -59,7 +59,7 @@ func NewBuilder() *Builder {
 // YAML
 func BuilderForYaml(doc string) *Builder {
 	b := NewBuilder()
-	err := yaml.Unmarshal([]byte(doc), &b.unstruct.object)
+	err := yaml.Unmarshal([]byte(doc), &b.unstruct.Object)
 	if err != nil {
 		b.errs = append(b.errs, err)
 	}
@@ -70,7 +70,7 @@ func BuilderForYaml(doc string) *Builder {
 // Unstruct Builder by making use of the provided object
 func BuilderForObject(obj *unstructured.Unstructured) *Builder {
 	b := NewBuilder()
-	b.unstruct.object = obj
+	b.unstruct.Object = obj
 	return b
 }
 
@@ -89,7 +89,7 @@ func (b *Builder) BuildAPIUnstructured() (*unstructured.Unstructured, error) {
 	if len(b.errs) != 0 {
 		return nil, errors.Errorf("errors {%+v}", b.errs)
 	}
-	return b.unstruct.object, nil
+	return b.unstruct.Object, nil
 }
 
 // UnstructList contains a list of Unstructured

--- a/pkg/unstruct/v1alpha2/unstruct_test.go
+++ b/pkg/unstruct/v1alpha2/unstruct_test.go
@@ -106,12 +106,14 @@ func TestBuilderForYAML(t *testing.T) {
 		"Test 2": {fakeInvalidK8sResource, "", true},
 	}
 	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
 		t.Run(name, func(t *testing.T) {
 			b := BuilderForYaml(mock.resourceYAML)
 			if mock.expectError && len(b.errs) == 0 {
 				t.Fatalf("Test %s failed, expected err but got 0", name)
-			} else if b.unstruct.object.GetName() != mock.expectedName {
-				t.Fatalf("Test %s failed, expected %v but got %v", name, mock.expectedName, b.unstruct.object.GetName())
+			} else if b.unstruct.Object.GetName() != mock.expectedName {
+				t.Fatalf("Test %s failed, expected %v but got %v", name, mock.expectedName, b.unstruct.Object.GetName())
 			}
 		})
 	}
@@ -125,11 +127,13 @@ func TestBuilderForObject(t *testing.T) {
 		"Test 2": {"icstcee1", "icstcee1"},
 	}
 	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
 		t.Run(name, func(t *testing.T) {
 			mockObj := fakeUnstructObject(mock.resourceName)
 			b := BuilderForObject(mockObj)
-			if b.unstruct.object.GetName() != mock.expectedName {
-				t.Fatalf("Test %s failed, expected %v but got %v", name, mock.expectedName, b.unstruct.object.GetName())
+			if b.unstruct.Object.GetName() != mock.expectedName {
+				t.Fatalf("Test %s failed, expected %v but got %v", name, mock.expectedName, b.unstruct.Object.GetName())
 			}
 		})
 	}
@@ -144,12 +148,14 @@ func TestBuilderForYamlBuild(t *testing.T) {
 		"Test 2": {fakeInvalidK8sResource, "", true},
 	}
 	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
 		t.Run(name, func(t *testing.T) {
 			b, err := BuilderForYaml(mock.resourceYAML).Build()
 			if mock.expectError && err == nil {
 				t.Fatalf("Test %s failed, expected err but got nil", name)
-			} else if b != nil && b.object.GetName() != mock.expectedName {
-				t.Fatalf("Test %s failed, expected %v but got %v", name, mock.expectedName, b.object.GetName())
+			} else if b != nil && b.Object.GetName() != mock.expectedName {
+				t.Fatalf("Test %s failed, expected %v but got %v", name, mock.expectedName, b.Object.GetName())
 			}
 		})
 	}
@@ -167,6 +173,8 @@ func TestListBuilderForYamls(t *testing.T) {
 		"Test 4": {fakeK8sResourceList(fakeInvalidK8sResource, 2), 0, true},
 	}
 	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
 		t.Run(name, func(t *testing.T) {
 			lb := ListBuilderForYamls(mock.resourceYAML)
 			if mock.expectErr && len(lb.errs) == 0 {
@@ -190,6 +198,8 @@ func TestListUnstructBuilderForObjects(t *testing.T) {
 		"Test 4": {[]*unstructured.Unstructured{fakePodObject(), fakeDeploymentObject(), fakeServiceObject(), fakeNamespaceObject()}, 4, false},
 	}
 	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
 		t.Run(name, func(t *testing.T) {
 			lb := ListBuilderForObjects(mock.availableResources...)
 			if mock.expectErr && len(lb.errs) == 0 {

--- a/pkg/unstruct/v1alpha2/unstruct_test.go
+++ b/pkg/unstruct/v1alpha2/unstruct_test.go
@@ -179,8 +179,8 @@ func TestListBuilderForYamls(t *testing.T) {
 			lb := ListBuilderForYamls(mock.resourceYAML)
 			if mock.expectErr && len(lb.errs) == 0 {
 				t.Fatalf("Test %s failed, expected err but got nil", name)
-			} else if len(lb.list.items) != mock.expectedResourceCount {
-				t.Fatalf("Test %s failed, expected resource count %v but got %v", name, mock.expectedResourceCount, len(lb.list.items))
+			} else if len(lb.list.Items) != mock.expectedResourceCount {
+				t.Fatalf("Test %s failed, expected resource count %v but got %v", name, mock.expectedResourceCount, len(lb.list.Items))
 			}
 		})
 	}
@@ -204,8 +204,8 @@ func TestListUnstructBuilderForObjects(t *testing.T) {
 			lb := ListBuilderForObjects(mock.availableResources...)
 			if mock.expectErr && len(lb.errs) == 0 {
 				t.Fatalf("Test %s failed, expected err but got nil", name)
-			} else if len(lb.list.items) != mock.expectedResourceCount {
-				t.Fatalf("Test %s failed, expected resource count %v but got %v", name, mock.expectedResourceCount, len(lb.list.items))
+			} else if len(lb.list.Items) != mock.expectedResourceCount {
+				t.Fatalf("Test %s failed, expected resource count %v but got %v", name, mock.expectedResourceCount, len(lb.list.Items))
 			}
 		})
 	}

--- a/pkg/upgrade/result/v1alpha1/kubernetes.go
+++ b/pkg/upgrade/result/v1alpha1/kubernetes.go
@@ -35,7 +35,7 @@ import (
 // abstracts fetching internal clientset
 type getClientsetFunc func() (cs *clientset.Clientset, err error)
 
-// getClientsetFromPathFn is a typed function that
+// getClientsetForPathFn is a typed function that
 // abstracts fetching of clientset from kubeConfigPath
 type getClientsetForPathFn func(kubeConfigPath string) (cs *clientset.Clientset, err error)
 

--- a/pkg/upgrade/result/v1alpha1/kubernetes.go
+++ b/pkg/upgrade/result/v1alpha1/kubernetes.go
@@ -35,6 +35,10 @@ import (
 // abstracts fetching internal clientset
 type getClientsetFunc func() (cs *clientset.Clientset, err error)
 
+// getClientsetFromPathFn is a typed function that
+// abstracts fetching of clientset from kubeConfigPath
+type getClientsetForPathFn func(kubeConfigPath string) (cs *clientset.Clientset, err error)
+
 // listFunc is a typed function that abstracts
 // listing upgrade result instances
 type listFunc func(cs *clientset.Clientset, namespace string, opts metav1.ListOptions) (*apis.UpgradeResultList, error)
@@ -66,13 +70,17 @@ type Kubeclient struct {
 	// make kubernetes API calls
 	clientset *clientset.Clientset
 	namespace string
+	// kubeconfig path to get kubernetes clientset
+	kubeConfigPath string
+
 	// functions useful during mocking
-	getClientset getClientsetFunc
-	list         listFunc
-	get          getFunc
-	create       createFunc
-	patch        patchFunc
-	update       updateFunc
+	getClientset        getClientsetFunc
+	list                listFunc
+	get                 getFunc
+	create              createFunc
+	patch               patchFunc
+	update              updateFunc
+	getClientsetForPath getClientsetForPathFn
 }
 
 // KubeclientBuildOption defines the abstraction
@@ -84,7 +92,17 @@ type KubeclientBuildOption func(*Kubeclient)
 func (k *Kubeclient) withDefaults() {
 	if k.getClientset == nil {
 		k.getClientset = func() (cs *clientset.Clientset, err error) {
-			config, err := client.GetConfig(client.New())
+			config, err := client.New().GetConfigForPathOrDirect()
+			if err != nil {
+				return nil, err
+			}
+			return clientset.NewForConfig(config)
+		}
+	}
+
+	if k.getClientsetForPath == nil {
+		k.getClientsetForPath = func(kubeConfigPath string) (clients *clientset.Clientset, err error) {
+			config, err := client.New(client.WithKubeConfigPath(kubeConfigPath)).GetConfigForPathOrDirect()
 			if err != nil {
 				return nil, err
 			}
@@ -143,9 +161,24 @@ func WithClientset(c *clientset.Clientset) KubeclientBuildOption {
 	}
 }
 
-// KubeClient returns a new instance of kubeclient meant for
+// WithKubeConfigPath sets the kubeConfig path
+// against client instance
+func WithKubeConfigPath(path string) KubeclientBuildOption {
+	return func(k *Kubeclient) {
+		k.kubeConfigPath = path
+	}
+}
+
+func (k *Kubeclient) getClientsetForPathOrDirect() (*clientset.Clientset, error) {
+	if k.kubeConfigPath != "" {
+		return k.getClientsetForPath(k.kubeConfigPath)
+	}
+	return k.getClientset()
+}
+
+// NewKubeClient returns a new instance of kubeclient meant for
 // upgrade result related operations
-func KubeClient(opts ...KubeclientBuildOption) *Kubeclient {
+func NewKubeClient(opts ...KubeclientBuildOption) *Kubeclient {
 	k := &Kubeclient{}
 	for _, o := range opts {
 		o(k)
@@ -167,11 +200,11 @@ func (k *Kubeclient) getClientOrCached() (*clientset.Clientset, error) {
 	if k.clientset != nil {
 		return k.clientset, nil
 	}
-	c, err := k.getClientset()
+	cs, err := k.getClientsetForPathOrDirect()
 	if err != nil {
 		return nil, err
 	}
-	k.clientset = c
+	k.clientset = cs
 	return k.clientset, nil
 }
 
@@ -337,7 +370,7 @@ func UpdateTasks(opts ...UpgradeResultForTaskOption) error {
 		return errors.New("failed to update upgrade result tasks: missing upgrade result name")
 	}
 	// First get the desired upgrade result instance
-	k := KubeClient()
+	k := NewKubeClient()
 	k.namespace = new.namespace
 	existing, err := k.Get(new.name, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/upgrade/result/v1alpha1/upgraderesult.go
+++ b/pkg/upgrade/result/v1alpha1/upgraderesult.go
@@ -26,7 +26,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type upgradeResult struct {
+//UpgradeResult holds the apis upgraderesult object
+type UpgradeResult struct {
 	// upgrade result object
 	object *apis.UpgradeResult
 }
@@ -35,13 +36,13 @@ type upgradeResult struct {
 // upgradeResults
 type UpgradeResultList struct {
 	// list of upgrade results
-	items []*upgradeResult
+	items []*UpgradeResult
 }
 
 // Builder enables building an instance of
 // upgradeResult
 type Builder struct {
-	*upgradeResult
+	*UpgradeResult
 	checks map[*Predicate]string
 	errors []error
 }
@@ -55,12 +56,12 @@ type Builder struct {
 // NOTE:
 // Predicate approach enables clear separation of conditionals from
 // imperatives i.e. actions that form the business logic
-type Predicate func(*upgradeResult) bool
+type Predicate func(*UpgradeResult) bool
 
 // NewBuilder returns a new instance of Builder
 func NewBuilder() *Builder {
 	return &Builder{
-		upgradeResult: &upgradeResult{
+		UpgradeResult: &UpgradeResult{
 			object: &apis.UpgradeResult{},
 		},
 		checks: make(map[*Predicate]string),
@@ -98,7 +99,7 @@ func (b *Builder) WithResultConfig(resource apis.ResourceDetails,
 // of Builder for a given template object
 func BuilderForYAMLObject(object []byte) *Builder {
 	b := &Builder{
-		upgradeResult: &upgradeResult{
+		UpgradeResult: &UpgradeResult{
 			object: &apis.UpgradeResult{},
 		},
 		checks: make(map[*Predicate]string),
@@ -120,14 +121,14 @@ func (b *Builder) Build() (*apis.UpgradeResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	return b.upgradeResult.object, nil
+	return b.UpgradeResult.object, nil
 }
 
 // validate will run checks against upgrade
 // result instance
 func (b *Builder) validate() error {
 	for cond := range b.checks {
-		pass := (*cond)(b.upgradeResult)
+		pass := (*cond)(b.UpgradeResult)
 		if !pass {
 			b.errors = append(b.errors,
 				errors.Errorf("validation failed: %s", b.checks[cond]))
@@ -183,7 +184,7 @@ func (b *ListBuilder) WithAPIList(list *apis.UpgradeResultList) *ListBuilder {
 		return b
 	}
 	for i := range list.Items {
-		b.list.items = append(b.list.items, &upgradeResult{object: &list.Items[i]})
+		b.list.items = append(b.list.items, &UpgradeResult{object: &list.Items[i]})
 	}
 	return b
 }

--- a/pkg/upgrade/result/v1alpha1/upgraderesult_test.go
+++ b/pkg/upgrade/result/v1alpha1/upgraderesult_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func fakePredicate() Predicate {
-	return func(p *upgradeResult) bool {
+	return func(p *UpgradeResult) bool {
 		return true
 	}
 }
@@ -43,9 +43,9 @@ func TestNewBuilder(t *testing.T) {
 		mock := mock // pin it
 		t.Run(name, func(t *testing.T) {
 			b := NewBuilder()
-			if (b.upgradeResult != nil) != mock.expectUpgradeResult {
+			if (b.UpgradeResult != nil) != mock.expectUpgradeResult {
 				t.Fatalf("test %s failed, expect upgraderesult: %t but got: %t",
-					name, mock.expectUpgradeResult, b.upgradeResult != nil)
+					name, mock.expectUpgradeResult, b.UpgradeResult != nil)
 			}
 			if (b.checks != nil) != mock.expectChecks {
 				t.Fatalf("test %s failed, expect checks: %t but got: %t",
@@ -80,7 +80,7 @@ func TestAddCheck(t *testing.T) {
 func TestWithAPIList(t *testing.T) {
 	inputURItems := []apis.UpgradeResult{apis.UpgradeResult{
 		ObjectMeta: metav1.ObjectMeta{Name: "upgradeResultList1"}}}
-	outputURItems := []*upgradeResult{&upgradeResult{object: &apis.UpgradeResult{
+	outputURItems := []*UpgradeResult{&UpgradeResult{object: &apis.UpgradeResult{
 		ObjectMeta: metav1.ObjectMeta{Name: "upgradeResultList1"}}}}
 	tests := map[string]struct {
 		inputURList    *apis.UpgradeResultList
@@ -113,7 +113,7 @@ func TestWithAPIList(t *testing.T) {
 func TestList(t *testing.T) {
 	inputURItems := []apis.UpgradeResult{apis.UpgradeResult{
 		ObjectMeta: metav1.ObjectMeta{Name: "upgradeResultList1"}}}
-	outputURItems := []*upgradeResult{&upgradeResult{object: &apis.UpgradeResult{
+	outputURItems := []*UpgradeResult{&UpgradeResult{object: &apis.UpgradeResult{
 		ObjectMeta: metav1.ObjectMeta{Name: "upgradeResultList1"}}}}
 	tests := map[string]struct {
 		inputURList    *apis.UpgradeResultList
@@ -176,7 +176,7 @@ func TestWithTypeMeta(t *testing.T) {
 		name := name // pin it
 		mock := mock // pin it
 		b := &Builder{
-			upgradeResult: &upgradeResult{
+			UpgradeResult: &UpgradeResult{
 				object: &apis.UpgradeResult{},
 			},
 			checks: make(map[*Predicate]string),
@@ -226,7 +226,7 @@ func TestWithObjectMeta(t *testing.T) {
 		name := name // pin it
 		mock := mock // pin it
 		b := &Builder{
-			upgradeResult: &upgradeResult{
+			UpgradeResult: &UpgradeResult{
 				object: &apis.UpgradeResult{},
 			},
 			checks: make(map[*Predicate]string),
@@ -271,7 +271,7 @@ func TestWithTasks(t *testing.T) {
 		name := name // pin it
 		mock := mock // pin it
 		b := &Builder{
-			upgradeResult: &upgradeResult{
+			UpgradeResult: &UpgradeResult{
 				object: &apis.UpgradeResult{},
 			},
 			checks: make(map[*Predicate]string),
@@ -312,7 +312,7 @@ func TestWithResultConfig(t *testing.T) {
 		name := name
 		mock := mock
 		b := &Builder{
-			upgradeResult: &upgradeResult{
+			UpgradeResult: &UpgradeResult{
 				object: &apis.UpgradeResult{},
 			},
 			checks: make(map[*Predicate]string),

--- a/pkg/util/http/v1alpha1/http.go
+++ b/pkg/util/http/v1alpha1/http.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The OpenEBS Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"io"
+	"net/http"
+)
+
+// Fetch gives the response body of the url provided
+func Fetch(url string) (io.ReadCloser, error) {
+	httpClient := *http.DefaultClient
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Body, nil
+}

--- a/tests/operations.go
+++ b/tests/operations.go
@@ -406,9 +406,9 @@ func (ops *Operations) GetPodCompletedCount(namespace, lselector string) int {
 		Len()
 }
 
-// VerifyUpgradeResultTasksIsSuccess checks whether all the tasks in upgraderesult
+// VerifyUpgradeResultTasksIsNotFail checks whether all the tasks in upgraderesult
 // have success
-func (ops *Operations) VerifyUpgradeResultTasksIsSuccess(namespace, lselector string) bool {
+func (ops *Operations) VerifyUpgradeResultTasksIsNotFail(namespace, lselector string) bool {
 	urList, err := ops.URClient.
 		WithNamespace(namespace).
 		List(metav1.ListOptions{LabelSelector: lselector})

--- a/tests/operations.go
+++ b/tests/operations.go
@@ -45,7 +45,7 @@ import (
 )
 
 const (
-	maxRetry = 30
+	maxRetry = 50
 )
 
 // Options holds the args used for exec'ing into the pod

--- a/tests/upgrade/0.8.2-0.9.0/jiva/suite_test.go
+++ b/tests/upgrade/0.8.2-0.9.0/jiva/suite_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2019 The OpenEBS Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jiva
+
+import (
+	"flag"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strconv"
+
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	"github.com/openebs/maya/pkg/client/k8s/v1alpha1"
+	k8s "github.com/openebs/maya/pkg/client/k8s/v1alpha1"
+	pvc "github.com/openebs/maya/pkg/kubernetes/persistentvolumeclaim/v1alpha1"
+	sc "github.com/openebs/maya/pkg/kubernetes/storageclass/v1alpha1"
+	"github.com/openebs/maya/tests"
+	"github.com/openebs/maya/tests/artifacts"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	// auth plugins
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+)
+
+var (
+	kubeConfigPath        string
+	replicaCount          int
+	nsName                = "default"
+	scName                = "jiva-upgrade-sc"
+	openebsProvisioner    = "openebs.io/provisioner-iscsi"
+	replicaLabel          = "openebs.io/replica=jiva-replica"
+	ctrlLabel             = "openebs.io/controller=jiva-controller"
+	openebsCASConfigValue = "- name: ReplicaCount\n  Value: "
+	accessModes           = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
+	capacity              = "5G"
+	pvcObj                *corev1.PersistentVolumeClaim
+	pvcName               = "jiva-volume-claim"
+	scObj                 *storagev1.StorageClass
+	err                   error
+)
+
+func TestSource(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test jiva volume upgrade")
+}
+
+func init() {
+	flag.StringVar(&kubeConfigPath, "kubeconfig", "", "path to kubeconfig to invoke kubernetes API calls")
+	flag.IntVar(&replicaCount, "replicas", 1, "number of replicas to be created")
+}
+
+var ops *tests.Operations
+
+var _ = BeforeSuite(func() {
+
+	ops = tests.NewOperations(tests.WithKubeConfigPath(kubeConfigPath))
+	openebsCASConfigValue = openebsCASConfigValue + strconv.Itoa(replicaCount)
+
+	// Setting the path in environemnt variable
+	err = os.Setenv(string(v1alpha1.KubeConfigEnvironmentKey), kubeConfigPath)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	By("applying openebs 0.8.2")
+	applyYAMLFromURL("https://openebs.github.io/charts/openebs-operator-0.8.2.yaml", "")
+
+	By("waiting for maya-apiserver pod to come into running state")
+	podCount := ops.GetPodRunningCountEventually(
+		string(artifacts.OpenebsNamespace),
+		string(artifacts.MayaAPIServerLabelSelector),
+		1,
+	)
+	Expect(podCount).To(Equal(1))
+
+	annotations := map[string]string{
+		string(apis.CASTypeKey):   string(apis.JivaVolume),
+		string(apis.CASConfigKey): openebsCASConfigValue,
+	}
+
+	By("building a storageclass")
+	scObj, err = sc.NewBuilder().
+		WithName(scName).
+		WithAnnotations(annotations).
+		WithProvisioner(openebsProvisioner).Build()
+	Expect(err).ShouldNot(HaveOccurred(), "while building storageclass {%s}", scName)
+
+	By("creating above storageclass")
+	_, err = ops.SCClient.Create(scObj)
+	Expect(err).To(BeNil(), "while creating storageclass {%s}", scObj.Name)
+
+	By("building a pvc")
+	pvcObj, err = pvc.NewBuilder().
+		WithName(pvcName).
+		WithNamespace(nsName).
+		WithStorageClass(scName).
+		WithAccessModes(accessModes).
+		WithCapacity(capacity).Build()
+	Expect(err).ShouldNot(
+		HaveOccurred(),
+		"while building pvc {%s} in namespace {%s}",
+		pvcName,
+		nsName,
+	)
+
+	By("creating above pvc")
+	_, err = ops.PVCClient.WithNamespace(nsName).Create(pvcObj)
+	Expect(err).To(
+		BeNil(),
+		"while creating pvc {%s} in namespace {%s}",
+		pvcName,
+		nsName,
+	)
+
+	By("verifying controller pod count ")
+	controllerPodCount := ops.GetPodRunningCountEventually(nsName, ctrlLabel, replicaCount)
+	Expect(controllerPodCount).To(Equal(replicaCount), "while checking controller pod count")
+
+	By("verifying replica pod count ")
+	replicaPodCount := ops.GetPodRunningCountEventually(nsName, replicaLabel, replicaCount)
+	Expect(replicaPodCount).To(Equal(replicaCount), "while checking replica pod count")
+
+	By("verifying status as bound")
+	status := ops.IsPVCBound(pvcName)
+	Expect(status).To(Equal(true), "while checking status equal to bound")
+
+	// TODO
+	// By("applying openebs 0.9.0")
+	// applyYAMLFromURL("https://openebs.github.io/charts/openebs-operator-0.9.0-RC3.yaml", "")
+
+})
+
+var _ = AfterSuite(func() {
+
+	By("deleting above pvc")
+	err := ops.PVCClient.Delete(pvcName, &metav1.DeleteOptions{})
+	Expect(err).To(
+		BeNil(),
+		"while deleting pvc {%s} in namespace {%s}",
+		pvcName,
+		nsName,
+	)
+
+	By("verifying controller pod count")
+	controllerPodCount := ops.GetPodRunningCountEventually(nsName, ctrlLabel, 0)
+	Expect(controllerPodCount).To(Equal(0), "while checking controller pod count")
+
+	By("verifying replica pod count")
+	replicaPodCount := ops.GetPodRunningCountEventually(nsName, replicaLabel, 0)
+	Expect(replicaPodCount).To(Equal(0), "while checking replica pod count")
+
+	By("deleting storageclass")
+	err = ops.SCClient.Delete(scName, &metav1.DeleteOptions{})
+	Expect(err).To(BeNil(), "while deleting storageclass {%s}", scObj.Name)
+
+})
+
+func applyYAMLFromURL(url string, flag string) {
+	// Read yaml file from the url
+	o, err := fetch(url)
+	Expect(err).ShouldNot(HaveOccurred())
+	defer o.Close()
+	b, err := ioutil.ReadAll(o)
+	Expect(err).ShouldNot(HaveOccurred())
+	// Connvert the yaml to unstructured objects
+	yamlString := string(b)
+	artifactString := artifacts.Artifact(yamlString)
+	artifactList, errs := artifacts.GetArtifactsListUnstructured(artifactString)
+	Expect(errs).Should(HaveLen(0))
+	// Applying unstructured objects
+	for i, artifact := range artifactList {
+		if flag == "job" && i == 0 {
+			unstructured.SetNestedStringMap(artifact.Object, data, "data")
+		}
+		if flag == "job" && i == 1 {
+			artifact.SetNamespace("default")
+		}
+		cu := k8s.CreateOrUpdate(
+			k8s.GroupVersionResourceFromGVK(artifact),
+			artifact.GetNamespace(),
+		)
+		_, err = cu.Apply(artifact)
+		Expect(err).ShouldNot(HaveOccurred())
+	}
+}
+
+func fetch(url string) (io.ReadCloser, error) {
+	httpClient := *http.DefaultClient
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Body, nil
+}

--- a/tests/upgrade/0.8.2-0.9.0/jiva/volume_test.go
+++ b/tests/upgrade/0.8.2-0.9.0/jiva/volume_test.go
@@ -41,23 +41,23 @@ var _ = Describe("[jiva] TEST VOLUME UPGRADE", func() {
 			urLable = urLable + pvName
 
 			By("applying rbac.yaml")
-			applyYAML(rbacYAML, "")
+			applyFromURL(rbacURL)
 
 			By("applying cr.yaml")
-			applyYAML(crYAML, "")
+			applyFromURL(crURL)
 
 			By("applying jiva_upgrade_runtask.yaml")
-			applyYAML(runtaskYAML, "")
+			applyFromURL(runtaskURL)
 
 			By("applying volume-upgrade-job.yaml")
-			applyYAML(jobYAML, "job")
+			applyFromURL(jobURL)
 
 			By("verifying completed pod count as 1")
 			completedPodCount := ops.GetPodCompletedCountEventually("default", jobLable, 1)
 			Expect(completedPodCount).To(Equal(1), "while checking complete pod count")
 
 			By("verifying upgraderesult")
-			status := ops.VerifyUpgradeResultTasksIsSuccess(nsName, urLable)
+			status := ops.VerifyUpgradeResultTasksIsNotFail(nsName, urLable)
 			Expect(status).To(Equal(true), "while checking upgraderesult")
 
 			By("verifying controller pod count")

--- a/tests/upgrade/0.8.2-0.9.0/jiva/volume_test.go
+++ b/tests/upgrade/0.8.2-0.9.0/jiva/volume_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jiva
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	jobLable      = "job-name=jiva-volume-upgrade"
+	urLable       = "upgradejob.openebs.io/name=jiva-volume-upgrade,upgradeitem.openebs.io/name="
+	upgradedLabel = "openebs.io/persistent-volume-claim=jiva-volume-claim,openebs.io/version=0.9.0-RC4"
+	data          map[string]string
+)
+
+var _ = Describe("[jiva] TEST VOLUME UPGRADE", func() {
+
+	When("jiva pvc is upgraded", func() {
+		It("should create new controller and replica pods of version 0.9.0", func() {
+
+			// fetching name of pv to update the configmap with the resource to
+			// be upgraded
+			pvName := ops.GetPVName(pvcName)
+			data = make(map[string]string)
+			data["upgrade"] = "casTemplate: jiva-volume-update-0.8.2-0.9.0\nresources:\n- name: " + pvName + "\n  kind: jiva-volume\n  namespace: default\n"
+			urLable = urLable + pvName
+
+			By("applying rbac.yaml")
+			applyYAMLFromURL("https://raw.githubusercontent.com/openebs/openebs/master/k8s/upgrades/0.8.2-0.9.0/rbac.yaml", "")
+
+			By("applying cr.yaml")
+			applyYAMLFromURL("https://raw.githubusercontent.com/openebs/openebs/master/k8s/upgrades/0.8.2-0.9.0/jiva/cr.yaml", "")
+
+			By("applying jiva_upgrade_runtask.yaml")
+			applyYAMLFromURL("https://raw.githubusercontent.com/openebs/openebs/master/k8s/upgrades/0.8.2-0.9.0/jiva/jiva_upgrade_runtask.yaml", "")
+
+			By("applying volume-upgrade-job.yaml")
+			applyYAMLFromURL("https://raw.githubusercontent.com/openebs/openebs/master/k8s/upgrades/0.8.2-0.9.0/jiva/volume-upgrade-job.yaml", "job")
+
+			By("verifying completed pod count as 1")
+			completedPodCount := ops.GetPodCompletedCountEventually("default", jobLable, 1)
+			Expect(completedPodCount).To(Equal(1), "while checking complete pod count")
+
+			By("verifying upgraderesult")
+			status := ops.CheckUpgradeResult(nsName, urLable)
+			Expect(status).To(Equal(true), "while checking upgraderesult")
+
+			By("verifying controller pod count")
+			controllerPodCount := ops.GetPodRunningCountEventually("default", ctrlLabel, replicaCount)
+			Expect(controllerPodCount).To(Equal(replicaCount), "while checking controller pod count")
+
+			By("verifying replica pod count")
+			replicaPodCount := ops.GetPodRunningCountEventually("default", replicaLabel, replicaCount)
+			Expect(replicaPodCount).To(Equal(replicaCount), "while checking replica pod count")
+
+			By("verifying pod version as 0.9.0")
+			podCount := ops.GetPodRunningCountEventually("default", upgradedLabel, replicaCount+1)
+			Expect(podCount).To(Equal(replicaCount+1), "while checking pod version")
+
+		})
+	})
+
+})

--- a/tests/upgrade/0.8.2-0.9.0/jiva/volume_test.go
+++ b/tests/upgrade/0.8.2-0.9.0/jiva/volume_test.go
@@ -35,29 +35,29 @@ var _ = Describe("[jiva] TEST VOLUME UPGRADE", func() {
 
 			// fetching name of pv to update the configmap with the resource to
 			// be upgraded
-			pvName := ops.GetPVName(pvcName)
+			pvName := ops.GetPVNameFromPVCName(pvcName)
 			data = make(map[string]string)
 			data["upgrade"] = "casTemplate: jiva-volume-update-0.8.2-0.9.0\nresources:\n- name: " + pvName + "\n  kind: jiva-volume\n  namespace: default\n"
 			urLable = urLable + pvName
 
 			By("applying rbac.yaml")
-			applyArtifact(rbacArtifact, "")
+			applyYAML(rbacYAML, "")
 
 			By("applying cr.yaml")
-			applyArtifact(crArtifact, "")
+			applyYAML(crYAML, "")
 
 			By("applying jiva_upgrade_runtask.yaml")
-			applyArtifact(runtaskArtifact, "")
+			applyYAML(runtaskYAML, "")
 
 			By("applying volume-upgrade-job.yaml")
-			applyArtifact(jobArtifact, "job")
+			applyYAML(jobYAML, "job")
 
 			By("verifying completed pod count as 1")
 			completedPodCount := ops.GetPodCompletedCountEventually("default", jobLable, 1)
 			Expect(completedPodCount).To(Equal(1), "while checking complete pod count")
 
 			By("verifying upgraderesult")
-			status := ops.CheckUpgradeResult(nsName, urLable)
+			status := ops.VerifyUpgradeResultTasksIsSuccess(nsName, urLable)
 			Expect(status).To(Equal(true), "while checking upgraderesult")
 
 			By("verifying controller pod count")

--- a/tests/upgrade/0.8.2-0.9.0/jiva/volume_test.go
+++ b/tests/upgrade/0.8.2-0.9.0/jiva/volume_test.go
@@ -24,7 +24,7 @@ import (
 var (
 	jobLable      = "job-name=jiva-volume-upgrade"
 	urLable       = "upgradejob.openebs.io/name=jiva-volume-upgrade,upgradeitem.openebs.io/name="
-	upgradedLabel = "openebs.io/persistent-volume-claim=jiva-volume-claim,openebs.io/version=0.9.0-RC4"
+	upgradedLabel = "openebs.io/persistent-volume-claim=jiva-volume-claim,openebs.io/version=0.9.0"
 	data          map[string]string
 )
 
@@ -41,16 +41,16 @@ var _ = Describe("[jiva] TEST VOLUME UPGRADE", func() {
 			urLable = urLable + pvName
 
 			By("applying rbac.yaml")
-			applyYAMLFromURL("https://raw.githubusercontent.com/openebs/openebs/master/k8s/upgrades/0.8.2-0.9.0/rbac.yaml", "")
+			applyArtifact(rbacArtifact, "")
 
 			By("applying cr.yaml")
-			applyYAMLFromURL("https://raw.githubusercontent.com/openebs/openebs/master/k8s/upgrades/0.8.2-0.9.0/jiva/cr.yaml", "")
+			applyArtifact(crArtifact, "")
 
 			By("applying jiva_upgrade_runtask.yaml")
-			applyYAMLFromURL("https://raw.githubusercontent.com/openebs/openebs/master/k8s/upgrades/0.8.2-0.9.0/jiva/jiva_upgrade_runtask.yaml", "")
+			applyArtifact(runtaskArtifact, "")
 
 			By("applying volume-upgrade-job.yaml")
-			applyYAMLFromURL("https://raw.githubusercontent.com/openebs/openebs/master/k8s/upgrades/0.8.2-0.9.0/jiva/volume-upgrade-job.yaml", "job")
+			applyArtifact(jobArtifact, "job")
 
 			By("verifying completed pod count as 1")
 			completedPodCount := ops.GetPodCompletedCountEventually("default", jobLable, 1)


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Adds BDD test for upgrading jiva volume from 0.8.2 to 0.9.0


**Assumptions made**:
 - The cluster does not have openebs installed.
 - The cluster have no resources in default namespace. (Will be changed to other namespace)

**Sample test output**:
Can provide kubeconfigpath and replica count while running the test.

```
user:jiva$ ginkgo -v -- -kubeconfig=/home/user/.kube/config -replicas=1
Running Suite: Test jiva volume upgrade
=======================================
Random Seed: 1558765568
Will run 1 of 1 specs

STEP: applying openebs 0.8.2
STEP: waiting for maya-apiserver pod to come into running state
STEP: building a storageclass
STEP: creating above storageclass
STEP: building a pvc
STEP: creating above pvc
STEP: verifying controller pod count 
STEP: verifying replica pod count 
STEP: verifying status as bound
[jiva] TEST VOLUME UPGRADE when jiva pvc is upgraded 
  should create new controller and replica pods of version 0.9.0
  /home/user/work/src/github.com/openebs/maya/tests/upgrade/0.8.2-0.9.0/jiva/volume_test.go:34
STEP: applying rbac.yaml
STEP: applying cr.yaml
STEP: applying jiva_upgrade_runtask.yaml
STEP: applying volume-upgrade-job.yaml
STEP: verifying completed pod count as 1
STEP: verifying upgraderesult
STEP: verifying controller pod count
STEP: verifying replica pod count
STEP: verifying pod version as 0.9.0

• [SLOW TEST:58.088 seconds]
[jiva] TEST VOLUME UPGRADE
/home/user/work/src/github.com/openebs/maya/tests/upgrade/0.8.2-0.9.0/jiva/volume_test.go:31
  when jiva pvc is upgraded
  /home/user/work/src/github.com/openebs/maya/tests/upgrade/0.8.2-0.9.0/jiva/volume_test.go:33
    should create new controller and replica pods of version 0.9.0
    /home/user/work/src/github.com/openebs/maya/tests/upgrade/0.8.2-0.9.0/jiva/volume_test.go:34
------------------------------
STEP: deleting above pvc
STEP: verifying controller pod count
STEP: verifying replica pod count
STEP: deleting storageclass
STEP: Cleanup

Ran 1 of 1 Specs in 231.712 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 3m56.11207824s
Test Suite Passed

```


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests