### PR TITLE
fix(cstor-operator): honour spc type in case of manual provisioning of cStor pool

### DIFF
--- a/pkg/algorithm/nodeselect/v1alpha1/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node.go
@@ -247,42 +247,23 @@ func (ac *Config) getBlockDevice() (*ndmapis.BlockDeviceList, error) {
 	if err != nil {
 		return nil, err
 	}
+	filterList := []string{blockdevice.FilterNonInactive}
 
-	if ProvisioningType(ac.Spc) == ProvisioningTypeManual {
-		bdl, err = ac.getBlockDeviceListInManualMode(bdList, diskType)
+	if diskType == string(apis.TypeSparseCPV) {
+		filterList = append(filterList, blockdevice.FilterSparseDevices)
 	} else {
-		bdl, err = ac.getBlockDeviceListInAutoMode(bdList, diskType)
+		filterList = append(filterList, blockdevice.FilterNonSparseDevices)
 	}
-	if err != nil {
-		return nil, err
+
+	if ProvisioningType(ac.Spc) == ProvisioningTypeAuto {
+		filterList = append(filterList, blockdevice.FilterNonFSType)
+	}
+
+	bdl = bdList.Filter(filterList...)
+	if len(bdl.Items) == 0 {
+		return nil, errors.Errorf("type {%s} devices are not available to provision pools in %s mode", diskType, ProvisioningType(ac.Spc))
 	}
 	return bdl.BlockDeviceList, nil
-}
-
-func (ac *Config) getBlockDeviceListInManualMode(bdList *blockdevice.BlockDeviceList, diskType string) (*blockdevice.BlockDeviceList, error) {
-	var bdl *blockdevice.BlockDeviceList
-	if diskType == string(apis.TypeSparseCPV) {
-		bdl = bdList.Filter(blockdevice.FilterNonInactive, blockdevice.FilterSparseDevices)
-	} else {
-		bdl = bdList.Filter(blockdevice.FilterNonInactive, blockdevice.FilterNonSparseDevices)
-	}
-	if len(bdl.Items) == 0 {
-		return nil, errors.Errorf("type {%s} devices are not available to create pool", diskType)
-	}
-	return bdl, nil
-}
-
-func (ac *Config) getBlockDeviceListInAutoMode(bdList *blockdevice.BlockDeviceList, diskType string) (*blockdevice.BlockDeviceList, error) {
-	var bdl *blockdevice.BlockDeviceList
-	if diskType == string(apis.TypeSparseCPV) {
-		bdl = bdList.Filter(blockdevice.FilterNonInactive, blockdevice.FilterNonFSType, blockdevice.FilterSparseDevices)
-	} else {
-		bdl = bdList.Filter(blockdevice.FilterNonInactive, blockdevice.FilterNonFSType, blockdevice.FilterNonSparseDevices)
-	}
-	if len(bdl.Items) == 0 {
-		return nil, errors.Errorf("type {%s} devices are not available to create pool", diskType)
-	}
-	return bdl, nil
 }
 
 //TODO: Make changes in below code in refactor PR

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node_test.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node_test.go
@@ -243,10 +243,11 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 			expectedErr:            true,
 		},
 		//Test Case #5
+		// blockdevice0, blockdevice1 are of sparse type
 		"manualSPC5": {
 			fakeCasPool: &v1alpha1.StoragePoolClaim{
 				Spec: v1alpha1.StoragePoolClaimSpec{
-					Type: "sparse",
+					Type: "disk",
 					PoolSpec: v1alpha1.CStorPoolAttr{
 						PoolType: "striped",
 					},
@@ -255,19 +256,19 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 					},
 				},
 			},
-			expectedDiskListLength: 3,
+			expectedDiskListLength: 1,
 			expectedErr:            false,
 		},
 		// Test Case #6
 		"manualSPC6": {
 			fakeCasPool: &v1alpha1.StoragePoolClaim{
 				Spec: v1alpha1.StoragePoolClaimSpec{
-					Type: "sparse",
+					Type: "disk",
 					PoolSpec: v1alpha1.CStorPoolAttr{
 						PoolType: "mirrored",
 					},
 					BlockDevices: v1alpha1.BlockDeviceAttr{
-						BlockDeviceList: []string{"blockdevice1", "blockdevice2"},
+						BlockDeviceList: []string{"blockdevice3", "blockdevice4"},
 					},
 				},
 			},
@@ -459,7 +460,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 						PoolType: "raidz2",
 					},
 					BlockDevices: v1alpha1.BlockDeviceAttr{
-						BlockDeviceList: []string{"blockdevice1", "blockdevice2", "blockdevice3", "blockdevice4", "blockdevice5", "blockdevice6"},
+						BlockDeviceList: []string{"blockdevice3", "blockdevice4", "blockdevice5", "blockdevice6", "blockdevice7", "blockdevice8"},
 					},
 				},
 			},

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node_test.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node_test.go
@@ -515,6 +515,22 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 			expectedDiskListLength: 0,
 			expectedErr:            false,
 		},
+		// Test Case #22
+		"manualSPC22Raidz2": {
+			fakeCasPool: &v1alpha1.StoragePoolClaim{
+				Spec: v1alpha1.StoragePoolClaimSpec{
+					Type: "disk",
+					PoolSpec: v1alpha1.CStorPoolAttr{
+						PoolType: "mirrored",
+					},
+					BlockDevices: v1alpha1.BlockDeviceAttr{
+						BlockDeviceList: []string{"blockdevice0", "blockdevice1"},
+					},
+				},
+			},
+			expectedDiskListLength: 6,
+			expectedErr:            true,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**Manual Provisioning in 0.9.0:**
  Manual provisioning implies specifying exact disks on which cStor pools need to be created. In other words, update diskList field on which pools need to be created.

**Example spc 0.9.0 yaml:**
```yaml
apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: cstor-disk
spec:
  name: cstor-disk
  type: disk
  maxPools: 1
  poolSpec:
    poolType: striped
  disks:
    diskList:
    - disk-5a93ced3e2ee21eac7b930f670b5eab5
    - sparse-5a92ced3e2ee21eac7b930f670b5eab5
    - disk-5a94ced3e2ee21eac7b930f670b5eab5
```

**What this PR does / why we need it**:
In case of manual provisioning in 0.9.0 we are honoring spc.spec.type
For example in above yaml 
1) If spc.spec.type is specified as a `disk` we are creating pools only on disks in given diskList.
2) If spc.spec.type is specified as a `sparse` we are creating pools only on sparse disks in given    diskList.
To sync up with above changes in `1.0` this PR honours the `spc.spec.type`. Based on specified type we will create pools on corresponding type either `disk` or `sparse-disk`. 

**New SPC yaml:**
```yaml
apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: cstor-disk
spec:
  name: cstor-disk
  type: disk
  poolSpec:
    poolType: mirrored
  blockDevices:
    blockDeviceList:
    - blockdevice-5a92ced3e2ee21eac7b930f670b5eab5
    - blockdevice-5e508018b4dd2c8e2530fbdae8e44bb6
    - sparse-177b6bc2ae2dd332c7a384a02179368b
    - sparse-37a7de580322f43a13338bf2467343f5
```
If we apply above yaml then cStor pools will be created only on disk.

  

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests