### PR TITLE
fix(bdd,exporter): rename metrics name

### DIFF
--- a/tests/exporter/exporter_test.go
+++ b/tests/exporter/exporter_test.go
@@ -32,6 +32,16 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
+const (
+	online, healthy float64 = 1, 1
+)
+
+const (
+	poolStatus                = "openebs_pool_status"
+	replicaStatus             = "openebs_replica_status"
+	noPoolAvailableErrorCount = "openebs_zpool_list_no_pool_available_error"
+)
+
 var _ = Describe("Test maya-exporter [single-pool-pod]", func() {
 	var (
 		err error
@@ -53,7 +63,7 @@ var _ = Describe("Test maya-exporter [single-pool-pod]", func() {
 			By("building spc object")
 			spcObj = spc.NewBuilder().
 				WithName(spcName).
-				WithDiskType(string(apis.TypeSparseCPV)).
+				WithDiskType(string(apis.TypeBlockDeviceCPV)).
 				WithMaxPool(1).
 				WithOverProvisioning(false).
 				WithPoolType(string(apis.PoolTypeStripedCPV)).
@@ -185,10 +195,10 @@ var _ = Describe("Test maya-exporter [single-pool-pod]", func() {
 			mapResp := stats.ToMap()
 
 			By("verifying whether pool status is online")
-			Expect(apis.GetValue("openebs_pool_status", mapResp)).To(Equal(float64(1)), "while getting pool status of", pod.Items[0].Name)
+			Expect(apis.GetValue(poolStatus, mapResp)).To(Equal(online), "while getting pool status of", pod.Items[0].Name)
 
 			By("verifying whether there is no error")
-			Expect(apis.GetValue("openebs_no_pool_available_error", mapResp)).To(Equal(float64(0)), "while getting total no of no pool available errors", pod.Items[0].Name, mapResp)
+			Expect(apis.GetValue(noPoolAvailableErrorCount, mapResp)).To(Equal(float64(0)), "while getting total no of no pool available errors", pod.Items[0].Name, mapResp)
 
 			By("building pvc object")
 			pvcObj, err = pvc.NewBuilder().
@@ -241,7 +251,7 @@ var _ = Describe("Test maya-exporter [single-pool-pod]", func() {
 			By("unmarshalling the metrics")
 			Expect(err).To(BeNil(), "while unmarshalling the stats", string(out))
 			mapResp = stats.ToMap()
-			Expect(apis.GetValue("openebs_replica_status", mapResp)).To(Equal(float64(1)), "while getting pool status of", pod.Items[0].Name, mapResp)
+			Expect(apis.GetValue(replicaStatus, mapResp)).To(Equal(healthy), "while getting pool status of", pod.Items[0].Name, mapResp)
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
- Make use of current spc schema where the value of spec.type has been changed to
  blockdevice irrespective of disk and sparse.
- Remove hardcoded strings and use constants instead
- Rename metrics name `openebs_no_pool_available_error` to
`openebs_zpool_list_no_pool_available_error`

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>

**Checklist:**
- [x] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests