### PR TITLE
chore(code-gen): change NDM Disk APIs to Cluster scope

### DIFF
--- a/pkg/apis/openebs.io/ndm/v1alpha1/disk_types.go
+++ b/pkg/apis/openebs.io/ndm/v1alpha1/disk_types.go
@@ -92,6 +92,7 @@ type DeviceInfo struct {
 }
 
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +resource:path=disk
 // +k8s:openapi-gen=true

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/disk.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/disk.go
@@ -30,7 +30,7 @@ import (
 // DisksGetter has a method to return a DiskInterface.
 // A group's client should implement this interface.
 type DisksGetter interface {
-	Disks(namespace string) DiskInterface
+	Disks() DiskInterface
 }
 
 // DiskInterface has methods to work with Disk resources.
@@ -50,14 +50,12 @@ type DiskInterface interface {
 // disks implements DiskInterface
 type disks struct {
 	client rest.Interface
-	ns     string
 }
 
 // newDisks returns a Disks
-func newDisks(c *OpenebsV1alpha1Client, namespace string) *disks {
+func newDisks(c *OpenebsV1alpha1Client) *disks {
 	return &disks{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -65,7 +63,6 @@ func newDisks(c *OpenebsV1alpha1Client, namespace string) *disks {
 func (c *disks) Get(name string, options v1.GetOptions) (result *v1alpha1.Disk, err error) {
 	result = &v1alpha1.Disk{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("disks").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -78,7 +75,6 @@ func (c *disks) Get(name string, options v1.GetOptions) (result *v1alpha1.Disk, 
 func (c *disks) List(opts v1.ListOptions) (result *v1alpha1.DiskList, err error) {
 	result = &v1alpha1.DiskList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("disks").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
@@ -90,7 +86,6 @@ func (c *disks) List(opts v1.ListOptions) (result *v1alpha1.DiskList, err error)
 func (c *disks) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("disks").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Watch()
@@ -100,7 +95,6 @@ func (c *disks) Watch(opts v1.ListOptions) (watch.Interface, error) {
 func (c *disks) Create(disk *v1alpha1.Disk) (result *v1alpha1.Disk, err error) {
 	result = &v1alpha1.Disk{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("disks").
 		Body(disk).
 		Do().
@@ -112,7 +106,6 @@ func (c *disks) Create(disk *v1alpha1.Disk) (result *v1alpha1.Disk, err error) {
 func (c *disks) Update(disk *v1alpha1.Disk) (result *v1alpha1.Disk, err error) {
 	result = &v1alpha1.Disk{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("disks").
 		Name(disk.Name).
 		Body(disk).
@@ -127,7 +120,6 @@ func (c *disks) Update(disk *v1alpha1.Disk) (result *v1alpha1.Disk, err error) {
 func (c *disks) UpdateStatus(disk *v1alpha1.Disk) (result *v1alpha1.Disk, err error) {
 	result = &v1alpha1.Disk{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("disks").
 		Name(disk.Name).
 		SubResource("status").
@@ -140,7 +132,6 @@ func (c *disks) UpdateStatus(disk *v1alpha1.Disk) (result *v1alpha1.Disk, err er
 // Delete takes name of the disk and deletes it. Returns an error if one occurs.
 func (c *disks) Delete(name string, options *v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("disks").
 		Name(name).
 		Body(options).
@@ -151,7 +142,6 @@ func (c *disks) Delete(name string, options *v1.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *disks) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("disks").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Body(options).
@@ -163,7 +153,6 @@ func (c *disks) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListO
 func (c *disks) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.Disk, err error) {
 	result = &v1alpha1.Disk{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("disks").
 		SubResource(subresources...).
 		Name(name).

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/fake/fake_disk.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/fake/fake_disk.go
@@ -31,7 +31,6 @@ import (
 // FakeDisks implements DiskInterface
 type FakeDisks struct {
 	Fake *FakeOpenebsV1alpha1
-	ns   string
 }
 
 var disksResource = schema.GroupVersionResource{Group: "openebs.io", Version: "v1alpha1", Resource: "disks"}
@@ -41,8 +40,7 @@ var disksKind = schema.GroupVersionKind{Group: "openebs.io", Version: "v1alpha1"
 // Get takes name of the disk, and returns the corresponding disk object, and an error if there is any.
 func (c *FakeDisks) Get(name string, options v1.GetOptions) (result *v1alpha1.Disk, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(disksResource, c.ns, name), &v1alpha1.Disk{})
-
+		Invokes(testing.NewRootGetAction(disksResource, name), &v1alpha1.Disk{})
 	if obj == nil {
 		return nil, err
 	}
@@ -52,8 +50,7 @@ func (c *FakeDisks) Get(name string, options v1.GetOptions) (result *v1alpha1.Di
 // List takes label and field selectors, and returns the list of Disks that match those selectors.
 func (c *FakeDisks) List(opts v1.ListOptions) (result *v1alpha1.DiskList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(disksResource, disksKind, c.ns, opts), &v1alpha1.DiskList{})
-
+		Invokes(testing.NewRootListAction(disksResource, disksKind, opts), &v1alpha1.DiskList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -74,15 +71,13 @@ func (c *FakeDisks) List(opts v1.ListOptions) (result *v1alpha1.DiskList, err er
 // Watch returns a watch.Interface that watches the requested disks.
 func (c *FakeDisks) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(disksResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(disksResource, opts))
 }
 
 // Create takes the representation of a disk and creates it.  Returns the server's representation of the disk, and an error, if there is any.
 func (c *FakeDisks) Create(disk *v1alpha1.Disk) (result *v1alpha1.Disk, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(disksResource, c.ns, disk), &v1alpha1.Disk{})
-
+		Invokes(testing.NewRootCreateAction(disksResource, disk), &v1alpha1.Disk{})
 	if obj == nil {
 		return nil, err
 	}
@@ -92,8 +87,7 @@ func (c *FakeDisks) Create(disk *v1alpha1.Disk) (result *v1alpha1.Disk, err erro
 // Update takes the representation of a disk and updates it. Returns the server's representation of the disk, and an error, if there is any.
 func (c *FakeDisks) Update(disk *v1alpha1.Disk) (result *v1alpha1.Disk, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(disksResource, c.ns, disk), &v1alpha1.Disk{})
-
+		Invokes(testing.NewRootUpdateAction(disksResource, disk), &v1alpha1.Disk{})
 	if obj == nil {
 		return nil, err
 	}
@@ -104,8 +98,7 @@ func (c *FakeDisks) Update(disk *v1alpha1.Disk) (result *v1alpha1.Disk, err erro
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeDisks) UpdateStatus(disk *v1alpha1.Disk) (*v1alpha1.Disk, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(disksResource, "status", c.ns, disk), &v1alpha1.Disk{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(disksResource, "status", disk), &v1alpha1.Disk{})
 	if obj == nil {
 		return nil, err
 	}
@@ -115,14 +108,13 @@ func (c *FakeDisks) UpdateStatus(disk *v1alpha1.Disk) (*v1alpha1.Disk, error) {
 // Delete takes name of the disk and deletes it. Returns an error if one occurs.
 func (c *FakeDisks) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(disksResource, c.ns, name), &v1alpha1.Disk{})
-
+		Invokes(testing.NewRootDeleteAction(disksResource, name), &v1alpha1.Disk{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeDisks) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(disksResource, c.ns, listOptions)
+	action := testing.NewRootDeleteCollectionAction(disksResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.DiskList{})
 	return err
@@ -131,8 +123,7 @@ func (c *FakeDisks) DeleteCollection(options *v1.DeleteOptions, listOptions v1.L
 // Patch applies the patch and returns the patched disk.
 func (c *FakeDisks) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.Disk, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(disksResource, c.ns, name, data, subresources...), &v1alpha1.Disk{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(disksResource, name, data, subresources...), &v1alpha1.Disk{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/fake/fake_ndm_client.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/fake/fake_ndm_client.go
@@ -36,8 +36,8 @@ func (c *FakeOpenebsV1alpha1) BlockDeviceClaims(namespace string) v1alpha1.Block
 	return &FakeBlockDeviceClaims{c, namespace}
 }
 
-func (c *FakeOpenebsV1alpha1) Disks(namespace string) v1alpha1.DiskInterface {
-	return &FakeDisks{c, namespace}
+func (c *FakeOpenebsV1alpha1) Disks() v1alpha1.DiskInterface {
+	return &FakeDisks{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/ndm_client.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/typed/ndm/v1alpha1/ndm_client.go
@@ -45,8 +45,8 @@ func (c *OpenebsV1alpha1Client) BlockDeviceClaims(namespace string) BlockDeviceC
 	return newBlockDeviceClaims(c, namespace)
 }
 
-func (c *OpenebsV1alpha1Client) Disks(namespace string) DiskInterface {
-	return newDisks(c, namespace)
+func (c *OpenebsV1alpha1Client) Disks() DiskInterface {
+	return newDisks(c)
 }
 
 // NewForConfig creates a new OpenebsV1alpha1Client for the given config.

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/informer/externalversions/ndm/v1alpha1/disk.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/informer/externalversions/ndm/v1alpha1/disk.go
@@ -41,33 +41,32 @@ type DiskInformer interface {
 type diskInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewDiskInformer constructs a new informer for Disk type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewDiskInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredDiskInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewDiskInformer(client internalclientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredDiskInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredDiskInformer constructs a new informer for Disk type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredDiskInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredDiskInformer(client internalclientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.OpenebsV1alpha1().Disks(namespace).List(options)
+				return client.OpenebsV1alpha1().Disks().List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.OpenebsV1alpha1().Disks(namespace).Watch(options)
+				return client.OpenebsV1alpha1().Disks().Watch(options)
 			},
 		},
 		&ndmv1alpha1.Disk{},
@@ -77,7 +76,7 @@ func NewFilteredDiskInformer(client internalclientset.Interface, namespace strin
 }
 
 func (f *diskInformer) defaultInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredDiskInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredDiskInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *diskInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/informer/externalversions/ndm/v1alpha1/interface.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/informer/externalversions/ndm/v1alpha1/interface.go
@@ -55,5 +55,5 @@ func (v *version) BlockDeviceClaims() BlockDeviceClaimInformer {
 
 // Disks returns a DiskInformer.
 func (v *version) Disks() DiskInformer {
-	return &diskInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &diskInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/lister/ndm/v1alpha1/disk.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/lister/ndm/v1alpha1/disk.go
@@ -29,8 +29,8 @@ import (
 type DiskLister interface {
 	// List lists all Disks in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.Disk, err error)
-	// Disks returns an object that can list and get Disks.
-	Disks(namespace string) DiskNamespaceLister
+	// Get retrieves the Disk from the index for a given name.
+	Get(name string) (*v1alpha1.Disk, error)
 	DiskListerExpansion
 }
 
@@ -52,38 +52,9 @@ func (s *diskLister) List(selector labels.Selector) (ret []*v1alpha1.Disk, err e
 	return ret, err
 }
 
-// Disks returns an object that can list and get Disks.
-func (s *diskLister) Disks(namespace string) DiskNamespaceLister {
-	return diskNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// DiskNamespaceLister helps list and get Disks.
-type DiskNamespaceLister interface {
-	// List lists all Disks in the indexer for a given namespace.
-	List(selector labels.Selector) (ret []*v1alpha1.Disk, err error)
-	// Get retrieves the Disk from the indexer for a given namespace and name.
-	Get(name string) (*v1alpha1.Disk, error)
-	DiskNamespaceListerExpansion
-}
-
-// diskNamespaceLister implements the DiskNamespaceLister
-// interface.
-type diskNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all Disks in the indexer for a given namespace.
-func (s diskNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.Disk, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.Disk))
-	})
-	return ret, err
-}
-
-// Get retrieves the Disk from the indexer for a given namespace and name.
-func (s diskNamespaceLister) Get(name string) (*v1alpha1.Disk, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the Disk from the index for a given name.
+func (s *diskLister) Get(name string) (*v1alpha1.Disk, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/generated/openebs.io/ndm/v1alpha1/lister/ndm/v1alpha1/expansion_generated.go
+++ b/pkg/client/generated/openebs.io/ndm/v1alpha1/lister/ndm/v1alpha1/expansion_generated.go
@@ -37,7 +37,3 @@ type BlockDeviceClaimNamespaceListerExpansion interface{}
 // DiskListerExpansion allows custom methods to be added to
 // DiskLister.
 type DiskListerExpansion interface{}
-
-// DiskNamespaceListerExpansion allows custom methods to be added to
-// DiskNamespaceLister.
-type DiskNamespaceListerExpansion interface{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
When the NDM APIs were checked-in, it was made as namespace scoped. But the earlier disk resource was cluster scoped. This PR changes the Disk resource of NDM from `Namespace` scope to `Cluster` scope. 

**Special notes for your reviewer**:
Only one file(`pkg/apis/openebs.io/ndm/v1alpha1/disk_types.go`) has the actual changes. All other changes are from auto-generated code.

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests