### PR TITLE
[cherry-pick] (cstor-operator, cstor-pool-mgmt, bdc) #1281 #1280 #1288

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/pool-controller/new_pool_controller.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/new_pool_controller.go
@@ -115,8 +115,8 @@ func NewCStorPoolController(
 			if IsDeletionFailedBefore(cStorPool) || IsErrorDuplicate(cStorPool) {
 				return
 			}
-			if cStorPool.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
-				message := fmt.Sprintf("reconcile is disabled via %q label", string(apis.OpenEBSDisableReconcileKey))
+			if cStorPool.Annotations[string(apis.OpenEBSDisableReconcileKey)] == "true" {
+				message := fmt.Sprintf("reconcile is disabled via %q annotation", string(apis.OpenEBSDisableReconcileKey))
 				controller.recorder.Event(cStorPool, corev1.EventTypeWarning, "Create", message)
 				return
 			}
@@ -140,8 +140,8 @@ func NewCStorPoolController(
 			if IsDeletionFailedBefore(newCStorPool) || IsErrorDuplicate(newCStorPool) {
 				return
 			}
-			if newCStorPool.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
-				message := fmt.Sprintf("reconcile is disabled via %q label", string(apis.OpenEBSDisableReconcileKey))
+			if newCStorPool.Annotations[string(apis.OpenEBSDisableReconcileKey)] == "true" {
+				message := fmt.Sprintf("reconcile is disabled via %q annotation", string(apis.OpenEBSDisableReconcileKey))
 				controller.recorder.Event(newCStorPool, corev1.EventTypeWarning, "Update", message)
 				return
 			}
@@ -168,8 +168,8 @@ func NewCStorPoolController(
 			if !IsRightCStorPoolMgmt(cStorPool) {
 				return
 			}
-			if cStorPool.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
-				message := fmt.Sprintf("reconcile is disabled via %q label", string(apis.OpenEBSDisableReconcileKey))
+			if cStorPool.Annotations[string(apis.OpenEBSDisableReconcileKey)] == "true" {
+				message := fmt.Sprintf("reconcile is disabled via %q annotation", string(apis.OpenEBSDisableReconcileKey))
 				controller.recorder.Event(cStorPool, corev1.EventTypeWarning, "Delete", message)
 				return
 			}

--- a/cmd/cstor-pool-mgmt/controller/pool-controller/new_pool_controller.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/new_pool_controller.go
@@ -17,6 +17,8 @@ limitations under the License.
 package poolcontroller
 
 import (
+	"fmt"
+
 	"github.com/golang/glog"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -113,6 +115,11 @@ func NewCStorPoolController(
 			if IsDeletionFailedBefore(cStorPool) || IsErrorDuplicate(cStorPool) {
 				return
 			}
+			if cStorPool.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
+				message := fmt.Sprintf("reconcile is disabled via %q label", string(apis.OpenEBSDisableReconcileKey))
+				controller.recorder.Event(cStorPool, corev1.EventTypeWarning, "Create", message)
+				return
+			}
 			q.Operation = common.QOpAdd
 			glog.Infof("cStorPool Added event : %v, %v", cStorPool.ObjectMeta.Name, string(cStorPool.ObjectMeta.UID))
 			controller.recorder.Event(cStorPool, corev1.EventTypeNormal, string(common.SuccessSynced), string(common.MessageCreateSynced))
@@ -131,6 +138,11 @@ func NewCStorPoolController(
 				return
 			}
 			if IsDeletionFailedBefore(newCStorPool) || IsErrorDuplicate(newCStorPool) {
+				return
+			}
+			if newCStorPool.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
+				message := fmt.Sprintf("reconcile is disabled via %q label", string(apis.OpenEBSDisableReconcileKey))
+				controller.recorder.Event(newCStorPool, corev1.EventTypeWarning, "Update", message)
 				return
 			}
 			// Periodic resync will send update events for all known CStorPool.
@@ -154,6 +166,11 @@ func NewCStorPoolController(
 		DeleteFunc: func(obj interface{}) {
 			cStorPool := obj.(*apis.CStorPool)
 			if !IsRightCStorPoolMgmt(cStorPool) {
+				return
+			}
+			if cStorPool.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
+				message := fmt.Sprintf("reconcile is disabled via %q label", string(apis.OpenEBSDisableReconcileKey))
+				controller.recorder.Event(cStorPool, corev1.EventTypeWarning, "Delete", message)
 				return
 			}
 			glog.Infof("cStorPool Resource deleted event: %v, %v", cStorPool.ObjectMeta.Name, string(cStorPool.ObjectMeta.UID))

--- a/cmd/maya-apiserver/cstor-operator/spc/controller.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/controller.go
@@ -156,8 +156,8 @@ func (c *Controller) addSpc(obj interface{}) {
 		runtime.HandleError(fmt.Errorf("Couldn't get spc object %#v", obj))
 		return
 	}
-	if spc.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
-		message := fmt.Sprintf("reconcile is disabled via %q label", string(apis.OpenEBSDisableReconcileKey))
+	if spc.Annotations[string(apis.OpenEBSDisableReconcileKey)] == "true" {
+		message := fmt.Sprintf("reconcile is disabled via %q annotation", string(apis.OpenEBSDisableReconcileKey))
 		c.recorder.Event(spc, corev1.EventTypeWarning, "Create", message)
 		return
 	}
@@ -172,8 +172,8 @@ func (c *Controller) updateSpc(oldSpc, newSpc interface{}) {
 		runtime.HandleError(fmt.Errorf("Couldn't get spc object %#v", newSpc))
 		return
 	}
-	if spc.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
-		message := fmt.Sprintf("reconcile is disabled via %q label", string(apis.OpenEBSDisableReconcileKey))
+	if spc.Annotations[string(apis.OpenEBSDisableReconcileKey)] == "true" {
+		message := fmt.Sprintf("reconcile is disabled via %q annotation", string(apis.OpenEBSDisableReconcileKey))
 		c.recorder.Event(spc, corev1.EventTypeWarning, "Update", message)
 		return
 	}
@@ -198,8 +198,8 @@ func (c *Controller) deleteSpc(obj interface{}) {
 			return
 		}
 	}
-	if spc.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
-		message := fmt.Sprintf("reconcile is disabled via %q label", string(apis.OpenEBSDisableReconcileKey))
+	if spc.Annotations[string(apis.OpenEBSDisableReconcileKey)] == "true" {
+		message := fmt.Sprintf("reconcile is disabled via %q annotation", string(apis.OpenEBSDisableReconcileKey))
 		c.recorder.Event(spc, corev1.EventTypeWarning, "Delete", message)
 		return
 	}

--- a/cmd/maya-apiserver/cstor-operator/spc/controller.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/controller.go
@@ -149,11 +149,16 @@ func (cb *ControllerBuilder) Build() (*Controller, error) {
 	return cb.Controller, nil
 }
 
-// addSpc is the add event handler for spc.
+// addSpc is the add event handler for spc
 func (c *Controller) addSpc(obj interface{}) {
 	spc, ok := obj.(*apis.StoragePoolClaim)
 	if !ok {
 		runtime.HandleError(fmt.Errorf("Couldn't get spc object %#v", obj))
+		return
+	}
+	if spc.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
+		message := fmt.Sprintf("reconcile is disabled via %q label", string(apis.OpenEBSDisableReconcileKey))
+		c.recorder.Event(spc, corev1.EventTypeWarning, "Create", message)
 		return
 	}
 	glog.V(4).Infof("Queuing SPC %s for add event", spc.Name)
@@ -165,6 +170,11 @@ func (c *Controller) updateSpc(oldSpc, newSpc interface{}) {
 	spc, ok := newSpc.(*apis.StoragePoolClaim)
 	if !ok {
 		runtime.HandleError(fmt.Errorf("Couldn't get spc object %#v", newSpc))
+		return
+	}
+	if spc.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
+		message := fmt.Sprintf("reconcile is disabled via %q label", string(apis.OpenEBSDisableReconcileKey))
+		c.recorder.Event(spc, corev1.EventTypeWarning, "Update", message)
 		return
 	}
 	// Enqueue spc only when there is a pending pool to be created.
@@ -187,6 +197,11 @@ func (c *Controller) deleteSpc(obj interface{}) {
 			runtime.HandleError(fmt.Errorf("Tombstone contained object that is not a storagepoolclaim %#v", obj))
 			return
 		}
+	}
+	if spc.Labels[string(apis.OpenEBSDisableReconcileKey)] == "true" {
+		message := fmt.Sprintf("reconcile is disabled via %q label", string(apis.OpenEBSDisableReconcileKey))
+		c.recorder.Event(spc, corev1.EventTypeWarning, "Delete", message)
+		return
 	}
 	glog.V(4).Infof("Deleting storagepoolclaim %s", spc.Name)
 	c.enqueueSpc(spc)

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node_test.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node_test.go
@@ -243,10 +243,11 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 			expectedErr:            true,
 		},
 		//Test Case #5
+		// blockdevice0, blockdevice1 are of sparse type
 		"manualSPC5": {
 			fakeCasPool: &v1alpha1.StoragePoolClaim{
 				Spec: v1alpha1.StoragePoolClaimSpec{
-					Type: "sparse",
+					Type: "disk",
 					PoolSpec: v1alpha1.CStorPoolAttr{
 						PoolType: "striped",
 					},
@@ -255,19 +256,19 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 					},
 				},
 			},
-			expectedDiskListLength: 3,
+			expectedDiskListLength: 1,
 			expectedErr:            false,
 		},
 		// Test Case #6
 		"manualSPC6": {
 			fakeCasPool: &v1alpha1.StoragePoolClaim{
 				Spec: v1alpha1.StoragePoolClaimSpec{
-					Type: "sparse",
+					Type: "disk",
 					PoolSpec: v1alpha1.CStorPoolAttr{
 						PoolType: "mirrored",
 					},
 					BlockDevices: v1alpha1.BlockDeviceAttr{
-						BlockDeviceList: []string{"blockdevice1", "blockdevice2"},
+						BlockDeviceList: []string{"blockdevice3", "blockdevice4"},
 					},
 				},
 			},
@@ -459,7 +460,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 						PoolType: "raidz2",
 					},
 					BlockDevices: v1alpha1.BlockDeviceAttr{
-						BlockDeviceList: []string{"blockdevice1", "blockdevice2", "blockdevice3", "blockdevice4", "blockdevice5", "blockdevice6"},
+						BlockDeviceList: []string{"blockdevice3", "blockdevice4", "blockdevice5", "blockdevice6", "blockdevice7", "blockdevice8"},
 					},
 				},
 			},
@@ -513,6 +514,22 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 			},
 			expectedDiskListLength: 0,
 			expectedErr:            false,
+		},
+		// Test Case #22
+		"manualSPC22Raidz2": {
+			fakeCasPool: &v1alpha1.StoragePoolClaim{
+				Spec: v1alpha1.StoragePoolClaimSpec{
+					Type: "disk",
+					PoolSpec: v1alpha1.CStorPoolAttr{
+						PoolType: "mirrored",
+					},
+					BlockDevices: v1alpha1.BlockDeviceAttr{
+						BlockDeviceList: []string{"blockdevice0", "blockdevice1"},
+					},
+				},
+			},
+			expectedDiskListLength: 6,
+			expectedErr:            true,
 		},
 	}
 

--- a/pkg/apis/openebs.io/v1alpha1/cas_keys.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_keys.go
@@ -45,6 +45,9 @@ const (
 	// OpenEBS
 	OpenEBSVersionKey CASKey = "openebs.io/version"
 
+	// OpenEBSDisableReconcileKey is the label key decides to reconcile or not
+	OpenEBSDisableReconcileKey CASKey = "reconcile.openebs.io/disable"
+
 	// CASConfigKey is the key to fetch configurations w.r.t a CAS entity
 	CASConfigKey CASKey = "cas.openebs.io/config"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR cherry-pick's the following commits
1. feat[cstor-operator, cstor-pool-mgmt, upgrade]: add support to stop reconciliation during upgrade       ( #1280 )
2. fix(cstor-operator): honour spc type in case of manual provisioning of cStor pool (#1281)
3. feat(cstor-operator, cstor-pool-mgmt, upgrade): add support to stop reconciliation during upgrade using annotations (#1288) 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests