### PR TITLE
fix(cvr, delete): add finalizer to reclaim space on volume delete

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/common/common.go
+++ b/cmd/cstor-pool-mgmt/controller/common/common.go
@@ -75,10 +75,18 @@ const (
 	MessageResourceSyncSuccess EventReason = "Resource successfully synced"
 	// MessageResourceSyncFailure holds message for corresponding failed sync of resource.
 	MessageResourceSyncFailure EventReason = "Resource sync failed:"
+
 	// FailureDestroy holds status for corresponding failed destroy resource.
 	FailureDestroy EventReason = "FailDestroy"
-	// MessageResourceFailDestroy holds message for corresponding failed destroy resource.
+
+	// FailureRemoveFinalizer holds the status when
+	// the resource's finalizers could not be removed
+	FailureRemoveFinalizer EventReason = "FailRemoveFinalizer"
+
+	// MessageResourceFailDestroy holds descriptive message for
+	// resource could not be deleted
 	MessageResourceFailDestroy EventReason = "Resource Destroy failed"
+
 	// FailureValidate holds status for corresponding failed validate resource.
 	FailureValidate EventReason = "FailValidate"
 	// MessageResourceFailValidate holds message for corresponding failed validate resource.

--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -706,6 +706,7 @@ spec:
       of the pools from resources list
       */}}
       name: {{ .Volume.owner }}-{{ pluck .ListItems.currentRepeatResource .ListItems.cvolPoolList.pools | first }}
+      finalizers: ["cstorvolumereplica.openebs.io/finalizer"]
       labels:
         cstorpool.openebs.io/name: {{ pluck .ListItems.currentRepeatResource .ListItems.cvolPoolList.pools | first }}
         cstorpool.openebs.io/uid: {{ .ListItems.currentRepeatResource }}


### PR DESCRIPTION
This commit reverts a previous commit i.e. https://github.com/openebs/maya/pull/955

There were a few observations (that were expected) due to above commit. CVR used to have finalizers to execute cleanup operations due to delete event of corresponding volume. This is a standard
practice in kubernetes community to handle cleanups via reconciliation process.

### Why 955 commit?
However, we had to remove finalizers as seen in the commit 955 due to various reasons. These were:

[1] Inability to delete a openebs system namespace and expect entire openebs to get uninstalled

[2] Deletion of cstor volume did not delete CVRs due to the presence of finalizers. This was seen most of the times across various users and platforms. This was not easily reproducible in development environments.

### Current Issue
With the current release i.e. 0.9.0 some users have started to face issues like space not getting reclaimed even after cstor volumes get deleted successfully. On further analysis, it was found that user had tried following operation:

`kubectl delete pvc --all -n some-namespace`

which led to deletion of pvc, pv, cv, cvr resources from k8s cluster but corresponding events especially cvr based events were received much later at the controller code. This resulted in `cvr resource not found` and hence these resources were not cleaned up successfully leading to space issues.

### Current Fix
With this fix we expect original symptoms to recur. However, we plan to provide another fix after the automated test suite is able to discover these issues at will. This next fix will deal only with symptom '2'

NOTE: Ability to un-install openebs by deleting openebs system namespace needs to be handled by a higher order logic/process. This is now considered as out of scope w.r.t cvr controller.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests