### PR TITLE
[cherry-pick] feat(usage): collect anonymous info about local-pv provisionioner #1289

### DIFF
--- a/pkg/usage/const.go
+++ b/pkg/usage/const.go
@@ -29,8 +29,7 @@ const (
 	VolumeProvision string = "volume-provision"
 	//VolumeDeprovision event is sent when a volume is deleted
 	VolumeDeprovision string = "volume-deprovision"
-
-	AppName string = "OpenEBS"
+	AppName           string = "OpenEBS"
 
 	// Event labels
 	RunningStatus      string = "running"
@@ -43,4 +42,8 @@ const (
 
 	// Event application name constant for volume event
 	DefaultCASType string = "jiva"
+
+	// LocalPVReplicaCount is the constant used by usage to represent
+	// replication factor in LocalPV
+	LocalPVReplicaCount string = "1"
 )


### PR DESCRIPTION
(#1289)

This PR adds the support to send the provision and deprovision 
GA events for Local PV, iff GA is enabled on the local provisioner. 

Signed-off-by: Harsh Vardhan <harsh.vardhan@mayadata.io>

**What this PR does / why we need it**:
/kind chore
/kind release

**Special notes for your reviewer**:
This is a cherry-pick of the #1298 PR

**Checklist:**
- [x] Fixes #771 
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests