### PR TITLE
refactor(code): allocate maps during initialization

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/common/common.go
+++ b/cmd/cstor-pool-mgmt/controller/common/common.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openebs/maya/cmd/cstor-pool-mgmt/pool"
 	"github.com/openebs/maya/cmd/cstor-pool-mgmt/volumereplica"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	zpool "github.com/openebs/maya/pkg/apis/openebs.io/zpool/v1alpha1"
 	clientset "github.com/openebs/maya/pkg/client/generated/clientset/versioned"
 	"github.com/openebs/maya/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -260,5 +261,15 @@ func Init() {
 
 	// Making RunnerVar to use RealRunner
 	pool.RunnerVar = util.RealRunner{}
+
+	// Creating maps to store imported pool info
+	if pool.ImportedCStorPools == nil {
+		pool.ImportedCStorPools = map[string]*apis.CStorPool{}
+	}
+
+	if pool.CStorZpools == nil {
+		pool.CStorZpools = map[string]zpool.Topology{}
+	}
+
 	volumereplica.RunnerVar = util.RealRunner{}
 }

--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
@@ -158,14 +158,6 @@ func (c *CStorPoolController) cStorPoolEventHandler(operation common.QueueOperat
 
 // cStorPoolAddEvent does import of pool, and, if it fails, attemps to create pool based on CSP CR state
 func (c *CStorPoolController) cStorPoolAddEvent(cStorPoolGot *apis.CStorPool) (string, error) {
-	if pool.ImportedCStorPools == nil {
-		pool.ImportedCStorPools = map[string]*apis.CStorPool{}
-	}
-
-	if pool.CStorZpools == nil {
-		pool.CStorZpools = map[string]zpool.Topology{}
-	}
-
 	devIDList, err := c.getDeviceIDs(cStorPoolGot)
 	if err != nil {
 		return string(apis.CStorPoolStatusOffline), errors.Wrapf(err, "failed to get device id of disks for csp %s", cStorPoolGot.Name)

--- a/cmd/maya-apiserver/cstor-operator/spc/storagepool_create_test.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/storagepool_create_test.go
@@ -74,7 +74,7 @@ func FakeDiskCreator(dc *blockdevice.KubernetesClient) {
 				Name: "blockdevice" + diskIdentifier,
 				Labels: map[string]string{
 					"kubernetes.io/hostname": "gke-ashu-cstor-default-pool-a4065fd6-vxsh" + strconv.Itoa(nodeIdentifer),
-					key:                      diskLabel,
+					key: diskLabel,
 				},
 			},
 			Status: ndmapis.DeviceStatus{
@@ -123,7 +123,7 @@ func (focs *PoolCreateConfig) FakeDiskCreator() {
 				Name: "blockdevice" + diskIdentifier,
 				Labels: map[string]string{
 					"kubernetes.io/hostname": "gke-ashu-cstor-default-pool-a4065fd6-vxsh" + strconv.Itoa(nodeIdentifer),
-					key:                      diskLabel,
+					key: diskLabel,
 				},
 			},
 			Status: ndmapis.DeviceStatus{

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node_test.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node_test.go
@@ -70,7 +70,7 @@ func FakeDiskCreator(bdc *blockdevice.KubernetesClient) {
 				Name: "blockdevice" + diskIdentifier,
 				Labels: map[string]string{
 					"kubernetes.io/hostname": "gke-ashu-cstor-default-pool-a4065fd6-vxsh" + strconv.Itoa(nodeIdentifer),
-					key:                      diskLabel,
+					key: diskLabel,
 				},
 			},
 			Status: ndmapis.DeviceStatus{


### PR DESCRIPTION
Signed-off-by: Vitta <vitta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Currently, map that stores info about imported pools is allocated in CStorPoolAddEvent. But, ideally, it should be in initialization code section.
This PR is to move the map allocation to common initialization code section.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests