### PR TITLE
refact(cstor-pool,sparse): Update SPC type to sparse

### DIFF
--- a/pkg/install/v1alpha1/cstor_sparse_pool_claim.go
+++ b/pkg/install/v1alpha1/cstor_sparse_pool_claim.go
@@ -74,7 +74,7 @@ metadata:
       #      cpu: 100m
 spec:
   name: cstor-sparse-pool
-  type: blockdevice
+  type: sparse
   maxPools: 3
   poolSpec:
     poolType: striped


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
With latest cstor pool configuration changes, to create StoragePoolClaim we have to
use **spec.type** as `sparse` or `disk`.

In order to create pools on sparse files use type as `sparse`
Similarly to create pools on disk use type as `disk`.

Refer PR #https://github.com/openebs/maya/pull/1274 for more details


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests