### PR TITLE
feat(cstor-operator): add a support to create pools on unclaimed BD in manual mode

### DIFF
--- a/cmd/maya-apiserver/cstor-operator/spc/handler.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/handler.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/golang/glog"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
-	blockdevice "github.com/openebs/maya/pkg/blockdevice/v1alpha1"
 	openebs "github.com/openebs/maya/pkg/client/generated/clientset/versioned"
 	env "github.com/openebs/maya/pkg/env/v1alpha1"
 	"github.com/pkg/errors"
@@ -192,18 +191,6 @@ func validateAutoSpcMaxPool(spc *apis.StoragePoolClaim) error {
 		}
 		if *maxPools < 0 {
 			return errors.Errorf("aborting storagepool create operation for %s as invalid maxPool value %d", spc.Name, maxPools)
-		}
-	}
-	return nil
-}
-
-// validateBDCount validates the block device count in case of manual
-// provisioning
-func validateBDCount(spc *apis.StoragePoolClaim) error {
-	if isManualProvisioning(spc) {
-		minReqBDCount := blockdevice.DefaultDiskCount[spc.Spec.PoolSpec.PoolType]
-		if len(spc.Spec.BlockDevices.BlockDeviceList)%minReqBDCount != 0 {
-			return errors.Errorf("validation of spc object is failed as invalid no.of of block device  in spc %s", spc.Name)
 		}
 	}
 	return nil

--- a/cmd/maya-apiserver/cstor-operator/spc/handler.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/handler.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/golang/glog"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	blockdevice "github.com/openebs/maya/pkg/blockdevice/v1alpha1"
 	openebs "github.com/openebs/maya/pkg/client/generated/clientset/versioned"
 	env "github.com/openebs/maya/pkg/env/v1alpha1"
 	"github.com/pkg/errors"
@@ -159,6 +160,7 @@ type validateFunc func(*apis.StoragePoolClaim) error
 var validateFuncList = []validateFunc{
 	validatePoolType,
 	validateDiskType,
+	validateBDCount,
 	validateAutoSpcMaxPool,
 }
 
@@ -191,6 +193,18 @@ func validateAutoSpcMaxPool(spc *apis.StoragePoolClaim) error {
 		}
 		if *maxPools < 0 {
 			return errors.Errorf("aborting storagepool create operation for %s as invalid maxPool value %d", spc.Name, maxPools)
+		}
+	}
+	return nil
+}
+
+// validateBDCount validates the block device count in case of manual
+// provisioning
+func validateBDCount(spc *apis.StoragePoolClaim) error {
+	if isManualProvisioning(spc) {
+		minReqBDCount := blockdevice.DefaultDiskCount[spc.Spec.PoolSpec.PoolType]
+		if len(spc.Spec.BlockDevices.BlockDeviceList)%minReqBDCount != 0 {
+			return errors.Errorf("validation of spc object is failed as invalid no.of of block device  in spc %s", spc.Name)
 		}
 	}
 	return nil

--- a/cmd/maya-apiserver/cstor-operator/spc/handler.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/handler.go
@@ -160,7 +160,6 @@ type validateFunc func(*apis.StoragePoolClaim) error
 var validateFuncList = []validateFunc{
 	validatePoolType,
 	validateDiskType,
-	validateBDCount,
 	validateAutoSpcMaxPool,
 }
 

--- a/cmd/maya-apiserver/cstor-operator/spc/handler_test.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/handler_test.go
@@ -306,14 +306,16 @@ func TestValidateSpc(t *testing.T) {
 						PoolType: string(apis.PoolTypeRaidz2CPV),
 					},
 					BlockDevices: apis.BlockDeviceAttr{
-						BlockDeviceList: []string{"blockdevice-1"},
+						BlockDeviceList: []string{"blockdevice-1",
+							"blockdevice-2", "blockdevice-3",
+							"bolckdevice-4", "blockdevice-5", "blockdevice-6"},
 					},
 					Type: string(apis.TypeBlockDeviceCPV),
 				},
 			},
 			expectedError: false,
 		},
-		"InValid Auto SPC with invalid pool type": {
+		"InValid Auto SPC with invalid spc type": {
 			spc: &apis.StoragePoolClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-pool-claim-1",
@@ -327,6 +329,25 @@ func TestValidateSpc(t *testing.T) {
 				},
 			},
 			expectedError: true,
+		},
+		"Invalid Manual SPC with invalid BDCount": {
+			spc: &apis.StoragePoolClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pool-claim-1",
+				},
+				Spec: apis.StoragePoolClaimSpec{
+					PoolSpec: apis.CStorPoolAttr{
+						PoolType: string(apis.PoolTypeMirroredCPV),
+					},
+					BlockDevices: apis.BlockDeviceAttr{
+						BlockDeviceList: []string{"blockdevice-1",
+							"bolckdevice-2", "blockdevice-3",
+							"blockdevice-4", "blockdevice-5"},
+					},
+					Type: string(apis.TypeBlockDeviceCPV),
+				},
+			},
+			expectedError: false,
 		},
 	}
 

--- a/cmd/maya-apiserver/cstor-operator/spc/storagepool_create.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/storagepool_create.go
@@ -165,7 +165,7 @@ func (pc *PoolCreateConfig) withDisks(casPool *apis.CasPool, spc *apis.StoragePo
 	}
 
 	claimedNodeBDs, err := pc.ClaimBlockDevice(nodeBDs, spc)
-	if claimedNodeBDs == nil || len(claimedNodeBDs.BlockDeviceList) == 0 {
+	if err != nil {
 		return nil, errors.Wrapf(err, "aborting storagepool create operation as no claimed block devices available")
 	}
 

--- a/cmd/maya-apiserver/cstor-operator/spc/storagepool_create.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/storagepool_create.go
@@ -164,9 +164,9 @@ func (pc *PoolCreateConfig) withDisks(casPool *apis.CasPool, spc *apis.StoragePo
 		return nil, errors.Wrapf(err, "aborting storagepool create operation as no node qualified")
 	}
 
-	claimedNodeBDs := pc.ClaimBlockDevice(nodeBDs, spc)
-	if len(claimedNodeBDs.BlockDeviceList) == 0 {
-		return nil, errors.New("aborting storagepool create operation as no claimed block devices")
+	claimedNodeBDs, err := pc.ClaimBlockDevice(nodeBDs, spc)
+	if claimedNodeBDs == nil || len(claimedNodeBDs.BlockDeviceList) == 0 {
+		return nil, errors.Wrapf(err, "aborting storagepool create operation as no claimed block devices available")
 	}
 
 	// Fill the node name to the CasPool object.

--- a/cmd/maya-apiserver/cstor-operator/spc/storagepool_create.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/storagepool_create.go
@@ -163,27 +163,25 @@ func (pc *PoolCreateConfig) withDisks(casPool *apis.CasPool, spc *apis.StoragePo
 	if err != nil {
 		return nil, errors.Wrapf(err, "aborting storagepool create operation as no node qualified")
 	}
-	if len(nodeBDs.BlockDevices.Items) == 0 {
-		return nil, errors.New("aborting storagepool create operation as no block device was found")
+
+	claimedNodeBDs := pc.ClaimBlockDevice(nodeBDs, spc)
+	if len(claimedNodeBDs.BlockDeviceList) == 0 {
+		return nil, errors.New("aborting storagepool create operation as no claimed block devices")
 	}
 
 	// Fill the node name to the CasPool object.
-	casPool.NodeName = nodeBDs.NodeName
+	casPool.NodeName = claimedNodeBDs.NodeName
 	//casPool.DiskList = nodeDisks.Disks.Items
 	//TODO: Improve Following Code
 	if spc.Spec.PoolSpec.PoolType == string(apis.PoolTypeStripedCPV) {
-		for _, bd := range nodeBDs.BlockDevices.Items {
+		for _, claimedBD := range claimedNodeBDs.BlockDeviceList {
 			var bdList []apis.CspBlockDevice
 			var group apis.BlockDeviceGroup
 			blockDevice := apis.CspBlockDevice{
-				Name:        bd,
+				Name:        claimedBD.BDName,
 				InUseByPool: true,
+				DeviceID:    claimedBD.DeviceID,
 			}
-			devID, err := pc.getDeviceID(blockDevice.Name)
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to get dev Id for block device %s for spc %s", blockDevice.Name, spc.Name)
-			}
-			blockDevice.DeviceID = devID
 			bdList = append(bdList, blockDevice)
 			group = apis.BlockDeviceGroup{
 				Item: bdList,
@@ -193,20 +191,16 @@ func (pc *PoolCreateConfig) withDisks(casPool *apis.CasPool, spc *apis.StoragePo
 		return casPool, nil
 	}
 	count := blockdevice.DefaultDiskCount[spc.Spec.PoolSpec.PoolType]
-	for i := 0; i < len(nodeBDs.BlockDevices.Items); i = i + count {
+	for i := 0; i < len(claimedNodeBDs.BlockDeviceList); i = i + count {
 		var bdList []apis.CspBlockDevice
 		var group apis.BlockDeviceGroup
 		for j := 0; j < count; j++ {
 
 			blockDevice := apis.CspBlockDevice{
-				Name:        nodeBDs.BlockDevices.Items[i+j],
+				Name:        claimedNodeBDs.BlockDeviceList[i+j].BDName,
 				InUseByPool: true,
+				DeviceID:    claimedNodeBDs.BlockDeviceList[i+j].DeviceID,
 			}
-			devID, err := pc.getDeviceID(blockDevice.Name)
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to get dev Id is for block device %s for spc %s", blockDevice.Name, spc.Name)
-			}
-			blockDevice.DeviceID = devID
 			bdList = append(bdList, blockDevice)
 		}
 		group = apis.BlockDeviceGroup{

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node.go
@@ -251,7 +251,7 @@ func (ac *Config) ClaimBlockDevice(nodeBDs *nodeBlockDevice, spc *apis.StoragePo
 			bdcName = bdObj.Spec.ClaimRef.Name
 			bdcObj := customBDCObjList.GetBlockDeviceClaim(bdcName)
 			if bdcObj == nil {
-				return nil, errors.Errorf("bolck device {%s} is already in use", bdcName)
+				return nil, errors.Errorf("block device {%s} is already in use", bdcName)
 			}
 		} else {
 			bdcName = "bdc-" + string(bdObj.UID)
@@ -282,6 +282,7 @@ func (ac *Config) ClaimBlockDevice(nodeBDs *nodeBlockDevice, spc *apis.StoragePo
 			// As a part of reconcilation we will create pool if all the block
 			// devices are claimed
 			pendingBDCCount++
+			continue
 		}
 		claimedBD.DeviceID = bdObj.GetDeviceID()
 		claimedBD.BDName = bdObj.Name

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node.go
@@ -27,20 +27,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ClaimedBDDetails holds the claimed block device details
-type ClaimedBDDetails struct {
+// BDDetails holds the claimed block device details
+type BDDetails struct {
 	DeviceID string
 	BDName   string
 }
 
-// NodeClaimedBDDetails holds the node name and
+// ClaimedBDDetails holds the node name and
 // claimed block device deatils corresponding to node
-type NodeClaimedBDDetails struct {
+type ClaimedBDDetails struct {
 	NodeName        string
-	BlockDeviceList []ClaimedBDDetails
+	BlockDeviceList []BDDetails
 }
 
-// NodeBlockDeviceSelector selects a node and disks attached to it.
+// NodeBlockDeviceSelector selects a node and block devices attached to it.
 func (ac *Config) NodeBlockDeviceSelector() (*nodeBlockDevice, error) {
 	listBD, err := ac.getBlockDevice()
 	if err != nil {
@@ -212,10 +212,10 @@ func (ac *Config) getBlockDevice() (*ndmapis.BlockDeviceList, error) {
 // 2) Refactor the below code before removing WIP
 
 // ClaimBlockDevice will create BDC for corresponding BD
-func (ac *Config) ClaimBlockDevice(nodeBDs *nodeBlockDevice, spc *apis.StoragePoolClaim) (*NodeClaimedBDDetails, error) {
-	nodeClaimedBDs := &NodeClaimedBDDetails{
+func (ac *Config) ClaimBlockDevice(nodeBDs *nodeBlockDevice, spc *apis.StoragePoolClaim) (*ClaimedBDDetails, error) {
+	nodeClaimedBDs := &ClaimedBDDetails{
 		NodeName:        "",
-		BlockDeviceList: []ClaimedBDDetails{},
+		BlockDeviceList: []BDDetails{},
 	}
 
 	if nodeBDs == nil || len(nodeBDs.BlockDevices.Items) == 0 {
@@ -239,7 +239,7 @@ func (ac *Config) ClaimBlockDevice(nodeBDs *nodeBlockDevice, spc *apis.StoragePo
 
 	for _, bdName := range nodeBDs.BlockDevices.Items {
 		var hostName, bdcName string
-		claimedBD := ClaimedBDDetails{}
+		claimedBD := BDDetails{}
 
 		bdObj, err := ac.BlockDeviceClient.Get(bdName, metav1.GetOptions{})
 		if err != nil {

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node.go
@@ -142,23 +142,23 @@ func (ac *Config) selectNode(nodeBlockDeviceMap map[string]*blockDeviceList) *no
 			Items: []string{},
 		},
 	}
-	// diskCount will hold the number of disk that will be selected from a qualified
+	// bdCount will hold the number of block devices that will be selected from a qualified
 	// node for specific pool type
-	var diskCount int
+	var bdCount int
 	// minRequiredDiskCount will hold the required number of disk that should be selected from a qualified
 	// node for specific pool type
 	minRequiredDiskCount := blockdevice.DefaultDiskCount[ac.poolType()]
 	for node, val := range nodeBlockDeviceMap {
-		// If the current disk count on the node is less than the required disks
+		// If the current block device count on the node is less than the required disks
 		// then this is a dirty node and it will not qualify.
 		if len(val.Items) < minRequiredDiskCount {
 			continue
 		}
-		diskCount = minRequiredDiskCount
+		bdCount = minRequiredDiskCount
 		if ProvisioningType(ac.Spc) == ProvisioningTypeManual {
-			diskCount = (len(val.Items) / minRequiredDiskCount) * minRequiredDiskCount
+			bdCount = (len(val.Items) / minRequiredDiskCount) * minRequiredDiskCount
 		}
-		for i := 0; i < diskCount; i++ {
+		for i := 0; i < bdCount; i++ {
 			selectedBlockDevice.BlockDevices.Items = append(selectedBlockDevice.BlockDevices.Items, val.Items[i])
 		}
 		selectedBlockDevice.NodeName = node

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node.go
@@ -270,13 +270,18 @@ func (ac *Config) ClaimBlockDevice(nodeBDs *nodeBlockDevice, spc *apis.StoragePo
 		} else {
 			//TODO: Use HasLabel Predicate for below check
 			bdcName = bdObj.Spec.ClaimRef.Name
-			if bdObj.Labels[string(apis.StoragePoolClaimCPK)] == "" {
-				err = bdcKubeclient.PatchBDCWithLabel(labels, bdcName)
+			bdcObj, err := bdcKubeclient.Get(bdcName, metav1.GetOptions{})
+			if err != nil {
+				glog.Infof("failed to get block device claim {%s}", bdcName)
+				continue
+			}
+			if bdcObj.Labels[string(apis.StoragePoolClaimCPK)] == "" {
+				err = bdcKubeclient.PatchBDCWithLabel(labels, bdcObj)
 				if err != nil {
 					glog.Errorf("failed to patch block device claim {%s}", bdcName)
 					continue
 				}
-			} else if bdObj.Labels[string(apis.StoragePoolClaimCPK)] != spc.Name {
+			} else if bdcObj.Labels[string(apis.StoragePoolClaimCPK)] != spc.Name {
 				glog.Errorf("block device %s is already in use", bdName)
 				continue
 			}

--- a/pkg/blockdevice/v1alpha1/blockdevice.go
+++ b/pkg/blockdevice/v1alpha1/blockdevice.go
@@ -283,3 +283,13 @@ func (bd *BlockDevice) GetLink() string {
 func (bd *BlockDevice) GetPath() string {
 	return bd.Spec.Path
 }
+
+// GetBlockDevice returns the block device object present in the block device list
+func (bdl *BlockDeviceList) GetBlockDevice(bdcName string) *ndm.BlockDevice {
+	for _, bdcObj := range bdl.Items {
+		if bdcObj.Name == bdcName {
+			return &bdcObj
+		}
+	}
+	return nil
+}

--- a/pkg/blockdevice/v1alpha1/blockdevice.go
+++ b/pkg/blockdevice/v1alpha1/blockdevice.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"github.com/golang/glog"
 	ndm "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
@@ -248,4 +249,39 @@ func (bdl *BlockDeviceList) Hasitems() (string, bool) {
 		return "No item found in blockdevice list", false
 	}
 	return "", true
+}
+
+// IsClaimed returns true if block device is claimed
+func (bd *BlockDevice) IsClaimed() bool {
+	glog.Infof("[DEBUG] Status of BD: %s", bd.Status.ClaimState)
+	return bd.Status.ClaimState == ndm.BlockDeviceClaimed
+}
+
+// GetDeviceID returns the device link of the block device.
+// If device link is not found it returns device path.
+// For a cstor pool creation -- this link or path is used.
+// For convenience, we call it as device ID.
+// Hence, device ID can either be a  device link or device path
+// depending on what was available in block device cr.
+func (bd *BlockDevice) GetDeviceID() string {
+	deviceID := bd.GetLink()
+	if deviceID != "" {
+		return deviceID
+	}
+	return bd.GetPath()
+}
+
+// GetLink returns the link of the block device
+// if present else return empty string
+func (bd *BlockDevice) GetLink() string {
+	if len(bd.Spec.DevLinks) != 0 &&
+		len(bd.Spec.DevLinks[0].Links) != 0 {
+		return bd.Spec.DevLinks[0].Links[0]
+	}
+	return ""
+}
+
+// GetPath returns path of the block device
+func (bd *BlockDevice) GetPath() string {
+	return bd.Spec.Path
 }

--- a/pkg/blockdevice/v1alpha1/blockdevice.go
+++ b/pkg/blockdevice/v1alpha1/blockdevice.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/golang/glog"
 	ndm "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
@@ -253,7 +252,6 @@ func (bdl *BlockDeviceList) Hasitems() (string, bool) {
 
 // IsClaimed returns true if block device is claimed
 func (bd *BlockDevice) IsClaimed() bool {
-	glog.Infof("[DEBUG] Status of BD: %s", bd.Status.ClaimState)
 	return bd.Status.ClaimState == ndm.BlockDeviceClaimed
 }
 

--- a/pkg/blockdevice/v1alpha1/blockdevice.go
+++ b/pkg/blockdevice/v1alpha1/blockdevice.go
@@ -287,6 +287,7 @@ func (bd *BlockDevice) GetPath() string {
 // GetBlockDevice returns the block device object present in the block device list
 func (bdl *BlockDeviceList) GetBlockDevice(bdcName string) *ndm.BlockDevice {
 	for _, bdcObj := range bdl.Items {
+		bdcObj := bdcObj
 		if bdcObj.Name == bdcName {
 			return &bdcObj
 		}

--- a/pkg/blockdevice/v1alpha1/blockdevice_test.go
+++ b/pkg/blockdevice/v1alpha1/blockdevice_test.go
@@ -376,3 +376,46 @@ func TestHasitems(t *testing.T) {
 		})
 	}
 }
+
+func TestIsClaimed(t *testing.T) {
+	tests := map[string]struct {
+		blockDevice    *BlockDevice
+		expectedOutput bool
+	}{
+		"Test Claimed Status": {
+			blockDevice: &BlockDevice{
+				BlockDevice: &ndm.BlockDevice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "blockdevice",
+					},
+					Status: ndm.DeviceStatus{
+						ClaimState: ndm.BlockDeviceClaimed,
+					},
+				},
+			},
+			expectedOutput: true,
+		},
+		"Test UnClaimed Status": {
+			blockDevice: &BlockDevice{
+				BlockDevice: &ndm.BlockDevice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "blockdevice",
+					},
+					Status: ndm.DeviceStatus{
+						ClaimState: ndm.BlockDeviceUnclaimed,
+					},
+				},
+			},
+			expectedOutput: false,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			output := test.blockDevice.IsClaimed()
+			if output != test.expectedOutput {
+				t.Errorf("Test %q failed expected status: %t and got: %t", name, test.expectedOutput, output)
+			}
+		})
+	}
+}

--- a/pkg/blockdevice/v1alpha1/kubernetes_client.go
+++ b/pkg/blockdevice/v1alpha1/kubernetes_client.go
@@ -21,20 +21,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Get is Kubernetes client implementation to get disk.
+// Get is Kubernetes client implementation to get block device
 func (k *KubernetesClient) Get(name string, opts metav1.GetOptions) (*BlockDevice, error) {
 	bd, err := k.Clientset.OpenebsV1alpha1().BlockDevices(k.Namespace).Get(name, opts)
 
 	return &BlockDevice{bd, nil}, err
 }
 
-// List is kubernetes client implementation to list disk.
+// List is kubernetes client implementation to list block device
 func (k *KubernetesClient) List(opts metav1.ListOptions) (*BlockDeviceList, error) {
 	bdl, err := k.Clientset.OpenebsV1alpha1().BlockDevices(k.Namespace).List(opts)
 	return &BlockDeviceList{bdl, nil}, err
 }
 
-// Create is kubernetes client implementation to create disk.
+// Create is kubernetes client implementation to create block device
 func (k *KubernetesClient) Create(bdObj *ndm.BlockDevice) (*BlockDevice, error) {
 	bdObj, err := k.Clientset.OpenebsV1alpha1().BlockDevices(k.Namespace).Create(bdObj)
 	return &BlockDevice{bdObj, nil}, err

--- a/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim.go
+++ b/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim.go
@@ -38,12 +38,12 @@ type BlockDeviceClaimList struct {
 // provided block device claim instance
 type Predicate func(*BlockDeviceClaim) bool
 
-// predicateList holds the list of Predicates
-type predicateList []Predicate
+// PredicateList holds the list of Predicates
+type PredicateList []Predicate
 
 // all returns true if all the predicates succeed against the provided block
 // device instance.
-func (l predicateList) all(c *BlockDeviceClaim) bool {
+func (l PredicateList) all(c *BlockDeviceClaim) bool {
 	for _, pred := range l {
 		if !pred(c) {
 			return false
@@ -101,28 +101,6 @@ func IsStatus(status string) Predicate {
 // block device claim matches with provided status.
 func (bdc *BlockDeviceClaim) IsStatus(status string) bool {
 	return string(bdc.Object.Status.Phase) == status
-}
-
-// Filter will filter the BDC instances if all the predicates succeed
-// against that BDC.
-func (l *BlockDeviceClaimList) Filter(p ...Predicate) *BlockDeviceClaimList {
-	var plist predicateList
-	plist = append(plist, p...)
-	if len(plist) == 0 {
-		return l
-	}
-
-	filtered := NewListBuilder().List()
-	for _, bdcAPI := range l.ObjectList.Items {
-		bdcAPI := bdcAPI // pin it
-		BlockDeviceClaim := BuilderForAPIObject(&bdcAPI).BDC
-		if plist.all(BlockDeviceClaim) {
-			filtered.ObjectList.Items = append(
-				filtered.ObjectList.Items,
-				*BlockDeviceClaim.Object)
-		}
-	}
-	return filtered
 }
 
 // Len returns the length og BlockDeviceClaimList.

--- a/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim_test.go
+++ b/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim_test.go
@@ -1,0 +1,46 @@
+// Copyright © 2018-2019 The OpenEBS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
+)
+
+func fakeAPIBDCList(bdcNames []string) *apis.BlockDeviceClaimList {
+	if len(bdcNames) == 0 {
+		return nil
+	}
+	list := &apis.BlockDeviceClaimList{}
+	for _, name := range bdcNames {
+		bdc := apis.BlockDeviceClaim{}
+		bdc.SetName(name)
+		list.Items = append(list.Items, bdc)
+	}
+	return list
+}
+
+func fakeAPIBDCListFromNameStatusMap(bdcs map[string]apis.DeviceClaimPhase) *apis.BlockDeviceClaimList {
+	if len(bdcs) == 0 {
+		return nil
+	}
+	list := &apis.BlockDeviceClaimList{}
+	for k, v := range bdcs {
+		bdc := apis.BlockDeviceClaim{}
+		bdc.SetName(k)
+		bdc.Status.Phase = v
+		list.Items = append(list.Items, bdc)
+	}
+	return list
+}

--- a/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim_test.go
+++ b/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim_test.go
@@ -30,17 +30,3 @@ func fakeAPIBDCList(bdcNames []string) *apis.BlockDeviceClaimList {
 	}
 	return list
 }
-
-func fakeAPIBDCListFromNameStatusMap(bdcs map[string]apis.DeviceClaimPhase) *apis.BlockDeviceClaimList {
-	if len(bdcs) == 0 {
-		return nil
-	}
-	list := &apis.BlockDeviceClaimList{}
-	for k, v := range bdcs {
-		bdc := apis.BlockDeviceClaim{}
-		bdc.SetName(k)
-		bdc.Status.Phase = v
-		list.Items = append(list.Items, bdc)
-	}
-	return list
-}

--- a/pkg/blockdeviceclaim/v1alpha1/build.go
+++ b/pkg/blockdeviceclaim/v1alpha1/build.go
@@ -154,7 +154,7 @@ func (b *Builder) WithLabels(labels map[string]string) *Builder {
 		return b
 	}
 	if b.BDC.Object.Labels == nil {
-		b.BDC.Object.Labels = make(map[string]string)
+		return b.WithLabelsNew(labels)
 	}
 	for key, value := range labels {
 		b.BDC.Object.Labels[key] = value

--- a/pkg/blockdeviceclaim/v1alpha1/build.go
+++ b/pkg/blockdeviceclaim/v1alpha1/build.go
@@ -26,6 +26,7 @@ import (
 )
 
 const (
+	// StoragePoolKind holds the value of StoragePoolClaim
 	StoragePoolKind = "StoragePoolClaim"
 )
 

--- a/pkg/blockdeviceclaim/v1alpha1/build.go
+++ b/pkg/blockdeviceclaim/v1alpha1/build.go
@@ -17,14 +17,17 @@ limitations under the License.
 package v1alpha1
 
 import (
+	ndm "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-
-	ndm "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//TODO: While using these packages UnitTest must be written to corresponding function
+const (
+	StoragePoolKind = "StoragePoolClaim"
+)
 
 // Builder is the builder object for BlockDeviceClaim
 type Builder struct {
@@ -218,5 +221,28 @@ func (b *Builder) WithCapacity(capacity string) *Builder {
 		corev1.ResourceName("capacity"): resCapacity,
 	}
 	b.BDC.Object.Spec.Requirements.Requests = resourceList
+	return b
+}
+
+// WithOwnerReference sets the OwnerReference field in BDC with required
+//fields
+func (b *Builder) WithOwnerReference(spc *apis.StoragePoolClaim) *Builder {
+	if spc == nil {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build BDC object: spc object is nil"),
+		)
+		return b
+	}
+	trueVal := true
+	reference := metav1.OwnerReference{
+		APIVersion:         string(apis.OpenEBSVersionKey),
+		Kind:               StoragePoolKind,
+		UID:                spc.ObjectMeta.UID,
+		Name:               spc.ObjectMeta.Name,
+		BlockOwnerDeletion: &trueVal,
+		Controller:         &trueVal,
+	}
+	b.BDC.Object.OwnerReferences = append(b.BDC.Object.OwnerReferences, reference)
 	return b
 }

--- a/pkg/blockdeviceclaim/v1alpha1/build_test.go
+++ b/pkg/blockdeviceclaim/v1alpha1/build_test.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"reflect"
+	"testing"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBuilderWithName(t *testing.T) {
+	tests := map[string]struct {
+		name      string
+		expectErr bool
+	}{
+		"Test Builder with name": {
+			name:      "BDC1",
+			expectErr: false,
+		},
+		"Test Builder without name": {
+			name:      "",
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := NewBuilder().WithName(mock.name)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuildWithNamespace(t *testing.T) {
+	tests := map[string]struct {
+		namespace string
+		expectErr bool
+	}{
+		"Test Builderwith namespae": {
+			namespace: "jiva-ns",
+			expectErr: false,
+		},
+		"Test Builderwithout namespace": {
+			namespace: "",
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := NewBuilder().WithNamespace(mock.namespace)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuildWithAnnotations(t *testing.T) {
+	tests := map[string]struct {
+		annotations map[string]string
+		expectErr   bool
+	}{
+		"Test Builderwith annotations": {
+			annotations: map[string]string{"persistent-volume": "PV", "application": "percona"},
+			expectErr:   false,
+		},
+		"Test Builderwithout annotations": {
+			annotations: map[string]string{},
+			expectErr:   true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := NewBuilder().WithAnnotations(mock.annotations)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuildWithLabelsNew(t *testing.T) {
+	tests := map[string]struct {
+		labels    map[string]string
+		expectErr bool
+	}{
+		"Test Builderwith labels": {
+			labels:    map[string]string{"persistent-volume": "PV", "application": "percona"},
+			expectErr: false,
+		},
+		"Test Builderwithout labels": {
+			labels:    map[string]string{},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := NewBuilder().WithLabels(mock.labels)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuildWithLabels(t *testing.T) {
+	tests := map[string]struct {
+		labels    map[string]string
+		builder   *Builder
+		expectErr bool
+	}{
+		"Test Builderwith labels": {
+			labels: map[string]string{"blockdeviceclaim": "BDC", "application": "percona"},
+			builder: &Builder{BDC: &BlockDeviceClaim{
+				Object: &apis.BlockDeviceClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"openebs.io/storage-pool-claim": "cstor-pool"},
+					},
+				},
+			}},
+			expectErr: false,
+		},
+		"Test Builderwithout labels": {
+			labels: map[string]string{},
+			builder: &Builder{BDC: &BlockDeviceClaim{
+				Object: &apis.BlockDeviceClaim{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithLabels(mock.labels)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuildWithCapacity(t *testing.T) {
+	tests := map[string]struct {
+		capacity  string
+		expectErr bool
+	}{
+		"Test Builderwith capacity": {
+			capacity:  "5G",
+			expectErr: false,
+		},
+		"Test Builderwithout capacity": {
+			capacity:  "",
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := NewBuilder().WithCapacity(mock.capacity)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuild(t *testing.T) {
+	tests := map[string]struct {
+		name        string
+		capacity    string
+		expectedBDC *apis.BlockDeviceClaim
+		expectedErr bool
+	}{
+		"BDC with correct details": {
+			name:     "BDC1",
+			capacity: "10Ti",
+			expectedBDC: &apis.BlockDeviceClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "BDC1"},
+				Spec: apis.DeviceClaimSpec{
+					Requirements: apis.DeviceClaimRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceName("capacity"): fakeCapacity("10Ti"),
+						},
+					},
+				},
+			},
+			expectedErr: false,
+		},
+		"BDC with error": {
+			name:        "",
+			capacity:    "500Gi",
+			expectedBDC: nil,
+			expectedErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			bdcObj, err := NewBuilder().WithName(mock.name).WithCapacity(mock.capacity).Build()
+			if mock.expectedErr && err == nil {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectedErr && err != nil {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+			if err == nil && !reflect.DeepEqual(bdcObj.Object, mock.expectedBDC) {
+				t.Fatalf("Test %q failed: bdc mismatch", name)
+			}
+		})
+	}
+}
+
+func fakeCapacity(capacity string) resource.Quantity {
+	q, _ := resource.ParseQuantity(capacity)
+	return q
+}

--- a/pkg/blockdeviceclaim/v1alpha1/buildlist.go
+++ b/pkg/blockdeviceclaim/v1alpha1/buildlist.go
@@ -89,6 +89,7 @@ func (lb *ListBuilder) WithFilter(pred ...Predicate) *ListBuilder {
 // ListBuilder
 func (lb *ListBuilder) GetBlockDeviceClaim(bdcName string) *ndm.BlockDeviceClaim {
 	for _, bdcObj := range lb.BlockDeviceClaimList.ObjectList.Items {
+		bdcObj := bdcObj
 		if bdcObj.Name == bdcName {
 			return &bdcObj
 		}

--- a/pkg/blockdeviceclaim/v1alpha1/buildlist.go
+++ b/pkg/blockdeviceclaim/v1alpha1/buildlist.go
@@ -20,11 +20,10 @@ import (
 	ndm "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
 )
 
-//TODO: While using these packages UnitTest must be written to corresponding function
-
 // ListBuilder is the builder object for BlockDeviceClaimList
 type ListBuilder struct {
 	BlockDeviceClaimList *BlockDeviceClaimList
+	filters              PredicateList
 }
 
 // NewListBuilder returns a new instance of ListBuilder object.
@@ -33,6 +32,7 @@ func NewListBuilder() *ListBuilder {
 		BlockDeviceClaimList: &BlockDeviceClaimList{
 			ObjectList: &ndm.BlockDeviceClaimList{},
 		},
+		filters: PredicateList{},
 	}
 }
 
@@ -61,8 +61,37 @@ func ListBuilderFromAPIList(bdcl *ndm.BlockDeviceClaimList) *ListBuilder {
 	return lb
 }
 
-// List returns the list of block device claim
-// instances that were built by this builder.
-func (b *ListBuilder) List() *BlockDeviceClaimList {
-	return b.BlockDeviceClaimList
+// List returns the list of bdc
+// instances that was built by this
+// builder
+func (lb *ListBuilder) List() *BlockDeviceClaimList {
+	if lb.filters == nil || len(lb.filters) == 0 {
+		return lb.BlockDeviceClaimList
+	}
+	filtered := NewListBuilder().List()
+	for _, bdcAPI := range lb.BlockDeviceClaimList.ObjectList.Items {
+		bdcAPI := bdcAPI // pin it
+		bdc := BuilderForAPIObject(&bdcAPI).BDC
+		if lb.filters.all(bdc) {
+			filtered.ObjectList.Items = append(filtered.ObjectList.Items, *bdc.Object)
+		}
+	}
+	return filtered
+}
+
+// WithFilter adds filters on which the bdc's has to be filtered
+func (lb *ListBuilder) WithFilter(pred ...Predicate) *ListBuilder {
+	lb.filters = append(lb.filters, pred...)
+	return lb
+}
+
+// GetBlockDeviceClaim returns block device claim object from existing
+// ListBuilder
+func (lb *ListBuilder) GetBlockDeviceClaim(bdcName string) *ndm.BlockDeviceClaim {
+	for _, bdcObj := range lb.BlockDeviceClaimList.ObjectList.Items {
+		if bdcObj.Name == bdcName {
+			return &bdcObj
+		}
+	}
+	return nil
 }

--- a/pkg/blockdeviceclaim/v1alpha1/buildlist_test.go
+++ b/pkg/blockdeviceclaim/v1alpha1/buildlist_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+)
+
+func TestListBuilderWithAPIList(t *testing.T) {
+	tests := map[string]struct {
+		availableBDCs  []string
+		expectedBDCLen int
+	}{
+		"BDC set 1": {[]string{}, 0},
+		"BDC set 2": {[]string{"bdc1"}, 1},
+		"BDC set 3": {[]string{"bdc1", "bdc2"}, 2},
+		"BDC set 4": {[]string{"bdc1", "bdc2", "bdc3"}, 3},
+		"BDC set 5": {[]string{"bdc1", "bdc2", "bdc3", "bdc4"}, 4},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := ListBuilderFromAPIList(fakeAPIBDCList(mock.availableBDCs)).List()
+			itemsLen := len(b.ObjectList.Items)
+			if mock.expectedBDCLen != itemsLen {
+				t.Fatalf("Test %v failed: expected %v got %v", name, mock.expectedBDCLen, itemsLen)
+			}
+		})
+	}
+}

--- a/pkg/blockdeviceclaim/v1alpha1/kubernetes.go
+++ b/pkg/blockdeviceclaim/v1alpha1/kubernetes.go
@@ -231,7 +231,6 @@ func (k *Kubeclient) Create(bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim,
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create bdc {%s} in namespace {%s}", bdc.Name, bdc.Namespace)
 	}
-	glog.Infof("[DEBUG] Create call of BDC: {%#v}", bdc)
 	return k.create(cli, k.namespace, bdc)
 }
 
@@ -270,20 +269,16 @@ func (k *Kubeclient) Patch(name string, pt types.PatchType, data []byte, subreso
 }
 
 // PatchBDCWithLabel patches the block device claim with provided labels
-func (k *Kubeclient) PatchBDCWithLabel(label map[string]string, bdcName string) error {
-	bdcObj, err := k.Get(bdcName, metav1.GetOptions{})
-	if err != nil {
-		return errors.Wrapf(err, "failed to get bdc {%s}", bdcName)
-	}
+func (k *Kubeclient) PatchBDCWithLabel(label map[string]string, bdcObj *apis.BlockDeviceClaim) error {
 	BuildObj, err := BuilderForAPIObject(bdcObj).
 		WithLabels(label).Build()
 	if err != nil {
-		return errors.Wrapf(err, "failed to build bdc {%s}", bdcName)
+		return errors.Wrapf(err, "failed to build bdc {%s}", bdcObj.Name)
 	}
 	bdcBytes, err := json.Marshal(BuildObj)
-	_, err = k.Patch(bdcName, types.MergePatchType, bdcBytes)
+	_, err = k.Patch(bdcObj.Name, types.MergePatchType, bdcBytes)
 	if err != nil {
-		return errors.Wrapf(err, "failed to patch bdc {%s}", bdcName)
+		return errors.Wrapf(err, "failed to patch bdc {%s}", bdcObj.Name)
 	}
 	return nil
 }

--- a/pkg/blockdeviceclaim/v1alpha1/kubernetes.go
+++ b/pkg/blockdeviceclaim/v1alpha1/kubernetes.go
@@ -21,11 +21,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/golang/glog"
 	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 	kclient "github.com/openebs/maya/pkg/kubernetes/client/v1alpha1"
-
-	"encoding/json"
 
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
 	clientset "github.com/openebs/maya/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset"
@@ -266,33 +263,4 @@ func (k *Kubeclient) Patch(name string, pt types.PatchType, data []byte, subreso
 		return nil, errors.Wrapf(err, "failed to patch bdc: {%s}", name)
 	}
 	return k.patch(cli, k.namespace, name, pt, data, subresources...)
-}
-
-// PatchBDCWithLabel patches the block device claim with provided labels
-func (k *Kubeclient) PatchBDCWithLabel(label map[string]string, bdcObj *apis.BlockDeviceClaim) error {
-	BuildObj, err := BuilderForAPIObject(bdcObj).
-		WithLabels(label).Build()
-	if err != nil {
-		return errors.Wrapf(err, "failed to build bdc {%s}", bdcObj.Name)
-	}
-	bdcBytes, err := json.Marshal(BuildObj)
-	_, err = k.Patch(bdcObj.Name, types.MergePatchType, bdcBytes)
-	if err != nil {
-		return errors.Wrapf(err, "failed to patch bdc {%s}", bdcObj.Name)
-	}
-	return nil
-}
-
-// DeleteMultiPleBDCs deletes list of block device claim
-func (k *Kubeclient) DeleteMultipleBDCs(bdcList []string) error {
-	if bdcList == nil && len(bdcList) == 0 {
-		return nil
-	}
-	for _, bdcName := range bdcList {
-		err := k.Delete(bdcName, &metav1.DeleteOptions{})
-		if err != nil {
-			glog.Errorf("failed to delete BDC {%s} in namespace {%s}", bdcName, k.namespace)
-		}
-	}
-	return nil
 }

--- a/pkg/blockdeviceclaim/v1alpha1/kubernetes_test.go
+++ b/pkg/blockdeviceclaim/v1alpha1/kubernetes_test.go
@@ -62,23 +62,9 @@ func fakeDeleteFnErr(cli *clientset.Clientset, name, namespace string, opts *met
 	return errors.New("some error")
 }
 
-func fakeSetClientset(k *Kubeclient) {
-	k.clientset = &clientset.Clientset{}
-}
-
-func fakeSetKubeConfigPath(k *Kubeclient) {
-	k.kubeConfigPath = "fake-path"
-}
-
-func fakeSetNilClientset(k *Kubeclient) {
-	k.clientset = nil
-}
-
 func fakeGetClientsetErr() (clientset *clientset.Clientset, err error) {
 	return nil, errors.New("Some error")
 }
-
-func fakeClientset(k *Kubeclient) {}
 
 func fakeCreateFnOk(cli *clientset.Clientset, namespace string, bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim, error) {
 	return &apis.BlockDeviceClaim{}, nil

--- a/pkg/blockdeviceclaim/v1alpha1/kubernetes_test.go
+++ b/pkg/blockdeviceclaim/v1alpha1/kubernetes_test.go
@@ -1,0 +1,499 @@
+// Copyright © 2018-2019 The OpenEBS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
+	clientset "github.com/openebs/maya/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func fakeGetClientsetOk() (cli *clientset.Clientset, err error) {
+	return &clientset.Clientset{}, nil
+}
+
+func fakeGetClientsetForPathOk(fakeConfigPath string) (cli *clientset.Clientset, err error) {
+	return &clientset.Clientset{}, nil
+}
+
+func fakeGetClientsetForPathErr(fakeConfigPath string) (cli *clientset.Clientset, err error) {
+	return nil, errors.New("fake error")
+}
+
+func fakeGetFnOk(cli *clientset.Clientset, name, namespace string, opts metav1.GetOptions) (*apis.BlockDeviceClaim, error) {
+	return &apis.BlockDeviceClaim{}, nil
+}
+
+func fakeListFnOk(cli *clientset.Clientset, namespace string, opts metav1.ListOptions) (*apis.BlockDeviceClaimList, error) {
+	return &apis.BlockDeviceClaimList{}, nil
+}
+
+func fakeDeleteFnOk(cli *clientset.Clientset, name, namespace string, opts *metav1.DeleteOptions) error {
+	return nil
+}
+
+func fakeListFnErr(cli *clientset.Clientset, namespace string, opts metav1.ListOptions) (*apis.BlockDeviceClaimList, error) {
+	return &apis.BlockDeviceClaimList{}, errors.New("some error")
+}
+
+func fakeGetFnErr(cli *clientset.Clientset, name, namespace string, opts metav1.GetOptions) (*apis.BlockDeviceClaim, error) {
+	return &apis.BlockDeviceClaim{}, errors.New("some error")
+}
+
+func fakeDeleteFnErr(cli *clientset.Clientset, name, namespace string, opts *metav1.DeleteOptions) error {
+	return errors.New("some error")
+}
+
+func fakeSetClientset(k *Kubeclient) {
+	k.clientset = &clientset.Clientset{}
+}
+
+func fakeSetKubeConfigPath(k *Kubeclient) {
+	k.kubeConfigPath = "fake-path"
+}
+
+func fakeSetNilClientset(k *Kubeclient) {
+	k.clientset = nil
+}
+
+func fakeGetClientsetErr() (clientset *clientset.Clientset, err error) {
+	return nil, errors.New("Some error")
+}
+
+func fakeClientset(k *Kubeclient) {}
+
+func fakeCreateFnOk(cli *clientset.Clientset, namespace string, bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim, error) {
+	return &apis.BlockDeviceClaim{}, nil
+}
+
+func fakeCreateErr(cli *clientset.Clientset, namespace string, bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim, error) {
+	return nil, errors.New("failed to create BDC")
+}
+
+func fakePatchFnOk(cli *clientset.Clientset, namespace, name string, pt types.PatchType, data []byte, subresources ...string) (*apis.BlockDeviceClaim, error) {
+	return &apis.BlockDeviceClaim{}, nil
+}
+
+func fakePatchFnErr(cli *clientset.Clientset, namespace, name string, pt types.PatchType, data []byte, subresources ...string) (*apis.BlockDeviceClaim, error) {
+	return nil, errors.New("fake error")
+}
+
+func TestWithDefaultOptionsForClientset(t *testing.T) {
+	tests := map[string]struct {
+		getClientset        getClientsetFn
+		getClientsetForPath getClientsetForPathFn
+	}{
+		"TestCase1":               {nil, nil},
+		"When clientset is error": {fakeGetClientsetErr, fakeGetClientsetForPathErr},
+		"When clientset is ok":    {fakeGetClientsetOk, fakeGetClientsetForPathOk},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientsetForPath,
+			}
+			fc.WithDefaults()
+			if fc.getClientset == nil {
+				t.Fatalf("test %q failed: expected getClientset not to be empty", name)
+			}
+			if fc.getClientsetForPath == nil {
+				t.Fatalf("test %q failed: expected getClientset not to be nil", name)
+			}
+		})
+	}
+}
+
+func TestWithDefaultOptionsForCRUDOPS(t *testing.T) {
+	tests := map[string]struct {
+		list          listFn
+		get           getFn
+		create        createFn
+		del           deleteFn
+		delCollection deleteCollectionFn
+	}{
+		"TestCase1":               {nil, nil, nil, nil, nil},
+		"When clientset is error": {fakeListFnErr, fakeGetFnErr, fakeCreateErr, fakeDeleteFnErr, nil},
+		"When clientset is ok":    {fakeListFnOk, fakeGetFnOk, fakeCreateFnOk, fakeDeleteFnOk, nil},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{
+				list:          mock.list,
+				get:           mock.get,
+				create:        mock.create,
+				del:           mock.del,
+				delCollection: mock.delCollection,
+			}
+			fc.WithDefaults()
+			if fc.list == nil {
+				t.Fatalf("test %q failed: expected list not to be empty", name)
+			}
+			if fc.get == nil {
+				t.Fatalf("test %q failed: expected get not to be empty", name)
+			}
+			if fc.create == nil {
+				t.Fatalf("test %q failed: expected create not to be empty", name)
+			}
+			if fc.del == nil {
+				t.Fatalf("test %q failed: expected del not to be empty", name)
+			}
+			if fc.delCollection == nil {
+				t.Fatalf("test %q failed: expected delCollection not to be empty", name)
+			}
+		})
+	}
+}
+
+func TestGetClientsetForPathOrDirect(t *testing.T) {
+	tests := map[string]struct {
+		getClientset        getClientsetFn
+		getClientsetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		isErr               bool
+	}{
+		// Positive tests
+		"Positive 1": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "", false},
+		"Positive 2": {fakeGetClientsetErr, fakeGetClientsetForPathOk, "fake-path", false},
+		"Positive 3": {fakeGetClientsetOk, fakeGetClientsetForPathErr, "", false},
+
+		// Negative tests
+		"Negative 1": {fakeGetClientsetErr, fakeGetClientsetForPathOk, "", true},
+		"Negative 2": {fakeGetClientsetOk, fakeGetClientsetForPathErr, "fake-path", true},
+		"Negative 3": {fakeGetClientsetErr, fakeGetClientsetForPathErr, "fake-path", true},
+		"Negative 4": {fakeGetClientsetErr, fakeGetClientsetForPathErr, "", true},
+	}
+
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientsetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+			}
+			_, err := fc.getClientsetForPathOrDirect()
+			if mock.isErr && err == nil {
+				t.Fatalf("test %q failed : expected error not to be nil but got %v", name, err)
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("test %q failed : expected error be nil but got %v", name, err)
+			}
+		})
+	}
+}
+
+func TestWithClientsetBuildOption(t *testing.T) {
+	tests := map[string]struct {
+		Clientset             *clientset.Clientset
+		expectKubeClientEmpty bool
+	}{
+		"Clientset is empty":     {nil, true},
+		"Clientset is not empty": {&clientset.Clientset{}, false},
+	}
+
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			h := WithKubeClient(mock.Clientset)
+			fake := &Kubeclient{}
+			h(fake)
+			if mock.expectKubeClientEmpty && fake.clientset != nil {
+				t.Fatalf("test %q failed expected fake.clientset to be empty", name)
+			}
+			if !mock.expectKubeClientEmpty && fake.clientset == nil {
+				t.Fatalf("test %q failed expected fake.clientset not to be empty", name)
+			}
+		})
+	}
+}
+
+func TestGetClientOrCached(t *testing.T) {
+	tests := map[string]struct {
+		getClientset        getClientsetFn
+		getClientsetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		expectErr           bool
+	}{
+		// Positive tests
+		"Positive 1": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "", false},
+		"Positive 2": {fakeGetClientsetErr, fakeGetClientsetForPathOk, "fake-path", false},
+		"Positive 3": {fakeGetClientsetOk, fakeGetClientsetForPathErr, "", false},
+
+		// Negative tests
+		"Negative 1": {fakeGetClientsetErr, fakeGetClientsetForPathOk, "", true},
+		"Negative 2": {fakeGetClientsetOk, fakeGetClientsetForPathErr, "fake-path", true},
+		"Negative 3": {fakeGetClientsetErr, fakeGetClientsetForPathErr, "fake-path", true},
+		"Negative 4": {fakeGetClientsetErr, fakeGetClientsetForPathErr, "", true},
+	}
+
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientsetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+			}
+			_, err := fc.getClientsetOrCached()
+			if mock.expectErr && err == nil {
+				t.Fatalf("test %q failed : expected error not to be nil but got %v", name, err)
+			}
+			if !mock.expectErr && err != nil {
+				t.Fatalf("test %q failed : expected error be nil but got %v", name, err)
+			}
+		})
+	}
+}
+
+func TestBlockDeviceClaimList(t *testing.T) {
+	tests := map[string]struct {
+		getClientset        getClientsetFn
+		getClientsetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		list                listFn
+		expectedErr         bool
+	}{
+		// Positive tests
+		"Positive 1": {nil, fakeGetClientsetForPathOk, "fake-path", fakeListFnOk, false},
+		"Positive 2": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "", fakeListFnOk, false},
+		"Positive 3": {fakeGetClientsetErr, fakeGetClientsetForPathOk, "fake-path", fakeListFnOk, false},
+		"Positive 4": {fakeGetClientsetOk, fakeGetClientsetForPathErr, "", fakeListFnOk, false},
+
+		// Negative tests
+		"Negative 1": {fakeGetClientsetErr, fakeGetClientsetForPathOk, "", fakeListFnOk, true},
+		"Negative 2": {fakeGetClientsetOk, fakeGetClientsetForPathErr, "fake-path", fakeListFnOk, true},
+		"Negative 3": {fakeGetClientsetErr, fakeGetClientsetForPathErr, "fake-path", fakeListFnOk, true},
+		"Negative 4": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "", fakeListFnErr, true},
+	}
+
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientsetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+				list:                mock.list,
+			}
+			_, err := fc.List(metav1.ListOptions{})
+			if mock.expectedErr && err == nil {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectedErr && err != nil {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBlockDeviceClaimGet(t *testing.T) {
+	tests := map[string]struct {
+		getClientset        getClientsetFn
+		getClientsetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		get                 getFn
+		bdName              string
+		expectErr           bool
+	}{
+		"Test 1": {fakeGetClientsetErr, fakeGetClientsetForPathOk, "", fakeGetFnOk, "bd-1", true},
+		"Test 2": {fakeGetClientsetOk, fakeGetClientsetForPathErr, "fake-path", fakeGetFnOk, "bd-1", true},
+		"Test 3": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "", fakeGetFnOk, "bd-2", false},
+		"Test 4": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "fp", fakeGetFnErr, "bd-3", true},
+		"Test 5": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "fakepath", fakeGetFnOk, "", true},
+	}
+
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			k := &Kubeclient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientsetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+				namespace:           "default",
+				get:                 mock.get,
+			}
+			_, err := k.Get(mock.bdName, metav1.GetOptions{})
+			if mock.expectErr && err == nil {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && err != nil {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBlockDeviceClaimDelete(t *testing.T) {
+	tests := map[string]struct {
+		getClientset        getClientsetFn
+		getClientsetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		bdName              string
+		delete              deleteFn
+		expectErr           bool
+	}{
+		"Test 1": {fakeGetClientsetErr, fakeGetClientsetForPathOk, "", "bd-1", fakeDeleteFnOk, true},
+		"Test 2": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "fake-path2", "bd-2", fakeDeleteFnOk, false},
+		"Test 3": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "", "bd-3", fakeDeleteFnErr, true},
+		"Test 4": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "fakepath", "", fakeDeleteFnOk, true},
+		"Test 5": {fakeGetClientsetOk, fakeGetClientsetForPathErr, "fake-path2", "bd1", fakeDeleteFnOk, true},
+		"Test 6": {fakeGetClientsetOk, fakeGetClientsetForPathErr, "fake-path2", "bd1", fakeDeleteFnErr, true},
+	}
+
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			k := &Kubeclient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientsetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+				namespace:           "",
+				del:                 mock.delete,
+			}
+			err := k.Delete(mock.bdName, &metav1.DeleteOptions{})
+			if mock.expectErr && err == nil {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && err != nil {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBlockDeviceClaimCreate(t *testing.T) {
+	tests := map[string]struct {
+		getClientset        getClientsetFn
+		getClientsetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		create              createFn
+		bdc                 *apis.BlockDeviceClaim
+		expectErr           bool
+	}{
+		"Test 1": {
+			getClientset:        fakeGetClientsetErr,
+			getClientsetForPath: fakeGetClientsetForPathErr,
+			kubeConfigPath:      "",
+			create:              fakeCreateFnOk,
+			bdc:                 &apis.BlockDeviceClaim{ObjectMeta: metav1.ObjectMeta{Name: "BDC-1"}},
+			expectErr:           true,
+		},
+		"Test 2": {
+			getClientset:        fakeGetClientsetOk,
+			getClientsetForPath: fakeGetClientsetForPathOk,
+			kubeConfigPath:      "",
+			create:              fakeCreateErr,
+			bdc:                 &apis.BlockDeviceClaim{ObjectMeta: metav1.ObjectMeta{Name: "BDC-2"}},
+			expectErr:           true,
+		},
+		"Test 3": {
+			getClientset:        fakeGetClientsetOk,
+			getClientsetForPath: fakeGetClientsetForPathOk,
+			kubeConfigPath:      "fake-path",
+			create:              fakeCreateErr,
+			bdc:                 nil,
+			expectErr:           true,
+		},
+		"Test 4": {
+			getClientset:        fakeGetClientsetErr,
+			getClientsetForPath: fakeGetClientsetForPathOk,
+			kubeConfigPath:      "fake-path",
+			create:              fakeCreateFnOk,
+			bdc:                 nil,
+			expectErr:           true,
+		},
+		"Test 5": {
+			getClientset:        fakeGetClientsetOk,
+			getClientsetForPath: fakeGetClientsetForPathErr,
+			kubeConfigPath:      "fake-path",
+			create:              fakeCreateFnOk,
+			bdc:                 nil,
+			expectErr:           true,
+		},
+	}
+
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientsetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+				create:              mock.create,
+			}
+			_, err := fc.Create(mock.bdc)
+			if mock.expectErr && err == nil {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && err != nil {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBlockDeviceClaimPatch(t *testing.T) {
+	tests := map[string]struct {
+		getClientset        getClientsetFn
+		getClientsetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		patch               patchFn
+		bdName              string
+		expectErr           bool
+	}{
+		"Test 1": {fakeGetClientsetErr, fakeGetClientsetForPathOk, "", fakePatchFnOk, "vsd-1", true},
+		"Test 2": {fakeGetClientsetOk, fakeGetClientsetForPathErr, "fake-path", fakePatchFnOk, "vsd-1", true},
+		"Test 3": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "", fakePatchFnOk, "vsd-2", false},
+		"Test 4": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "fp", fakePatchFnErr, "vsd-3", true},
+		"Test 5": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "fakepath", fakePatchFnOk, "", true},
+	}
+
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			k := &Kubeclient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientsetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+				patch:               mock.patch,
+			}
+			//fake data
+			data, _ := json.Marshal(mock)
+			_, err := k.Patch(mock.bdName, types.MergePatchType, data)
+			if mock.expectErr && err == nil {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && err != nil {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}

--- a/pkg/volume/rounding.go
+++ b/pkg/volume/rounding.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2018 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import "fmt"
+
+const (
+	unit = 1024
+)
+
+// ByteCount converts bytes into corresponding unit
+func ByteCount(b uint64) string {
+	if b < unit {
+		return fmt.Sprintf("%dB", b)
+	}
+	div, index := uint64(unit), 0
+	for val := b / unit; val >= unit; val /= unit {
+		div *= unit
+		index++
+	}
+	return fmt.Sprintf("%d%c",
+		uint64(b)/uint64(div), "KMGTPE"[index])
+}

--- a/pkg/volume/rounding.go
+++ b/pkg/volume/rounding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The OpenEBS Authors
+Copyright 2019 The OpenEBS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/volume/rounding_test.go
+++ b/pkg/volume/rounding_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2018 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"testing"
+)
+
+func TestByteCount(t *testing.T) {
+	tests := map[string]struct {
+		size           uint64
+		expectedOutput string
+	}{
+		"2T in bytes": {
+			size:           2199023255552,
+			expectedOutput: "2T",
+		},
+		"10G in bytes": {
+			size:           10737418240,
+			expectedOutput: "10G",
+		},
+		"100G in bytes": {
+			size:           107374182400,
+			expectedOutput: "100G",
+		},
+		"512M in bytes": {
+			size:           536870912,
+			expectedOutput: "512M",
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			output := ByteCount(test.size)
+			if test.expectedOutput != output {
+				t.Fatalf("Test %q failed: expected {%s} got {%s}",
+					name, test.expectedOutput, output)
+			}
+		})
+	}
+}

--- a/pkg/volume/rounding_test.go
+++ b/pkg/volume/rounding_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The OpenEBS Authors
+Copyright 2019 The OpenEBS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds the support to create pool on unclaimed block devices.

Steps to create a pool on unclaimed block devices:
 1. Deploy latest openebs-operator.yaml using `kubectl apply -f <file_name>`.
 2. Check whether the openebs components are in running state or not
```bash
kubectl get po -n openebs
NAME                                         READY   STATUS             RESTARTS   AGE
maya-apiserver-78f66545fc-j5kvp              1/1     Running            0          15m
node-disk-operator-6c58d8596c-qk7rv          1/1     Running         0          15m
openebs-admission-server-f798484fd-v854b     1/1     Running            0          15m
openebs-localpv-provisioner-76ff6fd9-s9zwj   1/1     Running            0          15m
openebs-ndm-7547s                            1/1     Running            0          15m
openebs-provisioner-7f8fc569c4-nngjs         1/1     Running            0          15m
openebs-snapshot-operator-59b56fb897-rgt9p   2/2     Running            0          15m
```
 3. Get the blockdevice CR's using kubectl get blockdevice -n <openebs_namespace>
```bash
kubectl get blockdevice -n openebs
NAME                                      SIZE          CLAIMSTATE   STATUS   AGE
sparse-177b6bc2ae2dd332c7a384a02179368b   10737418240   Unclaimed    Active   7h
sparse-37a7de580322f43a13338bf2467343f5   10737418240   Unclaimed    Active   7h
sparse-5a92ced3e2ee21eac7b930f670b5eab5   10737418240   Unclaimed    Active   7h
sparse-5e508018b4dd2c8e2530fbdae8e44bb6   10737418240   Unclaimed    Active   7h
sparse-72971f3b2e173c1b79db9a43e4cb841f   10737418240   Unclaimed    Active   7h
sparse-a205e38ff5ec89c223654fdf1361f182   10737418240   Unclaimed    Active   7h
sparse-b6ffc62c1e15edd30c1b4150d897d5cb   10737418240   Unclaimed    Active   7h
sparse-c1f2bcd14c0c74e492f74651893eecee   10737418240   Unclaimed    Active   7h
```
4. Use above blockdevices in spc.yaml to create cstor pools (block devices should be unclaimed)
Manual provisioning (supported): Manual provisioning implies specifying exact blockdevices on which cStor pools need to be created. In other words, update blockDeviceList field with unclaimed blockdevices available on which pools need to be created.
```yaml
apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: cstor-disk
spec:
  name: cstor-disk
  type: blockdevice
  poolSpec:
    poolType: mirrored
  blockDevices:
    blockDeviceList:
    - sparse-177b6bc2ae2dd332c7a384a02179368b
    - sparse-37a7de580322f43a13338bf2467343f5
    - sparse-5a92ced3e2ee21eac7b930f670b5eab5
    - sparse-5e508018b4dd2c8e2530fbdae8e44bb6
    - sparse-72971f3b2e173c1b79db9a43e4cb841f
    - sparse-a205e38ff5ec89c223654fdf1361f182
    - sparse-b6ffc62c1e15edd30c1b4150d897d5cb
    - sparse-c1f2bcd14c0c74e492f74651893eecee
```


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
**TODO:**
1) Make the use of builder pattern to claim BD and to filter eligible block device.(In next PR)
2) UnitTest cases need to be written(some testcases will be handled in next PR])
3) Unclaim the claimed block device after deleting the spc(Done)
4) Make changes in travis of maya(Done)




**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests