### PR TITLE
cherry-pick(idiomatic-maya, exporter): pool exporter changes

### DIFF
--- a/cmd/maya-exporter/app/collector/types.go
+++ b/cmd/maya-exporter/app/collector/types.go
@@ -16,6 +16,7 @@ package collector
 
 import (
 	v1 "github.com/openebs/maya/pkg/stats/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type volumeStatus int
@@ -74,4 +75,11 @@ type Parser interface {
 // to collect the stats from the Jiva and Cstor.
 type Getter interface {
 	get() (v1.VolumeStats, error)
+}
+
+// Collector is an interface that is used for initializing
+// various collectors for collecting volume and pool metrics
+type Collector interface {
+	Describe(chan<- *prometheus.Desc)
+	Collect(chan<- prometheus.Metric)
 }

--- a/cmd/maya-exporter/app/collector/zvol/metrics.go
+++ b/cmd/maya-exporter/app/collector/zvol/metrics.go
@@ -44,18 +44,22 @@ type metrics struct {
 	rebuildDoneCount   *prometheus.GaugeVec
 	rebuildFailedCount *prometheus.GaugeVec
 
-	zfsCommandErrorCounter       prometheus.Gauge
-	zfsStatsParseErrorCounter    prometheus.Gauge
-	zfsStatsRejectRequestCounter prometheus.Gauge
+	zfsCommandErrorCounter                      prometheus.Gauge
+	zfsStatsParseErrorCounter                   prometheus.Gauge
+	zfsStatsRejectRequestCounter                prometheus.Gauge
+	zfsStatsNoDataSetAvailableErrorCounter      prometheus.Gauge
+	zfsStatsInitializeLibuzfsClientErrorCounter prometheus.Gauge
 }
 
 type listMetrics struct {
 	used      *prometheus.GaugeVec
 	available *prometheus.GaugeVec
 
-	zfsListParseErrorCounter    prometheus.Gauge
-	zfsListCommandErrorCounter  prometheus.Gauge
-	zfsListRequestRejectCounter prometheus.Gauge
+	zfsListParseErrorCounter                   prometheus.Gauge
+	zfsListCommandErrorCounter                 prometheus.Gauge
+	zfsListRequestRejectCounter                prometheus.Gauge
+	zfsListNoDataSetAvailableErrorCounter      prometheus.Gauge
+	zfsListInitializeLibuzfsClientErrorCounter prometheus.Gauge
 }
 
 type fields struct {
@@ -65,224 +69,338 @@ type fields struct {
 }
 
 // newMetrics initializes fields of the metrics and returns its instance
-func newListMetrics() listMetrics {
-	return listMetrics{
+func newListMetrics() *listMetrics {
+	return new(listMetrics)
+}
 
-		used: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "used_size",
-				Help:      "Used size of pool and volume",
-			},
-			[]string{"name"},
-		),
+func (l *listMetrics) withUsedSize() *listMetrics {
+	l.used = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "volume_replica_used_size",
+			Help:      "Used size of volume replica on a pool",
+		},
+		[]string{"name"},
+	)
+	return l
+}
+func (l *listMetrics) withAvailableSize() *listMetrics {
+	l.available = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "volume_replica_available_size",
+			Help:      "Available size of volume replica on a pool",
+		},
+		[]string{"name"},
+	)
+	return l
+}
 
-		available: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "available_size",
-				Help:      "Available size of pool and volume",
-			},
-			[]string{"name"},
-		),
+func (l *listMetrics) withParseErrorCounter() *listMetrics {
+	l.zfsListParseErrorCounter = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "zfs_list_parse_error",
+			Help:      "Total no of zfs list parse errors",
+		},
+	)
+	return l
+}
 
-		zfsListParseErrorCounter: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "zfs_list_parse_error",
-				Help:      "Total no of zfs list parse errors",
-			},
-		),
+func (l *listMetrics) withCommandErrorCounter() *listMetrics {
+	l.zfsListCommandErrorCounter = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "zfs_list_command_error",
+			Help:      "Total no of zfs command errors",
+		},
+	)
+	return l
+}
 
-		zfsListCommandErrorCounter: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "zfs_list_command_error",
-				Help:      "Total no of zfs command errors",
-			},
-		),
+func (l *listMetrics) withRequestRejectCounter() *listMetrics {
+	l.zfsListRequestRejectCounter = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "zfs_list_request_reject_count",
+			Help:      "Total no of rejected requests of zfs list",
+		},
+	)
+	return l
+}
 
-		zfsListRequestRejectCounter: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "zfs_list_request_reject_count",
-				Help:      "Total no of rejected requests of zfs list",
-			},
-		),
-	}
+func (l *listMetrics) withNoDatasetAvailableErrorCounter() *listMetrics {
+	l.zfsListNoDataSetAvailableErrorCounter = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "zfs_list_no_dataset_available_error_counter",
+			Help:      "Total no of no datasets error in zfs list command",
+		},
+	)
+	return l
+}
+
+func (l *listMetrics) withInitializeLibuzfsClientErrorCounter() *listMetrics {
+	l.zfsListInitializeLibuzfsClientErrorCounter = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "zfs_list_failed_to_initialize_libuzfs_client_error_counter",
+			Help:      "Total no of failed to initialize libuzfs client error in zfs list command",
+		},
+	)
+	return l
 }
 
 // newMetrics initializes fields of the metrics and returns its instance
-func newMetrics() metrics {
-	return metrics{
-		readBytes: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "total_read_bytes",
-				Help:      "Total read in bytes",
-			},
-			[]string{"vol", "pool"},
-		),
+func newMetrics() *metrics {
+	return new(metrics)
+}
 
-		writeBytes: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "total_write_bytes",
-				Help:      "Total write in bytes",
-			},
-			[]string{"vol", "pool"},
-		),
+func (m *metrics) withReadBytes() *metrics {
+	m.readBytes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "total_read_bytes",
+			Help:      "Total read in bytes of volume replica",
+		},
+		[]string{"vol", "pool"},
+	)
+	return m
+}
 
-		readCount: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "total_read_count",
-				Help:      "Total read io count",
-			},
-			[]string{"vol", "pool"},
-		),
+func (m *metrics) withWriteBytes() *metrics {
+	m.writeBytes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "total_write_bytes",
+			Help:      "Total write in bytes of volume replica",
+		},
+		[]string{"vol", "pool"},
+	)
+	return m
+}
 
-		writeCount: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "total_write_count",
-				Help:      "Total write io count",
-			},
-			[]string{"vol", "pool"},
-		),
+func (m *metrics) withReadCount() *metrics {
+	m.readCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "total_read_count",
+			Help:      "Total read io count of volume replica",
+		},
+		[]string{"vol", "pool"},
+	)
+	return m
+}
 
-		syncCount: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "sync_count",
-				Help:      "Total no of sync on replica",
-			},
-			[]string{"vol", "pool"},
-		),
+func (m *metrics) withWriteCount() *metrics {
+	m.writeCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "total_write_count",
+			Help:      "Total write io count of volume replica",
+		},
+		[]string{"vol", "pool"},
+	)
+	return m
+}
 
-		syncLatency: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "sync_latency",
-				Help:      "Sync latency on replica",
-			},
-			[]string{"vol", "pool"},
-		),
+func (m *metrics) withSyncCount() *metrics {
+	m.syncCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "sync_count",
+			Help:      "Total sync io count of volume replica",
+		},
+		[]string{"vol", "pool"},
+	)
+	return m
+}
 
-		readLatency: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "read_latency",
-				Help:      "Read latency on replica",
-			},
-			[]string{"vol", "pool"},
-		),
+func (m *metrics) withSyncLatency() *metrics {
+	m.syncLatency = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "sync_latency",
+			Help:      "Sync latency on volume replica",
+		},
+		[]string{"vol", "pool"},
+	)
+	return m
+}
 
-		writeLatency: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "write_latency",
-				Help:      "Write latency on replica",
-			},
-			[]string{"vol", "pool"},
-		),
+func (m *metrics) withReadLatency() *metrics {
+	m.readLatency = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "read_latency",
+			Help:      "Read latency on volume replica",
+		},
+		[]string{"vol", "pool"},
+	)
+	return m
+}
 
-		replicaStatus: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "replica_status",
-				Help:      `Status of replica (0, 1, 2, 3) = {"Offline", "Healthy", "Degraded", "Rebuilding"}`,
-			},
-			[]string{"vol", "pool"},
-		),
+func (m *metrics) withWriteLatency() *metrics {
+	m.writeLatency = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "write_latency",
+			Help:      "Write latency on volume replica",
+		},
+		[]string{"vol", "pool"},
+	)
+	return m
+}
 
-		inflightIOCount: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "inflight_io_count",
-				Help:      "Inflight IO's count",
-			},
-			[]string{"vol", "pool"},
-		),
+func (m *metrics) withReplicaStatus() *metrics {
+	m.replicaStatus = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "replica_status",
+			Help:      `Status of volume replica (0, 1, 2, 3) = {"Offline", "Healthy", "Degraded", "Rebuilding"}`,
+		},
+		[]string{"vol", "pool"},
+	)
+	return m
+}
 
-		dispatchedIOCount: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "dispatched_io_count",
-				Help:      "Dispatched IO's count",
-			},
-			[]string{"vol", "pool"},
-		),
+func (m *metrics) withinflightIOCount() *metrics {
+	m.inflightIOCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "inflight_io_count",
+			Help:      "Inflight IO's count of volume replica",
+		},
+		[]string{"vol", "pool"},
+	)
+	return m
+}
 
-		rebuildCount: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "rebuild_count",
-				Help:      "Rebuild count",
-			},
-			[]string{"vol", "pool"},
-		),
+func (m *metrics) withDispatchedIOCount() *metrics {
+	m.dispatchedIOCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "dispatched_io_count",
+			Help:      "Dispatched IO's count of volume replica",
+		},
+		[]string{"vol", "pool"},
+	)
+	return m
+}
 
-		rebuildBytes: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "rebuild_bytes",
-				Help:      "Rebuild bytes",
-			},
-			[]string{"vol", "pool"},
-		),
+func (m *metrics) withRebuildCount() *metrics {
+	m.rebuildCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "rebuild_count",
+			Help:      "Rebuild count of volume replica",
+		},
+		[]string{"vol", "pool"},
+	)
+	return m
+}
 
-		rebuildStatus: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "rebuild_status",
-				Help:      `Status of rebuild on replica (0, 1, 2, 3, 4, 5, 6)= {"INIT", "DONE", "SNAP REBUILD INPROGRESS", "ACTIVE DATASET REBUILD INPROGRESS", "ERRORED", "FAILED", "UNKNOWN"}`,
-			},
-			[]string{"vol", "pool"},
-		),
+func (m *metrics) withRebuildBytes() *metrics {
+	m.rebuildBytes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "rebuild_bytes",
+			Help:      "Rebuild bytes of volume replica",
+		},
+		[]string{"vol", "pool"},
+	)
+	return m
+}
 
-		rebuildDoneCount: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "total_rebuild_done",
-				Help:      "Total no of rebuild done on replica",
-			},
-			[]string{"vol", "pool"},
-		),
+func (m *metrics) withRebuildStatus() *metrics {
+	m.rebuildStatus = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "rebuild_status",
+			Help:      `Status of rebuild on volume replica (0, 1, 2, 3, 4, 5, 6)= {"INIT", "DONE", "SNAP REBUILD INPROGRESS", "ACTIVE DATASET REBUILD INPROGRESS", "ERRORED", "FAILED", "UNKNOWN"}`,
+		},
+		[]string{"vol", "pool"},
+	)
+	return m
+}
 
-		rebuildFailedCount: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "total_failed_rebuild",
-				Help:      "Total no of failed rebuilds on replica",
-			},
-			[]string{"vol", "pool"},
-		),
+func (m *metrics) withRebuildDone() *metrics {
+	m.rebuildDoneCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "total_rebuild_done",
+			Help:      "Total no of rebuild done on volume replica",
+		},
+		[]string{"vol", "pool"},
+	)
+	return m
+}
 
-		zfsCommandErrorCounter: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "zfs_command_error",
-				Help:      "Total no of zfs command errors",
-			},
-		),
+func (m *metrics) withFailedRebuild() *metrics {
+	m.rebuildFailedCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "total_failed_rebuild",
+			Help:      "Total no of failed rebuilds on volume replica",
+		},
+		[]string{"vol", "pool"},
+	)
+	return m
+}
 
-		zfsStatsParseErrorCounter: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "zfs_stats_parse_error_counter",
-				Help:      "Total no of zfs stats parse errors",
-			},
-		),
+func (m *metrics) withCommandErrorCounter() *metrics {
+	m.zfsCommandErrorCounter = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "zfs_stats_command_error",
+			Help:      "Total no of zfs command errors",
+		},
+	)
+	return m
+}
 
-		zfsStatsRejectRequestCounter: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace: "openebs",
-				Name:      "zfs_stats_reject_request_count",
-				Help:      "Total no of rejected requests of zfs stats",
-			},
-		),
-	}
+func (m *metrics) withParseErrorCounter() *metrics {
+	m.zfsStatsParseErrorCounter = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "zfs_stats_parse_error_counter",
+			Help:      "Total no of zfs stats parse errors",
+		},
+	)
+	return m
+}
+
+func (m *metrics) withRequestRejectCounter() *metrics {
+	m.zfsStatsRejectRequestCounter = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "zfs_stats_reject_request_count",
+			Help:      "Total no of rejected requests of zfs stats",
+		},
+	)
+	return m
+}
+
+func (m *metrics) withNoDatasetAvailableErrorCounter() *metrics {
+	m.zfsStatsNoDataSetAvailableErrorCounter = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "zfs_stats_no_dataset_available_error_counter",
+			Help:      "Total no of no datasets error in zfs stats command",
+		},
+	)
+	return m
+}
+
+func (m *metrics) withInitializeLibuzfsClientErrorCounter() *metrics {
+	m.zfsStatsInitializeLibuzfsClientErrorCounter = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "zfs_stats_failed_to_initialize_libuzfs_client_error_counter",
+			Help:      "Total no of failed to initialize libuzfs client error in zfs stats command",
+		},
+	)
+	return m
 }
 
 func parseFloat64(e string, m *listMetrics) float64 {

--- a/cmd/maya-exporter/app/collector/zvol/zvol_test.go
+++ b/cmd/maya-exporter/app/collector/zvol/zvol_test.go
@@ -15,264 +15,284 @@
 package zvol
 
 import (
-	"errors"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
-	"regexp"
 	"testing"
-	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
+	types "github.com/openebs/maya/pkg/exec"
+	mock "github.com/openebs/maya/pkg/exec/mock/v1alpha1"
+	mockServer "github.com/openebs/maya/pkg/prometheus/exporter/mock/v1alpha1"
+	zvol "github.com/openebs/maya/pkg/zvol/v1alpha1"
 )
 
-var count int
-
-type testRunner struct {
-	stdout  []byte
-	isError bool
-}
-
-func (r testRunner) RunCombinedOutput(cmd string, args ...string) ([]byte, error) {
-	return nil, nil
-}
-
-func (r testRunner) RunStdoutPipe(cmd string, args ...string) ([]byte, error) {
-	return nil, nil
-}
-
-func (r testRunner) RunCommandWithTimeoutContext(timeout time.Duration, cmd string, args ...string) ([]byte, error) {
-	if r.isError {
-		return nil, errors.New("some dummy error")
-	}
-	return r.stdout, nil
-}
-
-func TestGetZfsStats(t *testing.T) {
+func TestZfsStatsCollector(t *testing.T) {
+	var runner types.Runner
 	cases := map[string]struct {
-		run   testRunner
-		match []*regexp.Regexp
+		zfsStatsOutput string
+		isError        bool
+		expectedOutput []string
 	}{
 		"Test0": {
-			run: testRunner{
-				stdout: []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Healthy","rebuildStatus": "DONE","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
-			},
-			match: []*regexp.Regexp{
-				regexp.MustCompile(`openebs_total_read_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
-				regexp.MustCompile(`openebs_total_write_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
-				regexp.MustCompile(`openebs_total_read_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
-				regexp.MustCompile(`openebs_total_write_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
-				regexp.MustCompile(`openebs_sync_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 100`),
-				regexp.MustCompile(`openebs_sync_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 10`),
-				regexp.MustCompile(`openebs_read_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 150`),
-				regexp.MustCompile(`openebs_write_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 200`),
-				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
-				regexp.MustCompile(`openebs_inflight_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 2000`),
-				regexp.MustCompile(`openebs_dispatched_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 50`),
-				regexp.MustCompile(`openebs_rebuild_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 3`),
-				regexp.MustCompile(`openebs_rebuild_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 500`),
-				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
+			// expected output if there is one volume with different stats and status is Healthy and rebuild status id DONE.
+			zfsStatsOutput: `{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Healthy","rebuildStatus": "DONE","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`,
+			expectedOutput: []string{
+				`openebs_total_read_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`,
+				`openebs_total_write_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`,
+				`openebs_total_read_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`,
+				`openebs_total_write_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`,
+				`openebs_sync_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 100`,
+				`openebs_sync_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 10`,
+				`openebs_read_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 150`,
+				`openebs_write_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 200`,
+				`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1`,
+				`openebs_inflight_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 2000`,
+				`openebs_dispatched_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 50`,
+				`openebs_rebuild_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 3`,
+				`openebs_rebuild_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 500`,
+				`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1`,
 			},
 		},
 		"Test1": {
-			run: testRunner{
-				stdout: []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Offline","rebuildStatus": "INIT","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
-			},
-			match: []*regexp.Regexp{
-				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 0`),
-				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 0`),
+			// expected output if there is one volume with different stats and replica status is Offline and rebuild status is INIT.
+			zfsStatsOutput: `{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Offline","rebuildStatus": "INIT","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`,
+			expectedOutput: []string{
+				`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 0`,
+				`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 0`,
 			},
 		},
 		"Test2": {
-			run: testRunner{
-				stdout: []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Degraded","rebuildStatus": "INIT","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
-			},
-			match: []*regexp.Regexp{
-				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 2`),
-				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 0`),
+			// expected output if there is one volume with different stats and replica status is Degraded and rebuild status is INIT.
+			zfsStatsOutput: `{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Degraded","rebuildStatus": "INIT","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`,
+			expectedOutput: []string{
+				`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 2`,
+				`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 0`,
 			},
 		},
 		"Test3": {
-			run: testRunner{
-				stdout: []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Rebuilding","rebuildStatus": "SNAP REBUILD INPROGRESS","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
-			},
-			match: []*regexp.Regexp{
-				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 3`),
-				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 2`),
+			// expected output if there is one volume with different stats and replica status is Rebuilding and rebuild status is SNAP REBUILD INPROGRESS.
+			zfsStatsOutput: `{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Rebuilding","rebuildStatus": "SNAP REBUILD INPROGRESS","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`,
+			expectedOutput: []string{
+				`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 3`,
+				`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 2`,
 			},
 		},
 		"Test4": {
-			run: testRunner{
-				stdout: []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Rebuilding","rebuildStatus": "ACTIVE DATASET REBUILD INPROGRESS","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
-			},
-			match: []*regexp.Regexp{
-				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 3`),
-				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 3`),
+			// expected output if there is one volume with different stats and replica status is Rebuilding and rebuild status is ACTIVE DATASET REBUILD INPROGRESS.
+			zfsStatsOutput: `{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Rebuilding","rebuildStatus": "ACTIVE DATASET REBUILD INPROGRESS","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`,
+			expectedOutput: []string{
+				`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 3`,
+				`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 3`,
 			},
 		},
 		"Test5": {
-			run: testRunner{
-				stdout: []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Offline","rebuildStatus": "ERRORED  ","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
-			},
-			match: []*regexp.Regexp{
-				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 0`),
-				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 4`),
+			// expected output if there is one volume with different stats and replica status is Offline and rebuild status is ERRORED.
+			zfsStatsOutput: `{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Offline","rebuildStatus": "ERRORED  ","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`,
+			expectedOutput: []string{
+				`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 0`,
+				`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 4`,
 			},
 		},
 
 		"Test6": {
-			run: testRunner{
-				stdout: []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Offline","rebuildStatus": "FAILED","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
-			},
-			match: []*regexp.Regexp{
-				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 0`),
-				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 5`),
+			// expected output if there is one volume with different stats and replica status is Offline and rebuild status is FAILED.
+			zfsStatsOutput: `{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Offline","rebuildStatus": "FAILED","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`,
+			expectedOutput: []string{
+				`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 0`,
+				`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 5`,
 			},
 		},
 		"Test7": {
-			run: testRunner{
-				stdout: []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Offline","rebuildStatus": "UNKNOWN","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
-			},
-			match: []*regexp.Regexp{
-				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 0`),
-				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 6`),
+			// expected output if there is one volume with different stats and replica status is Offline and rebuild status is UNKNOWN.
+			zfsStatsOutput: `{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Offline","rebuildStatus": "UNKNOWN","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`,
+			expectedOutput: []string{
+				`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 0`,
+				`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 6`,
 			},
 		},
 		"Test8": {
-			run: testRunner{
-				isError: true,
-			},
-			match: []*regexp.Regexp{
-				regexp.MustCompile(`openebs_zfs_command_error 1`),
+			// expected error while running zfs binary
+			isError: true,
+			expectedOutput: []string{
+				`openebs_zfs_stats_command_error 1`,
 			},
 		},
 		"Test9": {
-			run: testRunner{
-				stdout: []byte(``),
-			},
-			match: []*regexp.Regexp{
-				regexp.MustCompile(`openebs_zfs_stats_parse_error_counter 1`),
+			// expected empty output from zfs
+			zfsStatsOutput: ``,
+			expectedOutput: []string{
+				`openebs_zfs_stats_parse_error_counter 1`,
 			},
 		},
 		"Test10": {
-			run: testRunner{
-				stdout: []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Healthy","rebuildStatus": "DONE","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50},{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a","status": "Healthy","rebuildStatus": "DONE","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
-			},
-			match: []*regexp.Regexp{
-				regexp.MustCompile(`openebs_total_read_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
-				regexp.MustCompile(`openebs_total_read_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
-				regexp.MustCompile(`openebs_total_write_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
-				regexp.MustCompile(`openebs_total_write_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
-				regexp.MustCompile(`openebs_total_read_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
-				regexp.MustCompile(`openebs_total_read_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
-				regexp.MustCompile(`openebs_total_write_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
-				regexp.MustCompile(`openebs_total_write_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
-				regexp.MustCompile(`openebs_sync_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 100`),
-				regexp.MustCompile(`openebs_sync_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 100`),
-				regexp.MustCompile(`openebs_sync_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 10`),
-				regexp.MustCompile(`openebs_sync_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 10`),
-				regexp.MustCompile(`openebs_read_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 150`),
-				regexp.MustCompile(`openebs_read_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 150`),
-				regexp.MustCompile(`openebs_write_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 200`),
-				regexp.MustCompile(`openebs_write_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 200`),
-				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
-				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
-				regexp.MustCompile(`openebs_inflight_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 2000`),
-				regexp.MustCompile(`openebs_inflight_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 2000`),
-				regexp.MustCompile(`openebs_dispatched_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 50`),
-				regexp.MustCompile(`openebs_dispatched_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 50`),
-				regexp.MustCompile(`openebs_rebuild_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 3`),
-				regexp.MustCompile(`openebs_rebuild_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 3`),
-				regexp.MustCompile(`openebs_rebuild_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 500`),
-				regexp.MustCompile(`openebs_rebuild_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 500`),
-				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
-				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
+			// expected output if there are two volumes with different stats and status is Healthy and rebuild status id DONE.
+			zfsStatsOutput: `{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Healthy","rebuildStatus": "DONE","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50},{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a","status": "Healthy","rebuildStatus": "DONE","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`,
+			expectedOutput: []string{
+				`openebs_total_read_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`,
+				`openebs_total_read_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`,
+				`openebs_total_write_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`,
+				`openebs_total_write_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`,
+				`openebs_total_read_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`,
+				`openebs_total_read_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`,
+				`openebs_total_write_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`,
+				`openebs_total_write_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`,
+				`openebs_sync_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 100`,
+				`openebs_sync_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 100`,
+				`openebs_sync_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 10`,
+				`openebs_sync_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 10`,
+				`openebs_read_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 150`,
+				`openebs_read_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 150`,
+				`openebs_write_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 200`,
+				`openebs_write_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 200`,
+				`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1`,
+				`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1`,
+				`openebs_inflight_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 2000`,
+				`openebs_inflight_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 2000`,
+				`openebs_dispatched_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 50`,
+				`openebs_dispatched_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 50`,
+				`openebs_rebuild_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 3`,
+				`openebs_rebuild_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 3`,
+				`openebs_rebuild_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 500`,
+				`openebs_rebuild_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 500`,
+				`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1`,
+				`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1`,
 			},
 		},
 		"Test11": {
-			run: testRunner{
-				stdout: []byte(`{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Healthy","rebuildStatus": "DONE","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50},{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a","status": "Healthy","rebuildStatus": "DONE","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50},{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a","status": "Healthy","rebuildStatus": "DONE","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`),
+			// expected output if there are three volumes with different stats and status is Healthy and rebuild status id DONE.
+			zfsStatsOutput: `{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Healthy","rebuildStatus": "DONE","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50},{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a","status": "Healthy","rebuildStatus": "DONE","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50},{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a","status": "Healthy","rebuildStatus": "DONE","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`,
+			expectedOutput: []string{
+				`openebs_total_read_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`,
+				`openebs_total_read_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`,
+				`openebs_total_read_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`,
+				`openebs_total_write_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`,
+				`openebs_total_write_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`,
+				`openebs_total_write_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`,
+				`openebs_total_read_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`,
+				`openebs_total_read_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`,
+				`openebs_total_read_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`,
+				`openebs_total_write_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`,
+				`openebs_total_write_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`,
+				`openebs_total_write_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`,
+				`openebs_sync_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 100`,
+				`openebs_sync_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 100`,
+				`openebs_sync_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 100`,
+				`openebs_sync_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 10`,
+				`openebs_sync_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 10`,
+				`openebs_sync_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 10`,
+				`openebs_read_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 150`,
+				`openebs_read_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 150`,
+				`openebs_read_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 150`,
+				`openebs_write_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 200`,
+				`openebs_write_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 200`,
+				`openebs_write_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 200`,
+				`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1`,
+				`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 1`,
+				`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1`,
+				`openebs_inflight_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 2000`,
+				`openebs_inflight_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 2000`,
+				`openebs_inflight_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 2000`,
+				`openebs_dispatched_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 50`,
+				`openebs_dispatched_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 50`,
+				`openebs_dispatched_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 50`,
+				`openebs_rebuild_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 3`,
+				`openebs_rebuild_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 3`,
+				`openebs_rebuild_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 3`,
+				`openebs_rebuild_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 500`,
+				`openebs_rebuild_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 500`,
+				`openebs_rebuild_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 500`,
+				`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1`,
+				`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 1`,
+				`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1`,
 			},
-			match: []*regexp.Regexp{
-				regexp.MustCompile(`openebs_total_read_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
-				regexp.MustCompile(`openebs_total_read_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
-				regexp.MustCompile(`openebs_total_read_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
-				regexp.MustCompile(`openebs_total_write_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
-				regexp.MustCompile(`openebs_total_write_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
-				regexp.MustCompile(`openebs_total_write_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`),
-				regexp.MustCompile(`openebs_total_read_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
-				regexp.MustCompile(`openebs_total_read_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
-				regexp.MustCompile(`openebs_total_read_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
-				regexp.MustCompile(`openebs_total_write_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
-				regexp.MustCompile(`openebs_total_write_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
-				regexp.MustCompile(`openebs_total_write_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`),
-				regexp.MustCompile(`openebs_sync_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 100`),
-				regexp.MustCompile(`openebs_sync_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 100`),
-				regexp.MustCompile(`openebs_sync_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 100`),
-				regexp.MustCompile(`openebs_sync_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 10`),
-				regexp.MustCompile(`openebs_sync_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 10`),
-				regexp.MustCompile(`openebs_sync_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 10`),
-				regexp.MustCompile(`openebs_read_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 150`),
-				regexp.MustCompile(`openebs_read_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 150`),
-				regexp.MustCompile(`openebs_read_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 150`),
-				regexp.MustCompile(`openebs_write_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 200`),
-				regexp.MustCompile(`openebs_write_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 200`),
-				regexp.MustCompile(`openebs_write_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 200`),
-				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
-				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
-				regexp.MustCompile(`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
-				regexp.MustCompile(`openebs_inflight_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 2000`),
-				regexp.MustCompile(`openebs_inflight_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 2000`),
-				regexp.MustCompile(`openebs_inflight_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 2000`),
-				regexp.MustCompile(`openebs_dispatched_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 50`),
-				regexp.MustCompile(`openebs_dispatched_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 50`),
-				regexp.MustCompile(`openebs_dispatched_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 50`),
-				regexp.MustCompile(`openebs_rebuild_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 3`),
-				regexp.MustCompile(`openebs_rebuild_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 3`),
-				regexp.MustCompile(`openebs_rebuild_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 3`),
-				regexp.MustCompile(`openebs_rebuild_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 500`),
-				regexp.MustCompile(`openebs_rebuild_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 500`),
-				regexp.MustCompile(`openebs_rebuild_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 500`),
-				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
-				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
-				regexp.MustCompile(`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1`),
+		},
+		"Test12": {
+			// expected output if there are three volumes with different stats and status of one is Healthy and rebuild status is DONE but status of other two volumes is Degraded and rebuild status is init.
+			zfsStatsOutput: `{"stats": [{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a","status": "Healthy","rebuildStatus": "DONE","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50},{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a","status": "Degraded","rebuildStatus": "INIT","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50},{"name": "cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a/pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a","status": "Degraded","rebuildStatus": "INIT","runningIONum": 0,"rebuildBytes": 500,"rebuildCnt": 3,"rebuildDoneCnt": 2,"rebuildFailedCnt": 0,"readCount": 1000,"readLatency": 150,"readByte": 1024,"writeCount": 1000,"writeLatency": 200,"writeByte": 1024,"syncCount": 100,"syncLatency": 10,"inflightIOCnt": 2000,"dispatchedIOCnt": 50}]}`,
+			expectedOutput: []string{
+				`openebs_total_read_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`,
+				`openebs_total_read_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`,
+				`openebs_total_read_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`,
+				`openebs_total_write_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`,
+				`openebs_total_write_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`,
+				`openebs_total_write_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1024`,
+				`openebs_total_read_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`,
+				`openebs_total_read_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`,
+				`openebs_total_read_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`,
+				`openebs_total_write_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`,
+				`openebs_total_write_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`,
+				`openebs_total_write_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 1000`,
+				`openebs_sync_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 100`,
+				`openebs_sync_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 100`,
+				`openebs_sync_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 100`,
+				`openebs_sync_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 10`,
+				`openebs_sync_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 10`,
+				`openebs_sync_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 10`,
+				`openebs_read_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 150`,
+				`openebs_read_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 150`,
+				`openebs_read_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 150`,
+				`openebs_write_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 200`,
+				`openebs_write_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 200`,
+				`openebs_write_latency{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 200`,
+				`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1`,
+				`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 2`,
+				`openebs_replica_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 2`,
+				`openebs_inflight_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 2000`,
+				`openebs_inflight_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 2000`,
+				`openebs_inflight_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 2000`,
+				`openebs_dispatched_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 50`,
+				`openebs_dispatched_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 50`,
+				`openebs_dispatched_io_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 50`,
+				`openebs_rebuild_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 3`,
+				`openebs_rebuild_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 3`,
+				`openebs_rebuild_count{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 3`,
+				`openebs_rebuild_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 500`,
+				`openebs_rebuild_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 500`,
+				`openebs_rebuild_bytes{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 500`,
+				`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c1698bb-2dc6-11e9-bbe3-42010a80017a"} 1`,
+				`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c2698bb-2dc6-11e9-bbe3-42010a80017a"} 0`,
+				`openebs_rebuild_status{pool="cstor-5ce4639a-2dc1-11e9-bbe3-42010a80017a",vol="pvc-1c3698bb-2dc6-11e9-bbe3-42010a80017a"} 0`,
+			},
+		},
+		"Test13": {
+			// if failed to initialize libuzfs client
+			zfsStatsOutput: zvol.InitializeLibuzfsClientErr.String(),
+			expectedOutput: []string{
+				`openebs_zfs_stats_failed_to_initialize_libuzfs_client_error_counter 1`,
+			},
+		},
+		"Test14": {
+			// if no dataset available
+			zfsStatsOutput: zvol.NoDataSetAvailable.String(),
+			expectedOutput: []string{
+				`openebs_zfs_stats_no_dataset_available_error_counter 1`,
 			},
 		},
 	}
 
 	for name, tt := range cases {
+		tt := tt
 		t.Run(name, func(t *testing.T) {
-			runner = tt.run
-			vol := New()
-			if err := prometheus.Register(vol); err != nil {
-				t.Fatalf("collector failed to register: %s", err)
+			if tt.isError {
+				runner = mock.StdoutBuilder().Error().Build()
+			} else {
+				out := tt.zfsStatsOutput
+				runner = mock.StdoutBuilder().WithOutput(out).Build()
 			}
-
-			server := httptest.NewServer(promhttp.Handler())
-
-			client := http.DefaultClient
-			client.Timeout = 5 * time.Second
-			resp, err := client.Get(server.URL)
-			if err != nil {
-				t.Fatalf("unexpected failed response from prometheus: %s", err)
-			}
-			defer resp.Body.Close()
-
-			buf, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				t.Fatalf("failed reading server response: %s", err)
-			}
-
-			for _, re := range tt.match {
+			// Build prometheus like output using regular expressions
+			out := tt.expectedOutput
+			regex := mockServer.BuildRegex(out)
+			vol := New(runner)
+			stop := make(chan struct{})
+			buf := mockServer.PrometheusService(vol, stop)
+			// expectedOutput the regex after parsing the expected output of zfs
+			// stats command into prometheus's format.
+			for _, re := range regex {
 				if !re.Match(buf) {
 					fmt.Println(string(buf))
-					t.Errorf("failed matching: %q", re)
+					t.Errorf("failed expectedOutputing: %q", re)
 				}
 			}
-			prometheus.Unregister(vol)
-			server.Close()
+			mockServer.Unregister(vol)
+			stop <- struct{}{}
 		})
 	}
 }

--- a/pkg/exec/mock/v1alpha1/mock.go
+++ b/pkg/exec/mock/v1alpha1/mock.go
@@ -1,0 +1,69 @@
+// Copyright © 2018-2019 The OpenEBS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"errors"
+
+	types "github.com/openebs/maya/pkg/exec"
+)
+
+// runner is used to mock os/exec.
+// Expected data is set against its
+// instance.
+type runner struct {
+	// output is the expected return
+	// value
+	output []byte
+
+	// isError flags this instance
+	// to return error
+	isError bool
+}
+
+// Builder ...
+type Builder struct {
+	runner *runner
+}
+
+// StdoutBuilder returns instance of Builder
+func StdoutBuilder() *Builder {
+	return &Builder{runner: &runner{}}
+}
+
+// WithOutput fills output field of runner struct
+func (b *Builder) WithOutput(output string) *Builder {
+	b.runner.output = []byte(output)
+	return b
+}
+
+// Error set isError field of runner to true
+func (b *Builder) Error() *Builder {
+	b.runner.isError = true
+	return b
+}
+
+// Build returns the instance of runner
+func (b *Builder) Build() types.Runner {
+	return b.runner
+}
+
+// RunCommandWithTimeoutContext mock the behaviour of actual RunCommandWithTimeoutContext.
+func (r *runner) RunCommandWithTimeoutContext() ([]byte, error) {
+	if r.isError {
+		return nil, errors.New("dummy error")
+	}
+	return r.output, nil
+}

--- a/pkg/exec/types.go
+++ b/pkg/exec/types.go
@@ -1,0 +1,27 @@
+// Copyright © 2018-2019 The OpenEBS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exec
+
+// Runner interface implements various methods of running binaries which can be
+// modified for unit testing.
+type Runner interface {
+	RunCommandWithTimeoutContext() ([]byte, error)
+}
+
+// BuilderInterface is used for building the object
+// of runner
+type BuilderInterface interface {
+	Build() Runner
+}

--- a/pkg/exec/v1alpha1/exec.go
+++ b/pkg/exec/v1alpha1/exec.go
@@ -1,0 +1,85 @@
+// Copyright © 2018-2019 The OpenEBS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"os/exec"
+	"time"
+
+	"context"
+
+	types "github.com/openebs/maya/pkg/exec"
+	"github.com/pkg/errors"
+)
+
+// runner implements the Runner interface
+type runner struct {
+	timeout time.Duration
+	command string
+	args    []string
+}
+
+// Builder is used for filling the values of runner struct
+type Builder struct {
+	runner *runner
+}
+
+// StdoutBuilder returns instance of builder
+func StdoutBuilder() *Builder {
+	return &Builder{runner: &runner{}}
+}
+
+// WithTimeout fill timeout field of runner struct
+func (b *Builder) WithTimeout(timeout time.Duration) *Builder {
+	b.runner.timeout = timeout
+	return b
+}
+
+// WithCommand fill command field of runner struct
+func (b *Builder) WithCommand(cmd string) *Builder {
+	b.runner.command = cmd
+	return b
+}
+
+// WithArgs fill args field of runner struct
+func (b *Builder) WithArgs(args ...string) *Builder {
+	b.runner.args = args
+	return b
+}
+
+// Build returns the instance of runner
+func (b *Builder) Build() types.Runner {
+	return b.runner
+}
+
+// RunCommandWithTimeoutContext executes command provides and returns stdout
+// error. If command does not returns within given timout interval command will
+// be killed and return "Context time exceeded"
+func (r runner) RunCommandWithTimeoutContext() ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), r.timeout)
+	defer cancel()
+
+	// #nosec
+	out, err := exec.CommandContext(ctx, r.command, r.args...).CombinedOutput()
+	if err != nil {
+		select {
+		case <-ctx.Done():
+			return nil, errors.Wrapf(ctx.Err(), "Failed to run command: %v %v", r.command, r.args)
+		default:
+			return nil, err
+		}
+	}
+	return out, nil
+}

--- a/pkg/prometheus/exporter/mock/v1alpha1/mock.go
+++ b/pkg/prometheus/exporter/mock/v1alpha1/mock.go
@@ -1,0 +1,80 @@
+// Copyright © 2018-2019 The OpenEBS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// BuildRegex returns the regular expression look alike prometheus's
+// response to get request.
+func BuildRegex(list []string) []*regexp.Regexp {
+	regexList := make([]*regexp.Regexp, 0)
+	for _, r := range list {
+		regexList = append(regexList, regexp.MustCompile(r))
+	}
+	return regexList
+}
+
+// PrometheusService is used to mock the behaviour of prometheus's client-go
+// apis for testing purpose.
+// Here, it registers the collector and then starts a test http server and send
+// a get request to which server reply with the response as expected
+func PrometheusService(col prometheus.Collector, stop chan struct{}) []byte {
+	if err := prometheus.Register(col); err != nil {
+		s := fmt.Sprintf("collector failed to register: %s", err)
+		panic(s)
+	}
+	var server *httptest.Server
+	start := make(chan struct{})
+	go func(start, stop chan struct{}) {
+		server = httptest.NewServer(promhttp.Handler())
+		start <- struct{}{}
+		<-stop
+	}(start, stop)
+
+	<-start
+	client := http.DefaultClient
+	client.Timeout = 5 * time.Second
+	resp, err := client.Get(server.URL)
+	if err != nil {
+		s := fmt.Sprintf("unexpected failed response from prometheus: %s", err)
+		panic(s)
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	buf, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		s := fmt.Sprintf("failed reading server response: %s", err)
+		panic(s)
+	}
+	return buf
+}
+
+// Unregister unregister the collector
+func Unregister(col prometheus.Collector) bool {
+	return prometheus.Unregister(col)
+}


### PR DESCRIPTION
This commit implements pool exporter as per idiomatic standards.

- Move mock functions for prometheus into collector/mock package so that it can be utilized by all the collectors.
- Move mock functions of RealRunner structure into pkg/util and make it public.
- Remove the goroutines for verifying the reject request counter.
- Fix namings of the Test functions.

Add following counters:
- zpoolInitializeLibuzfsClientErrorCounter
- zfsStatsNoDataSetAvailableErrorCounter
- zfsStatsInitializeLibuzfsClientErrorCounter
- zfsListNoDataSetAvailableErrorCounter
- zfsListInitializeLibuzfsClientErrorCounter

break each metrics into individual function

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests