### PR TITLE
feat[cstor-operator, cstor-pool-mgmt, upgrade]: add support to stop reconciliation during upgrade

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/pool-controller/new_pool_controller.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/new_pool_controller.go
@@ -117,7 +117,7 @@ func NewCStorPoolController(
 				return
 			}
 			if cStorPool.Labels[string(apis.OpenEBSVersionKey)] != curVersion {
-				glog.Infof("No action is taking on csp: %s current version: %s csp version: %s",
+				glog.Infof("csp %s is not reconciled current version of controller: %s csp version: %s",
 					cStorPool.Name, curVersion, cStorPool.Labels[string(apis.OpenEBSUpgradeKey)])
 				return
 			}
@@ -142,7 +142,7 @@ func NewCStorPoolController(
 				return
 			}
 			if newCStorPool.Labels[string(apis.OpenEBSVersionKey)] != curVersion {
-				glog.Infof("No action is taking on csp: %s current version: %s csp version: %s",
+				glog.Infof("csp %s is not reconciled current version of controller: %s csp version: %s",
 					newCStorPool.Name, curVersion, newCStorPool.Labels[string(apis.OpenEBSUpgradeKey)])
 				return
 			}
@@ -170,7 +170,7 @@ func NewCStorPoolController(
 				return
 			}
 			if cStorPool.Labels[string(apis.OpenEBSVersionKey)] != curVersion {
-				glog.Infof("No action is taking on csp: %s current version: %s csp version: %s",
+				glog.Infof("csp %s is not reconciled current version of controller: %s csp version: %s",
 					cStorPool.Name, curVersion, cStorPool.Labels[string(apis.OpenEBSUpgradeKey)])
 				return
 			}

--- a/cmd/cstor-pool-mgmt/controller/pool-controller/new_pool_controller.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/new_pool_controller.go
@@ -117,8 +117,8 @@ func NewCStorPoolController(
 				return
 			}
 			if cStorPool.Labels[string(apis.OpenEBSVersionKey)] != curVersion {
-				glog.Infof("csp %s is not reconciled current version of controller: %s csp version: %s",
-					cStorPool.Name, curVersion, cStorPool.Labels[string(apis.OpenEBSUpgradeKey)])
+				glog.Infof("csp %s is not reconciled due to mismatch of controller version: %s and csp version: %s",
+					cStorPool.Name, curVersion, cStorPool.Labels[string(apis.OpenEBSVersionKey)])
 				return
 			}
 			q.Operation = common.QOpAdd
@@ -142,8 +142,8 @@ func NewCStorPoolController(
 				return
 			}
 			if newCStorPool.Labels[string(apis.OpenEBSVersionKey)] != curVersion {
-				glog.Infof("csp %s is not reconciled current version of controller: %s csp version: %s",
-					newCStorPool.Name, curVersion, newCStorPool.Labels[string(apis.OpenEBSUpgradeKey)])
+				glog.Infof("csp %s is not reconciled due to mismatch of controller version: %s csp version: %s",
+					newCStorPool.Name, curVersion, newCStorPool.Labels[string(apis.OpenEBSVersionKey)])
 				return
 			}
 			// Periodic resync will send update events for all known CStorPool.
@@ -170,8 +170,8 @@ func NewCStorPoolController(
 				return
 			}
 			if cStorPool.Labels[string(apis.OpenEBSVersionKey)] != curVersion {
-				glog.Infof("csp %s is not reconciled current version of controller: %s csp version: %s",
-					cStorPool.Name, curVersion, cStorPool.Labels[string(apis.OpenEBSUpgradeKey)])
+				glog.Infof("csp %s is not reconciled due to mismatch of controller version: %s and csp version: %s",
+					cStorPool.Name, curVersion, cStorPool.Labels[string(apis.OpenEBSVersionKey)])
 				return
 			}
 			glog.Infof("cStorPool Resource deleted event: %v, %v", cStorPool.ObjectMeta.Name, string(cStorPool.ObjectMeta.UID))

--- a/cmd/cstor-pool-mgmt/controller/pool-controller/new_pool_controller.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/new_pool_controller.go
@@ -116,9 +116,7 @@ func NewCStorPoolController(
 				return
 			}
 			if cStorPool.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
-				message := fmt.Sprintf("Reconciliation stopped due to %q label "+
-					"value set to %q upgrade to latest version to create cStor pools",
-					string(apis.OpenEBSDisableReconcileKey), cStorPool.Labels[string(apis.OpenEBSDisableReconcileKey)])
+				message := fmt.Sprintf("reconcile is disabled via %q label", string(apis.OpenEBSDisableReconcileKey))
 				controller.recorder.Event(cStorPool, corev1.EventTypeWarning, "Create", message)
 				return
 			}
@@ -143,9 +141,7 @@ func NewCStorPoolController(
 				return
 			}
 			if newCStorPool.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
-				message := fmt.Sprintf("Reconciliation stopped due to %q label "+
-					"value set to %q upgrade to latest version to update cStor pools",
-					string(apis.OpenEBSDisableReconcileKey), newCStorPool.Labels[string(apis.OpenEBSDisableReconcileKey)])
+				message := fmt.Sprintf("reconcile is disabled via %q label", string(apis.OpenEBSDisableReconcileKey))
 				controller.recorder.Event(newCStorPool, corev1.EventTypeWarning, "Update", message)
 				return
 			}
@@ -173,9 +169,7 @@ func NewCStorPoolController(
 				return
 			}
 			if cStorPool.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
-				message := fmt.Sprintf("Reconciliation stopped due to %q label "+
-					"value set to %q upgrade to latest version to delete cStor pools",
-					string(apis.OpenEBSDisableReconcileKey), cStorPool.Labels[string(apis.OpenEBSDisableReconcileKey)])
+				message := fmt.Sprintf("reconcile is disabled via %q label", string(apis.OpenEBSDisableReconcileKey))
 				controller.recorder.Event(cStorPool, corev1.EventTypeWarning, "Delete", message)
 				return
 			}

--- a/cmd/maya-apiserver/cstor-operator/spc/controller.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/controller.go
@@ -157,10 +157,10 @@ func (c *Controller) addSpc(obj interface{}) {
 		return
 	}
 	if spc.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
-		glog.Infof("spc %s is not reconciled reason %s key set to : %s",
-			spc.Name,
-			string(apis.OpenEBSDisableReconcileKey),
-			spc.Labels[string(apis.OpenEBSDisableReconcileKey)])
+		message := fmt.Sprintf("Reconciliation stopped due to %q label "+
+			"value set to %q upgrade to latest version to create pools",
+			string(apis.OpenEBSDisableReconcileKey), spc.Labels[string(apis.OpenEBSDisableReconcileKey)])
+		c.recorder.Event(spc, corev1.EventTypeWarning, "Create", message)
 		return
 	}
 	glog.V(4).Infof("Queuing SPC %s for add event", spc.Name)
@@ -175,10 +175,10 @@ func (c *Controller) updateSpc(oldSpc, newSpc interface{}) {
 		return
 	}
 	if spc.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
-		glog.Infof("spc %s is not reconciled reason %s key set to : %s",
-			spc.Name,
-			string(apis.OpenEBSDisableReconcileKey),
-			spc.Labels[string(apis.OpenEBSDisableReconcileKey)])
+		message := fmt.Sprintf("Reconciliation stopped due to %q label "+
+			"value set to %q upgrade to latest version to update pool configurations",
+			string(apis.OpenEBSDisableReconcileKey), spc.Labels[string(apis.OpenEBSDisableReconcileKey)])
+		c.recorder.Event(spc, corev1.EventTypeWarning, "Update", message)
 		return
 	}
 	// Enqueue spc only when there is a pending pool to be created.
@@ -203,10 +203,10 @@ func (c *Controller) deleteSpc(obj interface{}) {
 		}
 	}
 	if spc.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
-		glog.Infof("spc %s is not reconciled reason %s key set to : %s",
-			spc.Name,
-			string(apis.OpenEBSDisableReconcileKey),
-			spc.Labels[string(apis.OpenEBSDisableReconcileKey)])
+		message := fmt.Sprintf("Reconciliation stopped due to %q "+
+			"label value set to %q upgrade to latest version to delete pools",
+			string(apis.OpenEBSDisableReconcileKey), spc.Labels[string(apis.OpenEBSDisableReconcileKey)])
+		c.recorder.Event(spc, corev1.EventTypeWarning, "Delete", message)
 		return
 	}
 	glog.V(4).Infof("Deleting storagepoolclaim %s", spc.Name)

--- a/cmd/maya-apiserver/cstor-operator/spc/controller.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/controller.go
@@ -156,6 +156,10 @@ func (c *Controller) addSpc(obj interface{}) {
 		runtime.HandleError(fmt.Errorf("Couldn't get spc object %#v", obj))
 		return
 	}
+	if spc.Labels[string(apis.OpenEBSUpgradeKey)] == "true" {
+		glog.Infof("No action is taking on spc: %s reason upgrade value: %s", spc.Name, spc.Labels[string(apis.OpenEBSUpgradeKey)])
+		return
+	}
 	glog.V(4).Infof("Queuing SPC %s for add event", spc.Name)
 	c.enqueueSpc(spc)
 }
@@ -165,6 +169,10 @@ func (c *Controller) updateSpc(oldSpc, newSpc interface{}) {
 	spc, ok := newSpc.(*apis.StoragePoolClaim)
 	if !ok {
 		runtime.HandleError(fmt.Errorf("Couldn't get spc object %#v", newSpc))
+		return
+	}
+	if spc.Labels[string(apis.OpenEBSUpgradeKey)] == "true" {
+		glog.Infof("No action is taking on spc: %s reason upgrade value: %s", spc.Name, spc.Labels[string(apis.OpenEBSUpgradeKey)])
 		return
 	}
 	// Enqueue spc only when there is a pending pool to be created.
@@ -187,6 +195,10 @@ func (c *Controller) deleteSpc(obj interface{}) {
 			runtime.HandleError(fmt.Errorf("Tombstone contained object that is not a storagepoolclaim %#v", obj))
 			return
 		}
+	}
+	if spc.Labels[string(apis.OpenEBSUpgradeKey)] == "true" {
+		glog.Infof("No action is taking on spc: %s reason upgrade value: %s", spc.Name, spc.Labels[string(apis.OpenEBSUpgradeKey)])
+		return
 	}
 	glog.V(4).Infof("Deleting storagepoolclaim %s", spc.Name)
 	c.enqueueSpc(spc)

--- a/cmd/maya-apiserver/cstor-operator/spc/controller.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/controller.go
@@ -156,8 +156,11 @@ func (c *Controller) addSpc(obj interface{}) {
 		runtime.HandleError(fmt.Errorf("Couldn't get spc object %#v", obj))
 		return
 	}
-	if spc.Labels[string(apis.OpenEBSUpgradeKey)] == "true" {
-		glog.Infof("spc %s is not reconciled reason upgrade value: %s", spc.Name, spc.Labels[string(apis.OpenEBSUpgradeKey)])
+	if spc.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
+		glog.Infof("spc %s is not reconciled reason %s key set to : %s",
+			spc.Name,
+			string(apis.OpenEBSDisableReconcileKey),
+			spc.Labels[string(apis.OpenEBSDisableReconcileKey)])
 		return
 	}
 	glog.V(4).Infof("Queuing SPC %s for add event", spc.Name)
@@ -171,8 +174,11 @@ func (c *Controller) updateSpc(oldSpc, newSpc interface{}) {
 		runtime.HandleError(fmt.Errorf("Couldn't get spc object %#v", newSpc))
 		return
 	}
-	if spc.Labels[string(apis.OpenEBSUpgradeKey)] == "true" {
-		glog.Infof("spc %s is not reconciled reason upgrade value: %s", spc.Name, spc.Labels[string(apis.OpenEBSUpgradeKey)])
+	if spc.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
+		glog.Infof("spc %s is not reconciled reason %s key set to : %s",
+			spc.Name,
+			string(apis.OpenEBSDisableReconcileKey),
+			spc.Labels[string(apis.OpenEBSDisableReconcileKey)])
 		return
 	}
 	// Enqueue spc only when there is a pending pool to be created.
@@ -196,8 +202,11 @@ func (c *Controller) deleteSpc(obj interface{}) {
 			return
 		}
 	}
-	if spc.Labels[string(apis.OpenEBSUpgradeKey)] == "true" {
-		glog.Infof("spc %s is not reconciled reason upgrade value: %s", spc.Name, spc.Labels[string(apis.OpenEBSUpgradeKey)])
+	if spc.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
+		glog.Infof("spc %s is not reconciled reason %s key set to : %s",
+			spc.Name,
+			string(apis.OpenEBSDisableReconcileKey),
+			spc.Labels[string(apis.OpenEBSDisableReconcileKey)])
 		return
 	}
 	glog.V(4).Infof("Deleting storagepoolclaim %s", spc.Name)

--- a/cmd/maya-apiserver/cstor-operator/spc/controller.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/controller.go
@@ -157,9 +157,7 @@ func (c *Controller) addSpc(obj interface{}) {
 		return
 	}
 	if spc.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
-		message := fmt.Sprintf("Reconciliation stopped due to %q label "+
-			"value set to %q upgrade to latest version to create pools",
-			string(apis.OpenEBSDisableReconcileKey), spc.Labels[string(apis.OpenEBSDisableReconcileKey)])
+		message := fmt.Sprintf("reconcile is disabled via %q label", string(apis.OpenEBSDisableReconcileKey))
 		c.recorder.Event(spc, corev1.EventTypeWarning, "Create", message)
 		return
 	}
@@ -175,9 +173,7 @@ func (c *Controller) updateSpc(oldSpc, newSpc interface{}) {
 		return
 	}
 	if spc.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
-		message := fmt.Sprintf("Reconciliation stopped due to %q label "+
-			"value set to %q upgrade to latest version to update pool configurations",
-			string(apis.OpenEBSDisableReconcileKey), spc.Labels[string(apis.OpenEBSDisableReconcileKey)])
+		message := fmt.Sprintf("reconcile is disabled via %q label", string(apis.OpenEBSDisableReconcileKey))
 		c.recorder.Event(spc, corev1.EventTypeWarning, "Update", message)
 		return
 	}
@@ -203,9 +199,7 @@ func (c *Controller) deleteSpc(obj interface{}) {
 		}
 	}
 	if spc.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
-		message := fmt.Sprintf("Reconciliation stopped due to %q "+
-			"label value set to %q upgrade to latest version to delete pools",
-			string(apis.OpenEBSDisableReconcileKey), spc.Labels[string(apis.OpenEBSDisableReconcileKey)])
+		message := fmt.Sprintf("reconcile is disabled via %q label", string(apis.OpenEBSDisableReconcileKey))
 		c.recorder.Event(spc, corev1.EventTypeWarning, "Delete", message)
 		return
 	}

--- a/cmd/maya-apiserver/cstor-operator/spc/controller.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/controller.go
@@ -149,7 +149,7 @@ func (cb *ControllerBuilder) Build() (*Controller, error) {
 	return cb.Controller, nil
 }
 
-// addSpc is the add event handler for spc.
+// addSpc is the add event handler for spc
 func (c *Controller) addSpc(obj interface{}) {
 	spc, ok := obj.(*apis.StoragePoolClaim)
 	if !ok {
@@ -157,7 +157,7 @@ func (c *Controller) addSpc(obj interface{}) {
 		return
 	}
 	if spc.Labels[string(apis.OpenEBSUpgradeKey)] == "true" {
-		glog.Infof("No action is taking on spc: %s reason upgrade value: %s", spc.Name, spc.Labels[string(apis.OpenEBSUpgradeKey)])
+		glog.Infof("spc %s is not reconciled reason upgrade value: %s", spc.Name, spc.Labels[string(apis.OpenEBSUpgradeKey)])
 		return
 	}
 	glog.V(4).Infof("Queuing SPC %s for add event", spc.Name)
@@ -172,7 +172,7 @@ func (c *Controller) updateSpc(oldSpc, newSpc interface{}) {
 		return
 	}
 	if spc.Labels[string(apis.OpenEBSUpgradeKey)] == "true" {
-		glog.Infof("No action is taking on spc: %s reason upgrade value: %s", spc.Name, spc.Labels[string(apis.OpenEBSUpgradeKey)])
+		glog.Infof("spc %s is not reconciled reason upgrade value: %s", spc.Name, spc.Labels[string(apis.OpenEBSUpgradeKey)])
 		return
 	}
 	// Enqueue spc only when there is a pending pool to be created.
@@ -197,7 +197,7 @@ func (c *Controller) deleteSpc(obj interface{}) {
 		}
 	}
 	if spc.Labels[string(apis.OpenEBSUpgradeKey)] == "true" {
-		glog.Infof("No action is taking on spc: %s reason upgrade value: %s", spc.Name, spc.Labels[string(apis.OpenEBSUpgradeKey)])
+		glog.Infof("spc %s is not reconciled reason upgrade value: %s", spc.Name, spc.Labels[string(apis.OpenEBSUpgradeKey)])
 		return
 	}
 	glog.V(4).Infof("Deleting storagepoolclaim %s", spc.Name)

--- a/pkg/apis/openebs.io/v1alpha1/cas_keys.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_keys.go
@@ -45,6 +45,9 @@ const (
 	// OpenEBS
 	OpenEBSVersionKey CASKey = "openebs.io/version"
 
+	// OpenEBSUpgradeKey is the label key which provides upgrade state
+	OpenEBSUpgradeKey CASKey = "openebs.io/upgrade"
+
 	// CASConfigKey is the key to fetch configurations w.r.t a CAS entity
 	CASConfigKey CASKey = "cas.openebs.io/config"
 

--- a/pkg/apis/openebs.io/v1alpha1/cas_keys.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_keys.go
@@ -45,8 +45,8 @@ const (
 	// OpenEBS
 	OpenEBSVersionKey CASKey = "openebs.io/version"
 
-	// OpenEBSUpgradeKey is the label key which provides upgrade state
-	OpenEBSUpgradeKey CASKey = "openebs.io/upgrade"
+	// OpenEBSDisableReconcileKey is the label key decides to reconcile or not
+	OpenEBSDisableReconcileKey CASKey = "reconcile.openebs.io/disable"
 
 	// CASConfigKey is the key to fetch configurations w.r.t a CAS entity
 	CASConfigKey CASKey = "cas.openebs.io/config"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR stops the reconciliation process during upgrade process based on labels present on csp and spc CR

1. If spc yaml contains label `reconcile.openebs.io/disable: "true"` then reconciliation stops on particular spc
example yaml
```yaml
apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: cstor-sparse
  labels:
     reconcile.openebs.io/disable: true
spec:
  name: cstor-sparse
  type: sparse
  maxPools: 1
  poolSpec:
    poolType: striped
  blockDevices:
    blockDeviceList:
    - sparse-177b6bc2ae2dd332c7a384a02179368b
```
2. If CSP CR contains label `reconcile.openebs.io/disable: "true"` then reconciliation stops on particular  csp resource.



**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests