### PR TITLE
feat(cstor-operator, blockdevice): add support to create cStor pools on unclaimed BD in auto mode

### DIFF
--- a/cmd/maya-apiserver/cstor-operator/spc/handler.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/handler.go
@@ -176,8 +176,7 @@ func validatePoolType(spc *apis.StoragePoolClaim) error {
 // validateDiskType validates the disk types in spc.
 func validateDiskType(spc *apis.StoragePoolClaim) error {
 	diskType := spc.Spec.Type
-	// TODO: Update below snippet to make use of predicates
-	if !spcv1alpha1.SupportedDiskType[diskType] {
+	if !spcv1alpha1.SupportedDiskTypes[apis.CasPoolValString(diskType)] {
 		return errors.Errorf("aborting storagepool create operation as specified type is %s which is invalid", diskType)
 	}
 	return nil

--- a/cmd/maya-apiserver/cstor-operator/spc/handler.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/handler.go
@@ -23,9 +23,9 @@ import (
 
 	"github.com/golang/glog"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
-	blockdevice "github.com/openebs/maya/pkg/blockdevice/v1alpha1"
 	openebs "github.com/openebs/maya/pkg/client/generated/clientset/versioned"
 	env "github.com/openebs/maya/pkg/env/v1alpha1"
+	spcv1alpha1 "github.com/openebs/maya/pkg/storagepoolclaim/v1alpha1"
 	"github.com/pkg/errors"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -177,7 +177,7 @@ func validatePoolType(spc *apis.StoragePoolClaim) error {
 func validateDiskType(spc *apis.StoragePoolClaim) error {
 	diskType := spc.Spec.Type
 	// TODO: Update below snippet to make use of predicates
-	if !blockdevice.SupportedDiskType[diskType] {
+	if !spcv1alpha1.SupportedDiskType[diskType] {
 		return errors.Errorf("aborting storagepool create operation as specified type is %s which is invalid", diskType)
 	}
 	return nil

--- a/cmd/maya-apiserver/cstor-operator/spc/handler.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/handler.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/golang/glog"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	blockdevice "github.com/openebs/maya/pkg/blockdevice/v1alpha1"
 	openebs "github.com/openebs/maya/pkg/client/generated/clientset/versioned"
 	env "github.com/openebs/maya/pkg/env/v1alpha1"
 	"github.com/pkg/errors"
@@ -146,7 +147,7 @@ func validate(spc *apis.StoragePoolClaim) error {
 	for _, v := range validateFuncList {
 		err := v(spc)
 		if err != nil {
-			return errors.Wrapf(err, "spc validation failed")
+			return err
 		}
 	}
 	return nil
@@ -176,7 +177,7 @@ func validatePoolType(spc *apis.StoragePoolClaim) error {
 func validateDiskType(spc *apis.StoragePoolClaim) error {
 	diskType := spc.Spec.Type
 	// TODO: Update below snippet to make use of predicates
-	if !(diskType == string(apis.TypeBlockDeviceCPV)) {
+	if !blockdevice.SupportedDiskType[diskType] {
 		return errors.Errorf("aborting storagepool create operation as specified type is %s which is invalid", diskType)
 	}
 	return nil

--- a/cmd/maya-apiserver/cstor-operator/spc/handler_test.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/handler_test.go
@@ -143,7 +143,7 @@ func TestValidateBlockDeviceType(t *testing.T) {
 					Type: string(apis.TypeSparseCPV),
 				},
 			},
-			expectedError: true,
+			expectedError: false,
 		},
 		"Disk pool type": {
 			spc: &apis.StoragePoolClaim{
@@ -154,7 +154,7 @@ func TestValidateBlockDeviceType(t *testing.T) {
 					Type: string(apis.TypeDiskCPV),
 				},
 			},
-			expectedError: true,
+			expectedError: false,
 		},
 		"block device pool type": {
 			spc: &apis.StoragePoolClaim{
@@ -165,7 +165,7 @@ func TestValidateBlockDeviceType(t *testing.T) {
 					Type: string(apis.TypeBlockDeviceCPV),
 				},
 			},
-			expectedError: false,
+			expectedError: true,
 		},
 		"Empty pool type": {
 			spc: &apis.StoragePoolClaim{
@@ -290,7 +290,7 @@ func TestValidateSpc(t *testing.T) {
 					PoolSpec: apis.CStorPoolAttr{
 						PoolType: string(apis.PoolTypeRaidz2CPV),
 					},
-					Type:     string(apis.TypeBlockDeviceCPV),
+					Type:     string(apis.TypeDiskCPV),
 					MaxPools: newInt(3),
 				},
 			},
@@ -310,7 +310,7 @@ func TestValidateSpc(t *testing.T) {
 							"blockdevice-2", "blockdevice-3",
 							"bolckdevice-4", "blockdevice-5", "blockdevice-6"},
 					},
-					Type: string(apis.TypeBlockDeviceCPV),
+					Type: string(apis.TypeDiskCPV),
 				},
 			},
 			expectedError: false,
@@ -328,7 +328,7 @@ func TestValidateSpc(t *testing.T) {
 					MaxPools: newInt(3),
 				},
 			},
-			expectedError: true,
+			expectedError: false,
 		},
 		"Invalid Manual SPC with invalid BDCount": {
 			spc: &apis.StoragePoolClaim{
@@ -344,10 +344,29 @@ func TestValidateSpc(t *testing.T) {
 							"bolckdevice-2", "blockdevice-3",
 							"blockdevice-4", "blockdevice-5"},
 					},
-					Type: string(apis.TypeBlockDeviceCPV),
+					Type: string(apis.TypeDiskCPV),
 				},
 			},
 			expectedError: false,
+		},
+		"Invalid SPC with invalid Disk type": {
+			spc: &apis.StoragePoolClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pool-claim-1",
+				},
+				Spec: apis.StoragePoolClaimSpec{
+					PoolSpec: apis.CStorPoolAttr{
+						PoolType: string(apis.PoolTypeMirroredCPV),
+					},
+					BlockDevices: apis.BlockDeviceAttr{
+						BlockDeviceList: []string{"blockdevice-1",
+							"bolckdevice-2", "blockdevice-3",
+							"blockdevice-4", "blockdevice-5"},
+					},
+					Type: "blockdevice",
+				},
+			},
+			expectedError: true,
 		},
 	}
 

--- a/cmd/maya-apiserver/cstor-operator/spc/storagepool_create.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/storagepool_create.go
@@ -76,7 +76,7 @@ func (pc *PoolCreateConfig) getCasPool(spc *apis.StoragePoolClaim) (*apis.CasPoo
 		Build()
 	casPoolWithDisks, err := pc.withDisks(casPool, spc)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to build cas pool for spc %s", spc.Name)
+		return nil, err
 	}
 	return casPoolWithDisks, nil
 }

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node.go
@@ -207,7 +207,7 @@ func (ac *Config) getBlockDevice() (*ndmapis.BlockDeviceList, error) {
 
 	if ProvisioningType(ac.Spc) == ProvisioningTypeManual {
 		bdl = bdList.Filter(blockdevice.FilterNonInactive)
-		//TODO:
+		//TODO: Validate partitions
 	} else {
 		bdl, err = ac.getBlockDeviceListInAutoMode(bdList, diskType)
 		if err != nil {
@@ -224,7 +224,6 @@ func (ac *Config) getBlockDeviceListInAutoMode(bdList *blockdevice.BlockDeviceLi
 	} else {
 		bdl = bdList.Filter(blockdevice.FilterNonInactive, blockdevice.FilterNonPartitions, blockdevice.FilterNonSparseDevices)
 	}
-
 	if len(bdl.Items) == 0 {
 		return nil, errors.Errorf("type {%s} devices are not available to create pool", diskType)
 	}

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node.go
@@ -86,7 +86,7 @@ func (ac *Config) getFilteredNodeBlockDevices(nodeBDs map[string]*blockDeviceLis
 		ObjectList: bdcList,
 	}
 
-	nodeClaimedBDs := customBDCList.GetBDList()
+	nodeClaimedBDs := customBDCList.GetBlockDeviceNamesByNode()
 
 	newNodeBDMap := make(map[string]*blockDeviceList)
 	for node, bdList := range nodeBDs {
@@ -207,7 +207,7 @@ func (ac *Config) selectNode(nodeBlockDeviceMap map[string]*blockDeviceList) *no
 
 // diskFilterConstraint takes a value for key "ndm.io/disk-type" and form a label.
 func diskFilterConstraint(diskType string) string {
-	if spcv1alpha1.SupportedDiskType[diskType] {
+	if spcv1alpha1.SupportedDiskTypes[apis.CasPoolValString(diskType)] {
 		return string(apis.NdmBlockDeviceTypeCPK) + "=" + string(apis.TypeBlockDeviceCPV)
 	}
 	return ""

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node_test.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node_test.go
@@ -46,7 +46,7 @@ func FakeDiskCreator(bdc *blockdevice.KubernetesClient) {
 	var diskObjectList [70]*ndmapis.BlockDevice
 
 	sparseDiskCount := 2
-	var key, diskLabel string
+	var key, diskLabel, deviceType string
 
 	// nodeIdentifer will help in naming a node and attaching multiple disks to a single node.
 	nodeIdentifer := 0
@@ -57,13 +57,13 @@ func FakeDiskCreator(bdc *blockdevice.KubernetesClient) {
 			sparseDiskCount = 0
 		}
 		if sparseDiskCount != 2 {
-			key = "ndm.io/disk-type"
-			diskLabel = "sparse"
+			deviceType = "sparse"
 			sparseDiskCount++
 		} else {
-			key = "ndm.io/blockdevice-type"
-			diskLabel = "blockdevice"
+			deviceType = "disk"
 		}
+		key = "ndm.io/blockdevice-type"
+		diskLabel = "blockdevice"
 		diskObjectList[diskListIndex] = &ndmapis.BlockDevice{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
@@ -71,6 +71,11 @@ func FakeDiskCreator(bdc *blockdevice.KubernetesClient) {
 				Labels: map[string]string{
 					"kubernetes.io/hostname": "gke-ashu-cstor-default-pool-a4065fd6-vxsh" + strconv.Itoa(nodeIdentifer),
 					key:                      diskLabel,
+				},
+			},
+			Spec: ndmapis.DeviceSpec{
+				Details: ndmapis.DeviceDetails{
+					DeviceType: deviceType,
 				},
 			},
 			Status: ndmapis.DeviceStatus{
@@ -134,7 +139,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 		// Test Case #1
 		"autoSPC1": {&v1alpha1.StoragePoolClaim{
 			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "blockdevice",
+				Type: "disk",
 				PoolSpec: v1alpha1.CStorPoolAttr{
 					PoolType: "striped",
 				},
@@ -145,7 +150,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 		// Test Case #2
 		"autoSPC2": {&v1alpha1.StoragePoolClaim{
 			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "blockdevice",
+				Type: "disk",
 				PoolSpec: v1alpha1.CStorPoolAttr{
 					PoolType: "mirrored",
 				},
@@ -220,7 +225,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 		// Test Case #8
 		"manualSPC8": {&v1alpha1.StoragePoolClaim{
 			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "blockdevice",
+				Type: "disk",
 				PoolSpec: v1alpha1.CStorPoolAttr{
 					PoolType: "mirrored",
 				},
@@ -234,7 +239,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 		// Test Case #8
 		"manualSPC9": {&v1alpha1.StoragePoolClaim{
 			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "blockdevice",
+				Type: "disk",
 				PoolSpec: v1alpha1.CStorPoolAttr{
 					PoolType: "mirrored",
 				},
@@ -248,7 +253,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 		// Test Case #10
 		"manualSPC10Raidz": {&v1alpha1.StoragePoolClaim{
 			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "blockdevice",
+				Type: "disk",
 				PoolSpec: v1alpha1.CStorPoolAttr{
 					PoolType: "raidz",
 				},
@@ -262,7 +267,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 		// Test Case #11
 		"manualSPC11Raidz": {&v1alpha1.StoragePoolClaim{
 			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "blockdevice",
+				Type: "disk",
 				PoolSpec: v1alpha1.CStorPoolAttr{
 					PoolType: "raidz",
 				},
@@ -276,7 +281,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 		// Test Case #12
 		"manualSPC12Raidz": {&v1alpha1.StoragePoolClaim{
 			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "blockdevice",
+				Type: "disk",
 				PoolSpec: v1alpha1.CStorPoolAttr{
 					PoolType: "raidz",
 				},
@@ -290,7 +295,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 		// Test Case #13
 		"manualSPC13Raidz": {&v1alpha1.StoragePoolClaim{
 			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "blockdevice",
+				Type: "disk",
 				PoolSpec: v1alpha1.CStorPoolAttr{
 					PoolType: "raidz",
 				},
@@ -304,7 +309,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 		// Test Case #14
 		"manualSPC14Raidz": {&v1alpha1.StoragePoolClaim{
 			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "blockdevice",
+				Type: "disk",
 				PoolSpec: v1alpha1.CStorPoolAttr{
 					PoolType: "raidz",
 				},
@@ -318,7 +323,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 		// Test Case #15
 		"manualSPC15Raidz2": {&v1alpha1.StoragePoolClaim{
 			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "blockdevice",
+				Type: "disk",
 				PoolSpec: v1alpha1.CStorPoolAttr{
 					PoolType: "raidz2",
 				},
@@ -332,7 +337,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 		// Test Case #16
 		"manualSPC16Raidz2": {&v1alpha1.StoragePoolClaim{
 			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "blockdevice",
+				Type: "disk",
 				PoolSpec: v1alpha1.CStorPoolAttr{
 					PoolType: "raidz2",
 				},
@@ -346,7 +351,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 		// Test Case #17
 		"manualSPC17Raidz2": {&v1alpha1.StoragePoolClaim{
 			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "blockdevice",
+				Type: "disk",
 				PoolSpec: v1alpha1.CStorPoolAttr{
 					PoolType: "raidz2",
 				},
@@ -360,7 +365,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 		// Test Case #18
 		"manualSPC18Raidz2": {&v1alpha1.StoragePoolClaim{
 			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "blockdevice",
+				Type: "disk",
 				PoolSpec: v1alpha1.CStorPoolAttr{
 					PoolType: "raidz2",
 				},
@@ -374,7 +379,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 		// Test Case #19
 		"manualSPC19Raidz2": {&v1alpha1.StoragePoolClaim{
 			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "blockdevice",
+				Type: "disk",
 				PoolSpec: v1alpha1.CStorPoolAttr{
 					PoolType: "raidz2",
 				},
@@ -388,7 +393,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 		// Test Case #20
 		"manualSPC20Raidz2": {&v1alpha1.StoragePoolClaim{
 			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "blockdevice",
+				Type: "disk",
 				PoolSpec: v1alpha1.CStorPoolAttr{
 					PoolType: "raidz2",
 				},

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node_test.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node_test.go
@@ -37,7 +37,7 @@ import (
 
 var blockDeviceK8sClient *blockdevice.KubernetesClient
 
-func FakeDiskCreator(bdc *blockdevice.KubernetesClient) {
+func FakeDiskCreator(bd *blockdevice.KubernetesClient) {
 	// Create some fake block device objects over nodes.
 	// For example, create 14 disk (out of 14 disks, 2 disks are sparse disks)for each of 5 nodes.
 	// That meant 14*5 i.e. 70 disk objects should be created
@@ -77,13 +77,14 @@ func FakeDiskCreator(bdc *blockdevice.KubernetesClient) {
 				Details: ndmapis.DeviceDetails{
 					DeviceType: deviceType,
 				},
+				Partitioned: "NO",
 			},
 			Status: ndmapis.DeviceStatus{
 				State:      DiskStateActive,
 				ClaimState: ndmapis.BlockDeviceClaimed,
 			},
 		}
-		_, err := bdc.Create(diskObjectList[diskListIndex])
+		_, err := bd.Create(diskObjectList[diskListIndex])
 		if err != nil {
 			glog.Error(err)
 		}
@@ -135,274 +136,331 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 		fakeCasPool *v1alpha1.StoragePoolClaim
 		// expectedDiskListLength holds the length of disk list
 		expectedDiskListLength int
+		expectedErr            bool
 	}{
 		// Test Case #1
-		"autoSPC1": {&v1alpha1.StoragePoolClaim{
-			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "disk",
-				PoolSpec: v1alpha1.CStorPoolAttr{
-					PoolType: "striped",
+		"autoSPC1": {
+			fakeCasPool: &v1alpha1.StoragePoolClaim{
+				Spec: v1alpha1.StoragePoolClaimSpec{
+					Type: "disk",
+					PoolSpec: v1alpha1.CStorPoolAttr{
+						PoolType: "striped",
+					},
 				},
 			},
-		},
-			1,
+			expectedDiskListLength: 1,
+			expectedErr:            true,
 		},
 		// Test Case #2
-		"autoSPC2": {&v1alpha1.StoragePoolClaim{
-			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "disk",
-				PoolSpec: v1alpha1.CStorPoolAttr{
-					PoolType: "mirrored",
+		"autoSPC2": {
+			fakeCasPool: &v1alpha1.StoragePoolClaim{
+				Spec: v1alpha1.StoragePoolClaimSpec{
+					Type: "disk",
+					PoolSpec: v1alpha1.CStorPoolAttr{
+						PoolType: "mirrored",
+					},
 				},
 			},
-		},
-			2,
+			expectedDiskListLength: 2,
+			expectedErr:            true,
 		},
 		// Test Case #3
-		"autoSPC3": {&v1alpha1.StoragePoolClaim{
-			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "sparse",
-				PoolSpec: v1alpha1.CStorPoolAttr{
-					PoolType: "striped",
+		"autoSPC3": {
+			fakeCasPool: &v1alpha1.StoragePoolClaim{
+				Spec: v1alpha1.StoragePoolClaimSpec{
+					Type: "sparse",
+					PoolSpec: v1alpha1.CStorPoolAttr{
+						PoolType: "striped",
+					},
 				},
 			},
-		},
-			1,
+			expectedDiskListLength: 1,
+			expectedErr:            true,
 		},
 		// Test Case #4
-		"autoSPC4": {&v1alpha1.StoragePoolClaim{
-			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "sparse",
-				PoolSpec: v1alpha1.CStorPoolAttr{
-					PoolType: "mirrored",
+		"autoSPC4": {
+			fakeCasPool: &v1alpha1.StoragePoolClaim{
+				Spec: v1alpha1.StoragePoolClaimSpec{
+					Type: "sparse",
+					PoolSpec: v1alpha1.CStorPoolAttr{
+						PoolType: "mirrored",
+					},
 				},
 			},
-		},
-			2,
+			expectedDiskListLength: 2,
+			expectedErr:            true,
 		},
 		//Test Case #5
-		"manualSPC5": {&v1alpha1.StoragePoolClaim{
-			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "sparse",
-				PoolSpec: v1alpha1.CStorPoolAttr{
-					PoolType: "striped",
-				},
-				BlockDevices: v1alpha1.BlockDeviceAttr{
-					BlockDeviceList: []string{"blockdevice0", "blockdevice1", "blockdevice2"},
+		"manualSPC5": {
+			fakeCasPool: &v1alpha1.StoragePoolClaim{
+				Spec: v1alpha1.StoragePoolClaimSpec{
+					Type: "sparse",
+					PoolSpec: v1alpha1.CStorPoolAttr{
+						PoolType: "striped",
+					},
+					BlockDevices: v1alpha1.BlockDeviceAttr{
+						BlockDeviceList: []string{"blockdevice0", "blockdevice1", "blockdevice2"},
+					},
 				},
 			},
-		},
-			2,
+			expectedDiskListLength: 3,
+			expectedErr:            false,
 		},
 		// Test Case #6
-		"manualSPC6": {&v1alpha1.StoragePoolClaim{
-			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "sparse",
-				PoolSpec: v1alpha1.CStorPoolAttr{
-					PoolType: "mirrored",
-				},
-				BlockDevices: v1alpha1.BlockDeviceAttr{
-					BlockDeviceList: []string{"blockdevice1", "blockdevice2"},
+		"manualSPC6": {
+			fakeCasPool: &v1alpha1.StoragePoolClaim{
+				Spec: v1alpha1.StoragePoolClaimSpec{
+					Type: "sparse",
+					PoolSpec: v1alpha1.CStorPoolAttr{
+						PoolType: "mirrored",
+					},
+					BlockDevices: v1alpha1.BlockDeviceAttr{
+						BlockDeviceList: []string{"blockdevice1", "blockdevice2"},
+					},
 				},
 			},
-		},
-			0,
+			expectedDiskListLength: 2,
+			expectedErr:            false,
 		},
 		// Test Case #7
-		"manualSPC7": {&v1alpha1.StoragePoolClaim{
-			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "sparse",
-				PoolSpec: v1alpha1.CStorPoolAttr{
-					PoolType: "mirrored",
-				},
-				BlockDevices: v1alpha1.BlockDeviceAttr{
-					BlockDeviceList: []string{"blockdevice1", "blockdevice7"},
+		"manualSPC7": {
+			fakeCasPool: &v1alpha1.StoragePoolClaim{
+				Spec: v1alpha1.StoragePoolClaimSpec{
+					Type: "sparse",
+					PoolSpec: v1alpha1.CStorPoolAttr{
+						PoolType: "mirrored",
+					},
+					BlockDevices: v1alpha1.BlockDeviceAttr{
+						BlockDeviceList: []string{"blockdevice1", "blockdevice71"},
+					},
 				},
 			},
-		},
-			0,
+			expectedDiskListLength: 0,
+			expectedErr:            false,
 		},
 		// Test Case #8
-		"manualSPC8": {&v1alpha1.StoragePoolClaim{
-			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "disk",
-				PoolSpec: v1alpha1.CStorPoolAttr{
-					PoolType: "mirrored",
-				},
-				BlockDevices: v1alpha1.BlockDeviceAttr{
-					BlockDeviceList: []string{"blockdevice2", "blockdevice3", "blockdevice4", "blockdevice5"},
+		"manualSPC8": {
+			fakeCasPool: &v1alpha1.StoragePoolClaim{
+				Spec: v1alpha1.StoragePoolClaimSpec{
+					Type: "disk",
+					PoolSpec: v1alpha1.CStorPoolAttr{
+						PoolType: "mirrored",
+					},
+					BlockDevices: v1alpha1.BlockDeviceAttr{
+						BlockDeviceList: []string{"blockdevice2", "blockdevice3", "blockdevice4", "blockdevice5"},
+					},
 				},
 			},
-		},
-			4,
+			expectedDiskListLength: 4,
+			expectedErr:            false,
 		},
 		// Test Case #8
-		"manualSPC9": {&v1alpha1.StoragePoolClaim{
-			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "disk",
-				PoolSpec: v1alpha1.CStorPoolAttr{
-					PoolType: "mirrored",
-				},
-				BlockDevices: v1alpha1.BlockDeviceAttr{
-					BlockDeviceList: []string{"blockdevice1", "blockdevice2", "blockdevice3"},
+		"manualSPC9": {
+			fakeCasPool: &v1alpha1.StoragePoolClaim{
+				Spec: v1alpha1.StoragePoolClaimSpec{
+					Type: "disk",
+					PoolSpec: v1alpha1.CStorPoolAttr{
+						PoolType: "mirrored",
+					},
+					BlockDevices: v1alpha1.BlockDeviceAttr{
+						BlockDeviceList: []string{"blockdevice1", "blockdevice2", "blockdevice3"},
+					},
 				},
 			},
-		},
-			2,
+			expectedDiskListLength: 2,
+			expectedErr:            false,
 		},
 		// Test Case #10
-		"manualSPC10Raidz": {&v1alpha1.StoragePoolClaim{
-			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "disk",
-				PoolSpec: v1alpha1.CStorPoolAttr{
-					PoolType: "raidz",
-				},
-				BlockDevices: v1alpha1.BlockDeviceAttr{
-					BlockDeviceList: []string{"blockdevice2", "blockdevice3", "blockdevice4"},
+		"manualSPC10Raidz": {
+			fakeCasPool: &v1alpha1.StoragePoolClaim{
+				Spec: v1alpha1.StoragePoolClaimSpec{
+					Type: "disk",
+					PoolSpec: v1alpha1.CStorPoolAttr{
+						PoolType: "raidz",
+					},
+					BlockDevices: v1alpha1.BlockDeviceAttr{
+						BlockDeviceList: []string{"blockdevice2", "blockdevice3", "blockdevice4"},
+					},
 				},
 			},
-		},
-			3,
+			expectedDiskListLength: 3,
+			expectedErr:            false,
 		},
 		// Test Case #11
-		"manualSPC11Raidz": {&v1alpha1.StoragePoolClaim{
-			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "disk",
-				PoolSpec: v1alpha1.CStorPoolAttr{
-					PoolType: "raidz",
-				},
-				BlockDevices: v1alpha1.BlockDeviceAttr{
-					BlockDeviceList: []string{"blockdevice5", "blockdevice6"},
+		"manualSPC11Raidz": {
+			fakeCasPool: &v1alpha1.StoragePoolClaim{
+				Spec: v1alpha1.StoragePoolClaimSpec{
+					Type: "disk",
+					PoolSpec: v1alpha1.CStorPoolAttr{
+						PoolType: "raidz",
+					},
+					BlockDevices: v1alpha1.BlockDeviceAttr{
+						BlockDeviceList: []string{"blockdevice5", "blockdevice6"},
+					},
 				},
 			},
-		},
-			0,
+			expectedDiskListLength: 0,
+			expectedErr:            false,
 		},
 		// Test Case #12
-		"manualSPC12Raidz": {&v1alpha1.StoragePoolClaim{
-			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "disk",
-				PoolSpec: v1alpha1.CStorPoolAttr{
-					PoolType: "raidz",
-				},
-				BlockDevices: v1alpha1.BlockDeviceAttr{
-					BlockDeviceList: []string{"blockdevice1", "blockdevice2", "blockdevice3", "blockdevice4"},
+		"manualSPC12Raidz": {
+			fakeCasPool: &v1alpha1.StoragePoolClaim{
+				Spec: v1alpha1.StoragePoolClaimSpec{
+					Type: "disk",
+					PoolSpec: v1alpha1.CStorPoolAttr{
+						PoolType: "raidz",
+					},
+					BlockDevices: v1alpha1.BlockDeviceAttr{
+						BlockDeviceList: []string{"blockdevice1", "blockdevice2", "blockdevice3", "blockdevice4"},
+					},
 				},
 			},
-		},
-			3,
+			expectedDiskListLength: 3,
+			expectedErr:            false,
 		},
 		// Test Case #13
-		"manualSPC13Raidz": {&v1alpha1.StoragePoolClaim{
-			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "disk",
-				PoolSpec: v1alpha1.CStorPoolAttr{
-					PoolType: "raidz",
-				},
-				BlockDevices: v1alpha1.BlockDeviceAttr{
-					BlockDeviceList: []string{"blockdevice1", "blockdevice2", "blockdevice3", "blockdevice4", "blockdevice5"},
+		"manualSPC13Raidz": {
+			fakeCasPool: &v1alpha1.StoragePoolClaim{
+				Spec: v1alpha1.StoragePoolClaimSpec{
+					Type: "disk",
+					PoolSpec: v1alpha1.CStorPoolAttr{
+						PoolType: "raidz",
+					},
+					BlockDevices: v1alpha1.BlockDeviceAttr{
+						BlockDeviceList: []string{"blockdevice1", "blockdevice2", "blockdevice3", "blockdevice4", "blockdevice5"},
+					},
 				},
 			},
-		},
-			3,
+			expectedDiskListLength: 3,
+			expectedErr:            false,
 		},
 		// Test Case #14
-		"manualSPC14Raidz": {&v1alpha1.StoragePoolClaim{
-			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "disk",
-				PoolSpec: v1alpha1.CStorPoolAttr{
-					PoolType: "raidz",
-				},
-				BlockDevices: v1alpha1.BlockDeviceAttr{
-					BlockDeviceList: []string{"blockdevice2"},
+		"manualSPC14Raidz": {
+			fakeCasPool: &v1alpha1.StoragePoolClaim{
+				Spec: v1alpha1.StoragePoolClaimSpec{
+					Type: "disk",
+					PoolSpec: v1alpha1.CStorPoolAttr{
+						PoolType: "raidz",
+					},
+					BlockDevices: v1alpha1.BlockDeviceAttr{
+						BlockDeviceList: []string{"blockdevice2"},
+					},
 				},
 			},
-		},
-			0,
+			expectedDiskListLength: 0,
+			expectedErr:            false,
 		},
 		// Test Case #15
-		"manualSPC15Raidz2": {&v1alpha1.StoragePoolClaim{
-			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "disk",
-				PoolSpec: v1alpha1.CStorPoolAttr{
-					PoolType: "raidz2",
-				},
-				BlockDevices: v1alpha1.BlockDeviceAttr{
-					BlockDeviceList: []string{"blockdevice1", "blockdevice2", "blockdevice3"},
+		"manualSPC15Raidz2": {
+			fakeCasPool: &v1alpha1.StoragePoolClaim{
+				Spec: v1alpha1.StoragePoolClaimSpec{
+					Type: "disk",
+					PoolSpec: v1alpha1.CStorPoolAttr{
+						PoolType: "raidz2",
+					},
+					BlockDevices: v1alpha1.BlockDeviceAttr{
+						BlockDeviceList: []string{"blockdevice1", "blockdevice2", "blockdevice3"},
+					},
 				},
 			},
-		},
-			0,
+			expectedDiskListLength: 0,
+			expectedErr:            false,
 		},
 		// Test Case #16
-		"manualSPC16Raidz2": {&v1alpha1.StoragePoolClaim{
-			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "disk",
-				PoolSpec: v1alpha1.CStorPoolAttr{
-					PoolType: "raidz2",
-				},
-				BlockDevices: v1alpha1.BlockDeviceAttr{
-					BlockDeviceList: []string{"blockdevice1", "blockdevice2"},
+		"manualSPC16Raidz2": {
+			fakeCasPool: &v1alpha1.StoragePoolClaim{
+				Spec: v1alpha1.StoragePoolClaimSpec{
+					Type: "disk",
+					PoolSpec: v1alpha1.CStorPoolAttr{
+						PoolType: "raidz2",
+					},
+					BlockDevices: v1alpha1.BlockDeviceAttr{
+						BlockDeviceList: []string{"blockdevice1", "blockdevice2"},
+					},
 				},
 			},
-		},
-			0,
+			expectedDiskListLength: 0,
+			expectedErr:            false,
 		},
 		// Test Case #17
-		"manualSPC17Raidz2": {&v1alpha1.StoragePoolClaim{
-			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "disk",
-				PoolSpec: v1alpha1.CStorPoolAttr{
-					PoolType: "raidz2",
-				},
-				BlockDevices: v1alpha1.BlockDeviceAttr{
-					BlockDeviceList: []string{"blockdevice1", "blockdevice2", "blockdevice3", "blockdevice4"},
+		"manualSPC17Raidz2": {
+			fakeCasPool: &v1alpha1.StoragePoolClaim{
+				Spec: v1alpha1.StoragePoolClaimSpec{
+					Type: "disk",
+					PoolSpec: v1alpha1.CStorPoolAttr{
+						PoolType: "raidz2",
+					},
+					BlockDevices: v1alpha1.BlockDeviceAttr{
+						BlockDeviceList: []string{"blockdevice1", "blockdevice2", "blockdevice3", "blockdevice4"},
+					},
 				},
 			},
-		},
-			0,
+			expectedDiskListLength: 0,
+			expectedErr:            false,
 		},
 		// Test Case #18
-		"manualSPC18Raidz2": {&v1alpha1.StoragePoolClaim{
-			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "disk",
-				PoolSpec: v1alpha1.CStorPoolAttr{
-					PoolType: "raidz2",
-				},
-				BlockDevices: v1alpha1.BlockDeviceAttr{
-					BlockDeviceList: []string{"blockdevice1", "blockdevice2", "blockdevice3", "blockdevice4", "blockdevice5", "blockdevice6"},
+		"manualSPC18Raidz2": {
+			fakeCasPool: &v1alpha1.StoragePoolClaim{
+				Spec: v1alpha1.StoragePoolClaimSpec{
+					Type: "disk",
+					PoolSpec: v1alpha1.CStorPoolAttr{
+						PoolType: "raidz2",
+					},
+					BlockDevices: v1alpha1.BlockDeviceAttr{
+						BlockDeviceList: []string{"blockdevice1", "blockdevice2", "blockdevice3", "blockdevice4", "blockdevice5", "blockdevice6"},
+					},
 				},
 			},
-		},
-			0,
+			expectedDiskListLength: 6,
+			expectedErr:            false,
 		},
 		// Test Case #19
-		"manualSPC19Raidz2": {&v1alpha1.StoragePoolClaim{
-			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "disk",
-				PoolSpec: v1alpha1.CStorPoolAttr{
-					PoolType: "raidz2",
-				},
-				BlockDevices: v1alpha1.BlockDeviceAttr{
-					BlockDeviceList: []string{"blockdevice2", "blockdevice3", "blockdevice4", "blockdevice5", "blockdevice6", "blockdevice7", "blockdevice8", "blockdevice9", "blockdevice10", "blockdevice11", "blockdevice12", "blockdevice13"},
+		"manualSPC19Raidz2": {
+			fakeCasPool: &v1alpha1.StoragePoolClaim{
+				Spec: v1alpha1.StoragePoolClaimSpec{
+					Type: "disk",
+					PoolSpec: v1alpha1.CStorPoolAttr{
+						PoolType: "raidz2",
+					},
+					BlockDevices: v1alpha1.BlockDeviceAttr{
+						BlockDeviceList: []string{"blockdevice2", "blockdevice3", "blockdevice4", "blockdevice5", "blockdevice6", "blockdevice7", "blockdevice8", "blockdevice9", "blockdevice10", "blockdevice11", "blockdevice12", "blockdevice13"},
+					},
 				},
 			},
-		},
-			12,
+			expectedDiskListLength: 12,
+			expectedErr:            false,
 		},
 		// Test Case #20
-		"manualSPC20Raidz2": {&v1alpha1.StoragePoolClaim{
-			Spec: v1alpha1.StoragePoolClaimSpec{
-				Type: "disk",
-				PoolSpec: v1alpha1.CStorPoolAttr{
-					PoolType: "raidz2",
-				},
-				BlockDevices: v1alpha1.BlockDeviceAttr{
-					BlockDeviceList: []string{"blockdevice1", "blockdevice2", "blockdevice3", "blockdevice4", "blockdevice5", "blockdevice6", "blockdevice7"},
+		"manualSPC20Raidz2": {
+			fakeCasPool: &v1alpha1.StoragePoolClaim{
+				Spec: v1alpha1.StoragePoolClaimSpec{
+					Type: "disk",
+					PoolSpec: v1alpha1.CStorPoolAttr{
+						PoolType: "raidz2",
+					},
+					BlockDevices: v1alpha1.BlockDeviceAttr{
+						BlockDeviceList: []string{"blockdevice1", "blockdevice2", "blockdevice3", "blockdevice4", "blockdevice5", "blockdevice6", "blockdevice7"},
+					},
 				},
 			},
+			expectedDiskListLength: 6,
+			expectedErr:            false,
 		},
-			6,
+		// Test Case #21
+		"manualSPC21Raidz2": {
+			fakeCasPool: &v1alpha1.StoragePoolClaim{
+				Spec: v1alpha1.StoragePoolClaimSpec{
+					Type: "disk",
+					PoolSpec: v1alpha1.CStorPoolAttr{
+						PoolType: "raidz2",
+					},
+					BlockDevices: v1alpha1.BlockDeviceAttr{
+						BlockDeviceList: []string{"blockdevice1", "blockdevice2", "blockdevice3", "blockdevice4", "blockdevice5", "blockdevice27"},
+					},
+				},
+			},
+			expectedDiskListLength: 0,
+			expectedErr:            false,
 		},
 	}
 
@@ -410,11 +468,14 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			ac := fakeAlgorithmConfig(test.fakeCasPool)
-			blockdeviceList, _ := ac.NodeBlockDeviceSelector()
-			if blockdeviceList == nil {
-				t.Fatalf("Got nil blockdevice list")
+			blockdeviceList, err := ac.NodeBlockDeviceSelector()
+			if test.expectedErr && err == nil {
+				t.Fatalf("Test case failed expected error not to be nil")
 			}
-			if len(blockdeviceList.BlockDevices.Items) != test.expectedDiskListLength {
+			if !test.expectedErr && err != nil {
+				t.Fatalf("Test case failed expected error to be nil")
+			}
+			if !test.expectedErr && err == nil && len(blockdeviceList.BlockDevices.Items) != test.expectedDiskListLength {
 				t.Errorf("Test case failed as the expected blockdevice list length is %d but got %d", test.expectedDiskListLength, len(blockdeviceList.BlockDevices.Items))
 			}
 		})

--- a/pkg/apis/openebs.io/ndm/v1alpha1/blockdeviceclaim_types.go
+++ b/pkg/apis/openebs.io/ndm/v1alpha1/blockdeviceclaim_types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/blockdevice/v1alpha1/blockdevice.go
+++ b/pkg/blockdevice/v1alpha1/blockdevice.go
@@ -332,25 +332,3 @@ func (bdl *BlockDeviceList) GetBlockDevice(bdcName string) *ndm.BlockDevice {
 	}
 	return nil
 }
-
-// GetBDList returns matched block devices present in the list
-func (bdl *BlockDeviceList) GetBDList(bdcl *ndm.BlockDeviceClaimList) *BlockDeviceList {
-	if len(bdcl.Items) == 0 {
-		return bdl
-	}
-	bdListFromBDC := make(map[string]int)
-	for _, bdc := range bdcl.Items {
-		bdListFromBDC[bdc.Spec.BlockDeviceName]++
-	}
-
-	newBDL := &BlockDeviceList{
-		BlockDeviceList: &ndm.BlockDeviceList{},
-		errs:            nil,
-	}
-	for _, bd := range bdl.BlockDeviceList.Items {
-		if bdListFromBDC[bd.Name] == 1 {
-			newBDL.BlockDeviceList.Items = append(newBDL.BlockDeviceList.Items, bd)
-		}
-	}
-	return newBDL
-}

--- a/pkg/blockdevice/v1alpha1/blockdevice.go
+++ b/pkg/blockdevice/v1alpha1/blockdevice.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"strings"
+
 	ndm "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
@@ -29,18 +31,26 @@ import (
 //TODO: Update the file with latest pattern
 const (
 	// StorageNodePredicateKey is the key for StorageNodePredicate function.
-	FilterInactive       = "filterInactive"
-	FilterNonInactive    = "filterNonInactive"
-	FilterClaimedDevices = "filterClaimedDevices"
-	InActiveStatus       = "Inactive"
+	FilterInactive         = "filterInactive"
+	FilterNonInactive      = "filterNonInactive"
+	FilterNonPartitions    = "filterNonPartitions"
+	FilterSparseDevices    = "filterSparseDevices"
+	FilterNonSparseDevices = "filterNonSparseDevices"
+	InActiveStatus         = "Inactive"
 )
 
-// DefaultDiskCount is a map containing the default disk count of various raid types.
+// DefaultDiskCount is a map containing the default block device count of various raid types.
 var DefaultDiskCount = map[string]int{
 	string(apis.PoolTypeMirroredCPV): int(apis.MirroredBlockDeviceCountCPV),
 	string(apis.PoolTypeStripedCPV):  int(apis.StripedBlockDeviceCountCPV),
 	string(apis.PoolTypeRaidzCPV):    int(apis.RaidzBlockDeviceCountCPV),
 	string(apis.PoolTypeRaidz2CPV):   int(apis.Raidz2BlockDeviceCountCPV),
+}
+
+// SupportedDiskType is a map containing the valid disk type
+var SupportedDiskType = map[string]bool{
+	string(apis.TypeSparseCPV): true,
+	string(apis.TypeDiskCPV):   true,
 }
 
 // KubernetesClient is the kubernetes client which will implement block device actions/behaviours
@@ -105,9 +115,11 @@ var checkPredicatesFuncs = [...]predicate{
 // filterPredicatesFuncMap is an array of filter predicate functions
 // filter predicates should be tunable by client.
 var filterOptionFuncMap = map[string]filterOptionFunc{
-	FilterInactive:       filterInactive,
-	FilterNonInactive:    filterNonInactive,
-	FilterClaimedDevices: filterClaimedDevices,
+	FilterInactive:         filterInactive,
+	FilterNonInactive:      filterNonInactive,
+	FilterNonPartitions:    filterNonPartitions,
+	FilterSparseDevices:    filterSparseDevices,
+	FilterNonSparseDevices: filterNonSparseDevices,
 }
 
 // predicateFailedError returns the predicate error which is provided to this function as an argument
@@ -202,12 +214,12 @@ func (bdl *BlockDeviceList) Filter(predicateKeys ...string) *BlockDeviceList {
 }
 
 //filterInactive filter and give out all the inactive block device
-func filterInactive(orignialList *BlockDeviceList) *BlockDeviceList {
+func filterInactive(originalList *BlockDeviceList) *BlockDeviceList {
 	filteredList := &BlockDeviceList{
 		BlockDeviceList: &ndm.BlockDeviceList{},
 		errs:            nil,
 	}
-	for _, device := range orignialList.Items {
+	for _, device := range originalList.Items {
 		if device.Status.State == InActiveStatus {
 			filteredList.Items = append(filteredList.Items, device)
 		}
@@ -229,13 +241,39 @@ func filterNonInactive(orignialList *BlockDeviceList) *BlockDeviceList {
 	return filteredList
 }
 
-func filterClaimedDevices(orignialList *BlockDeviceList) *BlockDeviceList {
+func filterNonPartitions(originalList *BlockDeviceList) *BlockDeviceList {
 	filteredList := &BlockDeviceList{
 		BlockDeviceList: &ndm.BlockDeviceList{},
 		errs:            nil,
 	}
-	for _, device := range orignialList.Items {
-		if device.Status.ClaimState == ndm.BlockDeviceClaimed {
+	for _, device := range originalList.Items {
+		if strings.EqualFold(device.Spec.Partitioned, "No") {
+			filteredList.Items = append(filteredList.Items, device)
+		}
+	}
+	return filteredList
+}
+
+func filterSparseDevices(originalList *BlockDeviceList) *BlockDeviceList {
+	filteredList := &BlockDeviceList{
+		BlockDeviceList: &ndm.BlockDeviceList{},
+		errs:            nil,
+	}
+	for _, device := range originalList.Items {
+		if strings.EqualFold(device.Spec.Details.DeviceType, string(apis.TypeSparseCPV)) {
+			filteredList.Items = append(filteredList.Items, device)
+		}
+	}
+	return filteredList
+}
+
+func filterNonSparseDevices(originalList *BlockDeviceList) *BlockDeviceList {
+	filteredList := &BlockDeviceList{
+		BlockDeviceList: &ndm.BlockDeviceList{},
+		errs:            nil,
+	}
+	for _, device := range originalList.Items {
+		if !strings.EqualFold(device.Spec.Details.DeviceType, string(apis.TypeSparseCPV)) {
 			filteredList.Items = append(filteredList.Items, device)
 		}
 	}
@@ -293,4 +331,26 @@ func (bdl *BlockDeviceList) GetBlockDevice(bdcName string) *ndm.BlockDevice {
 		}
 	}
 	return nil
+}
+
+// GetBDList returns matched block devices present in the list
+func (bdl *BlockDeviceList) GetBDList(bdcl *ndm.BlockDeviceClaimList) *BlockDeviceList {
+	if len(bdcl.Items) == 0 {
+		return bdl
+	}
+	bdListFromBDC := make(map[string]int)
+	for _, bdc := range bdcl.Items {
+		bdListFromBDC[bdc.Spec.BlockDeviceName]++
+	}
+
+	newBDL := &BlockDeviceList{
+		BlockDeviceList: &ndm.BlockDeviceList{},
+		errs:            nil,
+	}
+	for _, bd := range bdl.BlockDeviceList.Items {
+		if bdListFromBDC[bd.Name] == 1 {
+			newBDL.BlockDeviceList.Items = append(newBDL.BlockDeviceList.Items, bd)
+		}
+	}
+	return newBDL
 }

--- a/pkg/blockdevice/v1alpha1/blockdevice_test.go
+++ b/pkg/blockdevice/v1alpha1/blockdevice_test.go
@@ -310,8 +310,8 @@ func TestFilter(t *testing.T) {
 				},
 				errs: nil,
 			},
-			filterPredicate:          []string{FilterClaimedDevices},
-			expectedBlockDeviceCount: 2,
+			filterPredicate:          []string{FilterInactive, FilterNonInactive},
+			expectedBlockDeviceCount: 0,
 		},
 	}
 	for name, test := range tests {
@@ -415,6 +415,225 @@ func TestIsClaimed(t *testing.T) {
 			output := test.blockDevice.IsClaimed()
 			if output != test.expectedOutput {
 				t.Errorf("Test %q failed expected status: %t and got: %t", name, test.expectedOutput, output)
+			}
+		})
+	}
+}
+
+func TestFilterNonPartitions(t *testing.T) {
+	tests := map[string]struct {
+		// fakeCasPool holds the fake fakeCasPool object in test cases.
+		blockDeviceList *BlockDeviceList
+		// expectedBlockDeviceListLength holds the length of disk list
+		expectedBlockDeviceCount int
+	}{
+		"EmptyBlockDeviceList1": {
+			blockDeviceList: &BlockDeviceList{
+				BlockDeviceList: &ndm.BlockDeviceList{},
+				errs:            nil,
+			},
+			expectedBlockDeviceCount: 0,
+		},
+		"blockDeviceList2": {
+			blockDeviceList: &BlockDeviceList{
+				BlockDeviceList: &ndm.BlockDeviceList{
+					TypeMeta: metav1.TypeMeta{},
+					ListMeta: metav1.ListMeta{},
+					Items: []ndm.BlockDevice{
+						{
+							TypeMeta:   metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{},
+							Spec: ndm.DeviceSpec{
+								Path:        "/dev/sda",
+								Partitioned: "YES",
+							},
+							Status: ndm.DeviceStatus{
+								State: "Active",
+							},
+						},
+						{
+							TypeMeta:   metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{},
+							Spec: ndm.DeviceSpec{
+								Path:        "/dev/sdb",
+								Partitioned: "NO",
+							},
+							Status: ndm.DeviceStatus{
+								State: "Active",
+							},
+						},
+						{
+							TypeMeta:   metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{},
+							Spec: ndm.DeviceSpec{
+								Path:        "/dev/sdb",
+								Partitioned: "NO",
+							},
+							Status: ndm.DeviceStatus{
+								State: "Active",
+							},
+						},
+					},
+				},
+				errs: nil,
+			},
+			expectedBlockDeviceCount: 2,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			filtteredBlockDeviceList := filterNonPartitions(test.blockDeviceList)
+			if len(filtteredBlockDeviceList.Items) != test.expectedBlockDeviceCount {
+				t.Errorf("Test %q failed: expected block device object count %d but got %d", name, test.expectedBlockDeviceCount, len(filtteredBlockDeviceList.Items))
+			}
+		})
+	}
+}
+
+func TestFilterSparseDevices(t *testing.T) {
+	tests := map[string]struct {
+		// fakeCasPool holds the fake fakeCasPool object in test cases.
+		blockDeviceList *BlockDeviceList
+		// expectedBlockDeviceListLength holds the length of disk list
+		expectedBlockDeviceCount int
+	}{
+		"EmptyBlockDeviceList1": {
+			blockDeviceList: &BlockDeviceList{
+				BlockDeviceList: &ndm.BlockDeviceList{},
+				errs:            nil,
+			},
+			expectedBlockDeviceCount: 0,
+		},
+		"blockDeviceList2": {
+			blockDeviceList: &BlockDeviceList{
+				BlockDeviceList: &ndm.BlockDeviceList{
+					TypeMeta: metav1.TypeMeta{},
+					ListMeta: metav1.ListMeta{},
+					Items: []ndm.BlockDevice{
+						{
+							TypeMeta:   metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{},
+							Spec: ndm.DeviceSpec{
+								Details: ndm.DeviceDetails{
+									DeviceType: "sparse",
+								},
+							},
+							Status: ndm.DeviceStatus{
+								State: "Active",
+							},
+						},
+						{
+							TypeMeta:   metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{},
+							Spec: ndm.DeviceSpec{
+								Details: ndm.DeviceDetails{
+									DeviceType: "HDD",
+								},
+							},
+							Status: ndm.DeviceStatus{
+								State: "Active",
+							},
+						},
+						{
+							TypeMeta:   metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{},
+							Spec: ndm.DeviceSpec{
+								Details: ndm.DeviceDetails{
+									DeviceType: "SSD",
+								},
+							},
+							Status: ndm.DeviceStatus{
+								State: "Active",
+							},
+						},
+					},
+				},
+				errs: nil,
+			},
+			expectedBlockDeviceCount: 1,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			filtteredBlockDeviceList := filterSparseDevices(test.blockDeviceList)
+			if len(filtteredBlockDeviceList.Items) != test.expectedBlockDeviceCount {
+				t.Errorf("Test %q failed: expected block device object count %d but got %d", name, test.expectedBlockDeviceCount, len(filtteredBlockDeviceList.Items))
+			}
+		})
+	}
+}
+
+func TestFilterNonSparseDevices(t *testing.T) {
+	tests := map[string]struct {
+		// fakeCasPool holds the fake fakeCasPool object in test cases.
+		blockDeviceList *BlockDeviceList
+		// expectedBlockDeviceListLength holds the length of disk list
+		expectedBlockDeviceCount int
+	}{
+		"EmptyBlockDeviceList1": {
+			blockDeviceList: &BlockDeviceList{
+				BlockDeviceList: &ndm.BlockDeviceList{},
+				errs:            nil,
+			},
+			expectedBlockDeviceCount: 0,
+		},
+		"blockDeviceList2": {
+			blockDeviceList: &BlockDeviceList{
+				BlockDeviceList: &ndm.BlockDeviceList{
+					TypeMeta: metav1.TypeMeta{},
+					ListMeta: metav1.ListMeta{},
+					Items: []ndm.BlockDevice{
+						{
+							TypeMeta:   metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{},
+							Spec: ndm.DeviceSpec{
+								Details: ndm.DeviceDetails{
+									DeviceType: "sparse",
+								},
+							},
+							Status: ndm.DeviceStatus{
+								State: "Active",
+							},
+						},
+						{
+							TypeMeta:   metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{},
+							Spec: ndm.DeviceSpec{
+								Details: ndm.DeviceDetails{
+									DeviceType: "HDD",
+								},
+							},
+							Status: ndm.DeviceStatus{
+								State: "Active",
+							},
+						},
+						{
+							TypeMeta:   metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{},
+							Spec: ndm.DeviceSpec{
+								Details: ndm.DeviceDetails{
+									DeviceType: "SSD",
+								},
+							},
+							Status: ndm.DeviceStatus{
+								State: "Active",
+							},
+						},
+					},
+				},
+				errs: nil,
+			},
+			expectedBlockDeviceCount: 2,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			filtteredBlockDeviceList := filterNonSparseDevices(test.blockDeviceList)
+			if len(filtteredBlockDeviceList.Items) != test.expectedBlockDeviceCount {
+				t.Errorf("Test %q failed: expected block device object count %d but got %d", name, test.expectedBlockDeviceCount, len(filtteredBlockDeviceList.Items))
 			}
 		})
 	}

--- a/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim.go
+++ b/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim.go
@@ -111,8 +111,7 @@ func (bdcl *BlockDeviceClaimList) Len() int {
 // GetBDList returns map of node name and corresponding block devices to that
 // node from block device claim list
 func (bdcl *BlockDeviceClaimList) GetBDList() map[string][]string {
-	var newNodeBDList map[string][]string
-	newNodeBDList = make(map[string][]string)
+	newNodeBDList := make(map[string][]string)
 	if bdcl == nil {
 		return newNodeBDList
 	}

--- a/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim.go
+++ b/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim.go
@@ -104,6 +104,20 @@ func (bdc *BlockDeviceClaim) IsStatus(status string) bool {
 }
 
 // Len returns the length og BlockDeviceClaimList.
-func (l *BlockDeviceClaimList) Len() int {
-	return len(l.ObjectList.Items)
+func (bdcl *BlockDeviceClaimList) Len() int {
+	return len(bdcl.ObjectList.Items)
+}
+
+// GetBDList returns map of node name and corresponding block devices to that
+// node from block device claim list
+func (bdcl *BlockDeviceClaimList) GetBDList() map[string][]string {
+	var newNodeBDList map[string][]string
+	newNodeBDList = make(map[string][]string)
+	if bdcl == nil {
+		return newNodeBDList
+	}
+	for _, bdc := range bdcl.ObjectList.Items {
+		newNodeBDList[bdc.Spec.HostName] = append(newNodeBDList[bdc.Spec.HostName], bdc.Spec.BlockDeviceName)
+	}
+	return newNodeBDList
 }

--- a/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim.go
+++ b/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim.go
@@ -20,8 +20,6 @@ import (
 	ndm "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
 )
 
-//TODO: While using these packages UnitTest must be written to corresponding function
-
 // BlockDeviceClaim encapsulates BlockDeviceClaim api object.
 type BlockDeviceClaim struct {
 	// actual block device claim object
@@ -108,9 +106,9 @@ func (bdcl *BlockDeviceClaimList) Len() int {
 	return len(bdcl.ObjectList.Items)
 }
 
-// GetBDList returns map of node name and corresponding block devices to that
+// GetBlockDeviceNamesByNode returns map of node name and corresponding block devices to that
 // node from block device claim list
-func (bdcl *BlockDeviceClaimList) GetBDList() map[string][]string {
+func (bdcl *BlockDeviceClaimList) GetBlockDeviceNamesByNode() map[string][]string {
 	newNodeBDList := make(map[string][]string)
 	if bdcl == nil {
 		return newNodeBDList

--- a/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim_test.go
+++ b/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim_test.go
@@ -15,7 +15,11 @@
 package v1alpha1
 
 import (
+	"testing"
+
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
+	ndm "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func fakeAPIBDCList(bdcNames []string) *apis.BlockDeviceClaimList {
@@ -29,4 +33,58 @@ func fakeAPIBDCList(bdcNames []string) *apis.BlockDeviceClaimList {
 		list.Items = append(list.Items, bdc)
 	}
 	return list
+}
+
+func TestGetBDList(t *testing.T) {
+	tests := map[string]struct {
+		bdcList     *BlockDeviceClaimList
+		nodeCount   int
+		expectedLen []int
+	}{
+		"blockDeviceClaimList1": {
+			bdcList: &BlockDeviceClaimList{
+				ObjectList: &apis.BlockDeviceClaimList{
+					TypeMeta: metav1.TypeMeta{},
+					ListMeta: metav1.ListMeta{},
+					Items: []ndm.BlockDeviceClaim{
+						{
+							TypeMeta:   metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{},
+							Spec: ndm.DeviceClaimSpec{
+								HostName:        "openebs-1234",
+								BlockDeviceName: "blockdevice1",
+							},
+						},
+						{
+							TypeMeta:   metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{},
+							Spec: ndm.DeviceClaimSpec{
+								HostName:        "openebs-1234",
+								BlockDeviceName: "blockdevice2",
+							},
+						},
+						{
+							TypeMeta:   metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{},
+							Spec: ndm.DeviceClaimSpec{
+								HostName:        "openebs-1234",
+								BlockDeviceName: "blockdevice3",
+							},
+						},
+					},
+				},
+			},
+			nodeCount:   1,
+			expectedLen: []int{3},
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			nodeBDList := test.bdcList.GetBDList()
+			if len(nodeBDList) != test.nodeCount {
+				t.Errorf("Test %q failed: expected block device object count %d but got %d", name, test.nodeCount, len(nodeBDList))
+			}
+		})
+	}
 }

--- a/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim_test.go
+++ b/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim_test.go
@@ -81,7 +81,7 @@ func TestGetBDList(t *testing.T) {
 	for name, test := range tests {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
-			nodeBDList := test.bdcList.GetBDList()
+			nodeBDList := test.bdcList.GetBlockDeviceNamesByNode()
 			if len(nodeBDList) != test.nodeCount {
 				t.Errorf("Test %q failed: expected block device object count %d but got %d", name, test.nodeCount, len(nodeBDList))
 			}

--- a/pkg/storagepoolclaim/v1alpha1/storagepoolclaim.go
+++ b/pkg/storagepoolclaim/v1alpha1/storagepoolclaim.go
@@ -24,10 +24,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// SupportedDiskType is a map containing the valid disk type
-var SupportedDiskType = map[string]bool{
-	string(apis.TypeSparseCPV): true,
-	string(apis.TypeDiskCPV):   true,
+// SupportedDiskTypes is a map containing the valid disk type
+var SupportedDiskTypes = map[apis.CasPoolValString]bool{
+	apis.TypeSparseCPV: true,
+	apis.TypeDiskCPV:   true,
 }
 
 // SPC encapsulates StoragePoolClaim api object.

--- a/pkg/storagepoolclaim/v1alpha1/storagepoolclaim.go
+++ b/pkg/storagepoolclaim/v1alpha1/storagepoolclaim.go
@@ -24,6 +24,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// SupportedDiskType is a map containing the valid disk type
+var SupportedDiskType = map[string]bool{
+	string(apis.TypeSparseCPV): true,
+	string(apis.TypeDiskCPV):   true,
+}
+
 // SPC encapsulates StoragePoolClaim api object.
 type SPC struct {
 	// actual spc object


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR add the support to use unclaimed block devices(BD) during auto provisioning of pool creation.

#### Detailed notes to create the pools in auto provisioning mode

1) Deploy latest openebs-operator.yaml using `kubectl apply -f <file_name>`
2) Check whether the openebs components are in running state or not 

```bash
kubectl get po -n openebs
NAME                                         READY   STATUS             RESTARTS   AGE
maya-apiserver-78f66545fc-j5kvp              1/1     Running            0          15m
node-disk-operator-6c58d8596c-qk7rv          1/1     Running         0          15m
openebs-admission-server-f798484fd-v854b     1/1     Running            0          15m
openebs-localpv-provisioner-76ff6fd9-s9zwj   1/1     Running            0          15m
openebs-ndm-7547s                            1/1     Running            0          15m
openebs-provisioner-7f8fc569c4-nngjs         1/1     Running            0          15m
openebs-snapshot-operator-59b56fb897-rgt9p   2/2     Running            0          15m
```
3) Check all the openebs components are in running state or not
If all are in running state apply below spc.yaml to create pools

User needs to set _`spec.type`_ type as **`sparse`** or **`disk`**.

### Auto Provisioning:
1. If cstor pools need to be created on _top of sparse disks_.
```yaml
apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: cstor-sparse
spec:
  name: cstor-sparse
  type: sparse
  maxPools: 3
  poolSpec:
    poolType: striped
    overProvisioning: false
```

2. If cstor pools need to be created _on top of disks attached to the node_.
```yaml
apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: cstor-disk
spec:
  name: cstor-disk
  type: disk
  maxPools: 3
  poolSpec:
    poolType: mirrored
    overProvisioning: false
```

**TODO**
1. Fix travis failures [Done]
2. Add Sample yamls in PR description [Done]
3. Test in multi node cluster [ Done]


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests