### PR TITLE
feat(bdd, cstor) BDD for provisioning volume without disk

### DIFF
--- a/tests/cstor/pool/negative/provision_without_disk_test.go
+++ b/tests/cstor/pool/negative/provision_without_disk_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package negative
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	spc "github.com/openebs/maya/pkg/storagepoolclaim/v1alpha1"
+	"github.com/openebs/maya/tests/cstor"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("[cstor] [-ve] TEST PROVISION WITHOUT DISK", func() {
+	var (
+		err error
+	)
+
+	AfterEach(func() {
+
+		By("deleting storagepoolclaim")
+		_, err = ops.SPCClient.Delete(spcObj.Name, &metav1.DeleteOptions{})
+		Expect(err).To(BeNil(), "while deleting the storagepoolclaim {%s}", spcObj.Name)
+
+		By("fetching ndm pods")
+		podList, err := ops.PodClient.WithNamespace(openebsNamespace).
+			List(metav1.ListOptions{
+				LabelSelector: "name=openebs-ndm",
+			})
+		Expect(err).ShouldNot(HaveOccurred(), "while fetching ndm pods")
+
+		By("deleting ndm pods to bring back bds")
+		for _, pod := range podList.Items {
+			err = ops.PodClient.WithNamespace(openebsNamespace).
+				Delete(pod.Name, &metav1.DeleteOptions{})
+			Expect(err).ShouldNot(HaveOccurred(), "while deleting ndm pods")
+		}
+	})
+
+	When("creating storagepoolclaim without disk", func() {
+		It("should not create any cstorpool", func() {
+
+			By("fetching bds")
+			bdList, err := ops.BDClient.List(metav1.ListOptions{})
+			Expect(err).ShouldNot(HaveOccurred(), "while fetching bds")
+
+			By("deleting bd to remove disk")
+			for _, bd := range bdList.Items {
+				err = ops.BDClient.WithNamespace(openebsNamespace).
+					Delete(bd.Name, &metav1.DeleteOptions{})
+				Expect(err).ShouldNot(HaveOccurred(), "while deleting bd")
+			}
+
+			By("building storagepoolclaim with invalid disk type")
+			spcObj = spc.NewBuilder().
+				WithGenerateName(spcName).
+				WithDiskType(string(apis.TypeSparseCPV)).
+				WithMaxPool(cstor.PoolCount).
+				WithOverProvisioning(false).
+				WithPoolType(string(apis.PoolTypeStripedCPV)).
+				Build().Object
+
+			By("creating above storagepoolclaim")
+			spcObj, err = ops.SPCClient.Create(spcObj)
+			Expect(err).To(BeNil(), "while creating storagepoolclaim {%s}", spcObj.Name)
+
+			By("verifying cstorpool count as 0")
+			cspCount := ops.GetCSPCount(spcObj.Name, cstor.PoolCount)
+			Expect(cspCount).To(Equal(0), "while checking cstorpool count")
+
+		})
+	})
+})

--- a/tests/operations.go
+++ b/tests/operations.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	bd "github.com/openebs/maya/pkg/blockdevice/v1alpha2"
 	csp "github.com/openebs/maya/pkg/cstorpool/v1alpha3"
 	cv "github.com/openebs/maya/pkg/cstorvolume/v1alpha1"
 	cvr "github.com/openebs/maya/pkg/cstorvolumereplica/v1alpha1"
@@ -76,6 +77,7 @@ type Operations struct {
 	URClient       *result.Kubeclient
 	UnstructClient *unstruct.Kubeclient
 	DeployClient   *deploy.Kubeclient
+	BDClient       *bd.Kubeclient
 	kubeConfigPath string
 }
 
@@ -174,6 +176,9 @@ func (ops *Operations) withDefaults() {
 	}
 	if ops.DeployClient == nil {
 		ops.DeployClient = deploy.NewKubeClient(deploy.WithKubeConfigPath(ops.kubeConfigPath))
+	}
+	if ops.BDClient == nil {
+		ops.BDClient = bd.NewKubeClient(bd.WithKubeConfigPath(ops.kubeConfigPath))
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds a negative test of provisioning cstor volume without any disk.

**Sample test output**:
```
user:negative$ ginkgo -focus=WITHOUT -v -- -kubeconfig=$HOME/.kube/config
Running Suite: Test cstor invalid config
========================================
Random Seed: 1560344530
Will run 1 of 5 specs

STEP: waiting for maya-apiserver pod to come into running state
STEP: waiting for openebs-provisioner pod to come into running state
STEP: Verifying 'admission-server' pod status as running
STEP: building a namespace
STEP: creating a namespace
[cstor] [-ve] TEST PROVISION WITHOUT DISK when creating storagepoolclaim without disk 
  should not create any cstorpool
  /home/user/work/src/github.com/openebs/maya/tests/cstor/pool/negative/provision_without_disk_test.go:56
STEP: fetching bds
STEP: deleting bd to remove disk
STEP: building storagepoolclaim with invalid disk type
STEP: creating above storagepoolclaim
STEP: verifying cstorpool count as 0
STEP: deleting storagepoolclaim
STEP: fetching ndm pods
STEP: deleting ndm pods to bring back bds

• [SLOW TEST:157.684 seconds]
[cstor] [-ve] TEST PROVISION WITHOUT DISK
/home/user/work/src/github.com/openebs/maya/tests/cstor/pool/negative/provision_without_disk_test.go:29
  when creating storagepoolclaim without disk
  /home/user/work/src/github.com/openebs/maya/tests/cstor/pool/negative/provision_without_disk_test.go:55
    should not create any cstorpool
    /home/user/work/src/github.com/openebs/maya/tests/cstor/pool/negative/provision_without_disk_test.go:56
------------------------------
SSSSSTEP: deleting namespace

Ran 1 of 5 Specs in 157.826 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 4 Skipped
PASS

Ginkgo ran 1 suite in 2m43.842974837s
Test Suite Passed

```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests