### PR TITLE
refactor(CAST, exec): refactor runtask pod exec functionality

### DIFF
--- a/pkg/kubernetes/podexec/v1alpha1/podexec.go
+++ b/pkg/kubernetes/podexec/v1alpha1/podexec.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"github.com/ghodss/yaml"
-	"github.com/openebs/maya/pkg/template"
 	api_core_v1 "k8s.io/api/core/v1"
 )
 
@@ -40,23 +39,18 @@ func (p *podexec) AsAPIPodExec() (*api_core_v1.PodExecOptions, error) {
 	return p.object, nil
 }
 
-// WithTemplate takes Yaml values which is given in runtask and key in which configuration
-// is present and unmarshal it with PodExecOptions.
-func WithTemplate(context, yamlString string, values map[string]interface{}) (p *podexec) {
-	p = &podexec{}
-	b, err := template.AsTemplatedBytes(context, yamlString, values)
-	if err != nil {
-		p.errs = append(p.errs, err)
-		return
-	}
+// BuilderForYAMLObject returns a new instance
+// of Builder for a given template object
+func BuilderForYAMLObject(object []byte) *podexec {
+	p := &podexec{}
 	exec := &api_core_v1.PodExecOptions{}
-	err = yaml.Unmarshal(b, exec)
+	err := yaml.Unmarshal(object, exec)
 	if err != nil {
 		p.errs = append(p.errs, err)
-		return
+		return p
 	}
 	p.object = exec
-	return
+	return p
 }
 
 // Validate validates PodExecOptions it mainly checks for container name is present or not and

--- a/pkg/kubernetes/podexec/v1alpha1/podexec.go
+++ b/pkg/kubernetes/podexec/v1alpha1/podexec.go
@@ -23,7 +23,8 @@ import (
 	api_core_v1 "k8s.io/api/core/v1"
 )
 
-type podexec struct {
+// PodExec represents the details of pod exec options
+type PodExec struct {
 	object       *api_core_v1.PodExecOptions
 	ignoreErrors bool
 	errs         []error
@@ -31,7 +32,7 @@ type podexec struct {
 
 // AsAPIPodExec validate and returns PodExecOptions object pointer and error
 // depending on ignoreErrors opt and errors
-func (p *podexec) AsAPIPodExec() (*api_core_v1.PodExecOptions, error) {
+func (p *PodExec) AsAPIPodExec() (*api_core_v1.PodExecOptions, error) {
 	err := p.Validate()
 	if err != nil && !p.ignoreErrors {
 		return nil, err
@@ -41,8 +42,8 @@ func (p *podexec) AsAPIPodExec() (*api_core_v1.PodExecOptions, error) {
 
 // BuilderForYAMLObject returns a new instance
 // of Builder for a given template object
-func BuilderForYAMLObject(object []byte) *podexec {
-	p := &podexec{}
+func BuilderForYAMLObject(object []byte) *PodExec {
+	p := &PodExec{}
 	exec := &api_core_v1.PodExecOptions{}
 	err := yaml.Unmarshal(object, exec)
 	if err != nil {
@@ -55,7 +56,7 @@ func BuilderForYAMLObject(object []byte) *podexec {
 
 // Validate validates PodExecOptions it mainly checks for container name is present or not and
 // commands are present or not.
-func (p *podexec) Validate() error {
+func (p *PodExec) Validate() error {
 	if len(p.errs) != 0 {
 		return fmt.Errorf("validation failed: %v", p.errs)
 	}
@@ -68,17 +69,19 @@ func (p *podexec) Validate() error {
 	return nil
 }
 
-type buildOption func(*podexec)
+// BuildOption represents the various build options
+// against PodExec operation
+type BuildOption func(*PodExec)
 
 // IgnoreErrors is a buildOption that is used ignore errors
-func IgnoreErrors() buildOption {
-	return func(p *podexec) {
+func IgnoreErrors() BuildOption {
+	return func(p *PodExec) {
 		p.ignoreErrors = true
 	}
 }
 
-// Apply applies all build options in podexec
-func (p *podexec) Apply(opts ...buildOption) *podexec {
+// Apply applies all build options in PodExec
+func (p *PodExec) Apply(opts ...BuildOption) *PodExec {
 	for _, o := range opts {
 		o(p)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->
**What this PR does / why we need it**:

This PR refactors pod exec functionality in order to improve the following -

- It adds exec as an operation to pod so that it can be called in the same way as other pod operations like get, list, delete, etc are called by caller.

- It tries to enhance pod exec code to be in idiomatic maya way.

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests

Signed-off-by: sagarkrsd <sagar.kumar@openebs.io>