### PR TITLE
refact(bdd) added flag to take replica count as input

### DIFF
--- a/tests/cstor-pool/cstor_integration_test.go
+++ b/tests/cstor-pool/cstor_integration_test.go
@@ -128,7 +128,7 @@ var _ = Describe("STRIPED SPARSE SPC", func() {
 
 			// We expect 1 cstorPool objects.
 			cspCount := ops.isHealthyCspCount(spcObj.Name, 1)
-			Expect(cspCount).To(Equal(3))
+			Expect(cspCount).To(Equal(1))
 		})
 	})
 
@@ -384,10 +384,6 @@ func (ops *operations) isHealthyCspCount(spcName string, expectedCspCount int) i
 		if cspCount == expectedCspCount {
 			return expectedCspCount
 		}
-		if maxRetry == 0 {
-			break
-		}
-		maxRetry--
 		time.Sleep(5 * time.Second)
 	}
 	return cspCount

--- a/tests/jiva/clone/provision_test.go
+++ b/tests/jiva/clone/provision_test.go
@@ -19,6 +19,7 @@ package snapshot
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openebs/maya/tests/jiva"
 
 	pvc "github.com/openebs/maya/pkg/kubernetes/persistentvolumeclaim/v1alpha1"
 	snap "github.com/openebs/maya/pkg/kubernetes/snapshot/v1alpha1"
@@ -74,8 +75,8 @@ var _ = Describe("[jiva] TEST JIVA CLONE CREATION", func() {
 			Expect(controllerPodCount).To(Equal(1), "while checking controller pod count")
 
 			By("verifying replica pod count")
-			replicaPodCount := ops.GetPodRunningCountEventually(nsName, replicaLabel, replicaCount)
-			Expect(replicaPodCount).To(Equal(replicaCount), "while checking replica pod count")
+			replicaPodCount := ops.GetPodRunningCountEventually(nsName, replicaLabel, jiva.ReplicaCount)
+			Expect(replicaPodCount).To(Equal(jiva.ReplicaCount), "while checking replica pod count")
 
 			By("verifying status as bound")
 			status := ops.IsPVCBound(pvcName)
@@ -149,8 +150,8 @@ var _ = Describe("[jiva] TEST JIVA CLONE CREATION", func() {
 			)
 
 			By("verifying clone pod count")
-			clonePodCount := ops.GetPodRunningCountEventually(nsName, cloneLable, replicaCount+1)
-			Expect(clonePodCount).To(Equal(replicaCount+1), "while checking clone pvc pod count")
+			clonePodCount := ops.GetPodRunningCountEventually(nsName, cloneLable, jiva.ReplicaCount+1)
+			Expect(clonePodCount).To(Equal(jiva.ReplicaCount+1), "while checking clone pvc pod count")
 
 		})
 	})

--- a/tests/jiva/clone/provision_test.go
+++ b/tests/jiva/clone/provision_test.go
@@ -43,8 +43,8 @@ var _ = Describe("[jiva] TEST JIVA CLONE CREATION", func() {
 		cloneName = "jiva-clone"
 	)
 
-	When("jiva pvc with replicacount 1 is created", func() {
-		It("should create 1 controller pod and 1 replica pod", func() {
+	When("jiva pvc with replicacount n is created", func() {
+		It("should create 1 controller pod and n replica pod", func() {
 
 			By("building a pvc")
 			pvcObj, err = pvc.NewBuilder().
@@ -69,13 +69,13 @@ var _ = Describe("[jiva] TEST JIVA CLONE CREATION", func() {
 				nsName,
 			)
 
-			By("verifying controller pod count as 1")
+			By("verifying controller pod count")
 			controllerPodCount := ops.GetPodRunningCountEventually(nsName, ctrlLabel, 1)
 			Expect(controllerPodCount).To(Equal(1), "while checking controller pod count")
 
-			By("verifying replica pod count as 1")
-			replicaPodCount := ops.GetPodRunningCountEventually(nsName, replicaLabel, 1)
-			Expect(replicaPodCount).To(Equal(1), "while checking replica pod count")
+			By("verifying replica pod count")
+			replicaPodCount := ops.GetPodRunningCountEventually(nsName, replicaLabel, replicaCount)
+			Expect(replicaPodCount).To(Equal(replicaCount), "while checking replica pod count")
 
 			By("verifying status as bound")
 			status := ops.IsPVCBound(pvcName)
@@ -148,9 +148,9 @@ var _ = Describe("[jiva] TEST JIVA CLONE CREATION", func() {
 				nsName,
 			)
 
-			By("verifying clone pod count as 2")
-			clonePodCount := ops.GetPodRunningCountEventually(nsName, cloneLable, 2)
-			Expect(clonePodCount).To(Equal(2), "while checking clone pvc pod count")
+			By("verifying clone pod count")
+			clonePodCount := ops.GetPodRunningCountEventually(nsName, cloneLable, replicaCount+1)
+			Expect(clonePodCount).To(Equal(replicaCount+1), "while checking clone pvc pod count")
 
 		})
 	})

--- a/tests/jiva/clone/suite_test.go
+++ b/tests/jiva/clone/suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package snapshot
 
 import (
-	"flag"
 	"strconv"
 
 	"testing"
@@ -30,6 +29,7 @@ import (
 	sc "github.com/openebs/maya/pkg/kubernetes/storageclass/v1alpha1"
 	"github.com/openebs/maya/tests"
 	"github.com/openebs/maya/tests/artifacts"
+	"github.com/openebs/maya/tests/jiva"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,8 +39,6 @@ import (
 )
 
 var (
-	kubeConfigPath        string
-	replicaCount          int
 	nsObj                 *corev1.Namespace
 	snapObj               *snapshot.VolumeSnapshot
 	scObj                 *storagev1.StorageClass
@@ -58,18 +56,17 @@ func TestSource(t *testing.T) {
 }
 
 func init() {
-	flag.StringVar(&kubeConfigPath, "kubeconfig", "", "path to kubeconfig to invoke kubernetes API calls")
-	flag.IntVar(&replicaCount, "replicas", 1, "value of replica count")
+	jiva.ParseFlags()
 }
 
 var ops *tests.Operations
 
 var _ = BeforeSuite(func() {
 
-	ops = tests.NewOperations(tests.WithKubeConfigPath(kubeConfigPath))
+	ops = tests.NewOperations(tests.WithKubeConfigPath(jiva.KubeConfigPath))
 
 	annotations[string(apis.CASTypeKey)] = string(apis.JivaVolume)
-	annotations[string(apis.CASConfigKey)] = openebsCASConfigValue + strconv.Itoa(replicaCount)
+	annotations[string(apis.CASConfigKey)] = openebsCASConfigValue + strconv.Itoa(jiva.ReplicaCount)
 
 	By("waiting for maya-apiserver pod to come into running state")
 	podCount := ops.GetPodRunningCountEventually(

--- a/tests/jiva/clone/suite_test.go
+++ b/tests/jiva/clone/suite_test.go
@@ -18,6 +18,7 @@ package snapshot
 
 import (
 	"flag"
+	"strconv"
 
 	"testing"
 
@@ -39,18 +40,16 @@ import (
 
 var (
 	kubeConfigPath        string
+	replicaCount          int
 	nsObj                 *corev1.Namespace
 	snapObj               *snapshot.VolumeSnapshot
 	scObj                 *storagev1.StorageClass
-	nsName                = "jiva-ns"
-	scName                = "jiva-sc"
+	nsName                = "jiva-clone-ns"
+	scName                = "jiva-clone-sc"
 	openebsProvisioner    = "openebs.io/provisioner-iscsi"
-	openebsCASConfigValue = "- name: ReplicaCount\n  Value: 1"
-	annotations           = map[string]string{
-		string(apis.CASTypeKey):   string(apis.JivaVolume),
-		string(apis.CASConfigKey): openebsCASConfigValue,
-	}
-	err error
+	openebsCASConfigValue = "- name: ReplicaCount\n  Value: "
+	annotations           = map[string]string{}
+	err                   error
 )
 
 func TestSource(t *testing.T) {
@@ -60,6 +59,7 @@ func TestSource(t *testing.T) {
 
 func init() {
 	flag.StringVar(&kubeConfigPath, "kubeconfig", "", "path to kubeconfig to invoke kubernetes API calls")
+	flag.IntVar(&replicaCount, "replicas", 1, "value of replica count")
 }
 
 var ops *tests.Operations
@@ -67,6 +67,9 @@ var ops *tests.Operations
 var _ = BeforeSuite(func() {
 
 	ops = tests.NewOperations(tests.WithKubeConfigPath(kubeConfigPath))
+
+	annotations[string(apis.CASTypeKey)] = string(apis.JivaVolume)
+	annotations[string(apis.CASConfigKey)] = openebsCASConfigValue + strconv.Itoa(replicaCount)
 
 	By("waiting for maya-apiserver pod to come into running state")
 	podCount := ops.GetPodRunningCountEventually(

--- a/tests/jiva/jiva.go
+++ b/tests/jiva/jiva.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2019 The OpenEBS Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jiva
+
+import "flag"
+
+var (
+	// KubeConfigPath is the path to
+	// the kubeconfig provided at runtime
+	KubeConfigPath string
+	// ReplicaCount is the value of
+	// replica count provided at runtime
+	ReplicaCount int
+)
+
+// ParseFlags gets the flag values at run time
+func ParseFlags() {
+	flag.StringVar(&KubeConfigPath, "kubeconfig", "", "path to kubeconfig to invoke kubernetes API calls")
+	flag.IntVar(&ReplicaCount, "replicas", 1, "value of replica count")
+}

--- a/tests/jiva/snapshot/provision_test.go
+++ b/tests/jiva/snapshot/provision_test.go
@@ -40,8 +40,8 @@ var _ = Describe("[jiva] TEST JIVA SNAPSHOT CREATION", func() {
 		snapName = "jivasnapshot"
 	)
 
-	When("jiva pvc with replicacount 1 is created", func() {
-		It("should create 1 controller pod and 1 replica pod", func() {
+	When("jiva pvc with replicacount n is created", func() {
+		It("should create 1 controller pod and n replica pod", func() {
 
 			By("building a pvc")
 			pvcObj, err = pvc.NewBuilder().
@@ -66,13 +66,13 @@ var _ = Describe("[jiva] TEST JIVA SNAPSHOT CREATION", func() {
 				nsName,
 			)
 
-			By("verifying controller pod count as 1")
+			By("verifying controller pod count")
 			controllerPodCount := ops.GetPodRunningCountEventually(nsName, ctrlLabel, 1)
 			Expect(controllerPodCount).To(Equal(1), "while checking controller pod count")
 
-			By("verifying replica pod count as 1")
-			replicaPodCount := ops.GetPodRunningCountEventually(nsName, replicaLabel, 1)
-			Expect(replicaPodCount).To(Equal(1), "while checking replica pod count")
+			By("verifying replica pod count")
+			replicaPodCount := ops.GetPodRunningCountEventually(nsName, replicaLabel, replicaCount)
+			Expect(replicaPodCount).To(Equal(replicaCount), "while checking replica pod count")
 
 			By("verifying status as bound")
 			status := ops.IsPVCBound(pvcName)

--- a/tests/jiva/snapshot/provision_test.go
+++ b/tests/jiva/snapshot/provision_test.go
@@ -19,6 +19,7 @@ package snapshot
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openebs/maya/tests/jiva"
 
 	pvc "github.com/openebs/maya/pkg/kubernetes/persistentvolumeclaim/v1alpha1"
 	snap "github.com/openebs/maya/pkg/kubernetes/snapshot/v1alpha1"
@@ -71,8 +72,8 @@ var _ = Describe("[jiva] TEST JIVA SNAPSHOT CREATION", func() {
 			Expect(controllerPodCount).To(Equal(1), "while checking controller pod count")
 
 			By("verifying replica pod count")
-			replicaPodCount := ops.GetPodRunningCountEventually(nsName, replicaLabel, replicaCount)
-			Expect(replicaPodCount).To(Equal(replicaCount), "while checking replica pod count")
+			replicaPodCount := ops.GetPodRunningCountEventually(nsName, replicaLabel, jiva.ReplicaCount)
+			Expect(replicaPodCount).To(Equal(jiva.ReplicaCount), "while checking replica pod count")
 
 			By("verifying status as bound")
 			status := ops.IsPVCBound(pvcName)

--- a/tests/jiva/snapshot/suite_test.go
+++ b/tests/jiva/snapshot/suite_test.go
@@ -17,13 +17,13 @@ limitations under the License.
 package snapshot
 
 import (
-	"flag"
 	"strconv"
 
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openebs/maya/tests/jiva"
 
 	snapshot "github.com/openebs/maya/pkg/apis/openebs.io/snapshot/v1alpha1"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
@@ -40,8 +40,6 @@ import (
 )
 
 var (
-	kubeConfigPath        string
-	replicaCount          int
 	nsObj                 *corev1.Namespace
 	snapObj               *snapshot.VolumeSnapshot
 	scObj                 *storagev1.StorageClass
@@ -59,18 +57,17 @@ func TestSource(t *testing.T) {
 }
 
 func init() {
-	flag.StringVar(&kubeConfigPath, "kubeconfig", "", "path to kubeconfig to invoke kubernetes API calls")
-	flag.IntVar(&replicaCount, "replicas", 1, "value of replica count")
+	jiva.ParseFlags()
 }
 
 var ops *tests.Operations
 
 var _ = BeforeSuite(func() {
 
-	ops = tests.NewOperations(tests.WithKubeConfigPath(kubeConfigPath))
+	ops = tests.NewOperations(tests.WithKubeConfigPath(jiva.KubeConfigPath))
 
 	annotations[string(apis.CASTypeKey)] = string(apis.JivaVolume)
-	annotations[string(apis.CASConfigKey)] = openebsCASConfigValue + strconv.Itoa(replicaCount)
+	annotations[string(apis.CASConfigKey)] = openebsCASConfigValue + strconv.Itoa(jiva.ReplicaCount)
 
 	By("waiting for maya-apiserver pod to come into running state")
 	podCount := ops.GetPodRunningCountEventually(

--- a/tests/jiva/volume/provision_test.go
+++ b/tests/jiva/volume/provision_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	pvc "github.com/openebs/maya/pkg/kubernetes/persistentvolumeclaim/v1alpha1"
+	"github.com/openebs/maya/tests/jiva"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -69,8 +70,8 @@ var _ = Describe("[jiva] TEST VOLUME PROVISIONING", func() {
 			Expect(controllerPodCount).To(Equal(1), "while checking controller pod count")
 
 			By("verifying replica pod count ")
-			replicaPodCount := ops.GetPodRunningCountEventually(nsName, replicaLabel, replicaCount)
-			Expect(replicaPodCount).To(Equal(replicaCount), "while checking replica pod count")
+			replicaPodCount := ops.GetPodRunningCountEventually(nsName, replicaLabel, jiva.ReplicaCount)
+			Expect(replicaPodCount).To(Equal(jiva.ReplicaCount), "while checking replica pod count")
 
 			By("verifying status as bound")
 			status := ops.IsPVCBound(pvcName)

--- a/tests/jiva/volume/provision_test.go
+++ b/tests/jiva/volume/provision_test.go
@@ -38,8 +38,8 @@ var _ = Describe("[jiva] TEST VOLUME PROVISIONING", func() {
 		pvcName = "jiva-volume-claim"
 	)
 
-	When("jiva pvc with replicacount 1 is created", func() {
-		It("should create 1 controller pod and 1 replica pod", func() {
+	When("jiva pvc with replicacount n is created", func() {
+		It("should create 1 controller pod and n replica pod", func() {
 
 			By("building a pvc")
 			pvcObj, err = pvc.NewBuilder().
@@ -64,13 +64,13 @@ var _ = Describe("[jiva] TEST VOLUME PROVISIONING", func() {
 				nsName,
 			)
 
-			By("verifying controller pod count as 1")
+			By("verifying controller pod count")
 			controllerPodCount := ops.GetPodRunningCountEventually(nsName, ctrlLabel, 1)
 			Expect(controllerPodCount).To(Equal(1), "while checking controller pod count")
 
-			By("verifying replica pod count as 1")
-			replicaPodCount := ops.GetPodRunningCountEventually(nsName, replicaLabel, 1)
-			Expect(replicaPodCount).To(Equal(1), "while checking replica pod count")
+			By("verifying replica pod count ")
+			replicaPodCount := ops.GetPodRunningCountEventually(nsName, replicaLabel, replicaCount)
+			Expect(replicaPodCount).To(Equal(replicaCount), "while checking replica pod count")
 
 			By("verifying status as bound")
 			status := ops.IsPVCBound(pvcName)

--- a/tests/jiva/volume/suite_test.go
+++ b/tests/jiva/volume/suite_test.go
@@ -15,6 +15,7 @@ package volume
 
 import (
 	"flag"
+	"strconv"
 
 	"testing"
 
@@ -36,16 +37,14 @@ import (
 
 var (
 	kubeConfigPath        string
-	nsName                = "provision-ns"
-	scName                = "jiva-pods-in-openebs-ns"
-	openebsCASConfigValue = "- name: ReplicaCount\n  Value: 1"
+	replicaCount          int
+	nsName                = "jiva-volume-ns"
+	scName                = "jiva-volume-sc"
+	openebsCASConfigValue = "- name: ReplicaCount\n  Value: "
 	openebsProvisioner    = "openebs.io/provisioner-iscsi"
 	nsObj                 *corev1.Namespace
 	scObj                 *storagev1.StorageClass
-	annotations           = map[string]string{
-		string(apis.CASTypeKey):   string(apis.JivaVolume),
-		string(apis.CASConfigKey): openebsCASConfigValue,
-	}
+	annotations           = map[string]string{}
 )
 
 func TestSource(t *testing.T) {
@@ -55,6 +54,7 @@ func TestSource(t *testing.T) {
 
 func init() {
 	flag.StringVar(&kubeConfigPath, "kubeconfig", "", "path to kubeconfig to invoke kubernetes API calls")
+	flag.IntVar(&replicaCount, "replicas", 1, "value of replica count")
 }
 
 var ops *tests.Operations
@@ -62,6 +62,9 @@ var ops *tests.Operations
 var _ = BeforeSuite(func() {
 
 	ops = tests.NewOperations(tests.WithKubeConfigPath(kubeConfigPath))
+
+	annotations[string(apis.CASTypeKey)] = string(apis.JivaVolume)
+	annotations[string(apis.CASConfigKey)] = openebsCASConfigValue + strconv.Itoa(replicaCount)
 
 	By("waiting for maya-apiserver pod to come into running state")
 	podCount := ops.GetPodRunningCountEventually(

--- a/tests/jiva/volume/suite_test.go
+++ b/tests/jiva/volume/suite_test.go
@@ -14,7 +14,6 @@ limitations under the License.
 package volume
 
 import (
-	"flag"
 	"strconv"
 
 	"testing"
@@ -23,6 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openebs/maya/tests"
 	"github.com/openebs/maya/tests/artifacts"
+	"github.com/openebs/maya/tests/jiva"
 
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	ns "github.com/openebs/maya/pkg/kubernetes/namespace/v1alpha1"
@@ -36,8 +36,6 @@ import (
 )
 
 var (
-	kubeConfigPath        string
-	replicaCount          int
 	nsName                = "jiva-volume-ns"
 	scName                = "jiva-volume-sc"
 	openebsCASConfigValue = "- name: ReplicaCount\n  Value: "
@@ -53,18 +51,17 @@ func TestSource(t *testing.T) {
 }
 
 func init() {
-	flag.StringVar(&kubeConfigPath, "kubeconfig", "", "path to kubeconfig to invoke kubernetes API calls")
-	flag.IntVar(&replicaCount, "replicas", 1, "value of replica count")
+	jiva.ParseFlags()
 }
 
 var ops *tests.Operations
 
 var _ = BeforeSuite(func() {
 
-	ops = tests.NewOperations(tests.WithKubeConfigPath(kubeConfigPath))
+	ops = tests.NewOperations(tests.WithKubeConfigPath(jiva.KubeConfigPath))
 
 	annotations[string(apis.CASTypeKey)] = string(apis.JivaVolume)
-	annotations[string(apis.CASConfigKey)] = openebsCASConfigValue + strconv.Itoa(replicaCount)
+	annotations[string(apis.CASConfigKey)] = openebsCASConfigValue + strconv.Itoa(jiva.ReplicaCount)
 
 	By("waiting for maya-apiserver pod to come into running state")
 	podCount := ops.GetPodRunningCountEventually(


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
 - Adds flag `replicas` to jiva related bdds to take replicacount value at run time.
    Example 
    ```
    ginkgo -v -- --kubeconfig=/home/user/.kube/config --replicas=1
    ```
 - refactored cstor-pool bdd to wait longer for csp to come to healthy state. 
   It was failing because of that.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests