### PR TITLE
feat(cstor,BDD): Add cstor volume BDD for volume provisioning

### DIFF
--- a/tests/cstor-volume/README.md
+++ b/tests/cstor-volume/README.md
@@ -1,1 +1,0 @@
-All cstor volume integration tests reside in this directory

--- a/tests/cstor/volume/provision_test.go
+++ b/tests/cstor/volume/provision_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	pvc "github.com/openebs/maya/pkg/kubernetes/persistentvolumeclaim/v1alpha1"
+	sc "github.com/openebs/maya/pkg/kubernetes/storageclass/v1alpha1"
+	spc "github.com/openebs/maya/pkg/storagepoolclaim/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("[cstor] TEST VOLUME PROVISIONING", func() {
+	var (
+		err     error
+		pvcName = "cstor-volume-claim"
+	)
+
+	BeforeEach(func() {
+		When(" creating a cstor based volume", func() {
+			By("building object of storageclass")
+			scObj, err = sc.NewBuilder().
+				WithName(scName).
+				WithAnnotations(annotations).
+				WithProvisioner(openebsProvisioner).Build()
+			Expect(err).ShouldNot(HaveOccurred(), "while building storageclass obj for storageclass {%s}", scName)
+
+			By("creating storageclass")
+			_, err = ops.SCClient.Create(scObj)
+			Expect(err).To(BeNil(), "while creating storageclass", scName)
+
+			By("building spc object")
+			spcObj = spc.NewBuilder().
+				WithName(spcName).
+				WithDiskType(string(apis.TypeSparseCPV)).
+				WithMaxPool(1).
+				WithOverProvisioning(false).
+				WithPoolType(string(apis.PoolTypeStripedCPV)).
+				Build().Object
+
+			By("creating storagepoolclaim")
+			_, err = ops.SPCClient.Create(spcObj)
+			Expect(err).To(BeNil(), "while creating spc", spcName)
+
+			By("verifying healthy csp count")
+			cspCount := ops.GetHealthyCSPCount(spcName, 1)
+			Expect(cspCount).To(Equal(1), "while checking cstorpool health count")
+
+		})
+	})
+
+	AfterEach(func() {
+		By("deleting resources created for testing cstor volume provisioning", func() {
+			By("deleting storageclass")
+			err = ops.SCClient.Delete(scName, &metav1.DeleteOptions{})
+			Expect(err).To(BeNil(), "while deleting storageclass", scName)
+
+			By("listing spc")
+			spcList, err = ops.SPCClient.List(metav1.ListOptions{})
+			Expect(err).To(BeNil(), "while listing spc clients", spcList)
+
+			By("deleting spc")
+			for _, spc := range spcList.Items {
+				_, err = ops.SPCClient.Delete(spc.Name, &metav1.DeleteOptions{})
+				Expect(err).To(BeNil(), "while deleting the spc's", spc)
+			}
+		})
+	})
+
+	When("cstor pvc with replicacount 1 is created", func() {
+		It("should create cstor volume target pod", func() {
+
+			By("building a pvc")
+			pvcObj, err = pvc.NewBuilder().
+				WithName(pvcName).
+				WithNamespace(nsName).
+				WithStorageClass(scName).
+				WithAccessModes(accessModes).
+				WithCapacity(capacity).Build()
+			Expect(err).ShouldNot(
+				HaveOccurred(),
+				"while building pvc {%s} in namespace {%s}",
+				pvcName,
+				nsName,
+			)
+
+			By("creating above pvc")
+			_, err = ops.PVCClient.WithNamespace(nsName).Create(pvcObj)
+			Expect(err).To(
+				BeNil(),
+				"while creating pvc {%s} in namespace {%s}",
+				pvcName,
+				nsName,
+			)
+
+			By("verifying target pod count as 1")
+			controllerPodCount := ops.GetPodRunningCountEventually(openebsNamespace, targetLabel, 1)
+			Expect(controllerPodCount).To(Equal(1), "while checking controller pod count")
+
+			By("verifying pvc status as bound")
+			status := ops.IsPVCBound(pvcName)
+			Expect(status).To(Equal(true), "while checking status equal to bound")
+
+			By("deleting above pvc")
+			err := ops.PVCClient.Delete(pvcName, &metav1.DeleteOptions{})
+			Expect(err).To(
+				BeNil(),
+				"while deleting pvc {%s} in namespace {%s}",
+				pvcName,
+				nsName,
+			)
+
+			By("verifying target pod count as 0")
+			controllerPodCount = ops.GetPodRunningCountEventually(openebsNamespace, targetLabel, 0)
+			Expect(controllerPodCount).To(Equal(0), "while checking controller pod count")
+
+			By("verifying deleted pvc")
+			pvc := ops.IsPVCDeleted(pvcName)
+			Expect(pvc).To(Equal(true), "while trying to get deleted pvc")
+
+			By("verifying if cstorvolume is deleted")
+			CstorVolumeLabel := "openebs.io/persistent-volume=" + pvcObj.Spec.VolumeName
+			cvCount := ops.GetCstorVolumeCountEventually(openebsNamespace, CstorVolumeLabel, 0)
+			Expect(cvCount).To(Equal(0), "while checking cstorvolume count")
+		})
+	})
+
+})

--- a/tests/cstor/volume/suite_test.go
+++ b/tests/cstor/volume/suite_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2019 The OpenEBS Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"flag"
+
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openebs/maya/tests"
+	"github.com/openebs/maya/tests/artifacts"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	ns "github.com/openebs/maya/pkg/kubernetes/namespace/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	// auth plugins
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+)
+
+var (
+	kubeConfigPath        string
+	openebsNamespace      = "openebs"
+	nsName                = "cstor-provision"
+	scName                = "cstor-volume"
+	openebsCASConfigValue = "- name: ReplicaCount\n  value: 1\n- name: StoragePoolClaim\n  value: sparse-pool-auto"
+	openebsProvisioner    = "openebs.io/provisioner-iscsi"
+	spcName               = "sparse-pool-auto"
+	nsObj                 *corev1.Namespace
+	scObj                 *storagev1.StorageClass
+	spcObj                *apis.StoragePoolClaim
+	pvcObj                *corev1.PersistentVolumeClaim
+	spcList               *apis.StoragePoolClaimList
+	targetLabel           = "openebs.io/target=cstor-target"
+	accessModes           = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
+	capacity              = "5G"
+	annotations           = map[string]string{
+		string(apis.CASTypeKey):   string(apis.CstorVolume),
+		string(apis.CASConfigKey): openebsCASConfigValue,
+	}
+)
+
+func TestSource(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test cstor volume provisioning")
+}
+
+func init() {
+	flag.StringVar(&kubeConfigPath, "kubeconfig", "", "path to kubeconfig to invoke kubernetes API calls")
+}
+
+var ops *tests.Operations
+
+var _ = BeforeSuite(func() {
+
+	ops = tests.NewOperations(tests.WithKubeConfigPath(kubeConfigPath))
+	var err error
+	By("waiting for maya-apiserver pod to come into running state")
+	podCount := ops.GetPodRunningCountEventually(
+		string(artifacts.OpenebsNamespace),
+		string(artifacts.MayaAPIServerLabelSelector),
+		1,
+	)
+	Expect(podCount).To(Equal(1))
+
+	By("waiting for openebs-provisioner pod to come into running state")
+	podCount = ops.GetPodRunningCountEventually(
+		string(artifacts.OpenebsNamespace),
+		string(artifacts.OpenEBSProvisionerLabelSelector),
+		1,
+	)
+	Expect(podCount).To(Equal(1))
+
+	By("building a namespace")
+	nsObj, err = ns.NewBuilder().
+		WithName(nsName).
+		APIObject()
+	Expect(err).ShouldNot(HaveOccurred(), "while building namespace {%s}", nsName)
+
+	By("creating a namespace")
+	_, err = ops.NSClient.Create(nsObj)
+	Expect(err).To(BeNil(), "while creating storageclass {%s}", nsObj.Name)
+})
+
+var _ = AfterSuite(func() {
+
+	By("deleting namespace")
+	err := ops.NSClient.Delete(nsName, &metav1.DeleteOptions{})
+	Expect(err).To(BeNil(), "while deleting namespace {%s}", nsObj.Name)
+
+})


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
 Adds BDD tests for cstor volume provisioning.

```sh
 ginkgo -v -- -kubeconfig="/var/run/kubernetes/admin.kubeconfig"
Running Suite: Test cstor volume provisioning
=============================================
Random Seed: 1558707760
Will run 1 of 1 specs

STEP: waiting for maya-apiserver pod to come into running state
STEP: waiting for openebs-provisioner pod to come into running state
STEP: building a namespace
STEP: creating a namespace
[cstor] TEST VOLUME PROVISIONING when cstor pvc with replicacount 1 is created 
  should create cstor volume target pod
  /home/prateek/gocode/src/github.com/openebs/maya/tests/cstor/volume/provision_test.go:96
STEP: building object of storageclass
STEP: creating storageclass
STEP: building spc object
STEP: creating storagepoolclaim
STEP: verifying healthy csp count
STEP: building a pvc
STEP: creating above pvc
STEP: verifying target pod count as 1
STEP: verifying pvc status as bound
STEP: deleting above pvc
STEP: verifying target pod count as 0
STEP: verifying deleted pvc
STEP: verifying if cstorvolume is deleted
STEP: deleting resources created for testing cstor volume provisioning
STEP: deleting storageclass
STEP: listing spc
STEP: deleting spc

• [SLOW TEST:75.817 seconds]
[cstor] TEST VOLUME PROVISIONING
/home/prateek/gocode/src/github.com/openebs/maya/tests/cstor/volume/provision_test.go:39
  when cstor pvc with replicacount 1 is created
  /home/prateek/gocode/src/github.com/openebs/maya/tests/cstor/volume/provision_test.go:95
    should create cstor volume target pod
    /home/prateek/gocode/src/github.com/openebs/maya/tests/cstor/volume/provision_test.go:96
------------------------------
STEP: deleting namespace

Ran 1 of 1 Specs in 75.873 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 1m19.03162385s
Test Suite Passed
```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests