### PR TITLE
refact(bdd, jiva) added target affinity check after controller and replica pods restart

### DIFF
--- a/tests/jiva/clone/provision_test.go
+++ b/tests/jiva/clone/provision_test.go
@@ -254,7 +254,7 @@ var _ = Describe("[jiva] TEST JIVA CLONE CREATION", func() {
 						WithVolumeMounts(
 							[]corev1.VolumeMount{
 								corev1.VolumeMount{
-									Name:      "demo-vol1",
+									Name:      "demo-vol2",
 									MountPath: "/mnt/store1",
 								},
 							},
@@ -262,7 +262,7 @@ var _ = Describe("[jiva] TEST JIVA CLONE CREATION", func() {
 				).
 				WithVolumeBuilder(
 					volume.NewBuilder().
-						WithName("demo-vol1").
+						WithName("demo-vol2").
 						WithPVCSource(cloneName),
 				).
 				Build()

--- a/tests/jiva/volume/provision_test.go
+++ b/tests/jiva/volume/provision_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package volume
 
 import (
+	"encoding/json"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	jivaClient "github.com/openebs/maya/pkg/client/jiva"
 	pvc "github.com/openebs/maya/pkg/kubernetes/persistentvolumeclaim/v1alpha1"
 	"github.com/openebs/maya/tests/jiva"
 	corev1 "k8s.io/api/core/v1"
@@ -26,17 +29,18 @@ import (
 )
 
 var (
-	replicaLabel = "openebs.io/replica=jiva-replica"
-	ctrlLabel    = "openebs.io/controller=jiva-controller"
-	accessModes  = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
-	capacity     = "5G"
-	pvcObj       *corev1.PersistentVolumeClaim
-	err          error
+	accessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
+	capacity    = "5G"
+	pvcObj      *corev1.PersistentVolumeClaim
+	podList     *corev1.PodList
 )
 
 var _ = Describe("[jiva] TEST VOLUME PROVISIONING", func() {
 	var (
-		pvcName = "jiva-volume-claim"
+		pvcName      = "jiva-volume-claim"
+		pvcLabel     = "openebs.io/persistent-volume-claim=" + pvcName
+		ctrlLabel    = jiva.CtrlLabel + "," + pvcLabel
+		replicaLabel = jiva.ReplicaLabel + "," + pvcLabel
 	)
 
 	When("jiva pvc with replicacount n is created", func() {
@@ -66,17 +70,128 @@ var _ = Describe("[jiva] TEST VOLUME PROVISIONING", func() {
 			)
 
 			By("verifying controller pod count")
-			controllerPodCount := ops.GetPodRunningCountEventually(namespaceObj.Name, ctrlLabel, 1)
-			Expect(controllerPodCount).To(Equal(1), "while checking controller pod count")
+			controllerPodCount := ops.GetPodRunningCountEventually(
+				namespaceObj.Name,
+				ctrlLabel,
+				1,
+			)
+			Expect(controllerPodCount).To(
+				Equal(1),
+				"while checking controller pod count",
+			)
 
 			By("verifying replica pod count ")
-			replicaPodCount := ops.GetPodRunningCountEventually(namespaceObj.Name, replicaLabel, jiva.ReplicaCount)
-			Expect(replicaPodCount).To(Equal(jiva.ReplicaCount), "while checking replica pod count")
+			replicaPodCount := ops.GetPodRunningCountEventually(
+				namespaceObj.Name,
+				replicaLabel,
+				jiva.ReplicaCount,
+			)
+			Expect(replicaPodCount).To(
+				Equal(jiva.ReplicaCount),
+				"while checking replica pod count",
+			)
 
 			By("verifying status as bound")
-			status := ops.IsPVCBound(pvcName)
+			status := ops.IsPVCBoundEventually(pvcName)
 			Expect(status).To(Equal(true), "while checking status equal to bound")
 
+		})
+	})
+
+	When("contoller pod is restarted", func() {
+		It("should register replica pods successfully", func() {
+
+			By("deleting controller pod")
+			podList, err = ops.PodClient.List(
+				metav1.ListOptions{LabelSelector: ctrlLabel},
+			)
+			Expect(err).ShouldNot(HaveOccurred(), "while listing controller pod")
+			err = ops.PodClient.WithNamespace(namespaceObj.Name).
+				Delete(podList.Items[0].Name, &metav1.DeleteOptions{})
+			Expect(err).ShouldNot(HaveOccurred(), "while deleting controller pod")
+
+			By("verifying deleted pod is terminated")
+			status := ops.IsPodDeletedEventually(
+				namespaceObj.Name,
+				podList.Items[0].Name,
+			)
+			Expect(status).To(Equal(true), "while checking for deleted pod")
+
+			By("verifying controller pod count")
+			controllerPodCount := ops.GetPodRunningCountEventually(
+				namespaceObj.Name,
+				ctrlLabel,
+				1,
+			)
+			Expect(controllerPodCount).To(
+				Equal(1),
+				"while checking controller pod count",
+			)
+
+			By("verifying registered replica count and replication factor")
+			podList, err = ops.PodClient.List(
+				metav1.ListOptions{LabelSelector: ctrlLabel},
+			)
+			Expect(err).ShouldNot(HaveOccurred(), "while listing controller pod")
+
+			status = areReplicasRegisteredEventually(
+				&podList.Items[0],
+				jiva.ReplicaCount,
+			)
+			Expect(status).To(
+				Equal(true),
+				"while verifying registered replica count as replication factor",
+			)
+		})
+	})
+
+	When("replica pods is restarted", func() {
+		It("should register replica pods to controller pod successfully", func() {
+			podList, err = ops.PodClient.List(
+				metav1.ListOptions{LabelSelector: ctrlLabel},
+			)
+			Expect(err).ShouldNot(HaveOccurred(), "while listing controller pod")
+
+			ctrlPod := podList.Items[0]
+
+			podList, err = ops.PodClient.List(
+				metav1.ListOptions{LabelSelector: replicaLabel},
+			)
+			Expect(err).ShouldNot(HaveOccurred(), "while listing replica pods")
+
+			By("deleting replica pods")
+			err = ops.PodClient.WithNamespace(namespaceObj.Name).
+				DeleteCollection(metav1.ListOptions{LabelSelector: replicaLabel},
+					&metav1.DeleteOptions{})
+			Expect(err).ShouldNot(HaveOccurred(), "while deleting replica pods")
+
+			By("verifying deleted pods are terminated")
+			for _, p := range podList.Items {
+				status := ops.IsPodDeletedEventually(namespaceObj.Name, p.Name)
+				Expect(status).To(
+					Equal(true),
+					"while checking for deleted pod {%s}",
+					p.Name,
+				)
+			}
+			By("verifying replica pod count")
+			replicaPodCount := ops.GetPodRunningCountEventually(
+				namespaceObj.Name,
+				replicaLabel,
+				jiva.ReplicaCount,
+			)
+			Expect(replicaPodCount).To(
+				Equal(jiva.ReplicaCount),
+				"while checking replica pod count",
+			)
+
+			By("verifying registered replica count and replication factor")
+
+			status := areReplicasRegisteredEventually(&ctrlPod, jiva.ReplicaCount)
+			Expect(status).To(
+				Equal(true),
+				"while verifying registered replica count as replication factor",
+			)
 		})
 	})
 
@@ -84,7 +199,7 @@ var _ = Describe("[jiva] TEST VOLUME PROVISIONING", func() {
 		It("should not have any jiva controller and replica pods", func() {
 
 			By("deleting above pvc")
-			err := ops.PVCClient.Delete(pvcName, &metav1.DeleteOptions{})
+			err = ops.PVCClient.Delete(pvcName, &metav1.DeleteOptions{})
 			Expect(err).To(
 				BeNil(),
 				"while deleting pvc {%s} in namespace {%s}",
@@ -93,11 +208,22 @@ var _ = Describe("[jiva] TEST VOLUME PROVISIONING", func() {
 			)
 
 			By("verifying controller pod count as 0")
-			controllerPodCount := ops.GetPodRunningCountEventually(namespaceObj.Name, ctrlLabel, 0)
-			Expect(controllerPodCount).To(Equal(0), "while checking controller pod count")
+			controllerPodCount := ops.GetPodRunningCountEventually(
+				namespaceObj.Name,
+				ctrlLabel,
+				0,
+			)
+			Expect(controllerPodCount).To(
+				Equal(0),
+				"while checking controller pod count",
+			)
 
 			By("verifying replica pod count as 0")
-			replicaPodCount := ops.GetPodRunningCountEventually(namespaceObj.Name, replicaLabel, 0)
+			replicaPodCount := ops.GetPodRunningCountEventually(
+				namespaceObj.Name,
+				replicaLabel,
+				0,
+			)
 			Expect(replicaPodCount).To(Equal(0), "while checking replica pod count")
 
 			By("verifying deleted pvc")
@@ -108,3 +234,31 @@ var _ = Describe("[jiva] TEST VOLUME PROVISIONING", func() {
 	})
 
 })
+
+func areReplicasRegisteredEventually(ctrlPod *corev1.Pod, replicationFactor int) bool {
+	return Eventually(func() int {
+		out, err := ops.PodClient.WithNamespace(namespaceObj.Name).
+			Exec(
+				ctrlPod.Name,
+				&corev1.PodExecOptions{
+					Command: []string{
+						"/bin/bash",
+						"-c",
+						"curl http://localhost:9501/v1/volumes",
+					},
+					Container: ctrlPod.Spec.Containers[0].Name,
+					Stdin:     false,
+					Stdout:    true,
+					Stderr:    true,
+				},
+			)
+		Expect(err).ShouldNot(HaveOccurred(), "while exec in application pod")
+
+		volumes := jivaClient.VolumeCollection{}
+		err = json.Unmarshal([]byte(out.Stdout), &volumes)
+		Expect(err).To(BeNil(), "while unmarshalling volumes %s", out.Stdout)
+
+		return volumes.Data[0].ReplicaCount
+	},
+		300, 10).Should(Equal(replicationFactor))
+}

--- a/tests/jiva/volume/suite_test.go
+++ b/tests/jiva/volume/suite_test.go
@@ -43,6 +43,7 @@ var (
 	namespaceObj          *corev1.Namespace
 	scObj                 *storagev1.StorageClass
 	annotations           = map[string]string{}
+	err                   error
 )
 
 func TestSource(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Adds a check to verify that the replica pods connect to controller after controller or replica pods are restarted.

**Sample test output**:
```
user:volume$ ginkgo -v -- -kubeconfig=/home/user/.kube/config
Running Suite: Test jiva volume provisioning
============================================
Random Seed: 1560147425
Will run 4 of 4 specs

STEP: waiting for maya-apiserver pod to come into running state
STEP: waiting for openebs-provisioner pod to come into running state
STEP: building a namespace
STEP: building a storageclass
STEP: creating a namespace
STEP: creating a storageclass
[jiva] TEST VOLUME PROVISIONING when jiva pvc with replicacount n is created 
  should create 1 controller pod and n replica pod
  /home/user/work/src/github.com/openebs/maya/tests/jiva/volume/provision_test.go:47
STEP: building a pvc
STEP: creating above pvc
STEP: verifying controller pod count
STEP: verifying replica pod count 
STEP: verifying status as bound

• [SLOW TEST:55.264 seconds]
[jiva] TEST VOLUME PROVISIONING
/home/user/work/src/github.com/openebs/maya/tests/jiva/volume/provision_test.go:38
  when jiva pvc with replicacount n is created
  /home/user/work/src/github.com/openebs/maya/tests/jiva/volume/provision_test.go:46
    should create 1 controller pod and n replica pod
    /home/user/work/src/github.com/openebs/maya/tests/jiva/volume/provision_test.go:47
------------------------------
[jiva] TEST VOLUME PROVISIONING when contoller pod is restarted 
  should register replica pods successfully
  /home/user/work/src/github.com/openebs/maya/tests/jiva/volume/provision_test.go:102
STEP: deleting controller pod
STEP: verifying deleted pod is terminated
STEP: verifying controller pod count
STEP: verifying registered replica count and replication factor

• [SLOW TEST:43.986 seconds]
[jiva] TEST VOLUME PROVISIONING
/home/user/work/src/github.com/openebs/maya/tests/jiva/volume/provision_test.go:38
  when contoller pod is restarted
  /home/user/work/src/github.com/openebs/maya/tests/jiva/volume/provision_test.go:101
    should register replica pods successfully
    /home/user/work/src/github.com/openebs/maya/tests/jiva/volume/provision_test.go:102
------------------------------
[jiva] TEST VOLUME PROVISIONING when replica pods is restarted 
  should register replica pods to controller pod successfully
  /home/user/work/src/github.com/openebs/maya/tests/jiva/volume/provision_test.go:149
STEP: deleting replica pods
STEP: verifying deleted pods are terminated
STEP: verifying replica pod count
STEP: verifying registered replica count and replication factor

• [SLOW TEST:27.723 seconds]
[jiva] TEST VOLUME PROVISIONING
/home/user/work/src/github.com/openebs/maya/tests/jiva/volume/provision_test.go:38
  when replica pods is restarted
  /home/user/work/src/github.com/openebs/maya/tests/jiva/volume/provision_test.go:148
    should register replica pods to controller pod successfully
    /home/user/work/src/github.com/openebs/maya/tests/jiva/volume/provision_test.go:149
------------------------------
[jiva] TEST VOLUME PROVISIONING when jiva pvc is deleted 
  should not have any jiva controller and replica pods
  /home/user/work/src/github.com/openebs/maya/tests/jiva/volume/provision_test.go:199
STEP: deleting above pvc
STEP: verifying controller pod count as 0
STEP: verifying replica pod count as 0
STEP: verifying deleted pvc

• [SLOW TEST:27.310 seconds]
[jiva] TEST VOLUME PROVISIONING
/home/user/work/src/github.com/openebs/maya/tests/jiva/volume/provision_test.go:38
  when jiva pvc is deleted
  /home/user/work/src/github.com/openebs/maya/tests/jiva/volume/provision_test.go:198
    should not have any jiva controller and replica pods
    /home/user/work/src/github.com/openebs/maya/tests/jiva/volume/provision_test.go:199
------------------------------
STEP: deleting storageclass
STEP: deleting namespace

Ran 4 of 4 Specs in 155.015 seconds
SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 2m40.853956623s
Test Suite Passed

```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests