### PR TITLE
feat(bdd, localpv) add BDD for localpv provisioning using hostdevice

### DIFF
--- a/pkg/kubernetes/deployment/appsv1/v1alpha1/deployment.go
+++ b/pkg/kubernetes/deployment/appsv1/v1alpha1/deployment.go
@@ -154,8 +154,8 @@ func (b *Builder) WithLabels(labels map[string]string) *Builder {
 	return b
 }
 
-// WithLabelsAndSelector sets label selector for template and deployment
-func (b *Builder) WithLabelsAndSelector(labels map[string]string) *Builder {
+// WithLabelSelector sets label selector for template and deployment
+func (b *Builder) WithLabelSelector(labels map[string]string) *Builder {
 	if len(labels) == 0 {
 		b.errors = append(b.errors, errors.New("failed to build deployment: missing labels"))
 		return b

--- a/tests/kubernetes/deployment/app_test.go
+++ b/tests/kubernetes/deployment/app_test.go
@@ -48,7 +48,7 @@ var _ = Describe("TEST DEPLOYMENT CREATION ", func() {
 			deployObj, err = deploy.NewBuilder().
 				WithName(deployName).
 				WithNamespace(namespaceObj.Name).
-				WithLabelsAndSelector(labelselector).
+				WithLabelSelector(labelselector).
 				WithContainerBuilder(
 					con.NewBuilder().
 						WithName("busybox").

--- a/tests/localpv/hostdevice_test.go
+++ b/tests/localpv/hostdevice_test.go
@@ -1,0 +1,425 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package localpv
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	container "github.com/openebs/maya/pkg/kubernetes/container/v1alpha1"
+	deploy "github.com/openebs/maya/pkg/kubernetes/deployment/appsv1/v1alpha1"
+	pvc "github.com/openebs/maya/pkg/kubernetes/persistentvolumeclaim/v1alpha1"
+	volume "github.com/openebs/maya/pkg/kubernetes/volume/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("TEST HOSTDEVICE LOCAL PV", func() {
+	var (
+		pvcObj        *corev1.PersistentVolumeClaim
+		accessModes   = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
+		capacity      = "2Gi"
+		deployName    = "busybox-device"
+		label         = "demo=hostdevice-deployment"
+		pvcName       = "pvc-hd"
+		deployObj     *deploy.Deploy
+		labelselector = map[string]string{
+			"demo": "hostdevice-deployment",
+		}
+	)
+
+	When("pvc with storageclass openebs-device is created", func() {
+		It("should create a pvc ", func() {
+			var (
+				scName = "openebs-device"
+			)
+
+			By("building a pvc")
+			pvcObj, err = pvc.NewBuilder().
+				WithName(pvcName).
+				WithNamespace(namespaceObj.Name).
+				WithStorageClass(scName).
+				WithAccessModes(accessModes).
+				WithCapacity(capacity).Build()
+			Expect(err).ShouldNot(
+				HaveOccurred(),
+				"while building pvc {%s} in namespace {%s}",
+				pvcName,
+				namespaceObj.Name,
+			)
+
+			By("creating above pvc")
+			_, err = ops.PVCClient.WithNamespace(namespaceObj.Name).Create(pvcObj)
+			Expect(err).To(
+				BeNil(),
+				"while creating pvc {%s} in namespace {%s}",
+				pvcName,
+				namespaceObj.Name,
+			)
+		})
+	})
+
+	When("deployment with busybox image is created", func() {
+		It("should create a deployment and a running pod", func() {
+
+			By("building a deployment")
+			deployObj, err = deploy.NewBuilder().
+				WithName(deployName).
+				WithNamespace(namespaceObj.Name).
+				WithLabelSelector(labelselector).
+				WithContainerBuilder(
+					container.NewBuilder().
+						WithName("busybox").
+						WithImage("busybox").
+						WithCommand(
+							[]string{
+								"sleep",
+								"3600",
+							},
+						).
+						WithVolumeMounts(
+							[]corev1.VolumeMount{
+								corev1.VolumeMount{
+									Name:      "demo-vol2",
+									MountPath: "/mnt/store1",
+								},
+							},
+						),
+				).
+				WithVolumeBuilder(
+					volume.NewBuilder().
+						WithName("demo-vol2").
+						WithPVCSource(pvcName),
+				).
+				Build()
+			Expect(err).ShouldNot(
+				HaveOccurred(),
+				"while building delpoyment {%s} in namespace {%s}",
+				deployName,
+				namespaceObj.Name,
+			)
+
+			By("creating above deployment")
+			_, err = ops.DeployClient.WithNamespace(namespaceObj.Name).Create(deployObj.Object)
+			Expect(err).To(
+				BeNil(),
+				"while creating deployment {%s} in namespace {%s}",
+				deployName,
+				namespaceObj.Name,
+			)
+
+			By("verifying pod count as 1")
+			podCount := ops.GetPodRunningCountEventually(namespaceObj.Name, label, 1)
+			Expect(podCount).To(Equal(1), "while verifying pod count")
+
+		})
+	})
+
+	When("deployment is deleted", func() {
+		It("should not have any deployment or running pod", func() {
+
+			By("deleting above deployment")
+			err = ops.DeployClient.WithNamespace(namespaceObj.Name).Delete(deployName, &metav1.DeleteOptions{})
+			Expect(err).To(
+				BeNil(),
+				"while deleting deployment {%s} in namespace {%s}",
+				deployName,
+				namespaceObj.Name,
+			)
+
+			By("verifying pod count as 0")
+			podCount := ops.GetPodRunningCountEventually(namespaceObj.Name, label, 0)
+			Expect(podCount).To(Equal(0), "while verifying pod count")
+
+		})
+	})
+
+	When("pvc with storageclass openebs-device is deleted ", func() {
+		It("should delete the pvc", func() {
+
+			By("deleting above pvc")
+			err = ops.PVCClient.Delete(pvcName, &metav1.DeleteOptions{})
+			Expect(err).To(
+				BeNil(),
+				"while deleting pvc {%s} in namespace {%s}",
+				pvcName,
+				namespaceObj.Name,
+			)
+
+		})
+	})
+
+})
+
+var _ = Describe("[-ve] TEST HOSTDEVICE LOCAL PV", func() {
+	var (
+		pvcObj        *corev1.PersistentVolumeClaim
+		accessModes   = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
+		capacity      = "2Gi"
+		deployName    = "busybox-device"
+		label         = "demo=hostdevice-deployment"
+		pvcName       = "pvc-hd"
+		deployObj     *deploy.Deploy
+		labelselector = map[string]string{
+			"demo": "hostdevice-deployment",
+		}
+		scName                = "openebs-device"
+		existingPVCObj        *corev1.PersistentVolumeClaim
+		existingDeployName    = "existing-busybox-device"
+		existinglabel         = "demo=existing-hostdevice-deployment"
+		existingPVCName       = "existing-pvc-hd"
+		existingDeployObj     *deploy.Deploy
+		existingLabelselector = map[string]string{
+			"demo": "existing-hostdevice-deployment",
+		}
+	)
+	When("existing pvc with storageclass openebs-device is created", func() {
+		It("should create a pvc", func() {
+
+			By("building a pvc")
+			existingPVCObj, err = pvc.NewBuilder().
+				WithName(existingPVCName).
+				WithNamespace(namespaceObj.Name).
+				WithStorageClass(scName).
+				WithAccessModes(accessModes).
+				WithCapacity(capacity).Build()
+			Expect(err).ShouldNot(
+				HaveOccurred(),
+				"while building pvc {%s} in namespace {%s}",
+				existingPVCName,
+				namespaceObj.Name,
+			)
+
+			By("creating above pvc")
+			_, err = ops.PVCClient.WithNamespace(namespaceObj.Name).Create(existingPVCObj)
+			Expect(err).To(
+				BeNil(),
+				"while creating pvc {%s} in namespace {%s}",
+				existingPVCName,
+				namespaceObj.Name,
+			)
+		})
+	})
+
+	When("existing deployment with busybox image is created", func() {
+		It("should create a deployment and a running pod", func() {
+
+			By("building a deployment")
+			existingDeployObj, err = deploy.NewBuilder().
+				WithName(existingDeployName).
+				WithNamespace(namespaceObj.Name).
+				WithLabelSelector(existingLabelselector).
+				WithContainerBuilder(
+					container.NewBuilder().
+						WithName("busybox").
+						WithImage("busybox").
+						WithCommand(
+							[]string{
+								"sleep",
+								"3600",
+							},
+						).
+						WithVolumeMounts(
+							[]corev1.VolumeMount{
+								corev1.VolumeMount{
+									Name:      "demo-vol3",
+									MountPath: "/mnt/store1",
+								},
+							},
+						),
+				).
+				WithVolumeBuilder(
+					volume.NewBuilder().
+						WithName("demo-vol3").
+						WithPVCSource(existingPVCName),
+				).
+				Build()
+			Expect(err).ShouldNot(
+				HaveOccurred(),
+				"while building delpoyment {%s} in namespace {%s}",
+				existingDeployName,
+				namespaceObj.Name,
+			)
+
+			By("creating above deployment")
+			_, err = ops.DeployClient.WithNamespace(namespaceObj.Name).Create(existingDeployObj.Object)
+			Expect(err).To(
+				BeNil(),
+				"while creating deployment {%s} in namespace {%s}",
+				existingDeployName,
+				namespaceObj.Name,
+			)
+
+			By("verifying pod count as 1")
+			podCount := ops.GetPodRunningCountEventually(namespaceObj.Name, existinglabel, 1)
+			Expect(podCount).To(Equal(1), "while verifying pod count")
+
+		})
+	})
+
+	When("another pvc with storageclass openebs-device is created", func() {
+		It("should create a pvc ", func() {
+
+			By("building a pvc")
+			pvcObj, err = pvc.NewBuilder().
+				WithName(pvcName).
+				WithNamespace(namespaceObj.Name).
+				WithStorageClass(scName).
+				WithAccessModes(accessModes).
+				WithCapacity(capacity).Build()
+			Expect(err).ShouldNot(
+				HaveOccurred(),
+				"while building pvc {%s} in namespace {%s}",
+				pvcName,
+				namespaceObj.Name,
+			)
+
+			By("creating above pvc")
+			_, err = ops.PVCClient.WithNamespace(namespaceObj.Name).Create(pvcObj)
+			Expect(err).To(
+				BeNil(),
+				"while creating pvc {%s} in namespace {%s}",
+				pvcName,
+				namespaceObj.Name,
+			)
+		})
+	})
+
+	When("another deployment with busybox image and above pvc is created", func() {
+		It("should not create a deployment and a running pod", func() {
+
+			By("building a deployment")
+			deployObj, err = deploy.NewBuilder().
+				WithName(deployName).
+				WithNamespace(namespaceObj.Name).
+				WithLabelSelector(labelselector).
+				WithContainerBuilder(
+					container.NewBuilder().
+						WithName("busybox").
+						WithImage("busybox").
+						WithCommand(
+							[]string{
+								"sleep",
+								"3600",
+							},
+						).
+						WithVolumeMounts(
+							[]corev1.VolumeMount{
+								corev1.VolumeMount{
+									Name:      "demo-vol2",
+									MountPath: "/mnt/store1",
+								},
+							},
+						),
+				).
+				WithVolumeBuilder(
+					volume.NewBuilder().
+						WithName("demo-vol2").
+						WithPVCSource(pvcName),
+				).
+				Build()
+			Expect(err).ShouldNot(
+				HaveOccurred(),
+				"while building delpoyment {%s} in namespace {%s}",
+				deployName,
+				namespaceObj.Name,
+			)
+
+			By("creating above deployment")
+			_, err = ops.DeployClient.WithNamespace(namespaceObj.Name).Create(deployObj.Object)
+			Expect(err).To(
+				BeNil(),
+				"while creating deployment {%s} in namespace {%s}",
+				deployName,
+				namespaceObj.Name,
+			)
+
+			By("verifying pod count as 0")
+			podCount := ops.GetPodRunningCountEventually(namespaceObj.Name, label, 0)
+			Expect(podCount).To(Equal(0), "while verifying pod count")
+
+		})
+	})
+
+	When("above deployment is deleted", func() {
+		It("should not have any deployment or running pod", func() {
+
+			By("deleting above deployment")
+			err = ops.DeployClient.WithNamespace(namespaceObj.Name).Delete(deployName, &metav1.DeleteOptions{})
+			Expect(err).To(
+				BeNil(),
+				"while deleting deployment {%s} in namespace {%s}",
+				deployName,
+				namespaceObj.Name,
+			)
+
+			By("verifying pod count as 0")
+			podCount := ops.GetPodRunningCountEventually(namespaceObj.Name, label, 0)
+			Expect(podCount).To(Equal(0), "while verifying pod count")
+
+		})
+	})
+
+	When("above pvc with storageclass openebs-device is deleted ", func() {
+		It("should delete the pvc", func() {
+
+			By("deleting above pvc")
+			err = ops.PVCClient.Delete(pvcName, &metav1.DeleteOptions{})
+			Expect(err).To(
+				BeNil(),
+				"while deleting pvc {%s} in namespace {%s}",
+				pvcName,
+				namespaceObj.Name,
+			)
+
+		})
+	})
+
+	When("existing deployment is deleted", func() {
+		It("should not have any deployment or running pod", func() {
+
+			By("deleting above deployment")
+			err = ops.DeployClient.WithNamespace(namespaceObj.Name).
+				Delete(existingDeployName, &metav1.DeleteOptions{})
+			Expect(err).To(
+				BeNil(),
+				"while deleting deployment {%s} in namespace {%s}",
+				existingDeployName,
+				namespaceObj.Name,
+			)
+
+			By("verifying pod count as 0")
+			podCount := ops.GetPodRunningCountEventually(namespaceObj.Name, existinglabel, 0)
+			Expect(podCount).To(Equal(0), "while verifying pod count")
+
+		})
+	})
+
+	When("existing pvc with storageclass openebs-device is deleted ", func() {
+		It("should delete the pvc", func() {
+
+			By("deleting above pvc")
+			err = ops.PVCClient.Delete(existingPVCName, &metav1.DeleteOptions{})
+			Expect(err).To(
+				BeNil(),
+				"while deleting pvc {%s} in namespace {%s}",
+				existingPVCName,
+				namespaceObj.Name,
+			)
+
+		})
+	})
+})

--- a/tests/localpv/hostpath_test.go
+++ b/tests/localpv/hostpath_test.go
@@ -27,16 +27,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var (
-	deployName    = "busybox-deploy"
-	label         = "demo=deployment"
-	deployObj     *deploy.Deploy
-	labelselector = map[string]string{
-		"demo": "deployment",
-	}
-)
-
-var _ = Describe("TEST LOCAL PV", func() {
+var _ = Describe("TEST HOSTPATH LOCAL PV", func() {
+	var (
+		pvcObj        *corev1.PersistentVolumeClaim
+		accessModes   = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
+		capacity      = "2Gi"
+		deployName    = "busybox-hostpath"
+		label         = "demo=hostpath-deployment"
+		pvcName       = "pvc-hp"
+		deployObj     *deploy.Deploy
+		labelselector = map[string]string{
+			"demo": "hostpath-deployment",
+		}
+	)
 
 	When("pvc with storageclass openebs-hostpath is created", func() {
 		It("should create a pvc ", func() {
@@ -76,7 +79,7 @@ var _ = Describe("TEST LOCAL PV", func() {
 			deployObj, err = deploy.NewBuilder().
 				WithName(deployName).
 				WithNamespace(namespaceObj.Name).
-				WithLabelsAndSelector(labelselector).
+				WithLabelSelector(labelselector).
 				WithContainerBuilder(
 					container.NewBuilder().
 						WithName("busybox").

--- a/tests/localpv/suite_test.go
+++ b/tests/localpv/suite_test.go
@@ -35,10 +35,6 @@ var (
 	kubeConfigPath string
 	namespace      = "localpv-ns"
 	namespaceObj   *corev1.Namespace
-	pvcObj         *corev1.PersistentVolumeClaim
-	pvcName        = "pvc-hp"
-	accessModes    = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
-	capacity       = "2Gi"
 	err            error
 )
 


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds BDD test for provisioning localpv using `openebs-device` storageclass. This test requires a disk mounted to the node.

**Note**: *We can use* `--focus=HOSTPATH` *or* `--focus=HOSTDEVICE` *to run the specific test*. *Without the* `focus` *flag ginkgo will run both the tests*.

**Sample test output**:
```
user:localpv$ ginkgo --focus=HOSTDEVICE  -v -- -kubeconfig=/home/user/.kube/config
Running Suite: Test application deployment
==========================================
Random Seed: 1560177319
Will run 12 of 16 specs

STEP: waiting for maya-apiserver pod to come into running state
STEP: waiting for openebs-localpv-provisioner pod to come into running state
STEP: building a namespace
STEP: creating above namespace
[-ve] TEST HOSTDEVICE LOCAL PV when existing pvc with storageclass openebs-device is created 
  should create a pvc
  /home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:190
STEP: building a pvc
STEP: creating above pvc
•
------------------------------
[-ve] TEST HOSTDEVICE LOCAL PV when existing deployment with busybox image is created 
  should create a deployment and a running pod
  /home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:218
STEP: building a deployment
STEP: creating above deployment
STEP: verifying pod count as 1

• [SLOW TEST:11.497 seconds]
[-ve] TEST HOSTDEVICE LOCAL PV
/home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:167
  when existing deployment with busybox image is created
  /home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:217
    should create a deployment and a running pod
    /home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:218
------------------------------
[-ve] TEST HOSTDEVICE LOCAL PV when another pvc with storageclass openebs-device is created 
  should create a pvc 
  /home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:274
STEP: building a pvc
STEP: creating above pvc
•
------------------------------
[-ve] TEST HOSTDEVICE LOCAL PV when another deployment with busybox image and above pvc is created 
  should not create a deployment and a running pod
  /home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:302
STEP: building a deployment
STEP: creating above deployment
STEP: verifying pod count as 0
•
------------------------------
[-ve] TEST HOSTDEVICE LOCAL PV when above deployment is deleted 
  should not have any deployment or running pod
  /home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:358
STEP: deleting above deployment
STEP: verifying pod count as 0
•
------------------------------
[-ve] TEST HOSTDEVICE LOCAL PV when above pvc with storageclass openebs-device is deleted  
  should delete the pvc
  /home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:377
STEP: deleting above pvc
•
------------------------------
[-ve] TEST HOSTDEVICE LOCAL PV when existing deployment is deleted 
  should not have any deployment or running pod
  /home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:392
STEP: deleting above deployment
STEP: verifying pod count as 0

• [SLOW TEST:42.788 seconds]
[-ve] TEST HOSTDEVICE LOCAL PV
/home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:167
  when existing deployment is deleted
  /home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:391
    should not have any deployment or running pod
    /home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:392
------------------------------
[-ve] TEST HOSTDEVICE LOCAL PV when existing pvc with storageclass openebs-device is deleted  
  should delete the pvc
  /home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:412
STEP: deleting above pvc
•
------------------------------
TEST HOSTDEVICE LOCAL PV when pvc with storageclass openebs-device is created 
  should create a pvc 
  /home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:45
STEP: building a pvc
STEP: creating above pvc
•
------------------------------
TEST HOSTDEVICE LOCAL PV when deployment with busybox image is created 
  should create a deployment and a running pod
  /home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:76
STEP: building a deployment
STEP: creating above deployment
STEP: verifying pod count as 1

• [SLOW TEST:11.161 seconds]
TEST HOSTDEVICE LOCAL PV
/home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:30
  when deployment with busybox image is created
  /home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:75
    should create a deployment and a running pod
    /home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:76
------------------------------
TEST HOSTDEVICE LOCAL PV when deployment is deleted 
  should not have any deployment or running pod
  /home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:132
STEP: deleting above deployment
STEP: verifying pod count as 0

• [SLOW TEST:43.046 seconds]
TEST HOSTDEVICE LOCAL PV
/home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:30
  when deployment is deleted
  /home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:131
    should not have any deployment or running pod
    /home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:132
------------------------------
TEST HOSTDEVICE LOCAL PV when pvc with storageclass openebs-device is deleted  
  should delete the pvc
  /home/user/work/src/github.com/openebs/maya/tests/localpv/hostdevice_test.go:151
STEP: deleting above pvc
•SSSSSTEP: deleting namespace

Ran 12 of 16 Specs in 113.382 seconds
SUCCESS! -- 12 Passed | 0 Failed | 0 Pending | 4 Skipped
PASS

Ginkgo ran 1 suite in 1m59.481427759s
Test Suite Passed

```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests