### PR TITLE
feat(bdd,cstor): make replica count and pool count configurable

### DIFF
--- a/pkg/algorithm/cstorpoolselect/v1alpha1/select.go
+++ b/pkg/algorithm/cstorpoolselect/v1alpha1/select.go
@@ -179,7 +179,7 @@ type antiAffinityLabel struct {
 
 func defaultCVRList() cvrListFn {
 	return func(namespace string, opts metav1.ListOptions) (*apis.CStorVolumeReplicaList, error) {
-		return cvr.KubeClient(cvr.WithNamespace(namespace)).List(opts)
+		return cvr.NewKubeclient(cvr.WithNamespace(namespace)).List(opts)
 	}
 }
 

--- a/pkg/cstorvolumereplica/v1alpha1/kubernetes.go
+++ b/pkg/cstorvolumereplica/v1alpha1/kubernetes.go
@@ -15,52 +15,86 @@
 package v1alpha1
 
 import (
+	"errors"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	clientset "github.com/openebs/maya/pkg/client/generated/clientset/versioned"
-	kclient "github.com/openebs/maya/pkg/client/k8s/v1alpha1"
+
+	client "github.com/openebs/maya/pkg/kubernetes/client/v1alpha1"
 )
 
 // getClientsetFn is a typed function that
 // abstracts fetching of internal clientset
 type getClientsetFn func() (clientset *clientset.Clientset, err error)
 
+// getClientsetFromPathFn is a typed function that
+// abstracts fetching of clientset from kubeConfigPath
+type getClientsetForPathFn func(kubeConfigPath string) (clientset *clientset.Clientset, err error)
+
+// getFn is a typed function that abstracts get of cstorvolume replica instances
+type getFn func(cli *clientset.Clientset, name, namespace string,
+	opts metav1.GetOptions) (*apis.CStorVolumeReplica, error)
+
 // listFn is a typed function that abstracts
 // listing of cstor volume replica instances
 type listFn func(cli *clientset.Clientset, namespace string, opts metav1.ListOptions) (*apis.CStorVolumeReplicaList, error)
 
-// kubeclient enables kubernetes API operations
+// delFn is a typed function that abstracts delete of cstorvolume replica instances
+type delFn func(cli *clientset.Clientset, name, namespace string, opts *metav1.DeleteOptions) error
+
+// Kubeclient enables kubernetes API operations
 // on cstor volume replica instance
-type kubeclient struct {
+type Kubeclient struct {
 	// clientset refers to cstor volume replica's
 	// clientset that will be responsible to
 	// make kubernetes API calls
 	clientset *clientset.Clientset
 
+	kubeConfigPath string
 	// namespace holds the namespace on which
 	// kubeclient has to operate
 	namespace string
 
 	// functions useful during mocking
-	getClientset getClientsetFn
-	list         listFn
+	getClientset        getClientsetFn
+	getClientsetForPath getClientsetForPathFn
+	get                 getFn
+	list                listFn
+	del                 delFn
 }
 
 // kubeclientBuildOption defines the abstraction
 // to build a kubeclient instance
-type kubeclientBuildOption func(*kubeclient)
+type kubeclientBuildOption func(*Kubeclient)
 
 // withDefaults sets the default options
 // of kubeclient instance
-func (k *kubeclient) withDefaults() {
+func (k *Kubeclient) withDefaults() {
+
 	if k.getClientset == nil {
 		k.getClientset = func() (clients *clientset.Clientset, err error) {
-			config, err := kclient.Config().Get()
+			config, err := client.New().GetConfigForPathOrDirect()
 			if err != nil {
 				return nil, err
 			}
 			return clientset.NewForConfig(config)
+		}
+	}
+	if k.getClientsetForPath == nil {
+		k.getClientsetForPath = func(kubeConfigPath string) (clients *clientset.Clientset, err error) {
+			config, err := client.New(client.WithKubeConfigPath(kubeConfigPath)).GetConfigForPathOrDirect()
+			if err != nil {
+				return nil, err
+			}
+			return clientset.NewForConfig(config)
+		}
+	}
+
+	if k.get == nil {
+		k.get = func(cli *clientset.Clientset, name, namespace string, opts metav1.GetOptions) (*apis.CStorVolumeReplica, error) {
+			return cli.OpenebsV1alpha1().CStorVolumeReplicas(namespace).Get(name, opts)
 		}
 	}
 	if k.list == nil {
@@ -68,12 +102,25 @@ func (k *kubeclient) withDefaults() {
 			return cli.OpenebsV1alpha1().CStorVolumeReplicas(namespace).List(opts)
 		}
 	}
+	if k.del == nil {
+		k.del = func(cli *clientset.Clientset, name, namespace string, opts *metav1.DeleteOptions) error {
+			// The object exists in the key-value store until the garbage collector
+			// deletes all the dependents whose ownerReference.blockOwnerDeletion=true
+			// from the key-value store.  API sever will put the "foregroundDeletion"
+			// finalizer on the object, and sets its deletionTimestamp.  This policy is
+			// cascading, i.e., the dependents will be deleted with Foreground.
+			deletePropagation := metav1.DeletePropagationForeground
+			opts.PropagationPolicy = &deletePropagation
+			err := cli.OpenebsV1alpha1().CStorVolumeReplicas(namespace).Delete(name, opts)
+			return err
+		}
+	}
 }
 
 // WithKubeClient sets the kubernetes client against
 // the kubeclient instance
 func WithKubeClient(c *clientset.Clientset) kubeclientBuildOption {
-	return func(k *kubeclient) {
+	return func(k *Kubeclient) {
 		k.clientset = c
 	}
 }
@@ -81,15 +128,23 @@ func WithKubeClient(c *clientset.Clientset) kubeclientBuildOption {
 // WithNamespace sets the kubernetes client against
 // the provided namespace
 func WithNamespace(namespace string) kubeclientBuildOption {
-	return func(k *kubeclient) {
+	return func(k *Kubeclient) {
 		k.namespace = namespace
 	}
 }
 
-// KubeClient returns a new instance of kubeclient meant for
+// WithKubeConfigPath sets the kubernetes client against
+// the provided path
+func WithKubeConfigPath(path string) kubeclientBuildOption {
+	return func(k *Kubeclient) {
+		k.kubeConfigPath = path
+	}
+}
+
+// NewKubeclient returns a new instance of kubeclient meant for
 // cstor volume replica operations
-func KubeClient(opts ...kubeclientBuildOption) *kubeclient {
-	k := &kubeclient{}
+func NewKubeclient(opts ...kubeclientBuildOption) *Kubeclient {
+	k := &Kubeclient{}
 	for _, o := range opts {
 		o(k)
 	}
@@ -97,13 +152,20 @@ func KubeClient(opts ...kubeclientBuildOption) *kubeclient {
 	return k
 }
 
+func (k *Kubeclient) getClientsetForPathOrDirect() (*clientset.Clientset, error) {
+	if k.kubeConfigPath != "" {
+		return k.getClientsetForPath(k.kubeConfigPath)
+	}
+	return k.getClientset()
+}
+
 // getClientOrCached returns either a new instance
 // of kubernetes client or its cached copy
-func (k *kubeclient) getClientOrCached() (*clientset.Clientset, error) {
+func (k *Kubeclient) getClientOrCached() (*clientset.Clientset, error) {
 	if k.clientset != nil {
 		return k.clientset, nil
 	}
-	c, err := k.getClientset()
+	c, err := k.getClientsetForPathOrDirect()
 	if err != nil {
 		return nil, err
 	}
@@ -113,10 +175,31 @@ func (k *kubeclient) getClientOrCached() (*clientset.Clientset, error) {
 
 // List returns a list of cstor volume replica
 // instances present in kubernetes cluster
-func (k *kubeclient) List(opts metav1.ListOptions) (*apis.CStorVolumeReplicaList, error) {
+func (k *Kubeclient) List(opts metav1.ListOptions) (*apis.CStorVolumeReplicaList, error) {
 	cli, err := k.getClientOrCached()
 	if err != nil {
 		return nil, err
 	}
 	return k.list(cli, k.namespace, opts)
+}
+
+// Get returns cstorvolumereplica object for given name
+func (k *Kubeclient) Get(name string, opts metav1.GetOptions) (*apis.CStorVolumeReplica, error) {
+	if len(name) == 0 {
+		return nil, errors.New("failed to get cstorvolume: name can't be empty")
+	}
+	cli, err := k.getClientOrCached()
+	if err != nil {
+		return nil, err
+	}
+	return k.get(cli, name, k.namespace, opts)
+}
+
+// Delete delete the cstorvolume replica resource
+func (k *Kubeclient) Delete(name string) error {
+	cli, err := k.getClientOrCached()
+	if err != nil {
+		return err
+	}
+	return k.del(cli, name, k.namespace, &metav1.DeleteOptions{})
 }

--- a/tests/cstor/cstor.go
+++ b/tests/cstor/cstor.go
@@ -1,0 +1,36 @@
+/*
+:q
+Copyright 2019 The OpenEBS Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cstor
+
+import "flag"
+
+var (
+	// KubeConfigPath is the path to
+	// the kubeconfig provided at runtime
+	KubeConfigPath string
+	// ReplicaCount is the value of
+	// replica count provided at runtime
+	ReplicaCount int
+	// PoolCount is the value of
+	// max pool count in spc
+	PoolCount int
+)
+
+// ParseFlags gets the flag values at run time
+func ParseFlags() {
+	flag.StringVar(&KubeConfigPath, "kubeconfig", "", "path to kubeconfig to invoke kubernetes API calls")
+	flag.IntVar(&ReplicaCount, "cstor-replicas", 1, "value of replica count")
+	flag.IntVar(&PoolCount, "cstor-maxpools", 1, "value of maxpool count")
+}

--- a/tests/operations.go
+++ b/tests/operations.go
@@ -26,6 +26,7 @@ import (
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	csp "github.com/openebs/maya/pkg/cstorpool/v1alpha3"
 	cv "github.com/openebs/maya/pkg/cstorvolume/v1alpha1"
+	cvr "github.com/openebs/maya/pkg/cstorvolumereplica/v1alpha1"
 	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 	kubeclient "github.com/openebs/maya/pkg/kubernetes/client/v1alpha1"
 	ns "github.com/openebs/maya/pkg/kubernetes/namespace/v1alpha1"
@@ -70,6 +71,7 @@ type Operations struct {
 	SPCClient      *spc.Kubeclient
 	SVCClient      *svc.Kubeclient
 	CVClient       *cv.Kubeclient
+	CVRClient      *cvr.Kubeclient
 	URClient       *result.Kubeclient
 	UnstructClient *unstruct.Kubeclient
 	kubeConfigPath string
@@ -159,6 +161,9 @@ func (ops *Operations) withDefaults() {
 	if ops.CVClient == nil {
 		ops.CVClient = cv.NewKubeclient(cv.WithKubeConfigPath(ops.kubeConfigPath))
 	}
+	if ops.CVRClient == nil {
+		ops.CVRClient = cvr.NewKubeclient(cvr.WithKubeConfigPath(ops.kubeConfigPath))
+	}
 	if ops.URClient == nil {
 		ops.URClient = result.NewKubeClient(result.WithKubeConfigPath(ops.kubeConfigPath))
 	}
@@ -225,6 +230,16 @@ func (ops *Operations) GetCstorVolumeCountEventually(namespace, lselector string
 		60, 10).Should(Equal(expectedCVCount))
 }
 
+// GetCstorVolumeReplicaCountEventually gives the count of cstorvolume based on
+// selecter eventually
+func (ops *Operations) GetCstorVolumeReplicaCountEventually(namespace, lselector string, expectedCVRCount int) bool {
+	return Eventually(func() int {
+		cvCount := ops.GetCstorVolumeReplicaCount(namespace, lselector)
+		return cvCount
+	},
+		60, 10).Should(Equal(expectedCVRCount))
+}
+
 // GetPodRunningCount gives number of pods running currently
 func (ops *Operations) GetPodRunningCount(namespace, lselector string) int {
 	pods, err := ops.PodClient.
@@ -247,6 +262,19 @@ func (ops *Operations) GetCVCount(namespace, lselector string) int {
 		NewListBuilder().
 		WithAPIList(cvs).
 		WithFilter(cv.IsHealthy()).
+		List().
+		Len()
+}
+
+// GetCstorVolumeReplicaCount gives cstorvolumereplica healthy count currently based on selecter
+func (ops *Operations) GetCstorVolumeReplicaCount(namespace, lselector string) int {
+	cvrs, err := ops.CVRClient.
+		List(metav1.ListOptions{LabelSelector: lselector})
+	Expect(err).ShouldNot(HaveOccurred())
+	return cvr.
+		ListBuilder().
+		WithAPIList(cvrs).
+		WithFilter(cvr.IsHealthy()).
 		List().
 		Len()
 }

--- a/tests/sts/sts_test.go
+++ b/tests/sts/sts_test.go
@@ -145,7 +145,7 @@ var _ = Describe("StatefulSet", func() {
 		// Check for CVR to get healthy
 		Eventually(func() int {
 			cvrs, err := cvr.
-				KubeClient(cvr.WithNamespace("")).
+				NewKubeclient(cvr.WithNamespace("")).
 				List(metav1.ListOptions{LabelSelector: replicaAntiAffinityLabel})
 			Expect(err).ShouldNot(HaveOccurred())
 			return cvr.
@@ -270,7 +270,7 @@ var _ = Describe("StatefulSet", func() {
 			Expect(pvcList.Len()).Should(Equal(3), "pvc count should be "+string(3))
 
 			cvrs, err := cvr.
-				KubeClient(cvr.WithNamespace("")).
+				NewKubeclient(cvr.WithNamespace("")).
 				List(metav1.ListOptions{LabelSelector: replicaAntiAffinityLabel})
 			Expect(cvrs.Items).Should(HaveLen(3), "cvr count should be "+string(3))
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Make replica count and maxpool count configurable using flags.

example:

`ginkgo -v -- --kubeconfig=/var/run/kubernetes/admin.kubeconfig --cstor-replicas=1 --cstor-maxpools=1`

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->



**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests