### PR TITLE
[cherry-pick] feat(localpv): allow creating Local PV on unformatted devices (#1283)

### DIFF
--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -41,17 +41,20 @@ const (
 	//KeyPVBasePath defines base directory for hostpath volumes
 	// can be configured via the StorageClass annotations.
 	KeyPVBasePath = "BasePath"
+	//KeyPVFSType defines filesystem type to be used with devices
+	// and can be configured via the StorageClass annotations.
+	KeyPVFSType = "FSType"
 	//KeyPVRelativePath defines the alternate folder name under the BasePath
 	// By default, the pv name will be used as the folder name.
 	// KeyPVBasePath can be useful for providing the same underlying folder
 	// name for all replicas in a Statefulset.
 	// Will be a property of the PVC annotations.
-	KeyPVRelativePath = "RelativePath"
+	//KeyPVRelativePath = "RelativePath"
 	//KeyPVAbsolutePath specifies a complete hostpath instead of
 	// auto-generating using BasePath and RelativePath. This option
 	// is specified with PVC and is useful for granting shared access
 	// to underlying hostpaths across multiple pods.
-	KeyPVAbsolutePath = "AbsolutePath"
+	//KeyPVAbsolutePath = "AbsolutePath"
 )
 
 const (
@@ -120,6 +123,17 @@ func (c *VolumeConfig) GetStorageType() string {
 		return "hostpath"
 	}
 	return stgType
+}
+
+//GetFSType returns the FSType value configured
+// in StorageClass. Default is "", auto-determined
+// by Local PV
+func (c *VolumeConfig) GetFSType() string {
+	fsType := c.getValue(KeyPVFSType)
+	if len(strings.TrimSpace(fsType)) == 0 {
+		return ""
+	}
+	return fsType
 }
 
 //GetPath returns a valid PV path based on the configuration

--- a/cmd/provisioner-localpv/app/helper_hostpath.go
+++ b/cmd/provisioner-localpv/app/helper_hostpath.go
@@ -39,7 +39,8 @@ import (
 )
 
 var (
-	//CmdTimeoutCounts specifies the duration to wait for cleanup pod to be launched.
+	//CmdTimeoutCounts specifies the duration to wait for cleanup pod
+	//to be launched.
 	CmdTimeoutCounts = 120
 )
 
@@ -82,7 +83,8 @@ func (p *Provisioner) getPathAndNodeForPV(pv *corev1.PersistentVolume) (string, 
 	path := ""
 	local := pv.Spec.PersistentVolumeSource.Local
 	if local == nil {
-		//Handle the case of Local PV created in 0.9 using HostPathVolumeSource
+		//Handle the case of Local PV created in 0.9 using
+		//HostPathVolumeSource
 		hostPath := pv.Spec.PersistentVolumeSource.HostPath
 		if hostPath == nil {
 			return "", "", errors.Errorf("no HostPath set")
@@ -104,7 +106,8 @@ func (p *Provisioner) getPathAndNodeForPV(pv *corev1.PersistentVolume) (string, 
 	node := ""
 	for _, selectorTerm := range required.NodeSelectorTerms {
 		for _, expression := range selectorTerm.MatchExpressions {
-			if expression.Key == KeyNode && expression.Operator == corev1.NodeSelectorOpIn {
+			if expression.Key == KeyNode &&
+				expression.Operator == corev1.NodeSelectorOpIn {
 				if len(expression.Values) != 1 {
 					return "", "", errors.Errorf("multiple values for the node affinity")
 				}
@@ -141,42 +144,38 @@ func (p *Provisioner) createInitPod(pOpts *HelperPodOptions) error {
 		return vErr
 	}
 
-	conObj, _ := container.NewBuilder().
-		WithName("local-path-init").
-		WithImage(p.helperImage).
-		WithCommand(append(pOpts.cmdsForPath, filepath.Join("/data/", volumeDir))).
-		WithVolumeMounts([]corev1.VolumeMount{
-			{
-				Name:      "data",
-				ReadOnly:  false,
-				MountPath: "/data/",
-			},
-		}).
-		Build()
-	//containers := []v1.Container{conObj}
-
-	volObj, _ := volume.NewBuilder().
-		WithName("data").
-		WithHostDirectory(parentDir).
-		Build()
-	//volumes := []v1.Volume{*volObj}
-
-	helperPod, _ := pod.NewBuilder().
+	initPod, _ := pod.NewBuilder().
 		WithName("init-" + pOpts.name).
 		WithRestartPolicy(corev1.RestartPolicyNever).
 		WithNodeName(pOpts.nodeName).
-		WithContainer(conObj).
-		WithVolume(*volObj).
+		WithContainerBuilder(
+			container.NewBuilder().
+				WithName("local-path-init").
+				WithImage(p.helperImage).
+				WithCommand(append(pOpts.cmdsForPath, filepath.Join("/data/", volumeDir))).
+				WithVolumeMounts([]corev1.VolumeMount{
+					{
+						Name:      "data",
+						ReadOnly:  false,
+						MountPath: "/data/",
+					},
+				}),
+		).
+		WithVolumeBuilder(
+			volume.NewBuilder().
+				WithName("data").
+				WithHostDirectory(parentDir),
+		).
 		Build()
 
 	//Launch the init pod.
-	hPod, err := p.kubeClient.CoreV1().Pods(p.namespace).Create(helperPod)
+	iPod, err := p.kubeClient.CoreV1().Pods(p.namespace).Create(initPod)
 	if err != nil {
 		return err
 	}
 
 	defer func() {
-		e := p.kubeClient.CoreV1().Pods(p.namespace).Delete(hPod.Name, &metav1.DeleteOptions{})
+		e := p.kubeClient.CoreV1().Pods(p.namespace).Delete(iPod.Name, &metav1.DeleteOptions{})
 		if e != nil {
 			glog.Errorf("unable to delete the helper pod: %v", e)
 		}
@@ -185,7 +184,7 @@ func (p *Provisioner) createInitPod(pOpts *HelperPodOptions) error {
 	//Wait for the cleanup pod to complete it job and exit
 	completed := false
 	for i := 0; i < CmdTimeoutCounts; i++ {
-		checkPod, err := p.kubeClient.CoreV1().Pods(p.namespace).Get(hPod.Name, metav1.GetOptions{})
+		checkPod, err := p.kubeClient.CoreV1().Pods(p.namespace).Get(iPod.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		} else if checkPod.Status.Phase == corev1.PodSucceeded {
@@ -223,42 +222,38 @@ func (p *Provisioner) createCleanupPod(pOpts *HelperPodOptions) error {
 		return vErr
 	}
 
-	conObj, _ := container.NewBuilder().
-		WithName("local-path-cleanup").
-		WithImage(p.helperImage).
-		WithCommand(append(pOpts.cmdsForPath, filepath.Join("/data/", volumeDir))).
-		WithVolumeMounts([]corev1.VolumeMount{
-			{
-				Name:      "data",
-				ReadOnly:  false,
-				MountPath: "/data/",
-			},
-		}).
-		Build()
-	//containers := []v1.Container{conObj}
-
-	volObj, _ := volume.NewBuilder().
-		WithName("data").
-		WithHostDirectory(parentDir).
-		Build()
-	//volumes := []v1.Volume{*volObj}
-
-	helperPod, _ := pod.NewBuilder().
+	cleanerPod, _ := pod.NewBuilder().
 		WithName("cleanup-" + pOpts.name).
 		WithRestartPolicy(corev1.RestartPolicyNever).
 		WithNodeName(pOpts.nodeName).
-		WithContainer(conObj).
-		WithVolume(*volObj).
+		WithContainerBuilder(
+			container.NewBuilder().
+				WithName("local-path-cleanup").
+				WithImage(p.helperImage).
+				WithCommand(append(pOpts.cmdsForPath, filepath.Join("/data/", volumeDir))).
+				WithVolumeMounts([]corev1.VolumeMount{
+					{
+						Name:      "data",
+						ReadOnly:  false,
+						MountPath: "/data/",
+					},
+				}),
+		).
+		WithVolumeBuilder(
+			volume.NewBuilder().
+				WithName("data").
+				WithHostDirectory(parentDir),
+		).
 		Build()
 
 	//Launch the cleanup pod.
-	hPod, err := p.kubeClient.CoreV1().Pods(p.namespace).Create(helperPod)
+	cPod, err := p.kubeClient.CoreV1().Pods(p.namespace).Create(cleanerPod)
 	if err != nil {
 		return err
 	}
 
 	defer func() {
-		e := p.kubeClient.CoreV1().Pods(p.namespace).Delete(hPod.Name, &metav1.DeleteOptions{})
+		e := p.kubeClient.CoreV1().Pods(p.namespace).Delete(cPod.Name, &metav1.DeleteOptions{})
 		if e != nil {
 			glog.Errorf("unable to delete the helper pod: %v", e)
 		}
@@ -267,7 +262,7 @@ func (p *Provisioner) createCleanupPod(pOpts *HelperPodOptions) error {
 	//Wait for the cleanup pod to complete it job and exit
 	completed := false
 	for i := 0; i < CmdTimeoutCounts; i++ {
-		checkPod, err := p.kubeClient.CoreV1().Pods(p.namespace).Get(hPod.Name, metav1.GetOptions{})
+		checkPod, err := p.kubeClient.CoreV1().Pods(p.namespace).Get(cPod.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		} else if checkPod.Status.Phase == corev1.PodSucceeded {

--- a/pkg/kubernetes/persistentvolume/v1alpha1/build.go
+++ b/pkg/kubernetes/persistentvolume/v1alpha1/build.go
@@ -107,13 +107,21 @@ func (b *Builder) WithCapacityQty(resCapacity resource.Quantity) *Builder {
 
 // WithLocalHostDirectory sets the LocalVolumeSource field of PV with provided hostpath
 func (b *Builder) WithLocalHostDirectory(path string) *Builder {
+	return b.WithLocalHostPathFormat(path, "")
+}
+
+// WithLocalHostPathFormat sets the LocalVolumeSource field of PV with provided hostpath
+// and request to format it with fstype - if not already formatted. A "" value for fstype
+// indicates that the Local PV can determine the type of FS.
+func (b *Builder) WithLocalHostPathFormat(path, fstype string) *Builder {
 	if len(path) == 0 {
 		b.errs = append(b.errs, errors.New("failed to build PV object: missing PV path"))
 		return b
 	}
 	volumeSource := corev1.PersistentVolumeSource{
 		Local: &corev1.LocalVolumeSource{
-			Path: path,
+			Path:   path,
+			FSType: &fstype,
 		},
 	}
 

--- a/pkg/kubernetes/persistentvolume/v1alpha1/build_test.go
+++ b/pkg/kubernetes/persistentvolume/v1alpha1/build_test.go
@@ -272,6 +272,7 @@ func TestBuildWithNodeAffinity(t *testing.T) {
 }
 
 func TestBuildHostPath(t *testing.T) {
+	fsType := ""
 
 	tests := map[string]struct {
 		name        string
@@ -295,7 +296,7 @@ func TestBuildHostPath(t *testing.T) {
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
 						Local: &corev1.LocalVolumeSource{
 							Path:   "/var/openebs/local/PV1",
-							FSType: nil,
+							FSType: &fsType,
 						},
 					},
 					NodeAffinity: &corev1.VolumeNodeAffinity{


### PR DESCRIPTION
When supporting OpenEBS Local PV using the block devices attached to the nodes, these block devices can be in one of the following states:

(a) User has attached the block device, formatted and mounted them.
For Example: GKE with Local SSD

(b) User has attached the block device, un-formatted and not mounted.
For Example: GKE with GPD

(c) Similar to (b), but device has only device path, but no dev links.
For Example: VM with VMDK disks or AWS node with EBS

Initial version of the Local PV with block device supported (a). In other words, it expects user to format and mount these devices.

With this PR, (b) and (c) are also supported.

Provisioner will check if the device has a mounted path, if not it will pass either the dev link or the device path to the Local PV, along with the configured FileSystem that needs to be put on it. A custom FSType can be passed via Storage Class (FSType - StoragePolicy). If no FSType is specified, Local PV will default to ext4.

Signed-off-by: kmova <kiran.mova@mayadata.io>
(cherry picked from commit a6fcd0fb325e2eba5edd65f3d6d032f3c0ba7ed7)

