### PR TITLE
chore(code-gen): change NDM apis to cluster scope

### DIFF
--- a/pkg/apis/openebs.io/ndm/v1alpha1/blockdevice_types.go
+++ b/pkg/apis/openebs.io/ndm/v1alpha1/blockdevice_types.go
@@ -80,6 +80,7 @@ const (
 )
 
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +resource:path=blockDevice
 // +k8s:openapi-gen=true

--- a/pkg/apis/openebs.io/ndm/v1alpha1/blockdeviceclaim_types.go
+++ b/pkg/apis/openebs.io/ndm/v1alpha1/blockdeviceclaim_types.go
@@ -75,6 +75,7 @@ type DeviceClaimDetails struct {
 }
 
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +resource:path=blockDeviceClaim
 // +k8s:openapi-gen=true

--- a/pkg/apis/openebs.io/ndm/v1alpha1/disk_types.go
+++ b/pkg/apis/openebs.io/ndm/v1alpha1/disk_types.go
@@ -92,6 +92,7 @@ type DeviceInfo struct {
 }
 
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +resource:path=disk
 // +k8s:openapi-gen=true

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/blockdevice.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/blockdevice.go
@@ -30,7 +30,7 @@ import (
 // BlockDevicesGetter has a method to return a BlockDeviceInterface.
 // A group's client should implement this interface.
 type BlockDevicesGetter interface {
-	BlockDevices(namespace string) BlockDeviceInterface
+	BlockDevices() BlockDeviceInterface
 }
 
 // BlockDeviceInterface has methods to work with BlockDevice resources.
@@ -50,14 +50,12 @@ type BlockDeviceInterface interface {
 // blockDevices implements BlockDeviceInterface
 type blockDevices struct {
 	client rest.Interface
-	ns     string
 }
 
 // newBlockDevices returns a BlockDevices
-func newBlockDevices(c *OpenebsV1alpha1Client, namespace string) *blockDevices {
+func newBlockDevices(c *OpenebsV1alpha1Client) *blockDevices {
 	return &blockDevices{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -65,7 +63,6 @@ func newBlockDevices(c *OpenebsV1alpha1Client, namespace string) *blockDevices {
 func (c *blockDevices) Get(name string, options v1.GetOptions) (result *v1alpha1.BlockDevice, err error) {
 	result = &v1alpha1.BlockDevice{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("blockdevices").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -78,7 +75,6 @@ func (c *blockDevices) Get(name string, options v1.GetOptions) (result *v1alpha1
 func (c *blockDevices) List(opts v1.ListOptions) (result *v1alpha1.BlockDeviceList, err error) {
 	result = &v1alpha1.BlockDeviceList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("blockdevices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
@@ -90,7 +86,6 @@ func (c *blockDevices) List(opts v1.ListOptions) (result *v1alpha1.BlockDeviceLi
 func (c *blockDevices) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("blockdevices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Watch()
@@ -100,7 +95,6 @@ func (c *blockDevices) Watch(opts v1.ListOptions) (watch.Interface, error) {
 func (c *blockDevices) Create(blockDevice *v1alpha1.BlockDevice) (result *v1alpha1.BlockDevice, err error) {
 	result = &v1alpha1.BlockDevice{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("blockdevices").
 		Body(blockDevice).
 		Do().
@@ -112,7 +106,6 @@ func (c *blockDevices) Create(blockDevice *v1alpha1.BlockDevice) (result *v1alph
 func (c *blockDevices) Update(blockDevice *v1alpha1.BlockDevice) (result *v1alpha1.BlockDevice, err error) {
 	result = &v1alpha1.BlockDevice{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("blockdevices").
 		Name(blockDevice.Name).
 		Body(blockDevice).
@@ -127,7 +120,6 @@ func (c *blockDevices) Update(blockDevice *v1alpha1.BlockDevice) (result *v1alph
 func (c *blockDevices) UpdateStatus(blockDevice *v1alpha1.BlockDevice) (result *v1alpha1.BlockDevice, err error) {
 	result = &v1alpha1.BlockDevice{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("blockdevices").
 		Name(blockDevice.Name).
 		SubResource("status").
@@ -140,7 +132,6 @@ func (c *blockDevices) UpdateStatus(blockDevice *v1alpha1.BlockDevice) (result *
 // Delete takes name of the blockDevice and deletes it. Returns an error if one occurs.
 func (c *blockDevices) Delete(name string, options *v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("blockdevices").
 		Name(name).
 		Body(options).
@@ -151,7 +142,6 @@ func (c *blockDevices) Delete(name string, options *v1.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *blockDevices) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("blockdevices").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Body(options).
@@ -163,7 +153,6 @@ func (c *blockDevices) DeleteCollection(options *v1.DeleteOptions, listOptions v
 func (c *blockDevices) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.BlockDevice, err error) {
 	result = &v1alpha1.BlockDevice{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("blockdevices").
 		SubResource(subresources...).
 		Name(name).

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/blockdeviceclaim.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/blockdeviceclaim.go
@@ -30,7 +30,7 @@ import (
 // BlockDeviceClaimsGetter has a method to return a BlockDeviceClaimInterface.
 // A group's client should implement this interface.
 type BlockDeviceClaimsGetter interface {
-	BlockDeviceClaims(namespace string) BlockDeviceClaimInterface
+	BlockDeviceClaims() BlockDeviceClaimInterface
 }
 
 // BlockDeviceClaimInterface has methods to work with BlockDeviceClaim resources.
@@ -50,14 +50,12 @@ type BlockDeviceClaimInterface interface {
 // blockDeviceClaims implements BlockDeviceClaimInterface
 type blockDeviceClaims struct {
 	client rest.Interface
-	ns     string
 }
 
 // newBlockDeviceClaims returns a BlockDeviceClaims
-func newBlockDeviceClaims(c *OpenebsV1alpha1Client, namespace string) *blockDeviceClaims {
+func newBlockDeviceClaims(c *OpenebsV1alpha1Client) *blockDeviceClaims {
 	return &blockDeviceClaims{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -65,7 +63,6 @@ func newBlockDeviceClaims(c *OpenebsV1alpha1Client, namespace string) *blockDevi
 func (c *blockDeviceClaims) Get(name string, options v1.GetOptions) (result *v1alpha1.BlockDeviceClaim, err error) {
 	result = &v1alpha1.BlockDeviceClaim{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("blockdeviceclaims").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -78,7 +75,6 @@ func (c *blockDeviceClaims) Get(name string, options v1.GetOptions) (result *v1a
 func (c *blockDeviceClaims) List(opts v1.ListOptions) (result *v1alpha1.BlockDeviceClaimList, err error) {
 	result = &v1alpha1.BlockDeviceClaimList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("blockdeviceclaims").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
@@ -90,7 +86,6 @@ func (c *blockDeviceClaims) List(opts v1.ListOptions) (result *v1alpha1.BlockDev
 func (c *blockDeviceClaims) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("blockdeviceclaims").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Watch()
@@ -100,7 +95,6 @@ func (c *blockDeviceClaims) Watch(opts v1.ListOptions) (watch.Interface, error) 
 func (c *blockDeviceClaims) Create(blockDeviceClaim *v1alpha1.BlockDeviceClaim) (result *v1alpha1.BlockDeviceClaim, err error) {
 	result = &v1alpha1.BlockDeviceClaim{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("blockdeviceclaims").
 		Body(blockDeviceClaim).
 		Do().
@@ -112,7 +106,6 @@ func (c *blockDeviceClaims) Create(blockDeviceClaim *v1alpha1.BlockDeviceClaim) 
 func (c *blockDeviceClaims) Update(blockDeviceClaim *v1alpha1.BlockDeviceClaim) (result *v1alpha1.BlockDeviceClaim, err error) {
 	result = &v1alpha1.BlockDeviceClaim{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("blockdeviceclaims").
 		Name(blockDeviceClaim.Name).
 		Body(blockDeviceClaim).
@@ -127,7 +120,6 @@ func (c *blockDeviceClaims) Update(blockDeviceClaim *v1alpha1.BlockDeviceClaim) 
 func (c *blockDeviceClaims) UpdateStatus(blockDeviceClaim *v1alpha1.BlockDeviceClaim) (result *v1alpha1.BlockDeviceClaim, err error) {
 	result = &v1alpha1.BlockDeviceClaim{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("blockdeviceclaims").
 		Name(blockDeviceClaim.Name).
 		SubResource("status").
@@ -140,7 +132,6 @@ func (c *blockDeviceClaims) UpdateStatus(blockDeviceClaim *v1alpha1.BlockDeviceC
 // Delete takes name of the blockDeviceClaim and deletes it. Returns an error if one occurs.
 func (c *blockDeviceClaims) Delete(name string, options *v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("blockdeviceclaims").
 		Name(name).
 		Body(options).
@@ -151,7 +142,6 @@ func (c *blockDeviceClaims) Delete(name string, options *v1.DeleteOptions) error
 // DeleteCollection deletes a collection of objects.
 func (c *blockDeviceClaims) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("blockdeviceclaims").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Body(options).
@@ -163,7 +153,6 @@ func (c *blockDeviceClaims) DeleteCollection(options *v1.DeleteOptions, listOpti
 func (c *blockDeviceClaims) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.BlockDeviceClaim, err error) {
 	result = &v1alpha1.BlockDeviceClaim{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("blockdeviceclaims").
 		SubResource(subresources...).
 		Name(name).

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/disk.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/disk.go
@@ -30,7 +30,7 @@ import (
 // DisksGetter has a method to return a DiskInterface.
 // A group's client should implement this interface.
 type DisksGetter interface {
-	Disks(namespace string) DiskInterface
+	Disks() DiskInterface
 }
 
 // DiskInterface has methods to work with Disk resources.
@@ -50,14 +50,12 @@ type DiskInterface interface {
 // disks implements DiskInterface
 type disks struct {
 	client rest.Interface
-	ns     string
 }
 
 // newDisks returns a Disks
-func newDisks(c *OpenebsV1alpha1Client, namespace string) *disks {
+func newDisks(c *OpenebsV1alpha1Client) *disks {
 	return &disks{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -65,7 +63,6 @@ func newDisks(c *OpenebsV1alpha1Client, namespace string) *disks {
 func (c *disks) Get(name string, options v1.GetOptions) (result *v1alpha1.Disk, err error) {
 	result = &v1alpha1.Disk{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("disks").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -78,7 +75,6 @@ func (c *disks) Get(name string, options v1.GetOptions) (result *v1alpha1.Disk, 
 func (c *disks) List(opts v1.ListOptions) (result *v1alpha1.DiskList, err error) {
 	result = &v1alpha1.DiskList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("disks").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
@@ -90,7 +86,6 @@ func (c *disks) List(opts v1.ListOptions) (result *v1alpha1.DiskList, err error)
 func (c *disks) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("disks").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Watch()
@@ -100,7 +95,6 @@ func (c *disks) Watch(opts v1.ListOptions) (watch.Interface, error) {
 func (c *disks) Create(disk *v1alpha1.Disk) (result *v1alpha1.Disk, err error) {
 	result = &v1alpha1.Disk{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("disks").
 		Body(disk).
 		Do().
@@ -112,7 +106,6 @@ func (c *disks) Create(disk *v1alpha1.Disk) (result *v1alpha1.Disk, err error) {
 func (c *disks) Update(disk *v1alpha1.Disk) (result *v1alpha1.Disk, err error) {
 	result = &v1alpha1.Disk{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("disks").
 		Name(disk.Name).
 		Body(disk).
@@ -127,7 +120,6 @@ func (c *disks) Update(disk *v1alpha1.Disk) (result *v1alpha1.Disk, err error) {
 func (c *disks) UpdateStatus(disk *v1alpha1.Disk) (result *v1alpha1.Disk, err error) {
 	result = &v1alpha1.Disk{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("disks").
 		Name(disk.Name).
 		SubResource("status").
@@ -140,7 +132,6 @@ func (c *disks) UpdateStatus(disk *v1alpha1.Disk) (result *v1alpha1.Disk, err er
 // Delete takes name of the disk and deletes it. Returns an error if one occurs.
 func (c *disks) Delete(name string, options *v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("disks").
 		Name(name).
 		Body(options).
@@ -151,7 +142,6 @@ func (c *disks) Delete(name string, options *v1.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *disks) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("disks").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Body(options).
@@ -163,7 +153,6 @@ func (c *disks) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListO
 func (c *disks) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.Disk, err error) {
 	result = &v1alpha1.Disk{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("disks").
 		SubResource(subresources...).
 		Name(name).

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/fake/fake_blockdevice.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/fake/fake_blockdevice.go
@@ -31,7 +31,6 @@ import (
 // FakeBlockDevices implements BlockDeviceInterface
 type FakeBlockDevices struct {
 	Fake *FakeOpenebsV1alpha1
-	ns   string
 }
 
 var blockdevicesResource = schema.GroupVersionResource{Group: "openebs.io", Version: "v1alpha1", Resource: "blockdevices"}
@@ -41,8 +40,7 @@ var blockdevicesKind = schema.GroupVersionKind{Group: "openebs.io", Version: "v1
 // Get takes name of the blockDevice, and returns the corresponding blockDevice object, and an error if there is any.
 func (c *FakeBlockDevices) Get(name string, options v1.GetOptions) (result *v1alpha1.BlockDevice, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(blockdevicesResource, c.ns, name), &v1alpha1.BlockDevice{})
-
+		Invokes(testing.NewRootGetAction(blockdevicesResource, name), &v1alpha1.BlockDevice{})
 	if obj == nil {
 		return nil, err
 	}
@@ -52,8 +50,7 @@ func (c *FakeBlockDevices) Get(name string, options v1.GetOptions) (result *v1al
 // List takes label and field selectors, and returns the list of BlockDevices that match those selectors.
 func (c *FakeBlockDevices) List(opts v1.ListOptions) (result *v1alpha1.BlockDeviceList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(blockdevicesResource, blockdevicesKind, c.ns, opts), &v1alpha1.BlockDeviceList{})
-
+		Invokes(testing.NewRootListAction(blockdevicesResource, blockdevicesKind, opts), &v1alpha1.BlockDeviceList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -74,15 +71,13 @@ func (c *FakeBlockDevices) List(opts v1.ListOptions) (result *v1alpha1.BlockDevi
 // Watch returns a watch.Interface that watches the requested blockDevices.
 func (c *FakeBlockDevices) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(blockdevicesResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(blockdevicesResource, opts))
 }
 
 // Create takes the representation of a blockDevice and creates it.  Returns the server's representation of the blockDevice, and an error, if there is any.
 func (c *FakeBlockDevices) Create(blockDevice *v1alpha1.BlockDevice) (result *v1alpha1.BlockDevice, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(blockdevicesResource, c.ns, blockDevice), &v1alpha1.BlockDevice{})
-
+		Invokes(testing.NewRootCreateAction(blockdevicesResource, blockDevice), &v1alpha1.BlockDevice{})
 	if obj == nil {
 		return nil, err
 	}
@@ -92,8 +87,7 @@ func (c *FakeBlockDevices) Create(blockDevice *v1alpha1.BlockDevice) (result *v1
 // Update takes the representation of a blockDevice and updates it. Returns the server's representation of the blockDevice, and an error, if there is any.
 func (c *FakeBlockDevices) Update(blockDevice *v1alpha1.BlockDevice) (result *v1alpha1.BlockDevice, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(blockdevicesResource, c.ns, blockDevice), &v1alpha1.BlockDevice{})
-
+		Invokes(testing.NewRootUpdateAction(blockdevicesResource, blockDevice), &v1alpha1.BlockDevice{})
 	if obj == nil {
 		return nil, err
 	}
@@ -104,8 +98,7 @@ func (c *FakeBlockDevices) Update(blockDevice *v1alpha1.BlockDevice) (result *v1
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeBlockDevices) UpdateStatus(blockDevice *v1alpha1.BlockDevice) (*v1alpha1.BlockDevice, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(blockdevicesResource, "status", c.ns, blockDevice), &v1alpha1.BlockDevice{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(blockdevicesResource, "status", blockDevice), &v1alpha1.BlockDevice{})
 	if obj == nil {
 		return nil, err
 	}
@@ -115,14 +108,13 @@ func (c *FakeBlockDevices) UpdateStatus(blockDevice *v1alpha1.BlockDevice) (*v1a
 // Delete takes name of the blockDevice and deletes it. Returns an error if one occurs.
 func (c *FakeBlockDevices) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(blockdevicesResource, c.ns, name), &v1alpha1.BlockDevice{})
-
+		Invokes(testing.NewRootDeleteAction(blockdevicesResource, name), &v1alpha1.BlockDevice{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeBlockDevices) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(blockdevicesResource, c.ns, listOptions)
+	action := testing.NewRootDeleteCollectionAction(blockdevicesResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.BlockDeviceList{})
 	return err
@@ -131,8 +123,7 @@ func (c *FakeBlockDevices) DeleteCollection(options *v1.DeleteOptions, listOptio
 // Patch applies the patch and returns the patched blockDevice.
 func (c *FakeBlockDevices) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.BlockDevice, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(blockdevicesResource, c.ns, name, data, subresources...), &v1alpha1.BlockDevice{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(blockdevicesResource, name, data, subresources...), &v1alpha1.BlockDevice{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/fake/fake_blockdeviceclaim.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/fake/fake_blockdeviceclaim.go
@@ -31,7 +31,6 @@ import (
 // FakeBlockDeviceClaims implements BlockDeviceClaimInterface
 type FakeBlockDeviceClaims struct {
 	Fake *FakeOpenebsV1alpha1
-	ns   string
 }
 
 var blockdeviceclaimsResource = schema.GroupVersionResource{Group: "openebs.io", Version: "v1alpha1", Resource: "blockdeviceclaims"}
@@ -41,8 +40,7 @@ var blockdeviceclaimsKind = schema.GroupVersionKind{Group: "openebs.io", Version
 // Get takes name of the blockDeviceClaim, and returns the corresponding blockDeviceClaim object, and an error if there is any.
 func (c *FakeBlockDeviceClaims) Get(name string, options v1.GetOptions) (result *v1alpha1.BlockDeviceClaim, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(blockdeviceclaimsResource, c.ns, name), &v1alpha1.BlockDeviceClaim{})
-
+		Invokes(testing.NewRootGetAction(blockdeviceclaimsResource, name), &v1alpha1.BlockDeviceClaim{})
 	if obj == nil {
 		return nil, err
 	}
@@ -52,8 +50,7 @@ func (c *FakeBlockDeviceClaims) Get(name string, options v1.GetOptions) (result 
 // List takes label and field selectors, and returns the list of BlockDeviceClaims that match those selectors.
 func (c *FakeBlockDeviceClaims) List(opts v1.ListOptions) (result *v1alpha1.BlockDeviceClaimList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(blockdeviceclaimsResource, blockdeviceclaimsKind, c.ns, opts), &v1alpha1.BlockDeviceClaimList{})
-
+		Invokes(testing.NewRootListAction(blockdeviceclaimsResource, blockdeviceclaimsKind, opts), &v1alpha1.BlockDeviceClaimList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -74,15 +71,13 @@ func (c *FakeBlockDeviceClaims) List(opts v1.ListOptions) (result *v1alpha1.Bloc
 // Watch returns a watch.Interface that watches the requested blockDeviceClaims.
 func (c *FakeBlockDeviceClaims) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(blockdeviceclaimsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(blockdeviceclaimsResource, opts))
 }
 
 // Create takes the representation of a blockDeviceClaim and creates it.  Returns the server's representation of the blockDeviceClaim, and an error, if there is any.
 func (c *FakeBlockDeviceClaims) Create(blockDeviceClaim *v1alpha1.BlockDeviceClaim) (result *v1alpha1.BlockDeviceClaim, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(blockdeviceclaimsResource, c.ns, blockDeviceClaim), &v1alpha1.BlockDeviceClaim{})
-
+		Invokes(testing.NewRootCreateAction(blockdeviceclaimsResource, blockDeviceClaim), &v1alpha1.BlockDeviceClaim{})
 	if obj == nil {
 		return nil, err
 	}
@@ -92,8 +87,7 @@ func (c *FakeBlockDeviceClaims) Create(blockDeviceClaim *v1alpha1.BlockDeviceCla
 // Update takes the representation of a blockDeviceClaim and updates it. Returns the server's representation of the blockDeviceClaim, and an error, if there is any.
 func (c *FakeBlockDeviceClaims) Update(blockDeviceClaim *v1alpha1.BlockDeviceClaim) (result *v1alpha1.BlockDeviceClaim, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(blockdeviceclaimsResource, c.ns, blockDeviceClaim), &v1alpha1.BlockDeviceClaim{})
-
+		Invokes(testing.NewRootUpdateAction(blockdeviceclaimsResource, blockDeviceClaim), &v1alpha1.BlockDeviceClaim{})
 	if obj == nil {
 		return nil, err
 	}
@@ -104,8 +98,7 @@ func (c *FakeBlockDeviceClaims) Update(blockDeviceClaim *v1alpha1.BlockDeviceCla
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeBlockDeviceClaims) UpdateStatus(blockDeviceClaim *v1alpha1.BlockDeviceClaim) (*v1alpha1.BlockDeviceClaim, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(blockdeviceclaimsResource, "status", c.ns, blockDeviceClaim), &v1alpha1.BlockDeviceClaim{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(blockdeviceclaimsResource, "status", blockDeviceClaim), &v1alpha1.BlockDeviceClaim{})
 	if obj == nil {
 		return nil, err
 	}
@@ -115,14 +108,13 @@ func (c *FakeBlockDeviceClaims) UpdateStatus(blockDeviceClaim *v1alpha1.BlockDev
 // Delete takes name of the blockDeviceClaim and deletes it. Returns an error if one occurs.
 func (c *FakeBlockDeviceClaims) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(blockdeviceclaimsResource, c.ns, name), &v1alpha1.BlockDeviceClaim{})
-
+		Invokes(testing.NewRootDeleteAction(blockdeviceclaimsResource, name), &v1alpha1.BlockDeviceClaim{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeBlockDeviceClaims) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(blockdeviceclaimsResource, c.ns, listOptions)
+	action := testing.NewRootDeleteCollectionAction(blockdeviceclaimsResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.BlockDeviceClaimList{})
 	return err
@@ -131,8 +123,7 @@ func (c *FakeBlockDeviceClaims) DeleteCollection(options *v1.DeleteOptions, list
 // Patch applies the patch and returns the patched blockDeviceClaim.
 func (c *FakeBlockDeviceClaims) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.BlockDeviceClaim, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(blockdeviceclaimsResource, c.ns, name, data, subresources...), &v1alpha1.BlockDeviceClaim{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(blockdeviceclaimsResource, name, data, subresources...), &v1alpha1.BlockDeviceClaim{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/fake/fake_disk.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/fake/fake_disk.go
@@ -31,7 +31,6 @@ import (
 // FakeDisks implements DiskInterface
 type FakeDisks struct {
 	Fake *FakeOpenebsV1alpha1
-	ns   string
 }
 
 var disksResource = schema.GroupVersionResource{Group: "openebs.io", Version: "v1alpha1", Resource: "disks"}
@@ -41,8 +40,7 @@ var disksKind = schema.GroupVersionKind{Group: "openebs.io", Version: "v1alpha1"
 // Get takes name of the disk, and returns the corresponding disk object, and an error if there is any.
 func (c *FakeDisks) Get(name string, options v1.GetOptions) (result *v1alpha1.Disk, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(disksResource, c.ns, name), &v1alpha1.Disk{})
-
+		Invokes(testing.NewRootGetAction(disksResource, name), &v1alpha1.Disk{})
 	if obj == nil {
 		return nil, err
 	}
@@ -52,8 +50,7 @@ func (c *FakeDisks) Get(name string, options v1.GetOptions) (result *v1alpha1.Di
 // List takes label and field selectors, and returns the list of Disks that match those selectors.
 func (c *FakeDisks) List(opts v1.ListOptions) (result *v1alpha1.DiskList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(disksResource, disksKind, c.ns, opts), &v1alpha1.DiskList{})
-
+		Invokes(testing.NewRootListAction(disksResource, disksKind, opts), &v1alpha1.DiskList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -74,15 +71,13 @@ func (c *FakeDisks) List(opts v1.ListOptions) (result *v1alpha1.DiskList, err er
 // Watch returns a watch.Interface that watches the requested disks.
 func (c *FakeDisks) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(disksResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(disksResource, opts))
 }
 
 // Create takes the representation of a disk and creates it.  Returns the server's representation of the disk, and an error, if there is any.
 func (c *FakeDisks) Create(disk *v1alpha1.Disk) (result *v1alpha1.Disk, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(disksResource, c.ns, disk), &v1alpha1.Disk{})
-
+		Invokes(testing.NewRootCreateAction(disksResource, disk), &v1alpha1.Disk{})
 	if obj == nil {
 		return nil, err
 	}
@@ -92,8 +87,7 @@ func (c *FakeDisks) Create(disk *v1alpha1.Disk) (result *v1alpha1.Disk, err erro
 // Update takes the representation of a disk and updates it. Returns the server's representation of the disk, and an error, if there is any.
 func (c *FakeDisks) Update(disk *v1alpha1.Disk) (result *v1alpha1.Disk, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(disksResource, c.ns, disk), &v1alpha1.Disk{})
-
+		Invokes(testing.NewRootUpdateAction(disksResource, disk), &v1alpha1.Disk{})
 	if obj == nil {
 		return nil, err
 	}
@@ -104,8 +98,7 @@ func (c *FakeDisks) Update(disk *v1alpha1.Disk) (result *v1alpha1.Disk, err erro
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeDisks) UpdateStatus(disk *v1alpha1.Disk) (*v1alpha1.Disk, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(disksResource, "status", c.ns, disk), &v1alpha1.Disk{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(disksResource, "status", disk), &v1alpha1.Disk{})
 	if obj == nil {
 		return nil, err
 	}
@@ -115,14 +108,13 @@ func (c *FakeDisks) UpdateStatus(disk *v1alpha1.Disk) (*v1alpha1.Disk, error) {
 // Delete takes name of the disk and deletes it. Returns an error if one occurs.
 func (c *FakeDisks) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(disksResource, c.ns, name), &v1alpha1.Disk{})
-
+		Invokes(testing.NewRootDeleteAction(disksResource, name), &v1alpha1.Disk{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeDisks) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(disksResource, c.ns, listOptions)
+	action := testing.NewRootDeleteCollectionAction(disksResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.DiskList{})
 	return err
@@ -131,8 +123,7 @@ func (c *FakeDisks) DeleteCollection(options *v1.DeleteOptions, listOptions v1.L
 // Patch applies the patch and returns the patched disk.
 func (c *FakeDisks) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.Disk, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(disksResource, c.ns, name, data, subresources...), &v1alpha1.Disk{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(disksResource, name, data, subresources...), &v1alpha1.Disk{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/fake/fake_ndm_client.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/fake/fake_ndm_client.go
@@ -28,16 +28,16 @@ type FakeOpenebsV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeOpenebsV1alpha1) BlockDevices(namespace string) v1alpha1.BlockDeviceInterface {
-	return &FakeBlockDevices{c, namespace}
+func (c *FakeOpenebsV1alpha1) BlockDevices() v1alpha1.BlockDeviceInterface {
+	return &FakeBlockDevices{c}
 }
 
-func (c *FakeOpenebsV1alpha1) BlockDeviceClaims(namespace string) v1alpha1.BlockDeviceClaimInterface {
-	return &FakeBlockDeviceClaims{c, namespace}
+func (c *FakeOpenebsV1alpha1) BlockDeviceClaims() v1alpha1.BlockDeviceClaimInterface {
+	return &FakeBlockDeviceClaims{c}
 }
 
-func (c *FakeOpenebsV1alpha1) Disks(namespace string) v1alpha1.DiskInterface {
-	return &FakeDisks{c, namespace}
+func (c *FakeOpenebsV1alpha1) Disks() v1alpha1.DiskInterface {
+	return &FakeDisks{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/ndm_client.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/ndm_client.go
@@ -37,16 +37,16 @@ type OpenebsV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *OpenebsV1alpha1Client) BlockDevices(namespace string) BlockDeviceInterface {
-	return newBlockDevices(c, namespace)
+func (c *OpenebsV1alpha1Client) BlockDevices() BlockDeviceInterface {
+	return newBlockDevices(c)
 }
 
-func (c *OpenebsV1alpha1Client) BlockDeviceClaims(namespace string) BlockDeviceClaimInterface {
-	return newBlockDeviceClaims(c, namespace)
+func (c *OpenebsV1alpha1Client) BlockDeviceClaims() BlockDeviceClaimInterface {
+	return newBlockDeviceClaims(c)
 }
 
-func (c *OpenebsV1alpha1Client) Disks(namespace string) DiskInterface {
-	return newDisks(c, namespace)
+func (c *OpenebsV1alpha1Client) Disks() DiskInterface {
+	return newDisks(c)
 }
 
 // NewForConfig creates a new OpenebsV1alpha1Client for the given config.

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/informer/externalversions/ndm/v1alpha1/blockdevice.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/informer/externalversions/ndm/v1alpha1/blockdevice.go
@@ -41,33 +41,32 @@ type BlockDeviceInformer interface {
 type blockDeviceInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewBlockDeviceInformer constructs a new informer for BlockDevice type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewBlockDeviceInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredBlockDeviceInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewBlockDeviceInformer(client internalclientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredBlockDeviceInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredBlockDeviceInformer constructs a new informer for BlockDevice type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredBlockDeviceInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredBlockDeviceInformer(client internalclientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.OpenebsV1alpha1().BlockDevices(namespace).List(options)
+				return client.OpenebsV1alpha1().BlockDevices().List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.OpenebsV1alpha1().BlockDevices(namespace).Watch(options)
+				return client.OpenebsV1alpha1().BlockDevices().Watch(options)
 			},
 		},
 		&ndmv1alpha1.BlockDevice{},
@@ -77,7 +76,7 @@ func NewFilteredBlockDeviceInformer(client internalclientset.Interface, namespac
 }
 
 func (f *blockDeviceInformer) defaultInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredBlockDeviceInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredBlockDeviceInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *blockDeviceInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/informer/externalversions/ndm/v1alpha1/blockdeviceclaim.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/informer/externalversions/ndm/v1alpha1/blockdeviceclaim.go
@@ -41,33 +41,32 @@ type BlockDeviceClaimInformer interface {
 type blockDeviceClaimInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewBlockDeviceClaimInformer constructs a new informer for BlockDeviceClaim type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewBlockDeviceClaimInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredBlockDeviceClaimInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewBlockDeviceClaimInformer(client internalclientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredBlockDeviceClaimInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredBlockDeviceClaimInformer constructs a new informer for BlockDeviceClaim type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredBlockDeviceClaimInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredBlockDeviceClaimInformer(client internalclientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.OpenebsV1alpha1().BlockDeviceClaims(namespace).List(options)
+				return client.OpenebsV1alpha1().BlockDeviceClaims().List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.OpenebsV1alpha1().BlockDeviceClaims(namespace).Watch(options)
+				return client.OpenebsV1alpha1().BlockDeviceClaims().Watch(options)
 			},
 		},
 		&ndmv1alpha1.BlockDeviceClaim{},
@@ -77,7 +76,7 @@ func NewFilteredBlockDeviceClaimInformer(client internalclientset.Interface, nam
 }
 
 func (f *blockDeviceClaimInformer) defaultInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredBlockDeviceClaimInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredBlockDeviceClaimInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *blockDeviceClaimInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/informer/externalversions/ndm/v1alpha1/disk.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/informer/externalversions/ndm/v1alpha1/disk.go
@@ -41,33 +41,32 @@ type DiskInformer interface {
 type diskInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewDiskInformer constructs a new informer for Disk type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewDiskInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredDiskInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewDiskInformer(client internalclientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredDiskInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredDiskInformer constructs a new informer for Disk type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredDiskInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredDiskInformer(client internalclientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.OpenebsV1alpha1().Disks(namespace).List(options)
+				return client.OpenebsV1alpha1().Disks().List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.OpenebsV1alpha1().Disks(namespace).Watch(options)
+				return client.OpenebsV1alpha1().Disks().Watch(options)
 			},
 		},
 		&ndmv1alpha1.Disk{},
@@ -77,7 +76,7 @@ func NewFilteredDiskInformer(client internalclientset.Interface, namespace strin
 }
 
 func (f *diskInformer) defaultInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredDiskInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredDiskInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *diskInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/informer/externalversions/ndm/v1alpha1/interface.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/informer/externalversions/ndm/v1alpha1/interface.go
@@ -45,15 +45,15 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // BlockDevices returns a BlockDeviceInformer.
 func (v *version) BlockDevices() BlockDeviceInformer {
-	return &blockDeviceInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &blockDeviceInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
 // BlockDeviceClaims returns a BlockDeviceClaimInformer.
 func (v *version) BlockDeviceClaims() BlockDeviceClaimInformer {
-	return &blockDeviceClaimInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &blockDeviceClaimInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
 // Disks returns a DiskInformer.
 func (v *version) Disks() DiskInformer {
-	return &diskInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &diskInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/lister/ndm/v1alpha1/blockdevice.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/lister/ndm/v1alpha1/blockdevice.go
@@ -29,8 +29,8 @@ import (
 type BlockDeviceLister interface {
 	// List lists all BlockDevices in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.BlockDevice, err error)
-	// BlockDevices returns an object that can list and get BlockDevices.
-	BlockDevices(namespace string) BlockDeviceNamespaceLister
+	// Get retrieves the BlockDevice from the index for a given name.
+	Get(name string) (*v1alpha1.BlockDevice, error)
 	BlockDeviceListerExpansion
 }
 
@@ -52,38 +52,9 @@ func (s *blockDeviceLister) List(selector labels.Selector) (ret []*v1alpha1.Bloc
 	return ret, err
 }
 
-// BlockDevices returns an object that can list and get BlockDevices.
-func (s *blockDeviceLister) BlockDevices(namespace string) BlockDeviceNamespaceLister {
-	return blockDeviceNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// BlockDeviceNamespaceLister helps list and get BlockDevices.
-type BlockDeviceNamespaceLister interface {
-	// List lists all BlockDevices in the indexer for a given namespace.
-	List(selector labels.Selector) (ret []*v1alpha1.BlockDevice, err error)
-	// Get retrieves the BlockDevice from the indexer for a given namespace and name.
-	Get(name string) (*v1alpha1.BlockDevice, error)
-	BlockDeviceNamespaceListerExpansion
-}
-
-// blockDeviceNamespaceLister implements the BlockDeviceNamespaceLister
-// interface.
-type blockDeviceNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all BlockDevices in the indexer for a given namespace.
-func (s blockDeviceNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.BlockDevice, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.BlockDevice))
-	})
-	return ret, err
-}
-
-// Get retrieves the BlockDevice from the indexer for a given namespace and name.
-func (s blockDeviceNamespaceLister) Get(name string) (*v1alpha1.BlockDevice, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the BlockDevice from the index for a given name.
+func (s *blockDeviceLister) Get(name string) (*v1alpha1.BlockDevice, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/lister/ndm/v1alpha1/blockdeviceclaim.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/lister/ndm/v1alpha1/blockdeviceclaim.go
@@ -29,8 +29,8 @@ import (
 type BlockDeviceClaimLister interface {
 	// List lists all BlockDeviceClaims in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.BlockDeviceClaim, err error)
-	// BlockDeviceClaims returns an object that can list and get BlockDeviceClaims.
-	BlockDeviceClaims(namespace string) BlockDeviceClaimNamespaceLister
+	// Get retrieves the BlockDeviceClaim from the index for a given name.
+	Get(name string) (*v1alpha1.BlockDeviceClaim, error)
 	BlockDeviceClaimListerExpansion
 }
 
@@ -52,38 +52,9 @@ func (s *blockDeviceClaimLister) List(selector labels.Selector) (ret []*v1alpha1
 	return ret, err
 }
 
-// BlockDeviceClaims returns an object that can list and get BlockDeviceClaims.
-func (s *blockDeviceClaimLister) BlockDeviceClaims(namespace string) BlockDeviceClaimNamespaceLister {
-	return blockDeviceClaimNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// BlockDeviceClaimNamespaceLister helps list and get BlockDeviceClaims.
-type BlockDeviceClaimNamespaceLister interface {
-	// List lists all BlockDeviceClaims in the indexer for a given namespace.
-	List(selector labels.Selector) (ret []*v1alpha1.BlockDeviceClaim, err error)
-	// Get retrieves the BlockDeviceClaim from the indexer for a given namespace and name.
-	Get(name string) (*v1alpha1.BlockDeviceClaim, error)
-	BlockDeviceClaimNamespaceListerExpansion
-}
-
-// blockDeviceClaimNamespaceLister implements the BlockDeviceClaimNamespaceLister
-// interface.
-type blockDeviceClaimNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all BlockDeviceClaims in the indexer for a given namespace.
-func (s blockDeviceClaimNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.BlockDeviceClaim, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.BlockDeviceClaim))
-	})
-	return ret, err
-}
-
-// Get retrieves the BlockDeviceClaim from the indexer for a given namespace and name.
-func (s blockDeviceClaimNamespaceLister) Get(name string) (*v1alpha1.BlockDeviceClaim, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the BlockDeviceClaim from the index for a given name.
+func (s *blockDeviceClaimLister) Get(name string) (*v1alpha1.BlockDeviceClaim, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/lister/ndm/v1alpha1/disk.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/lister/ndm/v1alpha1/disk.go
@@ -29,8 +29,8 @@ import (
 type DiskLister interface {
 	// List lists all Disks in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.Disk, err error)
-	// Disks returns an object that can list and get Disks.
-	Disks(namespace string) DiskNamespaceLister
+	// Get retrieves the Disk from the index for a given name.
+	Get(name string) (*v1alpha1.Disk, error)
 	DiskListerExpansion
 }
 
@@ -52,38 +52,9 @@ func (s *diskLister) List(selector labels.Selector) (ret []*v1alpha1.Disk, err e
 	return ret, err
 }
 
-// Disks returns an object that can list and get Disks.
-func (s *diskLister) Disks(namespace string) DiskNamespaceLister {
-	return diskNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// DiskNamespaceLister helps list and get Disks.
-type DiskNamespaceLister interface {
-	// List lists all Disks in the indexer for a given namespace.
-	List(selector labels.Selector) (ret []*v1alpha1.Disk, err error)
-	// Get retrieves the Disk from the indexer for a given namespace and name.
-	Get(name string) (*v1alpha1.Disk, error)
-	DiskNamespaceListerExpansion
-}
-
-// diskNamespaceLister implements the DiskNamespaceLister
-// interface.
-type diskNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all Disks in the indexer for a given namespace.
-func (s diskNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.Disk, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.Disk))
-	})
-	return ret, err
-}
-
-// Get retrieves the Disk from the indexer for a given namespace and name.
-func (s diskNamespaceLister) Get(name string) (*v1alpha1.Disk, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the Disk from the index for a given name.
+func (s *diskLister) Get(name string) (*v1alpha1.Disk, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/lister/ndm/v1alpha1/expansion_generated.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/lister/ndm/v1alpha1/expansion_generated.go
@@ -22,22 +22,10 @@ package v1alpha1
 // BlockDeviceLister.
 type BlockDeviceListerExpansion interface{}
 
-// BlockDeviceNamespaceListerExpansion allows custom methods to be added to
-// BlockDeviceNamespaceLister.
-type BlockDeviceNamespaceListerExpansion interface{}
-
 // BlockDeviceClaimListerExpansion allows custom methods to be added to
 // BlockDeviceClaimLister.
 type BlockDeviceClaimListerExpansion interface{}
 
-// BlockDeviceClaimNamespaceListerExpansion allows custom methods to be added to
-// BlockDeviceClaimNamespaceLister.
-type BlockDeviceClaimNamespaceListerExpansion interface{}
-
 // DiskListerExpansion allows custom methods to be added to
 // DiskLister.
 type DiskListerExpansion interface{}
-
-// DiskNamespaceListerExpansion allows custom methods to be added to
-// DiskNamespaceLister.
-type DiskNamespaceListerExpansion interface{}


### PR DESCRIPTION
change disk, blockdevice and blockdeviceclaim to cluster scope and auto-gen code for the APIs

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
When the NDM APIs were checked-in, it was made as namespace scoped. But the earlier disk resource was cluster scoped. This PR changes the new NDM APIs to cluster scope from Namespace scope.

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests