### PR TITLE
[cherry-pick-1234] chore(log, debuggability): reduce flooding of install logs

### DIFF
--- a/pkg/install/v1alpha1/env.go
+++ b/pkg/install/v1alpha1/env.go
@@ -21,10 +21,11 @@ import (
 )
 
 const (
-	// DefaultCstorSparsePool is the environment variable that flags if default
-	// cstor pool should be configured or not
+	// DefaultCstorSparsePool is the environment variable that
+	// flags if default cstor pool should be configured or not
 	//
-	// If value is "true", default cstor pool will be installed/configured else
-	// for "false" it will not be configured
+	// If value is "true", default cstor pool will be
+	// installed/configured else for "false" it will
+	// not be configured
 	DefaultCstorSparsePool menv.ENVKey = "OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL"
 )

--- a/pkg/install/v1alpha1/env_setter.go
+++ b/pkg/install/v1alpha1/env_setter.go
@@ -24,7 +24,8 @@ import (
 	ver "github.com/openebs/maya/pkg/version"
 )
 
-// EnvStatus represents the status of operation against an env instance
+// EnvStatus represents the status of operation
+// against an env instance
 type EnvStatus string
 
 // env set completion statuses
@@ -44,11 +45,13 @@ type env struct {
 	Err     error
 }
 
-// envPredicate abstracts evaluation condition of the given instance and returns
-// the name of evaluation along with result of evaluation
+// envPredicate abstracts evaluation condition of
+// the given instance and returns the name of
+// evaluation along with result of evaluation
 type envPredicate func(given *env) (name string, success bool)
 
-// isEnvNotPresent returns true if env in not set previously
+// isEnvNotPresent returns true if env in not set
+// previously
 func isEnvNotPresent(given *env) (name string, success bool) {
 	name = "isEnvNotPresent"
 	if given == nil {
@@ -73,10 +76,11 @@ func isEnvError(given *env) (name string, hasErr bool) {
 	return
 }
 
-// envMiddleware abstracts updating the given env instance
+// envMiddleware abstracts updating given env instance
 type envMiddleware func(given *env) (updated *env)
 
-// EnvUpdateStatus updates the env instance with provided status info
+// EnvUpdateStatus updates the env instance with
+// provided status info
 func EnvUpdateStatus(context, reason string, status EnvStatus) envMiddleware {
 	return func(given *env) (updated *env) {
 		if given == nil {
@@ -90,7 +94,8 @@ func EnvUpdateStatus(context, reason string, status EnvStatus) envMiddleware {
 	}
 }
 
-// EnvUpdateError updates the env instance with provided error
+// EnvUpdateError updates the env instance with
+// provided error
 func EnvUpdateError(context string, err error) envMiddleware {
 	return func(given *env) (updated *env) {
 		if given == nil || err == nil {
@@ -102,7 +107,8 @@ func EnvUpdateError(context string, err error) envMiddleware {
 	}
 }
 
-// EnvUpdateSuccess updates the env instance with success status
+// EnvUpdateSuccess updates the env instance with
+// success status
 func EnvUpdateSuccess(context string) envMiddleware {
 	return func(given *env) (updated *env) {
 		return EnvUpdateStatus(context, "", EnvSetSuccess)(given)
@@ -154,7 +160,17 @@ func (l *envList) Infos() (msgs []string) {
 		if env == nil || env.Err != nil {
 			continue
 		}
-		msgs = append(msgs, fmt.Sprintf("{env '%s': val '%s': msg: '%s' '%s' '%s'}", env.Key, env.Value, env.Context, env.Status, env.Reason))
+		msgs = append(
+			msgs,
+			fmt.Sprintf(
+				"{env '%s': val '%s': msg: '%s' '%s' '%s'}",
+				env.Key,
+				env.Value,
+				env.Context,
+				env.Status,
+				env.Reason,
+			),
+		)
 	}
 	return
 }
@@ -230,7 +246,11 @@ func (e *envInstall) List() (l *envList, err error) {
 	l.Items = append(l.Items, &env{
 		Key: menv.CASTemplateToListVolumeENVK,
 		Value: strings.Join(ver.WithSuffixesIf(
-			[]string{"jiva-volume-list-default-0.6.0", "jiva-volume-list-default", "cstor-volume-list-default"},
+			[]string{
+				"jiva-volume-list-default-0.6.0",
+				"jiva-volume-list-default",
+				"cstor-volume-list-default",
+			},
 			ver.IsNotVersioned), ","),
 	})
 	l.Items = append(l.Items, &env{

--- a/pkg/install/v1alpha1/installer.go
+++ b/pkg/install/v1alpha1/installer.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// TODO
-// Make use of pkg/msg instead of errorList
-
 package v1alpha1
 
 import (
@@ -41,6 +38,8 @@ type Installer interface {
 type simpleInstaller struct {
 	artifactTemplater ArtifactMiddleware
 	envLister         EnvLister
+
+	// TODO use pkg/errors/v1alpha1
 	errorList
 }
 
@@ -52,7 +51,7 @@ func (i *simpleInstaller) prepareResources() k8s.UnstructedList {
 
 	// set the environments conditionally required for install
 	eslist := elist.SetIf(version.Current(), isEnvNotPresent)
-	glog.Infof("%+v", eslist.Infos())
+	glog.V(2).Infof("%+v", eslist.Infos())
 	i.addErrors(eslist.Errors())
 
 	// list the artifacts w.r.t latest version
@@ -115,7 +114,12 @@ func (i *simpleInstaller) Install() []error {
 		cu := k8s.CreateOrUpdate(k8s.GroupVersionResourceFromGVK(unstruct), unstruct.GetNamespace())
 		u, err := cu.Apply(unstruct)
 		if err == nil {
-			glog.Infof("'%s' '%s' installed successfully at namespace '%s'", u.GroupVersionKind(), u.GetName(), u.GetNamespace())
+			glog.V(2).Infof(
+				"{%s/%s} installed successfully at namespace {%s}",
+				u.GroupVersionKind(),
+				u.GetName(),
+				u.GetNamespace(),
+			)
 		} else {
 			i.addError(err)
 		}

--- a/pkg/install/v1alpha1/marshall.go
+++ b/pkg/install/v1alpha1/marshall.go
@@ -22,8 +22,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ConfigUnmarshaller abstracts un-marshalling of config specifications into an
-// instance of install config
+// ConfigUnmarshaller abstracts un-marshalling of
+// config specifications into an instance of install
+// config
 type ConfigUnmarshaller func(conf string) (config *InstallConfig, err error)
 
 // UnmarshallConfig is an implementation of ConfigUnmarshaller

--- a/pkg/install/v1alpha1/registrar.go
+++ b/pkg/install/v1alpha1/registrar.go
@@ -20,27 +20,31 @@ import (
 	"strings"
 )
 
-// MultiYamlFetcher abstracts aggregating and returning multiple yaml documents
-// as a string
+// MultiYamlFetcher abstracts aggregating and
+// returning multiple yaml documents as a string
 type MultiYamlFetcher interface {
 	FetchYamls() string
 }
 
-// ArtifactListPredicate abstracts evaluating a condition against the provided
-// artifact list
+// ArtifactListPredicate abstracts evaluating a
+// condition against the provided artifact list
 type ArtifactListPredicate func() bool
 
-// ParseArtifactListFromMultipleYamlsIf generates a list of Artifacts from
-// yaml documents if predicate evaluation succeeds
-func ParseArtifactListFromMultipleYamlsIf(m MultiYamlFetcher, p ArtifactListPredicate) (artifacts []*Artifact) {
+// ParseArtifactListFromMultipleYamlsIf generates a
+// list of Artifacts from yaml documents if predicate
+// evaluation succeeds
+func ParseArtifactListFromMultipleYamlsIf(
+	m MultiYamlFetcher,
+	p ArtifactListPredicate,
+) (artifacts []*Artifact) {
 	if p() {
 		return ParseArtifactListFromMultipleYamls(m)
 	}
 	return
 }
 
-// ParseArtifactListFromMultipleYamls generates a list of Artifacts from the
-// yaml documents.
+// ParseArtifactListFromMultipleYamls generates a list of
+// Artifacts from the yaml documents.
 //
 // NOTE:
 //  Each YAML document is assumed to be separated via "---"
@@ -56,16 +60,19 @@ func ParseArtifactListFromMultipleYamls(m MultiYamlFetcher) (artifacts []*Artifa
 	return
 }
 
-// RegisteredArtifacts returns the list of latest Artifacts that will get
-// installed
+// RegisteredArtifacts returns the list of latest
+// Artifacts that will get installed
 func RegisteredArtifacts() (list artifactList) {
-	//Note: CRDs have to be installed first. Keep this at top of the list.
+	// Note: CRDs need to be installed first
+	// Keep this at top of the list
 	list.Items = append(list.Items, OpenEBSCRDArtifacts().Items...)
 
 	list.Items = append(list.Items, JivaVolumeArtifacts().Items...)
-	//Contains the read/list/delete CAST for supporting older volumes
-	//The CAST defined here are provided as fallback options to latest CAST
+
+	// Contains read/list/delete CAST for supporting older volumes
+	// CAST defined here are provided as fallback options to latest CAST
 	list.Items = append(list.Items, JivaVolumeArtifactsFor060().Items...)
+
 	list.Items = append(list.Items, JivaPoolArtifacts().Items...)
 
 	list.Items = append(list.Items, CstorPoolArtifacts().Items...)
@@ -73,8 +80,9 @@ func RegisteredArtifacts() (list artifactList) {
 	list.Items = append(list.Items, CstorSnapshotArtifacts().Items...)
 	list.Items = append(list.Items, CstorSparsePoolArtifacts().Items...)
 
-	//Contains the SC to help with provisioning from clone.
-	//This is generic for release till K8s supports native way of cloning.
+	// Contains SC to help with provisioning from clone
+	// This is generic for release till K8s supports native
+	// way of cloning
 	list.Items = append(list.Items, SnapshotPromoterSCArtifacts().Items...)
 
 	// snapshots


### PR DESCRIPTION
This commit reduces flooding of logs during install of
openebs crds and resources by maya api server.

In addition, this commit puts few code & code comments well
within the limits of 80 chars.
cherry-pick #1234
Signed-off-by: AmitKumarDas <amit.das@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests