### PR TITLE
feat(localpv): allow creating Local PV on unformatted devices

### DIFF
--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -41,17 +41,20 @@ const (
 	//KeyPVBasePath defines base directory for hostpath volumes
 	// can be configured via the StorageClass annotations.
 	KeyPVBasePath = "BasePath"
+	//KeyPVFSType defines filesystem type to be used with devices
+	// and can be configured via the StorageClass annotations.
+	KeyPVFSType = "FSType"
 	//KeyPVRelativePath defines the alternate folder name under the BasePath
 	// By default, the pv name will be used as the folder name.
 	// KeyPVBasePath can be useful for providing the same underlying folder
 	// name for all replicas in a Statefulset.
 	// Will be a property of the PVC annotations.
-	KeyPVRelativePath = "RelativePath"
+	//KeyPVRelativePath = "RelativePath"
 	//KeyPVAbsolutePath specifies a complete hostpath instead of
 	// auto-generating using BasePath and RelativePath. This option
 	// is specified with PVC and is useful for granting shared access
 	// to underlying hostpaths across multiple pods.
-	KeyPVAbsolutePath = "AbsolutePath"
+	//KeyPVAbsolutePath = "AbsolutePath"
 )
 
 const (
@@ -120,6 +123,17 @@ func (c *VolumeConfig) GetStorageType() string {
 		return "hostpath"
 	}
 	return stgType
+}
+
+//GetFSType returns the FSType value configured
+// in StorageClass. Default is "", auto-determined
+// by Local PV
+func (c *VolumeConfig) GetFSType() string {
+	fsType := c.getValue(KeyPVFSType)
+	if len(strings.TrimSpace(fsType)) == 0 {
+		return ""
+	}
+	return fsType
 }
 
 //GetPath returns a valid PV path based on the configuration

--- a/cmd/provisioner-localpv/app/doc.go
+++ b/cmd/provisioner-localpv/app/doc.go
@@ -34,21 +34,24 @@ Local PVs are great in cases like:
   if the hostpaths are created on external storage like EBS/GPD, administrator
   have tools that can periodically take snapshots/backups.
 
-While the Kubernetes Local PVs are mainly recommended for cases where a complete
-storage device should be assigned to a Pod. OpenEBS Dynamic Local PV provisioner
-will help provisioning the Local PVs dynamically by integrating into the features
-offered by OpenEBS Node Storage Device Manager, and also offers the
-flexibility to either select a complete storage device or
-a hostpath (or subpath) directory.
-
-Infact in some cases, the Kubernetes nodes may have limited number of storage
-devices attached to the node and hostpath based Local PVs offer efficient management
-of the storage available on the node.
-
+OpenEBS Local PVs extends the capabilities provided by the Kubernetes Local PV
+by making use of the OpenEBS Node Storage Device Manager (NDM), the significant
+differences include:
+- Users need not pre-format and mount the devices in the node.
+- Supports Dynamic Local PVs - where the devices can be used by CAS solutions
+  and also by applications. CAS solutions typically directly access a device. 
+  OpenEBS Local PV ease the management of storage devices to be used between 
+  CAS solutions (direct access) and applications (via PV), by making use of
+  BlockDeviceClaims supported by OpenEBS NDM.
+- Supports using hostpath as well for provisioning a Local PV. In fact in some
+  cases, the Kubernetes nodes may have limited number of storage devices 
+  attached to the node and hostpath based Local PVs offer efficient management
+  of the storage available on the node.
+  
 Inspiration:
 ------------
-The implementation has been influenced by the prior work done by the Kubernetes community,
-specifically the following:
+OpenEBS Local PV has been inspired by the prior work done by the following 
+the Kubernetes projects:
 - https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/tree/master/examples/hostpath-provisioner
 - https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner
 - https://github.com/rancher/local-path-provisioner
@@ -73,12 +76,12 @@ metadata:
     openebs.io/cas-type: local
     cas.openebs.io/config: |
       #- name: StorageType
-      #  value: "storage-device"
+      #  value: "device"
       # (Default)
       - name: StorageType
         value: "hostpath"
       # If the StorageType is hostpath, then BasePath
-      # specifies the location where the volume subdirectory
+      # specifies the location where the volume sub-directory
       # should be created.
       # (Default)
       - name: BasePath
@@ -130,9 +133,9 @@ spec:
     namespace: default
     resourceVersion: "2060"
     uid: 2fe08284-6cf1-11e9-be8b-42010a800155
-  hostPath:
+  local:
     path: /var/openebs/local/pvc-2fe08284-6cf1-11e9-be8b-42010a800155
-    type: DirectoryOrCreate
+    fsType: ""
   nodeAffinity:
     required:
       nodeSelectorTerms:
@@ -157,48 +160,43 @@ Implementation Details:
     with other configuration options provided by OpenEBS.
 (b) When using StorageType as device, the Local Provisioner will
     interact with the OpenEBS Node Storage Device Manager (NDM) to
-    identify the device to be used.
+    identify the device to be used. Each PVC of type StorageType=device
+    will create a BDC and wait for the NDM to provide an appropriate BD.
+    From the BD, the provisioner will extract the path details and create
+    a Local PV. When using unformatted block devices, the administrator 
+    can specific the type of FS to be put on block devices using the
+    FSType CAS Policy in StorageClass.
 (c) The StorageClass can work either with `waitForConsumer`, in which
     case, the PV is created on the node where the Pod is scheduled or
     vice versa. (Note: In the initial version, only `waitForConsumer` is
     supported.)
 (d) When using the hostpath, the administrator can select the location using:
-    - BasePath: By default, the hostpath volumes will be created under `/var/openebs/local`.
-      This default path can be changed by passing the "OPENEBS_IO_BASE_PATH" ENV
-      variable to the Hostpath Provisioner Pod. It is also possible to specify
-      a different location using the CAS Policy `BasePath` in the StorageClass.
+    - BasePath: By default, the hostpath volumes will be created under 
+      `/var/openebs/local`. This default path can be changed by passing the 
+      "OPENEBS_IO_BASE_PATH" ENV variable to the Hostpath Provisioner Pod. 
+      It is also possible to specify a different location using the 
+      CAS Policy `BasePath` in the StorageClass.
 
-    The location of the hostpaths used in the above configuration options can be:
+    The hostpath used in the above configuration can be:
     - OS Disk  - possibly a folder dedicated to saving data on each node.
     - Additional Disks - mounted as ext4 or any other filesystem
     - External Storage - mounted as ext4 or any other filesystem
+(e) The backup and restore via Velero Plugin has been verified to work for 
+    OpenEBS Local PV. Supported from OpenEBS 1.0 and higher. 
 
-Future Work:
-------------
-The current implementation provides basic support for using Local PVs. This will
-be enhanced in the upcoming releases with the following features:
-- Ability to use a git backed hostpath, so data can be backed up to a github/gitlab
-- Ability to use hostpaths that are managed by NDM - that monitors for usage, helps
-  with expanding the storage of a given hostpath. For example - use LVM or ZFS to
-  create a host mount with attached disks. Where additional disks can be added or failed
-  disks replaced without impacting the workloads running on their hostpaths.
-- Integrate with Projects like Valero or Kasten that can handle backup and restor of data
-  stored on the Hostpath PVs attached to a workload.
-- Provide tools that can help with recovering from situations where PVs are tied to nodes
-  that can never recover. For example, a Stateful Workload can be associated with a
-  Hostpath PV on Node-z. Say Node-z  becomes inaccassible for reasons beyond the control
-  like - a site/zone/rack disaster or the disks went up in flames. The PV will still be
-  having the Node Affinity to Node-z, which will make the Workload to get stuck in pending
-  state.
-- Move towards using a CSI based Hostpath provisioner. Some of the features required to
-  use the Hostpath PVs like the Volume Topology are not yet available in the CSI. As the
-  CSI driver stabilizes, this can be moved into CSI.
-- Provide an option to specify a white list of paths which can be used by the application
-  developers. The white list can be tied into application developers namespace. For example:
-  all /var/developer1/* for PVCs in namespace developer1, etc.
-- Ability to enforce runtime capacity limits
-- Ability to enforce provisioning limits based on the node capacity or the number of PVs
-  already provisioned.
+Future Improvements and Limitations:
+------------------------------------
+- Ability to enforce capacity limits. The application can exceed it usage 
+  of capacity beyond what it requested.
+- Ability to enforce provisioning limits based on the capacity available 
+  on a given node or the number of PVs already provisioned.
+- Ability to use hostpaths and devices that can potentially support snapshots.
+  Example: a hostpath backed by github, or by LVM or ZFS where capacity also
+  can be enforced.  
+- Extend the capabilities of the Local PV provisioner to handle cases where 
+  underlying devices are moved to new node and needs changes to the node 
+  affinity. 
+- Move towards using a CSI based Hostpath provisioner. 
 
 */
 package app

--- a/cmd/provisioner-localpv/app/doc.go
+++ b/cmd/provisioner-localpv/app/doc.go
@@ -39,18 +39,18 @@ by making use of the OpenEBS Node Storage Device Manager (NDM), the significant
 differences include:
 - Users need not pre-format and mount the devices in the node.
 - Supports Dynamic Local PVs - where the devices can be used by CAS solutions
-  and also by applications. CAS solutions typically directly access a device. 
-  OpenEBS Local PV ease the management of storage devices to be used between 
+  and also by applications. CAS solutions typically directly access a device.
+  OpenEBS Local PV ease the management of storage devices to be used between
   CAS solutions (direct access) and applications (via PV), by making use of
   BlockDeviceClaims supported by OpenEBS NDM.
 - Supports using hostpath as well for provisioning a Local PV. In fact in some
-  cases, the Kubernetes nodes may have limited number of storage devices 
+  cases, the Kubernetes nodes may have limited number of storage devices
   attached to the node and hostpath based Local PVs offer efficient management
   of the storage available on the node.
-  
+
 Inspiration:
 ------------
-OpenEBS Local PV has been inspired by the prior work done by the following 
+OpenEBS Local PV has been inspired by the prior work done by the following
 the Kubernetes projects:
 - https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/tree/master/examples/hostpath-provisioner
 - https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner
@@ -163,7 +163,7 @@ Implementation Details:
     identify the device to be used. Each PVC of type StorageType=device
     will create a BDC and wait for the NDM to provide an appropriate BD.
     From the BD, the provisioner will extract the path details and create
-    a Local PV. When using unformatted block devices, the administrator 
+    a Local PV. When using unformatted block devices, the administrator
     can specific the type of FS to be put on block devices using the
     FSType CAS Policy in StorageClass.
 (c) The StorageClass can work either with `waitForConsumer`, in which
@@ -171,32 +171,32 @@ Implementation Details:
     vice versa. (Note: In the initial version, only `waitForConsumer` is
     supported.)
 (d) When using the hostpath, the administrator can select the location using:
-    - BasePath: By default, the hostpath volumes will be created under 
-      `/var/openebs/local`. This default path can be changed by passing the 
-      "OPENEBS_IO_BASE_PATH" ENV variable to the Hostpath Provisioner Pod. 
-      It is also possible to specify a different location using the 
+    - BasePath: By default, the hostpath volumes will be created under
+      `/var/openebs/local`. This default path can be changed by passing the
+      "OPENEBS_IO_BASE_PATH" ENV variable to the Hostpath Provisioner Pod.
+      It is also possible to specify a different location using the
       CAS Policy `BasePath` in the StorageClass.
 
     The hostpath used in the above configuration can be:
     - OS Disk  - possibly a folder dedicated to saving data on each node.
     - Additional Disks - mounted as ext4 or any other filesystem
     - External Storage - mounted as ext4 or any other filesystem
-(e) The backup and restore via Velero Plugin has been verified to work for 
-    OpenEBS Local PV. Supported from OpenEBS 1.0 and higher. 
+(e) The backup and restore via Velero Plugin has been verified to work for
+    OpenEBS Local PV. Supported from OpenEBS 1.0 and higher.
 
 Future Improvements and Limitations:
 ------------------------------------
-- Ability to enforce capacity limits. The application can exceed it usage 
+- Ability to enforce capacity limits. The application can exceed it usage
   of capacity beyond what it requested.
-- Ability to enforce provisioning limits based on the capacity available 
+- Ability to enforce provisioning limits based on the capacity available
   on a given node or the number of PVs already provisioned.
 - Ability to use hostpaths and devices that can potentially support snapshots.
   Example: a hostpath backed by github, or by LVM or ZFS where capacity also
-  can be enforced.  
-- Extend the capabilities of the Local PV provisioner to handle cases where 
-  underlying devices are moved to new node and needs changes to the node 
-  affinity. 
-- Move towards using a CSI based Hostpath provisioner. 
+  can be enforced.
+- Extend the capabilities of the Local PV provisioner to handle cases where
+  underlying devices are moved to new node and needs changes to the node
+  affinity.
+- Move towards using a CSI based Hostpath provisioner.
 
 */
 package app

--- a/cmd/provisioner-localpv/app/helper_hostpath.go
+++ b/cmd/provisioner-localpv/app/helper_hostpath.go
@@ -144,7 +144,7 @@ func (p *Provisioner) createInitPod(pOpts *HelperPodOptions) error {
 		return vErr
 	}
 
-	helperPod, _ := pod.NewBuilder().
+	initPod, _ := pod.NewBuilder().
 		WithName("init-" + pOpts.name).
 		WithRestartPolicy(corev1.RestartPolicyNever).
 		WithNodeName(pOpts.nodeName).
@@ -169,13 +169,13 @@ func (p *Provisioner) createInitPod(pOpts *HelperPodOptions) error {
 		Build()
 
 	//Launch the init pod.
-	hPod, err := p.kubeClient.CoreV1().Pods(p.namespace).Create(helperPod)
+	iPod, err := p.kubeClient.CoreV1().Pods(p.namespace).Create(initPod)
 	if err != nil {
 		return err
 	}
 
 	defer func() {
-		e := p.kubeClient.CoreV1().Pods(p.namespace).Delete(hPod.Name, &metav1.DeleteOptions{})
+		e := p.kubeClient.CoreV1().Pods(p.namespace).Delete(iPod.Name, &metav1.DeleteOptions{})
 		if e != nil {
 			glog.Errorf("unable to delete the helper pod: %v", e)
 		}
@@ -184,7 +184,7 @@ func (p *Provisioner) createInitPod(pOpts *HelperPodOptions) error {
 	//Wait for the cleanup pod to complete it job and exit
 	completed := false
 	for i := 0; i < CmdTimeoutCounts; i++ {
-		checkPod, err := p.kubeClient.CoreV1().Pods(p.namespace).Get(hPod.Name, metav1.GetOptions{})
+		checkPod, err := p.kubeClient.CoreV1().Pods(p.namespace).Get(iPod.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		} else if checkPod.Status.Phase == corev1.PodSucceeded {
@@ -222,7 +222,7 @@ func (p *Provisioner) createCleanupPod(pOpts *HelperPodOptions) error {
 		return vErr
 	}
 
-	helperPod, _ := pod.NewBuilder().
+	cleanerPod, _ := pod.NewBuilder().
 		WithName("cleanup-" + pOpts.name).
 		WithRestartPolicy(corev1.RestartPolicyNever).
 		WithNodeName(pOpts.nodeName).
@@ -247,13 +247,13 @@ func (p *Provisioner) createCleanupPod(pOpts *HelperPodOptions) error {
 		Build()
 
 	//Launch the cleanup pod.
-	hPod, err := p.kubeClient.CoreV1().Pods(p.namespace).Create(helperPod)
+	cPod, err := p.kubeClient.CoreV1().Pods(p.namespace).Create(cleanerPod)
 	if err != nil {
 		return err
 	}
 
 	defer func() {
-		e := p.kubeClient.CoreV1().Pods(p.namespace).Delete(hPod.Name, &metav1.DeleteOptions{})
+		e := p.kubeClient.CoreV1().Pods(p.namespace).Delete(cPod.Name, &metav1.DeleteOptions{})
 		if e != nil {
 			glog.Errorf("unable to delete the helper pod: %v", e)
 		}
@@ -262,7 +262,7 @@ func (p *Provisioner) createCleanupPod(pOpts *HelperPodOptions) error {
 	//Wait for the cleanup pod to complete it job and exit
 	completed := false
 	for i := 0; i < CmdTimeoutCounts; i++ {
-		checkPod, err := p.kubeClient.CoreV1().Pods(p.namespace).Get(hPod.Name, metav1.GetOptions{})
+		checkPod, err := p.kubeClient.CoreV1().Pods(p.namespace).Get(cPod.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		} else if checkPod.Status.Phase == corev1.PodSucceeded {

--- a/cmd/provisioner-localpv/app/provisioner_blockdevice.go
+++ b/cmd/provisioner-localpv/app/provisioner_blockdevice.go
@@ -83,7 +83,7 @@ func (p *Provisioner) ProvisionBlockDevice(opts pvController.VolumeOptions, volu
 		WithAccessModes(pvc.Spec.AccessModes).
 		WithVolumeMode(fs).
 		WithCapacityQty(pvc.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]).
-		WithFormatLocalHostPath(path, fsType).
+		WithLocalHostPathFormat(path, fsType).
 		WithNodeAffinity(node.Name).
 		Build()
 

--- a/cmd/provisioner-localpv/app/provisioner_blockdevice.go
+++ b/cmd/provisioner-localpv/app/provisioner_blockdevice.go
@@ -35,6 +35,7 @@ func (p *Provisioner) ProvisionBlockDevice(opts pvController.VolumeOptions, volu
 	name := opts.PVName
 	capacity := opts.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
 	stgType := volumeConfig.GetStorageType()
+	fsType := volumeConfig.GetFSType()
 
 	//Extract the details to create a Block Device Claim
 	blkDevOpts := &HelperBlockDeviceOptions{
@@ -48,8 +49,11 @@ func (p *Provisioner) ProvisionBlockDevice(opts pvController.VolumeOptions, volu
 		glog.Infof("Initialize volume %v failed: %v", name, err)
 		return nil, err
 	}
-
 	glog.Infof("Creating volume %v on %v at %v(%v)", name, node.Name, path, blkPath)
+	if path == "" {
+		path = blkPath
+		glog.Infof("Using block device{%v} with fs{%v}", blkPath, fsType)
+	}
 
 	// TODO
 	// VolumeMode will always be specified as Filesystem for host path volume,
@@ -79,7 +83,7 @@ func (p *Provisioner) ProvisionBlockDevice(opts pvController.VolumeOptions, volu
 		WithAccessModes(pvc.Spec.AccessModes).
 		WithVolumeMode(fs).
 		WithCapacityQty(pvc.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]).
-		WithLocalHostDirectory(path).
+		WithFormatLocalHostPath(path, fsType).
 		WithNodeAffinity(node.Name).
 		Build()
 

--- a/pkg/kubernetes/persistentvolume/v1alpha1/build.go
+++ b/pkg/kubernetes/persistentvolume/v1alpha1/build.go
@@ -107,13 +107,21 @@ func (b *Builder) WithCapacityQty(resCapacity resource.Quantity) *Builder {
 
 // WithLocalHostDirectory sets the LocalVolumeSource field of PV with provided hostpath
 func (b *Builder) WithLocalHostDirectory(path string) *Builder {
+	return b.WithFormatLocalHostPath(path, "")
+}
+
+// WithFormatLocalHostPath sets the LocalVolumeSource field of PV with provided hostpath
+// and request to format it with fstype - if not already formatted. A "" value for fstype
+// indicates that the Local PV can determine the type of FS.
+func (b *Builder) WithFormatLocalHostPath(path, fstype string) *Builder {
 	if len(path) == 0 {
 		b.errs = append(b.errs, errors.New("failed to build PV object: missing PV path"))
 		return b
 	}
 	volumeSource := corev1.PersistentVolumeSource{
 		Local: &corev1.LocalVolumeSource{
-			Path: path,
+			Path:   path,
+			FSType: &fstype,
 		},
 	}
 

--- a/pkg/kubernetes/persistentvolume/v1alpha1/build.go
+++ b/pkg/kubernetes/persistentvolume/v1alpha1/build.go
@@ -107,13 +107,13 @@ func (b *Builder) WithCapacityQty(resCapacity resource.Quantity) *Builder {
 
 // WithLocalHostDirectory sets the LocalVolumeSource field of PV with provided hostpath
 func (b *Builder) WithLocalHostDirectory(path string) *Builder {
-	return b.WithFormatLocalHostPath(path, "")
+	return b.WithLocalHostPathFormat(path, "")
 }
 
-// WithFormatLocalHostPath sets the LocalVolumeSource field of PV with provided hostpath
+// WithLocalHostPathFormat sets the LocalVolumeSource field of PV with provided hostpath
 // and request to format it with fstype - if not already formatted. A "" value for fstype
 // indicates that the Local PV can determine the type of FS.
-func (b *Builder) WithFormatLocalHostPath(path, fstype string) *Builder {
+func (b *Builder) WithLocalHostPathFormat(path, fstype string) *Builder {
 	if len(path) == 0 {
 		b.errs = append(b.errs, errors.New("failed to build PV object: missing PV path"))
 		return b

--- a/pkg/kubernetes/persistentvolume/v1alpha1/build_test.go
+++ b/pkg/kubernetes/persistentvolume/v1alpha1/build_test.go
@@ -272,6 +272,7 @@ func TestBuildWithNodeAffinity(t *testing.T) {
 }
 
 func TestBuildHostPath(t *testing.T) {
+	fsType := ""
 
 	tests := map[string]struct {
 		name        string
@@ -295,7 +296,7 @@ func TestBuildHostPath(t *testing.T) {
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
 						Local: &corev1.LocalVolumeSource{
 							Path:   "/var/openebs/local/PV1",
-							FSType: nil,
+							FSType: &fsType,
 						},
 					},
 					NodeAffinity: &corev1.VolumeNodeAffinity{


### PR DESCRIPTION
When supporting OpenEBS Local PV using the block devices attached to the nodes, these block devices can be in one of the following states:

(a) User has attached the block device, formatted and mounted them.
  - For Example: GKE with Local SSD

(b) User has attached the block device, un-formatted and not mounted.
  - For Example: GKE with GPD

(c) Similar to (b), but device has only device path, but no dev links.
  - For Example: VM with VMDK disks or AWS node with EBS

Initial version of the Local PV with block device supported (a). In other words, it expects user to format and mount these devices. 

With this PR, (b) and (c) are also supported. 

Provisioner will check if the device has a mounted path, if not it will pass either the dev link or the device path to the Local PV, along with the configured FileSystem that needs to be put on it. A custom FSType can be passed via Storage Class (FSType - StoragePolicy). If no `FSType` is specified, Local PV will default to **`ext4`**. 

Signed-off-by: kmova <kiran.mova@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests