### PR TITLE
[cherry-pick] feat(cstor-operator): add a support to create pools on unclaimed BD in manual mode

### DIFF
--- a/cmd/maya-apiserver/cstor-operator/spc/handler_test.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/handler_test.go
@@ -306,14 +306,16 @@ func TestValidateSpc(t *testing.T) {
 						PoolType: string(apis.PoolTypeRaidz2CPV),
 					},
 					BlockDevices: apis.BlockDeviceAttr{
-						BlockDeviceList: []string{"blockdevice-1"},
+						BlockDeviceList: []string{"blockdevice-1",
+							"blockdevice-2", "blockdevice-3",
+							"bolckdevice-4", "blockdevice-5", "blockdevice-6"},
 					},
 					Type: string(apis.TypeBlockDeviceCPV),
 				},
 			},
 			expectedError: false,
 		},
-		"InValid Auto SPC with invalid pool type": {
+		"InValid Auto SPC with invalid spc type": {
 			spc: &apis.StoragePoolClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-pool-claim-1",
@@ -327,6 +329,25 @@ func TestValidateSpc(t *testing.T) {
 				},
 			},
 			expectedError: true,
+		},
+		"Invalid Manual SPC with invalid BDCount": {
+			spc: &apis.StoragePoolClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pool-claim-1",
+				},
+				Spec: apis.StoragePoolClaimSpec{
+					PoolSpec: apis.CStorPoolAttr{
+						PoolType: string(apis.PoolTypeMirroredCPV),
+					},
+					BlockDevices: apis.BlockDeviceAttr{
+						BlockDeviceList: []string{"blockdevice-1",
+							"bolckdevice-2", "blockdevice-3",
+							"blockdevice-4", "blockdevice-5"},
+					},
+					Type: string(apis.TypeBlockDeviceCPV),
+				},
+			},
+			expectedError: false,
 		},
 	}
 

--- a/pkg/blockdevice/v1alpha1/blockdevice.go
+++ b/pkg/blockdevice/v1alpha1/blockdevice.go
@@ -249,3 +249,48 @@ func (bdl *BlockDeviceList) Hasitems() (string, bool) {
 	}
 	return "", true
 }
+
+// IsClaimed returns true if block device is claimed
+func (bd *BlockDevice) IsClaimed() bool {
+	return bd.Status.ClaimState == ndm.BlockDeviceClaimed
+}
+
+// GetDeviceID returns the device link of the block device.
+// If device link is not found it returns device path.
+// For a cstor pool creation -- this link or path is used.
+// For convenience, we call it as device ID.
+// Hence, device ID can either be a  device link or device path
+// depending on what was available in block device cr.
+func (bd *BlockDevice) GetDeviceID() string {
+	deviceID := bd.GetLink()
+	if deviceID != "" {
+		return deviceID
+	}
+	return bd.GetPath()
+}
+
+// GetLink returns the link of the block device
+// if present else return empty string
+func (bd *BlockDevice) GetLink() string {
+	if len(bd.Spec.DevLinks) != 0 &&
+		len(bd.Spec.DevLinks[0].Links) != 0 {
+		return bd.Spec.DevLinks[0].Links[0]
+	}
+	return ""
+}
+
+// GetPath returns path of the block device
+func (bd *BlockDevice) GetPath() string {
+	return bd.Spec.Path
+}
+
+// GetBlockDevice returns the block device object present in the block device list
+func (bdl *BlockDeviceList) GetBlockDevice(bdcName string) *ndm.BlockDevice {
+	for _, bdcObj := range bdl.Items {
+		bdcObj := bdcObj
+		if bdcObj.Name == bdcName {
+			return &bdcObj
+		}
+	}
+	return nil
+}

--- a/pkg/blockdevice/v1alpha1/blockdevice_test.go
+++ b/pkg/blockdevice/v1alpha1/blockdevice_test.go
@@ -376,3 +376,46 @@ func TestHasitems(t *testing.T) {
 		})
 	}
 }
+
+func TestIsClaimed(t *testing.T) {
+	tests := map[string]struct {
+		blockDevice    *BlockDevice
+		expectedOutput bool
+	}{
+		"Test Claimed Status": {
+			blockDevice: &BlockDevice{
+				BlockDevice: &ndm.BlockDevice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "blockdevice",
+					},
+					Status: ndm.DeviceStatus{
+						ClaimState: ndm.BlockDeviceClaimed,
+					},
+				},
+			},
+			expectedOutput: true,
+		},
+		"Test UnClaimed Status": {
+			blockDevice: &BlockDevice{
+				BlockDevice: &ndm.BlockDevice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "blockdevice",
+					},
+					Status: ndm.DeviceStatus{
+						ClaimState: ndm.BlockDeviceUnclaimed,
+					},
+				},
+			},
+			expectedOutput: false,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			output := test.blockDevice.IsClaimed()
+			if output != test.expectedOutput {
+				t.Errorf("Test %q failed expected status: %t and got: %t", name, test.expectedOutput, output)
+			}
+		})
+	}
+}

--- a/pkg/blockdevice/v1alpha1/kubernetes_client.go
+++ b/pkg/blockdevice/v1alpha1/kubernetes_client.go
@@ -21,20 +21,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Get is Kubernetes client implementation to get disk.
+// Get is Kubernetes client implementation to get block device
 func (k *KubernetesClient) Get(name string, opts metav1.GetOptions) (*BlockDevice, error) {
 	bd, err := k.Clientset.OpenebsV1alpha1().BlockDevices(k.Namespace).Get(name, opts)
 
 	return &BlockDevice{bd, nil}, err
 }
 
-// List is kubernetes client implementation to list disk.
+// List is kubernetes client implementation to list block device
 func (k *KubernetesClient) List(opts metav1.ListOptions) (*BlockDeviceList, error) {
 	bdl, err := k.Clientset.OpenebsV1alpha1().BlockDevices(k.Namespace).List(opts)
 	return &BlockDeviceList{bdl, nil}, err
 }
 
-// Create is kubernetes client implementation to create disk.
+// Create is kubernetes client implementation to create block device
 func (k *KubernetesClient) Create(bdObj *ndm.BlockDevice) (*BlockDevice, error) {
 	bdObj, err := k.Clientset.OpenebsV1alpha1().BlockDevices(k.Namespace).Create(bdObj)
 	return &BlockDevice{bdObj, nil}, err

--- a/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim.go
+++ b/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim.go
@@ -38,12 +38,12 @@ type BlockDeviceClaimList struct {
 // provided block device claim instance
 type Predicate func(*BlockDeviceClaim) bool
 
-// predicateList holds the list of Predicates
-type predicateList []Predicate
+// PredicateList holds the list of Predicates
+type PredicateList []Predicate
 
 // all returns true if all the predicates succeed against the provided block
 // device instance.
-func (l predicateList) all(c *BlockDeviceClaim) bool {
+func (l PredicateList) all(c *BlockDeviceClaim) bool {
 	for _, pred := range l {
 		if !pred(c) {
 			return false
@@ -101,28 +101,6 @@ func IsStatus(status string) Predicate {
 // block device claim matches with provided status.
 func (bdc *BlockDeviceClaim) IsStatus(status string) bool {
 	return string(bdc.Object.Status.Phase) == status
-}
-
-// Filter will filter the BDC instances if all the predicates succeed
-// against that BDC.
-func (l *BlockDeviceClaimList) Filter(p ...Predicate) *BlockDeviceClaimList {
-	var plist predicateList
-	plist = append(plist, p...)
-	if len(plist) == 0 {
-		return l
-	}
-
-	filtered := NewListBuilder().List()
-	for _, bdcAPI := range l.ObjectList.Items {
-		bdcAPI := bdcAPI // pin it
-		BlockDeviceClaim := BuilderForAPIObject(&bdcAPI).BDC
-		if plist.all(BlockDeviceClaim) {
-			filtered.ObjectList.Items = append(
-				filtered.ObjectList.Items,
-				*BlockDeviceClaim.Object)
-		}
-	}
-	return filtered
 }
 
 // Len returns the length og BlockDeviceClaimList.

--- a/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim_test.go
+++ b/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim_test.go
@@ -1,0 +1,32 @@
+// Copyright © 2018-2019 The OpenEBS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
+)
+
+func fakeAPIBDCList(bdcNames []string) *apis.BlockDeviceClaimList {
+	if len(bdcNames) == 0 {
+		return nil
+	}
+	list := &apis.BlockDeviceClaimList{}
+	for _, name := range bdcNames {
+		bdc := apis.BlockDeviceClaim{}
+		bdc.SetName(name)
+		list.Items = append(list.Items, bdc)
+	}
+	return list
+}

--- a/pkg/blockdeviceclaim/v1alpha1/build_test.go
+++ b/pkg/blockdeviceclaim/v1alpha1/build_test.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"reflect"
+	"testing"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBuilderWithName(t *testing.T) {
+	tests := map[string]struct {
+		name      string
+		expectErr bool
+	}{
+		"Test Builder with name": {
+			name:      "BDC1",
+			expectErr: false,
+		},
+		"Test Builder without name": {
+			name:      "",
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := NewBuilder().WithName(mock.name)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuildWithNamespace(t *testing.T) {
+	tests := map[string]struct {
+		namespace string
+		expectErr bool
+	}{
+		"Test Builderwith namespae": {
+			namespace: "jiva-ns",
+			expectErr: false,
+		},
+		"Test Builderwithout namespace": {
+			namespace: "",
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := NewBuilder().WithNamespace(mock.namespace)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuildWithAnnotations(t *testing.T) {
+	tests := map[string]struct {
+		annotations map[string]string
+		expectErr   bool
+	}{
+		"Test Builderwith annotations": {
+			annotations: map[string]string{"persistent-volume": "PV", "application": "percona"},
+			expectErr:   false,
+		},
+		"Test Builderwithout annotations": {
+			annotations: map[string]string{},
+			expectErr:   true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := NewBuilder().WithAnnotations(mock.annotations)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuildWithLabelsNew(t *testing.T) {
+	tests := map[string]struct {
+		labels    map[string]string
+		expectErr bool
+	}{
+		"Test Builderwith labels": {
+			labels:    map[string]string{"persistent-volume": "PV", "application": "percona"},
+			expectErr: false,
+		},
+		"Test Builderwithout labels": {
+			labels:    map[string]string{},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := NewBuilder().WithLabels(mock.labels)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuildWithLabels(t *testing.T) {
+	tests := map[string]struct {
+		labels    map[string]string
+		builder   *Builder
+		expectErr bool
+	}{
+		"Test Builderwith labels": {
+			labels: map[string]string{"blockdeviceclaim": "BDC", "application": "percona"},
+			builder: &Builder{BDC: &BlockDeviceClaim{
+				Object: &apis.BlockDeviceClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"openebs.io/storage-pool-claim": "cstor-pool"},
+					},
+				},
+			}},
+			expectErr: false,
+		},
+		"Test Builderwithout labels": {
+			labels: map[string]string{},
+			builder: &Builder{BDC: &BlockDeviceClaim{
+				Object: &apis.BlockDeviceClaim{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithLabels(mock.labels)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuildWithCapacity(t *testing.T) {
+	tests := map[string]struct {
+		capacity  string
+		expectErr bool
+	}{
+		"Test Builderwith capacity": {
+			capacity:  "5G",
+			expectErr: false,
+		},
+		"Test Builderwithout capacity": {
+			capacity:  "",
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := NewBuilder().WithCapacity(mock.capacity)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuild(t *testing.T) {
+	tests := map[string]struct {
+		name        string
+		capacity    string
+		expectedBDC *apis.BlockDeviceClaim
+		expectedErr bool
+	}{
+		"BDC with correct details": {
+			name:     "BDC1",
+			capacity: "10Ti",
+			expectedBDC: &apis.BlockDeviceClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "BDC1"},
+				Spec: apis.DeviceClaimSpec{
+					Requirements: apis.DeviceClaimRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceName("capacity"): fakeCapacity("10Ti"),
+						},
+					},
+				},
+			},
+			expectedErr: false,
+		},
+		"BDC with error": {
+			name:        "",
+			capacity:    "500Gi",
+			expectedBDC: nil,
+			expectedErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			bdcObj, err := NewBuilder().WithName(mock.name).WithCapacity(mock.capacity).Build()
+			if mock.expectedErr && err == nil {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectedErr && err != nil {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+			if err == nil && !reflect.DeepEqual(bdcObj.Object, mock.expectedBDC) {
+				t.Fatalf("Test %q failed: bdc mismatch", name)
+			}
+		})
+	}
+}
+
+func fakeCapacity(capacity string) resource.Quantity {
+	q, _ := resource.ParseQuantity(capacity)
+	return q
+}

--- a/pkg/blockdeviceclaim/v1alpha1/buildlist_test.go
+++ b/pkg/blockdeviceclaim/v1alpha1/buildlist_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+)
+
+func TestListBuilderWithAPIList(t *testing.T) {
+	tests := map[string]struct {
+		availableBDCs  []string
+		expectedBDCLen int
+	}{
+		"BDC set 1": {[]string{}, 0},
+		"BDC set 2": {[]string{"bdc1"}, 1},
+		"BDC set 3": {[]string{"bdc1", "bdc2"}, 2},
+		"BDC set 4": {[]string{"bdc1", "bdc2", "bdc3"}, 3},
+		"BDC set 5": {[]string{"bdc1", "bdc2", "bdc3", "bdc4"}, 4},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := ListBuilderFromAPIList(fakeAPIBDCList(mock.availableBDCs)).List()
+			itemsLen := len(b.ObjectList.Items)
+			if mock.expectedBDCLen != itemsLen {
+				t.Fatalf("Test %v failed: expected %v got %v", name, mock.expectedBDCLen, itemsLen)
+			}
+		})
+	}
+}

--- a/pkg/blockdeviceclaim/v1alpha1/kubernetes_test.go
+++ b/pkg/blockdeviceclaim/v1alpha1/kubernetes_test.go
@@ -1,0 +1,485 @@
+// Copyright © 2018-2019 The OpenEBS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
+	clientset "github.com/openebs/maya/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func fakeGetClientsetOk() (cli *clientset.Clientset, err error) {
+	return &clientset.Clientset{}, nil
+}
+
+func fakeGetClientsetForPathOk(fakeConfigPath string) (cli *clientset.Clientset, err error) {
+	return &clientset.Clientset{}, nil
+}
+
+func fakeGetClientsetForPathErr(fakeConfigPath string) (cli *clientset.Clientset, err error) {
+	return nil, errors.New("fake error")
+}
+
+func fakeGetFnOk(cli *clientset.Clientset, name, namespace string, opts metav1.GetOptions) (*apis.BlockDeviceClaim, error) {
+	return &apis.BlockDeviceClaim{}, nil
+}
+
+func fakeListFnOk(cli *clientset.Clientset, namespace string, opts metav1.ListOptions) (*apis.BlockDeviceClaimList, error) {
+	return &apis.BlockDeviceClaimList{}, nil
+}
+
+func fakeDeleteFnOk(cli *clientset.Clientset, name, namespace string, opts *metav1.DeleteOptions) error {
+	return nil
+}
+
+func fakeListFnErr(cli *clientset.Clientset, namespace string, opts metav1.ListOptions) (*apis.BlockDeviceClaimList, error) {
+	return &apis.BlockDeviceClaimList{}, errors.New("some error")
+}
+
+func fakeGetFnErr(cli *clientset.Clientset, name, namespace string, opts metav1.GetOptions) (*apis.BlockDeviceClaim, error) {
+	return &apis.BlockDeviceClaim{}, errors.New("some error")
+}
+
+func fakeDeleteFnErr(cli *clientset.Clientset, name, namespace string, opts *metav1.DeleteOptions) error {
+	return errors.New("some error")
+}
+
+func fakeGetClientsetErr() (clientset *clientset.Clientset, err error) {
+	return nil, errors.New("Some error")
+}
+
+func fakeCreateFnOk(cli *clientset.Clientset, namespace string, bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim, error) {
+	return &apis.BlockDeviceClaim{}, nil
+}
+
+func fakeCreateErr(cli *clientset.Clientset, namespace string, bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim, error) {
+	return nil, errors.New("failed to create BDC")
+}
+
+func fakePatchFnOk(cli *clientset.Clientset, namespace, name string, pt types.PatchType, data []byte, subresources ...string) (*apis.BlockDeviceClaim, error) {
+	return &apis.BlockDeviceClaim{}, nil
+}
+
+func fakePatchFnErr(cli *clientset.Clientset, namespace, name string, pt types.PatchType, data []byte, subresources ...string) (*apis.BlockDeviceClaim, error) {
+	return nil, errors.New("fake error")
+}
+
+func TestWithDefaultOptionsForClientset(t *testing.T) {
+	tests := map[string]struct {
+		getClientset        getClientsetFn
+		getClientsetForPath getClientsetForPathFn
+	}{
+		"TestCase1":               {nil, nil},
+		"When clientset is error": {fakeGetClientsetErr, fakeGetClientsetForPathErr},
+		"When clientset is ok":    {fakeGetClientsetOk, fakeGetClientsetForPathOk},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientsetForPath,
+			}
+			fc.WithDefaults()
+			if fc.getClientset == nil {
+				t.Fatalf("test %q failed: expected getClientset not to be empty", name)
+			}
+			if fc.getClientsetForPath == nil {
+				t.Fatalf("test %q failed: expected getClientset not to be nil", name)
+			}
+		})
+	}
+}
+
+func TestWithDefaultOptionsForCRUDOPS(t *testing.T) {
+	tests := map[string]struct {
+		list          listFn
+		get           getFn
+		create        createFn
+		del           deleteFn
+		delCollection deleteCollectionFn
+	}{
+		"TestCase1":               {nil, nil, nil, nil, nil},
+		"When clientset is error": {fakeListFnErr, fakeGetFnErr, fakeCreateErr, fakeDeleteFnErr, nil},
+		"When clientset is ok":    {fakeListFnOk, fakeGetFnOk, fakeCreateFnOk, fakeDeleteFnOk, nil},
+	}
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{
+				list:          mock.list,
+				get:           mock.get,
+				create:        mock.create,
+				del:           mock.del,
+				delCollection: mock.delCollection,
+			}
+			fc.WithDefaults()
+			if fc.list == nil {
+				t.Fatalf("test %q failed: expected list not to be empty", name)
+			}
+			if fc.get == nil {
+				t.Fatalf("test %q failed: expected get not to be empty", name)
+			}
+			if fc.create == nil {
+				t.Fatalf("test %q failed: expected create not to be empty", name)
+			}
+			if fc.del == nil {
+				t.Fatalf("test %q failed: expected del not to be empty", name)
+			}
+			if fc.delCollection == nil {
+				t.Fatalf("test %q failed: expected delCollection not to be empty", name)
+			}
+		})
+	}
+}
+
+func TestGetClientsetForPathOrDirect(t *testing.T) {
+	tests := map[string]struct {
+		getClientset        getClientsetFn
+		getClientsetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		isErr               bool
+	}{
+		// Positive tests
+		"Positive 1": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "", false},
+		"Positive 2": {fakeGetClientsetErr, fakeGetClientsetForPathOk, "fake-path", false},
+		"Positive 3": {fakeGetClientsetOk, fakeGetClientsetForPathErr, "", false},
+
+		// Negative tests
+		"Negative 1": {fakeGetClientsetErr, fakeGetClientsetForPathOk, "", true},
+		"Negative 2": {fakeGetClientsetOk, fakeGetClientsetForPathErr, "fake-path", true},
+		"Negative 3": {fakeGetClientsetErr, fakeGetClientsetForPathErr, "fake-path", true},
+		"Negative 4": {fakeGetClientsetErr, fakeGetClientsetForPathErr, "", true},
+	}
+
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientsetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+			}
+			_, err := fc.getClientsetForPathOrDirect()
+			if mock.isErr && err == nil {
+				t.Fatalf("test %q failed : expected error not to be nil but got %v", name, err)
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("test %q failed : expected error be nil but got %v", name, err)
+			}
+		})
+	}
+}
+
+func TestWithClientsetBuildOption(t *testing.T) {
+	tests := map[string]struct {
+		Clientset             *clientset.Clientset
+		expectKubeClientEmpty bool
+	}{
+		"Clientset is empty":     {nil, true},
+		"Clientset is not empty": {&clientset.Clientset{}, false},
+	}
+
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			h := WithKubeClient(mock.Clientset)
+			fake := &Kubeclient{}
+			h(fake)
+			if mock.expectKubeClientEmpty && fake.clientset != nil {
+				t.Fatalf("test %q failed expected fake.clientset to be empty", name)
+			}
+			if !mock.expectKubeClientEmpty && fake.clientset == nil {
+				t.Fatalf("test %q failed expected fake.clientset not to be empty", name)
+			}
+		})
+	}
+}
+
+func TestGetClientOrCached(t *testing.T) {
+	tests := map[string]struct {
+		getClientset        getClientsetFn
+		getClientsetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		expectErr           bool
+	}{
+		// Positive tests
+		"Positive 1": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "", false},
+		"Positive 2": {fakeGetClientsetErr, fakeGetClientsetForPathOk, "fake-path", false},
+		"Positive 3": {fakeGetClientsetOk, fakeGetClientsetForPathErr, "", false},
+
+		// Negative tests
+		"Negative 1": {fakeGetClientsetErr, fakeGetClientsetForPathOk, "", true},
+		"Negative 2": {fakeGetClientsetOk, fakeGetClientsetForPathErr, "fake-path", true},
+		"Negative 3": {fakeGetClientsetErr, fakeGetClientsetForPathErr, "fake-path", true},
+		"Negative 4": {fakeGetClientsetErr, fakeGetClientsetForPathErr, "", true},
+	}
+
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientsetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+			}
+			_, err := fc.getClientsetOrCached()
+			if mock.expectErr && err == nil {
+				t.Fatalf("test %q failed : expected error not to be nil but got %v", name, err)
+			}
+			if !mock.expectErr && err != nil {
+				t.Fatalf("test %q failed : expected error be nil but got %v", name, err)
+			}
+		})
+	}
+}
+
+func TestBlockDeviceClaimList(t *testing.T) {
+	tests := map[string]struct {
+		getClientset        getClientsetFn
+		getClientsetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		list                listFn
+		expectedErr         bool
+	}{
+		// Positive tests
+		"Positive 1": {nil, fakeGetClientsetForPathOk, "fake-path", fakeListFnOk, false},
+		"Positive 2": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "", fakeListFnOk, false},
+		"Positive 3": {fakeGetClientsetErr, fakeGetClientsetForPathOk, "fake-path", fakeListFnOk, false},
+		"Positive 4": {fakeGetClientsetOk, fakeGetClientsetForPathErr, "", fakeListFnOk, false},
+
+		// Negative tests
+		"Negative 1": {fakeGetClientsetErr, fakeGetClientsetForPathOk, "", fakeListFnOk, true},
+		"Negative 2": {fakeGetClientsetOk, fakeGetClientsetForPathErr, "fake-path", fakeListFnOk, true},
+		"Negative 3": {fakeGetClientsetErr, fakeGetClientsetForPathErr, "fake-path", fakeListFnOk, true},
+		"Negative 4": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "", fakeListFnErr, true},
+	}
+
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientsetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+				list:                mock.list,
+			}
+			_, err := fc.List(metav1.ListOptions{})
+			if mock.expectedErr && err == nil {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectedErr && err != nil {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBlockDeviceClaimGet(t *testing.T) {
+	tests := map[string]struct {
+		getClientset        getClientsetFn
+		getClientsetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		get                 getFn
+		bdName              string
+		expectErr           bool
+	}{
+		"Test 1": {fakeGetClientsetErr, fakeGetClientsetForPathOk, "", fakeGetFnOk, "bd-1", true},
+		"Test 2": {fakeGetClientsetOk, fakeGetClientsetForPathErr, "fake-path", fakeGetFnOk, "bd-1", true},
+		"Test 3": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "", fakeGetFnOk, "bd-2", false},
+		"Test 4": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "fp", fakeGetFnErr, "bd-3", true},
+		"Test 5": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "fakepath", fakeGetFnOk, "", true},
+	}
+
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			k := &Kubeclient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientsetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+				namespace:           "default",
+				get:                 mock.get,
+			}
+			_, err := k.Get(mock.bdName, metav1.GetOptions{})
+			if mock.expectErr && err == nil {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && err != nil {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBlockDeviceClaimDelete(t *testing.T) {
+	tests := map[string]struct {
+		getClientset        getClientsetFn
+		getClientsetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		bdName              string
+		delete              deleteFn
+		expectErr           bool
+	}{
+		"Test 1": {fakeGetClientsetErr, fakeGetClientsetForPathOk, "", "bd-1", fakeDeleteFnOk, true},
+		"Test 2": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "fake-path2", "bd-2", fakeDeleteFnOk, false},
+		"Test 3": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "", "bd-3", fakeDeleteFnErr, true},
+		"Test 4": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "fakepath", "", fakeDeleteFnOk, true},
+		"Test 5": {fakeGetClientsetOk, fakeGetClientsetForPathErr, "fake-path2", "bd1", fakeDeleteFnOk, true},
+		"Test 6": {fakeGetClientsetOk, fakeGetClientsetForPathErr, "fake-path2", "bd1", fakeDeleteFnErr, true},
+	}
+
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			k := &Kubeclient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientsetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+				namespace:           "",
+				del:                 mock.delete,
+			}
+			err := k.Delete(mock.bdName, &metav1.DeleteOptions{})
+			if mock.expectErr && err == nil {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && err != nil {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBlockDeviceClaimCreate(t *testing.T) {
+	tests := map[string]struct {
+		getClientset        getClientsetFn
+		getClientsetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		create              createFn
+		bdc                 *apis.BlockDeviceClaim
+		expectErr           bool
+	}{
+		"Test 1": {
+			getClientset:        fakeGetClientsetErr,
+			getClientsetForPath: fakeGetClientsetForPathErr,
+			kubeConfigPath:      "",
+			create:              fakeCreateFnOk,
+			bdc:                 &apis.BlockDeviceClaim{ObjectMeta: metav1.ObjectMeta{Name: "BDC-1"}},
+			expectErr:           true,
+		},
+		"Test 2": {
+			getClientset:        fakeGetClientsetOk,
+			getClientsetForPath: fakeGetClientsetForPathOk,
+			kubeConfigPath:      "",
+			create:              fakeCreateErr,
+			bdc:                 &apis.BlockDeviceClaim{ObjectMeta: metav1.ObjectMeta{Name: "BDC-2"}},
+			expectErr:           true,
+		},
+		"Test 3": {
+			getClientset:        fakeGetClientsetOk,
+			getClientsetForPath: fakeGetClientsetForPathOk,
+			kubeConfigPath:      "fake-path",
+			create:              fakeCreateErr,
+			bdc:                 nil,
+			expectErr:           true,
+		},
+		"Test 4": {
+			getClientset:        fakeGetClientsetErr,
+			getClientsetForPath: fakeGetClientsetForPathOk,
+			kubeConfigPath:      "fake-path",
+			create:              fakeCreateFnOk,
+			bdc:                 nil,
+			expectErr:           true,
+		},
+		"Test 5": {
+			getClientset:        fakeGetClientsetOk,
+			getClientsetForPath: fakeGetClientsetForPathErr,
+			kubeConfigPath:      "fake-path",
+			create:              fakeCreateFnOk,
+			bdc:                 nil,
+			expectErr:           true,
+		},
+	}
+
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			fc := &Kubeclient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientsetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+				create:              mock.create,
+			}
+			_, err := fc.Create(mock.bdc)
+			if mock.expectErr && err == nil {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && err != nil {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBlockDeviceClaimPatch(t *testing.T) {
+	tests := map[string]struct {
+		getClientset        getClientsetFn
+		getClientsetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		patch               patchFn
+		bdName              string
+		expectErr           bool
+	}{
+		"Test 1": {fakeGetClientsetErr, fakeGetClientsetForPathOk, "", fakePatchFnOk, "vsd-1", true},
+		"Test 2": {fakeGetClientsetOk, fakeGetClientsetForPathErr, "fake-path", fakePatchFnOk, "vsd-1", true},
+		"Test 3": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "", fakePatchFnOk, "vsd-2", false},
+		"Test 4": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "fp", fakePatchFnErr, "vsd-3", true},
+		"Test 5": {fakeGetClientsetOk, fakeGetClientsetForPathOk, "fakepath", fakePatchFnOk, "", true},
+	}
+
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			k := &Kubeclient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientsetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+				patch:               mock.patch,
+			}
+			//fake data
+			data, _ := json.Marshal(mock)
+			_, err := k.Patch(mock.bdName, types.MergePatchType, data)
+			if mock.expectErr && err == nil {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && err != nil {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}

--- a/pkg/install/v1alpha1/cstor_sparse_pool_claim.go
+++ b/pkg/install/v1alpha1/cstor_sparse_pool_claim.go
@@ -53,13 +53,13 @@ metadata:
   name: cstor-sparse-pool
   annotations:
     cas.openebs.io/config: |
-      #For default sparse pool set the limit at 2Gi to safegaurd 
-      # cstor pool from consuming more memory and causing the node 
-      # to get into memory pressure condition. By default K8s will set the 
+      #For default sparse pool set the limit at 2Gi to safegaurd
+      # cstor pool from consuming more memory and causing the node
+      # to get into memory pressure condition. By default K8s will set the
       # Requests to the same value as Limits. For example, when Limit is
       # set to 2Gi, the pool could get stuck in pending schedule state,
-      # if node doesn't have Requested (2Gi) memory. 
-      # Hence setting the Requests to a minimum (0.5Gi). 
+      # if node doesn't have Requested (2Gi) memory.
+      # Hence setting the Requests to a minimum (0.5Gi).
       - name: PoolResourceRequests
         value: |-
             memory: 0.5Gi
@@ -74,7 +74,7 @@ metadata:
       #      cpu: 100m
 spec:
   name: cstor-sparse-pool
-  type: sparse
+  type: blockdevice
   maxPools: 3
   poolSpec:
     poolType: striped

--- a/pkg/volume/rounding.go
+++ b/pkg/volume/rounding.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import "fmt"
+
+const (
+	unit = 1024
+)
+
+// ByteCount converts bytes into corresponding unit
+func ByteCount(b uint64) string {
+	if b < unit {
+		return fmt.Sprintf("%dB", b)
+	}
+	div, index := uint64(unit), 0
+	for val := b / unit; val >= unit; val /= unit {
+		div *= unit
+		index++
+	}
+	return fmt.Sprintf("%d%c",
+		uint64(b)/uint64(div), "KMGTPE"[index])
+}

--- a/pkg/volume/rounding_test.go
+++ b/pkg/volume/rounding_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"testing"
+)
+
+func TestByteCount(t *testing.T) {
+	tests := map[string]struct {
+		size           uint64
+		expectedOutput string
+	}{
+		"2T in bytes": {
+			size:           2199023255552,
+			expectedOutput: "2T",
+		},
+		"10G in bytes": {
+			size:           10737418240,
+			expectedOutput: "10G",
+		},
+		"100G in bytes": {
+			size:           107374182400,
+			expectedOutput: "100G",
+		},
+		"512M in bytes": {
+			size:           536870912,
+			expectedOutput: "512M",
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			output := ByteCount(test.size)
+			if test.expectedOutput != output {
+				t.Fatalf("Test %q failed: expected {%s} got {%s}",
+					name, test.expectedOutput, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR contains following cherry-picks
1) https://github.com/openebs/maya/pull/1264
2) https://github.com/openebs/maya/pull/1265

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests