### PR TITLE
refact(cstor-pool,sparse): Update SPC type to blockdevice

### DIFF
--- a/pkg/install/v1alpha1/cstor_sparse_pool_claim.go
+++ b/pkg/install/v1alpha1/cstor_sparse_pool_claim.go
@@ -53,13 +53,13 @@ metadata:
   name: cstor-sparse-pool
   annotations:
     cas.openebs.io/config: |
-      #For default sparse pool set the limit at 2Gi to safegaurd 
-      # cstor pool from consuming more memory and causing the node 
-      # to get into memory pressure condition. By default K8s will set the 
+      #For default sparse pool set the limit at 2Gi to safegaurd
+      # cstor pool from consuming more memory and causing the node
+      # to get into memory pressure condition. By default K8s will set the
       # Requests to the same value as Limits. For example, when Limit is
       # set to 2Gi, the pool could get stuck in pending schedule state,
-      # if node doesn't have Requested (2Gi) memory. 
-      # Hence setting the Requests to a minimum (0.5Gi). 
+      # if node doesn't have Requested (2Gi) memory.
+      # Hence setting the Requests to a minimum (0.5Gi).
       - name: PoolResourceRequests
         value: |-
             memory: 0.5Gi
@@ -74,7 +74,7 @@ metadata:
       #      cpu: 100m
 spec:
   name: cstor-sparse-pool
-  type: sparse
+  type: blockdevice
   maxPools: 3
   poolSpec:
     poolType: striped


### PR DESCRIPTION
**What this PR does / why we need it**:

With latest cstor pool configuration changes, to create StoragePoolClaim we have to
use spc `type: blockdevice` as common type to create Storagepool based on either disk or sparse.

The type specific info i.e. `Sparse` and `Disk`  has been move to the `BlockDeviceClaim` resource.

#### 1. New SPC example where `type: blockdevice` has been set for all.
```yaml
apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: sparse-claim-auto
spec:
  name: sparse-claim-auto
  type: blockdevice
  maxPools: 1
  minPools: 1
  poolSpec:
    poolType: striped
    cacheFile: /var/openebs/sparse/sparse-claim-auto.cache
    overProvisioning: false
```
#### 2. Old SPC example where we have to set `type: sparse` to create a sparse based pool.
```yaml
apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: sparse-claim-auto
spec:
  name: sparse-claim-auto
  type: sparse
  maxPools: 1
  minPools: 1
  poolSpec:
    poolType: striped
    cacheFile: /var/openebs/sparse/sparse-claim-auto.cache
    overProvisioning: false
```
Refer PR https://github.com/openebs/maya/pull/1255 for more details

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests