### PR TITLE
feat(usage): ability to include installer type in GA events

### DIFF
--- a/pkg/usage/googleanalytics.go
+++ b/pkg/usage/googleanalytics.go
@@ -32,6 +32,8 @@ func (u *Usage) Send() {
 			return
 		}
 		gaClient.ClientID(u.clientID).
+			CampaignSource(u.campaignSource).
+			CampaignContent(u.clientID).
 			ApplicationID(u.appID).
 			ApplicationVersion(u.appVersion).
 			DataSource(u.dataSource).

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -79,8 +79,12 @@ type Application struct {
 type Gclient struct {
 	// constant tracking-id used to send a hit
 	trackID string
+
 	// anonymous client-id
 	clientID string
+
+	// anonymous campaign source
+	campaignSource string
 
 	// https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#ds
 	// (usecase) node-detail
@@ -106,6 +110,14 @@ func (u *Usage) SetDataSource(dataSource string) *Usage {
 // SetTrackingID Sets the GA-code for the project
 func (u *Usage) SetTrackingID(track string) *Usage {
 	u.trackID = track
+	return u
+}
+
+// SetCampaignSource : source of openebs installater like:
+// helm or operator etc. This will have to be configured
+// via ENV variable OPENEBS_IO_INSTALLER_TYPE
+func (u *Usage) SetCampaignSource(campaignSrc string) *Usage {
+	u.campaignSource = campaignSrc
 	return u
 }
 
@@ -176,7 +188,8 @@ func (u *Usage) Build() *Usage {
 	v.getVersion(false)
 	u.SetApplicationID(AppName).
 		SetTrackingID(GAclientID).
-		SetClientID(v.id)
+		SetClientID(v.id).
+		SetCampaignSource(v.installerType)
 	// TODO: Add condition for version over-ride
 	// Case: CAS/Jiva version, etc
 	return u

--- a/pkg/usage/versionset.go
+++ b/pkg/usage/versionset.go
@@ -29,6 +29,7 @@ var (
 	clusterArch    env.ENVKey = "OPENEBS_IO_K8S_ARCH"
 	openEBSversion env.ENVKey = "OPENEBS_IO_VERSION_TAG"
 	nodeType       env.ENVKey = "OPENEBS_IO_NODE_TYPE"
+	installerType  env.ENVKey = "OPENEBS_IO_INSTALLER_TYPE"
 )
 
 // versionSet is a struct which stores (sort of) fixed information about a
@@ -39,6 +40,7 @@ type versionSet struct {
 	k8sArch        string // OPENEBS_IO_K8S_ARCH
 	openebsVersion string // OPENEBS_IO_VERSION_TAG
 	nodeType       string // OPENEBS_IO_NODE_TYPE
+	installerType  string // OPENEBS_IO_INSTALLER_TYPE
 }
 
 // NewVersion returns a new versionSet struct
@@ -91,6 +93,7 @@ func (v *versionSet) getVersion(override bool) error {
 	v.k8sVersion = env.Get(clusterVersion)
 	v.nodeType = env.Get(nodeType)
 	v.openebsVersion = env.Get(openEBSversion)
+	v.installerType = env.Get(installerType)
 	return nil
 }
 


### PR DESCRIPTION
OpenEBS can be installed using different modes like helm,
operator, or partners like rancher, nks etc. This PR
helps track which type of installer are being used.

Also, this PR pushes the cluster identifier in an
additional field, that can be used by the reports
to co-relate volumes with clusters.

Signed-off-by: kmova <kiran.mova@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests