### PR TITLE
bdd(pvc, cstor): add bulk create and delete of pvcs in a given namespace

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -146,7 +146,7 @@ cover:
 
 format:
 	@echo "--> Running go fmt"
-	@go fmt $(PACKAGES)
+	@go fmt $(PACKAGES) $(PACKAGES_IT)
 
 # Target to run gometalinter in Travis (deadcode, golint, errcheck, unconvert, goconst)
 golint-travis:

--- a/pkg/kubernetes/persistentvolumeclaim/v1alpha1/build.go
+++ b/pkg/kubernetes/persistentvolumeclaim/v1alpha1/build.go
@@ -43,6 +43,21 @@ func (b *Builder) WithName(name string) *Builder {
 	return b
 }
 
+// WithGenerateName sets the GenerateName field of
+// PVC with provided value
+func (b *Builder) WithGenerateName(name string) *Builder {
+	if len(name) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build PVC object: missing PVC generateName"),
+		)
+		return b
+	}
+
+	b.pvc.object.GenerateName = name
+	return b
+}
+
 // WithNamespace sets the Namespace field of PVC provided arguments
 func (b *Builder) WithNamespace(namespace string) *Builder {
 	if len(namespace) == 0 {
@@ -62,13 +77,46 @@ func (b *Builder) WithAnnotations(annotations map[string]string) *Builder {
 	return b
 }
 
-// WithLabels sets the Labels field of PVC with provided arguments
+// WithLabels merges existing labels if any
+// with the ones that are provided here
 func (b *Builder) WithLabels(labels map[string]string) *Builder {
 	if len(labels) == 0 {
-		b.errs = append(b.errs, errors.New("failed to build PVC object: missing labels"))
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build PVC object: missing labels"),
+		)
 		return b
 	}
-	b.pvc.object.Labels = labels
+
+	if b.pvc.object.Labels == nil {
+		b.pvc.object.Labels = map[string]string{}
+	}
+
+	for key, value := range labels {
+		b.pvc.object.Labels[key] = value
+	}
+	return b
+}
+
+// WithLabelsNew resets existing labels if any with
+// ones that are provided here
+func (b *Builder) WithLabelsNew(labels map[string]string) *Builder {
+	if len(labels) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build PVC object: missing labels"),
+		)
+		return b
+	}
+
+	// copy of original map
+	newlbls := map[string]string{}
+	for key, value := range labels {
+		newlbls[key] = value
+	}
+
+	// override
+	b.pvc.object.Labels = newlbls
 	return b
 }
 

--- a/pkg/kubernetes/persistentvolumeclaim/v1alpha1/build_test.go
+++ b/pkg/kubernetes/persistentvolumeclaim/v1alpha1/build_test.go
@@ -165,6 +165,54 @@ func TestBuildWithLabels(t *testing.T) {
 	}
 }
 
+func TestBuildWithLabelsNew(t *testing.T) {
+	tests := map[string]struct {
+		labels    map[string]string
+		builder   *Builder
+		expectErr bool
+	}{
+		"Test 1 - with labels": {
+			labels: map[string]string{
+				"persistent-volume": "PV",
+				"application":       "percona",
+			},
+			builder: &Builder{pvc: &PVC{
+				object: &corev1.PersistentVolumeClaim{},
+			}},
+			expectErr: false,
+		},
+
+		"Test 2 - with empty labels": {
+			labels: map[string]string{},
+			builder: &Builder{pvc: &PVC{
+				object: &corev1.PersistentVolumeClaim{},
+			}},
+			expectErr: true,
+		},
+
+		"Test 3 - with nil labels": {
+			labels: nil,
+			builder: &Builder{pvc: &PVC{
+				object: &corev1.PersistentVolumeClaim{},
+			}},
+			expectErr: true,
+		},
+	}
+
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithLabelsNew(mock.labels)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
 func TestBuildWithAccessModes(t *testing.T) {
 	tests := map[string]struct {
 		accessModes []corev1.PersistentVolumeAccessMode

--- a/tests/cstor/volume/provision_bulk_test.go
+++ b/tests/cstor/volume/provision_bulk_test.go
@@ -1,0 +1,250 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"strconv"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	pvc "github.com/openebs/maya/pkg/kubernetes/persistentvolumeclaim/v1alpha1"
+	sc "github.com/openebs/maya/pkg/kubernetes/storageclass/v1alpha1"
+	spc "github.com/openebs/maya/pkg/storagepoolclaim/v1alpha1"
+	"github.com/openebs/maya/tests/cstor"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("[cstor] TEST BULK VOLUME PROVISIONING", func() {
+	var (
+		err           error
+		pvcNamePrefix = "cstor-volume-claim-"
+		bulkCount     = 10
+		pvcObjList    *v1.PersistentVolumeClaimList
+		pvcObjTpl     *v1.PersistentVolumeClaim
+	)
+
+	BeforeEach(func() {
+		When("creating a cstor based volume", func() {
+			By("building spc")
+			spcObj = spc.NewBuilder().
+				WithGenerateName(spcName).
+				WithDiskType(string(apis.TypeSparseCPV)).
+				WithMaxPool(cstor.PoolCount).
+				WithOverProvisioning(false).
+				WithPoolType(string(apis.PoolTypeStripedCPV)).
+				Build().Object
+
+			By("creating above spc")
+			spcObj, err = ops.SPCClient.Create(spcObj)
+			Expect(err).To(BeNil(), "while creating spc {%s}", spcName)
+
+			By("verifying healthy csp count")
+			cspCount := ops.GetHealthyCSPCountEventually(spcObj.Name, cstor.PoolCount)
+			Expect(cspCount).To(Equal(true), "while checking csp health status")
+
+			By("building cas config with above spc")
+			CASConfig := strings.Replace(
+				openebsCASConfigValue, "$spcName", spcObj.Name, 1,
+			)
+			CASConfig = strings.Replace(
+				CASConfig, "$count", strconv.Itoa(cstor.ReplicaCount), 1,
+			)
+			annotations[string(apis.CASTypeKey)] = string(apis.CstorVolume)
+			annotations[string(apis.CASConfigKey)] = CASConfig
+
+			By("building a storageclass")
+			scObj, err = sc.NewBuilder().
+				WithGenerateName(scName).
+				WithAnnotations(annotations).
+				WithProvisioner(openebsProvisioner).Build()
+			Expect(err).ShouldNot(
+				HaveOccurred(),
+				"while building storageclass {%s}", scName,
+			)
+
+			By("creating above storageclass")
+			scObj, err = ops.SCClient.Create(scObj)
+			Expect(err).To(BeNil(), "while creating storageclass {%s}", scName)
+
+		})
+	})
+
+	AfterEach(func() {
+		By("deleting resources created during this test", func() {
+
+			By("deleting spc")
+			_, err = ops.SPCClient.Delete(spcObj.Name, &metav1.DeleteOptions{})
+			Expect(err).To(BeNil(), "while deleting spc {%s}", spcObj.Name)
+
+			By("deleting storageclass")
+			err = ops.SCClient.Delete(scObj.Name, &metav1.DeleteOptions{})
+			Expect(err).To(BeNil(), "while deleting storageclass {%s}", scName)
+
+		})
+	})
+
+	// Actual tests begin here !!!
+	When("cstor pvcs are created", func() {
+		It("should create cstor volumes", func() {
+
+			By("building a pvc template")
+			pvcObjTpl, err = pvc.NewBuilder().
+				WithGenerateName(pvcNamePrefix).
+				WithNamespace(nsObj.Name).
+				WithStorageClass(scObj.Name).
+				WithAccessModes(accessModes).
+				WithCapacity(capacity).
+				WithLabels(
+					map[string]string{
+						"bulk.delete": nsObj.Name,
+					},
+				).
+				Build()
+			Expect(err).ShouldNot(
+				HaveOccurred(),
+				"while building pvc template {%s} in namespace {%s}",
+				pvcNamePrefix,
+				nsObj.Name,
+			)
+
+			By("building a list of pvcs")
+			pvcObjList, err = pvc.ListBuilderFromTemplate(pvcObjTpl).
+				WithCount(bulkCount).
+				APIList()
+
+			Expect(err).ShouldNot(
+				HaveOccurred(),
+				"while building a list of pvcs {%s} in namespace {%s}",
+				pvcNamePrefix,
+				nsObj.Name,
+			)
+
+			By("creating above pvcs in a bulk")
+			pvcObjList, err = ops.PVCClient.
+				WithNamespace(nsObj.Name).
+				CreateCollection(pvcObjList)
+			Expect(err).To(
+				BeNil(),
+				"while creating pvcs {%s} in namespace {%s}", pvcNamePrefix, nsObj.Name,
+			)
+
+			for _, pvcObj := range pvcObjList.Items {
+				By("verifying target pod count")
+				targetLabel := pvcLabel + pvcObj.Name
+				controllerPodCount := ops.GetPodRunningCountEventually(
+					openebsNamespace, targetLabel, 1,
+				)
+				Expect(controllerPodCount).To(
+					Equal(1),
+					"while checking target pod count",
+				)
+
+				By("verifying if cstorvolume is created")
+				cvLabel := pvLabel + pvcObj.Spec.VolumeName
+				cvCount := ops.GetCstorVolumeCountEventually(
+					openebsNamespace, cvLabel, 1,
+				)
+				Expect(cvCount).To(
+					Equal(true),
+					"while checking if cstorvolume is created",
+				)
+
+				By("verifying cvr count")
+				cvrLabel := pvLabel + pvcObj.Spec.VolumeName
+				cvrCount := ops.GetCstorVolumeReplicaCountEventually(
+					openebsNamespace, cvrLabel, cstor.ReplicaCount,
+				)
+				Expect(cvrCount).To(
+					Equal(true),
+					"while checking cvr count",
+				)
+
+				By("verifying pvc status as bound")
+				status := ops.IsPVCBound(pvcObj.Name)
+				Expect(status).To(Equal(true), "while checking status equal to bound")
+
+			}
+		})
+	})
+
+	When("cstor pvcs are deleted", func() {
+		It("should delete cstor volumes", func() {
+
+			By("deleting above pvcs in a bulk")
+			lopts := metav1.ListOptions{
+				LabelSelector: "bulk.delete=" + nsObj.Name,
+			}
+
+			deletePolicy := metav1.DeletePropagationForeground
+			dopts := &metav1.DeleteOptions{
+				PropagationPolicy: &deletePolicy,
+			}
+
+			err = ops.PVCClient.
+				WithNamespace(nsObj.Name).
+				DeleteCollection(lopts, dopts)
+			Expect(err).To(
+				BeNil(),
+				"while deleting pvcs {%s} in namespace {%s}", pvcNamePrefix, nsObj.Name,
+			)
+
+			for _, pvcObj := range pvcObjList.Items {
+
+				By("verifying target pod count as 0")
+				targetLabel := pvcLabel + pvcObj.Name
+				controllerPodCount := ops.GetPodRunningCountEventually(
+					openebsNamespace, targetLabel, 0)
+				Expect(controllerPodCount).To(
+					Equal(0),
+					"while checking controller pod count",
+				)
+
+				By("verifying deleted pvc")
+				pvc := ops.IsPVCDeleted(pvcObj.Name)
+				Expect(pvc).To(
+					Equal(true),
+					"while trying to get deleted pvc",
+				)
+
+				By("verifying if cstorvolume is deleted")
+				cvLabel := pvLabel + pvcObj.Spec.VolumeName
+				cvCount := ops.GetCstorVolumeCountEventually(
+					openebsNamespace, cvLabel, 0,
+				)
+				Expect(cvCount).To(
+					Equal(true),
+					"while checking if cstorvolume is deleted",
+				)
+
+				By("verifying if cvr is deleted")
+				cvrLabel := pvLabel + pvcObj.Spec.VolumeName
+				cvrCount := ops.GetCstorVolumeReplicaCountEventually(
+					openebsNamespace, cvrLabel, 0,
+				)
+				Expect(cvrCount).To(
+					Equal(true),
+					"while checking if cvr is deleted",
+				)
+
+			}
+		})
+	})
+})

--- a/tests/exporter/exporter_test.go
+++ b/tests/exporter/exporter_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Test maya-exporter [single-pool-pod]", func() {
 			By("listing cstor pool pods")
 			selector := map[string]string{
 				string(apis.StoragePoolClaimCPK): spcName,
-				"app": "cstor-pool",
+				"app":                            "cstor-pool",
 			}
 
 			ls := labels.Set(selector).


### PR DESCRIPTION
Signed-off-by: shubham shubham.bajpai@mayadata.io
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This commit adds test logic that does the following:

    creates multiple pvcs in a given namespace
    verifies if all these pvcs were created successfully
    deletes all these pvcs
    verifies if each pvc resources are deleted

**Sample test output**:
```
user:volume$ ginkgo -v --focus=BULK -- -kubeconfig=/home/user/.kube/config
Running Suite: Test cstor volume provisioning
=============================================
Random Seed: 1560250881
Will run 4 of 5 specs

STEP: waiting for maya-apiserver pod to come into running state
STEP: waiting for openebs-provisioner pod to come into running state
STEP: Verifying 'admission-server' pod status as running
STEP: building a namespace
STEP: creating a namespace
[cstor] TEST BULK VOLUME PROVISIONING when creating resources required by test 
  should create a spc and storageclass
  /home/user/work/src/github.com/openebs/maya/tests/cstor/volume/provision_bulk_test.go:46
STEP: building spc
STEP: creating above spc
STEP: verifying healthy csp count
STEP: building cas config with above spc
STEP: building a storageclass
STEP: creating above storageclass

• [SLOW TEST:32.032 seconds]
[cstor] TEST BULK VOLUME PROVISIONING
/home/user/work/src/github.com/openebs/maya/tests/cstor/volume/provision_bulk_test.go:36
  when creating resources required by test
  /home/user/work/src/github.com/openebs/maya/tests/cstor/volume/provision_bulk_test.go:45
    should create a spc and storageclass
    /home/user/work/src/github.com/openebs/maya/tests/cstor/volume/provision_bulk_test.go:46
------------------------------
[cstor] TEST BULK VOLUME PROVISIONING when cstor pvcs are created 
  should create cstor volumes
  /home/user/work/src/github.com/openebs/maya/tests/cstor/volume/provision_bulk_test.go:93
STEP: building a pvc template
STEP: building a list of pvcs
STEP: creating above pvcs in a bulk
STEP: verifying pvc status as bound
STEP: verifying target pod count
STEP: verifying if cstorvolume is created
STEP: verifying cvr count
STEP: verifying pvc status as bound
STEP: verifying target pod count
STEP: verifying if cstorvolume is created
STEP: verifying cvr count
STEP: verifying pvc status as bound
STEP: verifying target pod count
STEP: verifying if cstorvolume is created
STEP: verifying cvr count
STEP: verifying pvc status as bound
STEP: verifying target pod count
STEP: verifying if cstorvolume is created
STEP: verifying cvr count
STEP: verifying pvc status as bound
STEP: verifying target pod count
STEP: verifying if cstorvolume is created
STEP: verifying cvr count
STEP: verifying pvc status as bound
STEP: verifying target pod count
STEP: verifying if cstorvolume is created
STEP: verifying cvr count
STEP: verifying pvc status as bound
STEP: verifying target pod count
STEP: verifying if cstorvolume is created
STEP: verifying cvr count
STEP: verifying pvc status as bound
STEP: verifying target pod count
STEP: verifying if cstorvolume is created
STEP: verifying cvr count
STEP: verifying pvc status as bound
STEP: verifying target pod count
STEP: verifying if cstorvolume is created
STEP: verifying cvr count
STEP: verifying pvc status as bound
STEP: verifying target pod count
STEP: verifying if cstorvolume is created
STEP: verifying cvr count

• [SLOW TEST:186.175 seconds]
[cstor] TEST BULK VOLUME PROVISIONING
/home/user/work/src/github.com/openebs/maya/tests/cstor/volume/provision_bulk_test.go:36
  when cstor pvcs are created
  /home/user/work/src/github.com/openebs/maya/tests/cstor/volume/provision_bulk_test.go:92
    should create cstor volumes
    /home/user/work/src/github.com/openebs/maya/tests/cstor/volume/provision_bulk_test.go:93
------------------------------
[cstor] TEST BULK VOLUME PROVISIONING when cstor pvcs are deleted 
  should delete cstor volumes
  /home/user/work/src/github.com/openebs/maya/tests/cstor/volume/provision_bulk_test.go:186
STEP: fetching pvc list
STEP: deleting above pvcs in a bulk
STEP: verifying target pod count as 0
STEP: verifying deleted pvc
STEP: verifying if cstorvolume is deleted
STEP: verifying if cvr is deleted
STEP: verifying target pod count as 0
STEP: verifying deleted pvc
STEP: verifying if cstorvolume is deleted
STEP: verifying if cvr is deleted
STEP: verifying target pod count as 0
STEP: verifying deleted pvc
STEP: verifying if cstorvolume is deleted
STEP: verifying if cvr is deleted
STEP: verifying target pod count as 0
STEP: verifying deleted pvc
STEP: verifying if cstorvolume is deleted
STEP: verifying if cvr is deleted
STEP: verifying target pod count as 0
STEP: verifying deleted pvc
STEP: verifying if cstorvolume is deleted
STEP: verifying if cvr is deleted
STEP: verifying target pod count as 0
STEP: verifying deleted pvc
STEP: verifying if cstorvolume is deleted
STEP: verifying if cvr is deleted
STEP: verifying target pod count as 0
STEP: verifying deleted pvc
STEP: verifying if cstorvolume is deleted
STEP: verifying if cvr is deleted
STEP: verifying target pod count as 0
STEP: verifying deleted pvc
STEP: verifying if cstorvolume is deleted
STEP: verifying if cvr is deleted
STEP: verifying target pod count as 0
STEP: verifying deleted pvc
STEP: verifying if cstorvolume is deleted
STEP: verifying if cvr is deleted
STEP: verifying target pod count as 0
STEP: verifying deleted pvc
STEP: verifying if cstorvolume is deleted
STEP: verifying if cvr is deleted

• [SLOW TEST:88.146 seconds]
[cstor] TEST BULK VOLUME PROVISIONING
/home/user/work/src/github.com/openebs/maya/tests/cstor/volume/provision_bulk_test.go:36
  when cstor pvcs are deleted
  /home/user/work/src/github.com/openebs/maya/tests/cstor/volume/provision_bulk_test.go:185
    should delete cstor volumes
    /home/user/work/src/github.com/openebs/maya/tests/cstor/volume/provision_bulk_test.go:186
------------------------------
[cstor] TEST BULK VOLUME PROVISIONING when cleaning up test resources 
  should delete resources created during this test
  /home/user/work/src/github.com/openebs/maya/tests/cstor/volume/provision_bulk_test.go:254
STEP: deleting spc
STEP: deleting storageclass
•SSTEP: deleting namespace

Ran 4 of 5 Specs in 307.124 seconds
SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 1 Skipped
PASS

Ginkgo ran 1 suite in 5m12.375834307s
Test Suite Passed

```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests