### PR TITLE
refact(bdd, jiva) added data consistency check for clone creation BDD

### DIFF
--- a/pkg/kubernetes/pod/v1alpha1/build.go
+++ b/pkg/kubernetes/pod/v1alpha1/build.go
@@ -18,6 +18,8 @@ package v1alpha1
 
 import (
 	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
+	container "github.com/openebs/maya/pkg/kubernetes/container/v1alpha1"
+	volume "github.com/openebs/maya/pkg/kubernetes/volume/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -35,15 +37,67 @@ func NewBuilder() *Builder {
 // WithName sets the Name field of Pod with provided value.
 func (b *Builder) WithName(name string) *Builder {
 	if len(name) == 0 {
-		b.errs = append(b.errs, errors.New("failed to build Pod object: missing Pod name"))
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build Pod object: missing Pod name"),
+		)
 		return b
 	}
 	b.pod.object.Name = name
 	return b
 }
 
+// WithNamespace sets the Namespace field of Pod with provided value.
+func (b *Builder) WithNamespace(namespace string) *Builder {
+	if len(namespace) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build Pod object: missing namespace"),
+		)
+		return b
+	}
+	b.pod.object.Namespace = namespace
+	return b
+}
+
+// WithContainerBuilder adds a container to this pod object.
+//
+// NOTE:
+//   container details are present in the provided container
+// builder object
+func (b *Builder) WithContainerBuilder(
+	containerBuilder *container.Builder,
+) *Builder {
+	containerObj, err := containerBuilder.Build()
+	if err != nil {
+		b.errs = append(b.errs, errors.Wrap(err, "failed to build pod"))
+		return b
+	}
+	b.pod.object.Spec.Containers = append(
+		b.pod.object.Spec.Containers,
+		containerObj,
+	)
+	return b
+}
+
+// WithVolumeBuilder sets Volumes field of deployment.
+func (b *Builder) WithVolumeBuilder(volumeBuilder *volume.Builder) *Builder {
+	vol, err := volumeBuilder.Build()
+	if err != nil {
+		b.errs = append(b.errs, errors.Wrap(err, "failed to build deployment"))
+		return b
+	}
+	b.pod.object.Spec.Volumes = append(
+		b.pod.object.Spec.Volumes,
+		*vol,
+	)
+	return b
+}
+
 // WithRestartPolicy sets the RestartPolicy field in Pod with provided arguments
-func (b *Builder) WithRestartPolicy(restartPolicy corev1.RestartPolicy) *Builder {
+func (b *Builder) WithRestartPolicy(
+	restartPolicy corev1.RestartPolicy,
+) *Builder {
 	b.pod.object.Spec.RestartPolicy = restartPolicy
 	return b
 }
@@ -51,7 +105,10 @@ func (b *Builder) WithRestartPolicy(restartPolicy corev1.RestartPolicy) *Builder
 // WithNodeName sets the NodeName field of Pod with provided value.
 func (b *Builder) WithNodeName(nodeName string) *Builder {
 	if len(nodeName) == 0 {
-		b.errs = append(b.errs, errors.New("failed to build Pod object: missing Pod node name"))
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build Pod object: missing Pod node name"),
+		)
 		return b
 	}
 	b.pod.object.Spec.NodeName = nodeName
@@ -61,7 +118,10 @@ func (b *Builder) WithNodeName(nodeName string) *Builder {
 // WithContainers sets the Containers field in Pod with provided arguments
 func (b *Builder) WithContainers(containers []corev1.Container) *Builder {
 	if len(containers) == 0 {
-		b.errs = append(b.errs, errors.New("failed to build Pod object: missing containers"))
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build Pod object: missing containers"),
+		)
 		return b
 	}
 	b.pod.object.Spec.Containers = containers
@@ -76,7 +136,10 @@ func (b *Builder) WithContainer(container corev1.Container) *Builder {
 // WithVolumes sets the Volumes field in Pod with provided arguments
 func (b *Builder) WithVolumes(volumes []corev1.Volume) *Builder {
 	if len(volumes) == 0 {
-		b.errs = append(b.errs, errors.New("failed to build Pod object: missing volumes"))
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build Pod object: missing volumes"),
+		)
 		return b
 	}
 	b.pod.object.Spec.Volumes = volumes

--- a/pkg/kubernetes/pod/v1alpha1/kubernetes.go
+++ b/pkg/kubernetes/pod/v1alpha1/kubernetes.go
@@ -44,6 +44,10 @@ type getKubeConfigFn func() (config *rest.Config, err error)
 // abstracts fetching of config from kubeConfigPath
 type getKubeConfigForPathFn func(kubeConfigPath string) (config *rest.Config, err error)
 
+// createFn is a typed function that abstracts
+// creation of pod
+type createFn func(cli *clientset.Clientset, namespace string, pod *corev1.Pod) (*corev1.Pod, error)
+
 // listFn is a typed function that abstracts
 // listing of pods
 type listFn func(cli *clientset.Clientset, namespace string, opts metav1.ListOptions) (*corev1.PodList, error)
@@ -117,6 +121,7 @@ type KubeClient struct {
 	getKubeConfigForPath getKubeConfigForPathFn
 	getClientset         getClientsetFn
 	getClientsetForPath  getClientsetForPathFn
+	create               createFn
 	list                 listFn
 	del                  deleteFn
 	get                  getFn
@@ -143,7 +148,7 @@ func (k *KubeClient) withDefaults() {
 	}
 	if k.getKubeConfigForPath == nil {
 		k.getKubeConfigForPath = func(kubeConfigPath string) (config *rest.Config, err error) {
-			return client.New(client.WithKubeConfigPath(kubeConfigPath)).Config()
+			return client.New(client.WithKubeConfigPath(kubeConfigPath)).GetConfigForPathOrDirect()
 		}
 	}
 	if k.getClientset == nil {
@@ -154,6 +159,11 @@ func (k *KubeClient) withDefaults() {
 	if k.getClientsetForPath == nil {
 		k.getClientsetForPath = func(kubeConfigPath string) (clients *clientset.Clientset, err error) {
 			return client.New(client.WithKubeConfigPath(kubeConfigPath)).Clientset()
+		}
+	}
+	if k.create == nil {
+		k.create = func(cli *clientset.Clientset, namespace string, pod *corev1.Pod) (*corev1.Pod, error) {
+			return cli.CoreV1().Pods(namespace).Create(pod)
 		}
 	}
 	if k.list == nil {
@@ -217,7 +227,8 @@ func (k *KubeClient) WithKubeConfig(config *rest.Config) *KubeClient {
 	return k
 }
 
-func (k *KubeClient) getClientsetForPathOrDirect() (*clientset.Clientset, error) {
+func (k *KubeClient) getClientsetForPathOrDirect() (
+	*clientset.Clientset, error) {
 	if k.kubeConfigPath != "" {
 		return k.getClientsetForPath(k.kubeConfigPath)
 	}
@@ -278,26 +289,53 @@ func (k *KubeClient) Delete(name string, opts *metav1.DeleteOptions) error {
 	}
 	cli, err := k.getClientsetOrCached()
 	if err != nil {
-		return errors.Wrapf(err, "failed to delete pod {%s}: failed to get clientset", name)
+		return errors.Wrapf(
+			err,
+			"failed to delete pod {%s}: failed to get clientset",
+			name,
+		)
 	}
 	return k.del(cli, k.namespace, name, opts)
 }
 
+// Create creates a pod in specified namespace in kubernetes cluster
+func (k *KubeClient) Create(pod *corev1.Pod) (*corev1.Pod, error) {
+	if pod == nil {
+		return nil, errors.New("failed to create pod: nil pod object")
+	}
+	cli, err := k.getClientsetOrCached()
+	if err != nil {
+		return nil, errors.Wrapf(
+			err,
+			"failed to create pod {%s} in namespace {%s}",
+			pod.Name,
+			pod.Namespace,
+		)
+	}
+	return k.create(cli, k.namespace, pod)
+}
+
 // Get gets a pod object present in kubernetes cluster
-func (k *KubeClient) Get(name string, opts metav1.GetOptions) (*corev1.Pod, error) {
+func (k *KubeClient) Get(name string,
+	opts metav1.GetOptions) (*corev1.Pod, error) {
 	if len(name) == 0 {
 		return nil, errors.New("failed to get pod: missing pod name")
 	}
 	cli, err := k.getClientsetOrCached()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get pod {%s}: failed to get clientset", name)
+		return nil, errors.Wrapf(
+			err,
+			"failed to get pod {%s}: failed to get clientset",
+			name,
+		)
 	}
 	return k.get(cli, k.namespace, name, opts)
 }
 
 // GetRaw gets pod object for a given name and namespace present
 // in kubernetes cluster and returns result in raw byte.
-func (k *KubeClient) GetRaw(name string, opts metav1.GetOptions) ([]byte, error) {
+func (k *KubeClient) GetRaw(name string,
+	opts metav1.GetOptions) ([]byte, error) {
 	p, err := k.Get(name, opts)
 	if err != nil {
 		return nil, err

--- a/pkg/kubernetes/pod/v1alpha1/pod.go
+++ b/pkg/kubernetes/pod/v1alpha1/pod.go
@@ -45,6 +45,17 @@ func (pl *PodList) ToAPIList() *corev1.PodList {
 	return plist
 }
 
+type podBuildOption func(*Pod)
+
+// NewForAPIObject returns a new instance of Pod
+func NewForAPIObject(obj *corev1.Pod, opts ...podBuildOption) *Pod {
+	p := &Pod{object: obj}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
+}
+
 // Len returns the number of items present in the PodList
 func (pl *PodList) Len() int {
 	return len(pl.items)

--- a/tests/jiva/clone/provision_test.go
+++ b/tests/jiva/clone/provision_test.go
@@ -21,30 +21,34 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openebs/maya/tests/jiva"
 
+	container "github.com/openebs/maya/pkg/kubernetes/container/v1alpha1"
 	pvc "github.com/openebs/maya/pkg/kubernetes/persistentvolumeclaim/v1alpha1"
+	pod "github.com/openebs/maya/pkg/kubernetes/pod/v1alpha1"
 	snap "github.com/openebs/maya/pkg/kubernetes/snapshot/v1alpha1"
+	volume "github.com/openebs/maya/pkg/kubernetes/volume/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
-	replicaLabel = "openebs.io/replica=jiva-replica"
-	ctrlLabel    = "openebs.io/controller=jiva-controller"
-	accessModes  = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
-	capacity     = "5G"
-	pvcObj       *corev1.PersistentVolumeClaim
-	cloneObj     *corev1.PersistentVolumeClaim
-	cloneLable   = "openebs.io/persistent-volume-claim=jiva-clone"
+	accessModes         = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
+	capacity            = "5G"
+	pvcObj              *corev1.PersistentVolumeClaim
+	cloneObj            *corev1.PersistentVolumeClaim
+	cloneLable          = "openebs.io/persistent-volume-claim=jiva-clone"
+	podObj, clonePodObj *corev1.Pod
 )
 
 var _ = Describe("[jiva] TEST JIVA CLONE CREATION", func() {
 	var (
-		pvcName   = "jiva-pvc"
-		snapName  = "jiva-snapshot"
-		cloneName = "jiva-clone"
+		pvcName      = "jiva-pvc"
+		snapName     = "jiva-snapshot"
+		cloneName    = "jiva-clone"
+		appName      = "busybox-jiva"
+		cloneAppName = "busybox-jiva-clone"
 	)
 
-	When("jiva pvc with replicacount n is created", func() {
+	When("pvc with replicacount n is created", func() {
 		It("should create 1 controller pod and n replica pod", func() {
 
 			By("building a pvc")
@@ -62,7 +66,8 @@ var _ = Describe("[jiva] TEST JIVA CLONE CREATION", func() {
 			)
 
 			By("creating above pvc")
-			_, err = ops.PVCClient.WithNamespace(namespaceObj.Name).Create(pvcObj)
+			_, err = ops.PVCClient.WithNamespace(namespaceObj.Name).
+				Create(pvcObj)
 			Expect(err).To(
 				BeNil(),
 				"while creating pvc {%s} in namespace {%s}",
@@ -71,16 +76,79 @@ var _ = Describe("[jiva] TEST JIVA CLONE CREATION", func() {
 			)
 
 			By("verifying controller pod count")
-			controllerPodCount := ops.GetPodRunningCountEventually(namespaceObj.Name, ctrlLabel, 1)
-			Expect(controllerPodCount).To(Equal(1), "while checking controller pod count")
+			controllerPodCount := ops.GetPodRunningCountEventually(
+				namespaceObj.Name,
+				jiva.CtrlLabel,
+				1,
+			)
+			Expect(controllerPodCount).To(
+				Equal(1),
+				"while checking controller pod count",
+			)
 
 			By("verifying replica pod count")
-			replicaPodCount := ops.GetPodRunningCountEventually(namespaceObj.Name, replicaLabel, jiva.ReplicaCount)
-			Expect(replicaPodCount).To(Equal(jiva.ReplicaCount), "while checking replica pod count")
+			replicaPodCount := ops.GetPodRunningCountEventually(
+				namespaceObj.Name,
+				jiva.ReplicaLabel,
+				jiva.ReplicaCount,
+			)
+			Expect(replicaPodCount).To(
+				Equal(jiva.ReplicaCount),
+				"while checking replica pod count",
+			)
 
 			By("verifying status as bound")
-			status := ops.IsPVCBound(pvcName)
+			status := ops.IsPVCBoundEventually(pvcName)
 			Expect(status).To(Equal(true), "while checking status equal to bound")
+
+		})
+	})
+
+	When("creating application pod with above pvc as volume", func() {
+		It("should create a running pod", func() {
+			podObj, err = pod.NewBuilder().
+				WithName(appName).
+				WithNamespace(namespaceObj.Name).
+				WithContainerBuilder(
+					container.NewBuilder().
+						WithName("busybox").
+						WithImage("busybox").
+						WithCommand(
+							[]string{
+								"sh",
+								"-c",
+								"date > /mnt/store1/date.txt; sync; sleep 5; sync; tail -f /dev/null;",
+							},
+						).
+						WithVolumeMounts(
+							[]corev1.VolumeMount{
+								corev1.VolumeMount{
+									Name:      "demo-vol1",
+									MountPath: "/mnt/store1",
+								},
+							},
+						),
+				).
+				WithVolumeBuilder(
+					volume.NewBuilder().
+						WithName("demo-vol1").
+						WithPVCSource(pvcName),
+				).
+				Build()
+			Expect(err).ShouldNot(HaveOccurred(), "while building pod {%s}", appName)
+
+			By("creating pod with above pvc as volume")
+			podObj, err = ops.PodClient.WithNamespace(namespaceObj.Name).Create(podObj)
+			Expect(err).ShouldNot(
+				HaveOccurred(),
+				"while creating pod {%s} in namespace {%s}",
+				appName,
+				namespaceObj.Name,
+			)
+
+			By("verifying pod is running")
+			status := ops.IsPodRunningEventually(namespaceObj.Name, appName)
+			Expect(status).To(Equal(true), "while checking status of pod {%s}", appName)
 
 		})
 	})
@@ -150,8 +218,131 @@ var _ = Describe("[jiva] TEST JIVA CLONE CREATION", func() {
 			)
 
 			By("verifying clone pod count")
-			clonePodCount := ops.GetPodRunningCountEventually(namespaceObj.Name, cloneLable, jiva.ReplicaCount+1)
-			Expect(clonePodCount).To(Equal(jiva.ReplicaCount+1), "while checking clone pvc pod count")
+			clonePodCount := ops.GetPodRunningCountEventually(
+				namespaceObj.Name,
+				cloneLable,
+				jiva.ReplicaCount+1,
+			)
+			Expect(clonePodCount).To(
+				Equal(jiva.ReplicaCount+1),
+				"while checking clone pvc pod count",
+			)
+
+			By("verifying status as bound")
+			status := ops.IsPVCBound(cloneName)
+			Expect(status).To(Equal(true), "while checking status equal to bound")
+
+		})
+	})
+
+	When("creating application pod with above clone pvc as volume", func() {
+		It("should create a running pod", func() {
+			clonePodObj, err = pod.NewBuilder().
+				WithName(cloneAppName).
+				WithNamespace(namespaceObj.Name).
+				WithContainerBuilder(
+					container.NewBuilder().
+						WithName("busybox").
+						WithImage("busybox").
+						WithCommand(
+							[]string{
+								"sh",
+								"-c",
+								"tail -f /dev/null",
+							},
+						).
+						WithVolumeMounts(
+							[]corev1.VolumeMount{
+								corev1.VolumeMount{
+									Name:      "demo-vol1",
+									MountPath: "/mnt/store1",
+								},
+							},
+						),
+				).
+				WithVolumeBuilder(
+					volume.NewBuilder().
+						WithName("demo-vol1").
+						WithPVCSource(cloneName),
+				).
+				Build()
+			Expect(err).ShouldNot(
+				HaveOccurred(),
+				"while building pod {%s}",
+				cloneAppName,
+			)
+
+			By("creating pod with above pvc as volume")
+			clonePodObj, err = ops.PodClient.WithNamespace(namespaceObj.Name).
+				Create(clonePodObj)
+			Expect(err).ShouldNot(
+				HaveOccurred(),
+				"while creating pod {%s} in namespace {%s}",
+				cloneAppName,
+				namespaceObj.Name,
+			)
+
+			By("verifying pod is running")
+			status := ops.IsPodRunningEventually(namespaceObj.Name, cloneAppName)
+			Expect(status).To(
+				Equal(true),
+				"while checking status of pod {%s}",
+				cloneAppName,
+			)
+
+		})
+	})
+
+	When("verifying data consistency in pvc and clone pvc", func() {
+		It("should have consistent data between the two pvcs", func() {
+			By("fetching data from original pvc")
+			podOutput, err := ops.PodClient.WithNamespace(namespaceObj.Name).
+				Exec(
+					podObj.Name,
+					&corev1.PodExecOptions{
+						Command: []string{
+							"sh",
+							"-c",
+							"md5sum mnt/store1/date.txt",
+						},
+						Container: "busybox",
+						Stdin:     false,
+						Stdout:    true,
+						Stderr:    true,
+					},
+				)
+			Expect(err).ShouldNot(HaveOccurred(), "while exec in application pod")
+
+			By("fetching data from clone pvc")
+			clonePodOutput, err := ops.PodClient.WithNamespace(namespaceObj.Name).
+				Exec(
+					clonePodObj.Name,
+					&corev1.PodExecOptions{
+						Command: []string{
+							"sh",
+							"-c",
+							"md5sum mnt/store1/date.txt",
+						},
+						Container: "busybox",
+						Stdin:     false,
+						Stdout:    true,
+						Stderr:    true,
+					},
+				)
+			Expect(err).ShouldNot(HaveOccurred(), "while exec in clone application pod")
+
+			By("veryfing data consistency")
+			Expect(podOutput).To(Equal(clonePodOutput), "while checking data consistency")
+
+			By("deleting application pod")
+			err = ops.PodClient.WithNamespace(namespaceObj.Name).
+				Delete(podObj.Name, &metav1.DeleteOptions{})
+			Expect(err).ShouldNot(HaveOccurred(), "while deleting application pod")
+
+			By("deleting clone application pod")
+			err = ops.PodClient.WithNamespace(namespaceObj.Name).
+				Delete(clonePodObj.Name, &metav1.DeleteOptions{})
+			Expect(err).ShouldNot(HaveOccurred(), "while deleting clone application pod")
 
 		})
 	})
@@ -160,7 +351,8 @@ var _ = Describe("[jiva] TEST JIVA CLONE CREATION", func() {
 		It("should remove clone pvc pods", func() {
 
 			By("deleting above clone pvc")
-			err := ops.PVCClient.Delete(cloneName, &metav1.DeleteOptions{})
+			err := ops.PVCClient.WithNamespace(namespaceObj.Name).
+				Delete(cloneName, &metav1.DeleteOptions{})
 			Expect(err).To(
 				BeNil(),
 				"while deleting clone pvc {%s} in namespace {%s}",
@@ -169,7 +361,11 @@ var _ = Describe("[jiva] TEST JIVA CLONE CREATION", func() {
 			)
 
 			By("verifying clone pvc pods as 0")
-			clonePodCount := ops.GetPodRunningCountEventually(namespaceObj.Name, cloneLable, 0)
+			clonePodCount := ops.GetPodRunningCountEventually(
+				namespaceObj.Name,
+				cloneLable,
+				0,
+			)
 			Expect(clonePodCount).To(Equal(0), "while checking clone pvc pod count")
 
 			By("verifying deleted clone pvc")
@@ -202,7 +398,8 @@ var _ = Describe("[jiva] TEST JIVA CLONE CREATION", func() {
 		It("should not have any jiva controller and replica pods", func() {
 
 			By("deleting above pvc")
-			err := ops.PVCClient.Delete(pvcName, &metav1.DeleteOptions{})
+			err := ops.PVCClient.WithNamespace(namespaceObj.Name).
+				Delete(pvcName, &metav1.DeleteOptions{})
 			Expect(err).To(
 				BeNil(),
 				"while deleting pvc {%s} in namespace {%s}",
@@ -211,11 +408,19 @@ var _ = Describe("[jiva] TEST JIVA CLONE CREATION", func() {
 			)
 
 			By("verifying controller pod count as 0")
-			controllerPodCount := ops.GetPodRunningCountEventually(namespaceObj.Name, ctrlLabel, 0)
+			controllerPodCount := ops.GetPodRunningCountEventually(
+				namespaceObj.Name,
+				jiva.CtrlLabel,
+				0,
+			)
 			Expect(controllerPodCount).To(Equal(0), "while checking controller pod count")
 
 			By("verifying replica pod count as 0")
-			replicaPodCount := ops.GetPodRunningCountEventually(namespaceObj.Name, replicaLabel, 0)
+			replicaPodCount := ops.GetPodRunningCountEventually(
+				namespaceObj.Name,
+				jiva.ReplicaLabel,
+				0,
+			)
 			Expect(replicaPodCount).To(Equal(0), "while checking replica pod count")
 
 			By("verifying deleted pvc")

--- a/tests/operations.go
+++ b/tests/operations.go
@@ -312,6 +312,20 @@ func (ops *Operations) IsPVCBoundEventually(pvcName string) bool {
 		Should(BeTrue())
 }
 
+// IsPodRunningEventually checks if the pvc is bound or not eventually
+func (ops *Operations) IsPodRunningEventually(namespace, podName string) bool {
+	return Eventually(func() bool {
+		p, err := ops.PodClient.
+			WithNamespace(namespace).
+			Get(podName, metav1.GetOptions{})
+		Expect(err).ShouldNot(HaveOccurred())
+		return pod.NewForAPIObject(p).
+			IsRunning()
+	},
+		150, 10).
+		Should(BeTrue())
+}
+
 // GetSnapshotTypeEventually returns type of snapshot eventually
 func (ops *Operations) GetSnapshotTypeEventually(snapName string) string {
 	var snaptype string


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Adds data consistency check after creating clone pvc using two application pods.

**Sample test output**:
```
user:clone$ ginkgo -v -- -kubeconfig=/home/user/.kube/config
Running Suite: Test jiva clone provisioning
===========================================
Random Seed: 1559818349
Will run 9 of 9 specs

STEP: waiting for maya-apiserver pod to come into running state
STEP: waiting for openebs-provisioner pod to come into running state
STEP: waiting for openebs-snapshot-operator pod to come into running state
STEP: building a namespace
STEP: building a storageclass
STEP: creating a namespace
STEP: creating a storageclass
[jiva] TEST JIVA CLONE CREATION when pvc with replicacount n is created 
  should create 1 controller pod and n replica pod
  /home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:52
STEP: building a pvc
STEP: creating above pvc
STEP: verifying controller pod count
STEP: verifying replica pod count
STEP: verifying status as bound

• [SLOW TEST:58.385 seconds]
[jiva] TEST JIVA CLONE CREATION
/home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:42
  when pvc with replicacount n is created
  /home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:51
    should create 1 controller pod and n replica pod
    /home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:52
------------------------------
[jiva] TEST JIVA CLONE CREATION when creating application pod with above pvc as volume 
  should create a running pod
  /home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:93
STEP: creating pod with above pvc as volume
STEP: verifying pod is running

• [SLOW TEST:40.959 seconds]
[jiva] TEST JIVA CLONE CREATION
/home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:42
  when creating application pod with above pvc as volume
  /home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:92
    should create a running pod
    /home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:93
------------------------------
[jiva] TEST JIVA CLONE CREATION when jiva snapshot is created 
  should create a snapshot with type ready
  /home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:142
STEP: building a snapshot
STEP: creating above snapshot
STEP: verifying type as ready

• [SLOW TEST:5.164 seconds]
[jiva] TEST JIVA CLONE CREATION
/home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:42
  when jiva snapshot is created
  /home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:141
    should create a snapshot with type ready
    /home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:142
------------------------------
[jiva] TEST JIVA CLONE CREATION when jiva clone pvc is created 
  should create same number of pods as above pvc
  /home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:174
STEP: building a clone pvc
STEP: creating above clone pvc
STEP: verifying clone pod count

• [SLOW TEST:57.947 seconds]
[jiva] TEST JIVA CLONE CREATION
/home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:42
  when jiva clone pvc is created
  /home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:173
    should create same number of pods as above pvc
    /home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:174
------------------------------
[jiva] TEST JIVA CLONE CREATION when creating application pod with above pvc as volume 
  should create a running pod
  /home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:213
STEP: creating pod with above pvc as volume
STEP: verifying pod is running

• [SLOW TEST:82.378 seconds]
[jiva] TEST JIVA CLONE CREATION
/home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:42
  when creating application pod with above pvc as volume
  /home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:212
    should create a running pod
    /home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:213
------------------------------
[jiva] TEST JIVA CLONE CREATION when verifying data consistency in pvc and clone pvc 
  should have consistent data between the two pvcs
  /home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:262
STEP: fetching data from original pvc
STEP: fetching data from clone pvc
STEP: veryfing data consistency
STEP: deleting application pod
STEP: deleting clone application pod
•
------------------------------
[jiva] TEST JIVA CLONE CREATION when deleting clone pvc 
  should remove clone pvc pods
  /home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:314
STEP: deleting above clone pvc
STEP: verifying clone pvc pods as 0
STEP: verifying deleted clone pvc

• [SLOW TEST:76.881 seconds]
[jiva] TEST JIVA CLONE CREATION
/home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:42
  when deleting clone pvc
  /home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:313
    should remove clone pvc pods
    /home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:314
------------------------------
[jiva] TEST JIVA CLONE CREATION when jiva snapshot is deleted 
  should remove above snapshot
  /home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:338
STEP: deleting above snapshot
STEP: verifying deleted snapshot
•
------------------------------
[jiva] TEST JIVA CLONE CREATION when jiva pvc is deleted 
  should not have any jiva controller and replica pods
  /home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:357
STEP: deleting above pvc
STEP: verifying controller pod count as 0
STEP: verifying replica pod count as 0
STEP: verifying deleted pvc

• [SLOW TEST:39.030 seconds]
[jiva] TEST JIVA CLONE CREATION
/home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:42
  when jiva pvc is deleted
  /home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:356
    should not have any jiva controller and replica pods
    /home/user/work/src/github.com/openebs/maya/tests/jiva/clone/provision_test.go:357
------------------------------
STEP: deleting storageclass
STEP: deleting namespace

Ran 9 of 9 Specs in 365.055 seconds
SUCCESS! -- 9 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 6m9.948727902s
Test Suite Passed

```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests