### PR TITLE
feat(runtask, priviledged) replica deployment runtask for scheduling replica pod on openshift 

### DIFF
--- a/pkg/install/v1alpha1/jiva_volume.go
+++ b/pkg/install/v1alpha1/jiva_volume.go
@@ -1152,6 +1152,8 @@ spec:
             - --size
             - {{ .Volume.capacity }}
             - /openebs
+            securityContext:
+                privileged: true
             command:
             - launch
             image: {{ .Config.ReplicaImage.value }}


### PR DESCRIPTION
Signed-off-by: shashank855 <shashank.ranjan@mayadata.io>
- Refactor jiva-replica-deploment-runtask for jiva replica pod to get scheduled on Openshift (V-3.10).

**What this PR does / why we need it**:
- On Openshift (v-3.10) jiva replica pod goes into CrashLoopBackOff with the following log:
```
time="2019-06-05T01:02:50Z" level=error msg="failed to create tmp file /openebs/tmpFile.tmp, error: open /openebs/tmpFile.tmp: permission denied" 
time="2019-06-05T01:02:50Z" level=fatal msg="Error running start replica command: open /openebs/tmpFile.tmp: permission denied"
``` 

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests