### PR TITLE
feat(bdd, jiva) BDD to check node selector config

### DIFF
--- a/pkg/kubernetes/node/v1alpha1/kubernetes.go
+++ b/pkg/kubernetes/node/v1alpha1/kubernetes.go
@@ -83,7 +83,8 @@ func (k *Kubeclient) withDefaults() {
 		}
 	}
 	if k.getClientsetForPath == nil {
-		k.getClientsetForPath = func(kubeConfigPath string) (clients *kubernetes.Clientset, err error) {
+		k.getClientsetForPath = func(
+			kubeConfigPath string) (clients *kubernetes.Clientset, err error) {
 			return client.New(client.WithKubeConfigPath(kubeConfigPath)).Clientset()
 		}
 	}
@@ -93,7 +94,8 @@ func (k *Kubeclient) withDefaults() {
 		}
 	}
 	if k.list == nil {
-		k.list = func(cli *kubernetes.Clientset, opts metav1.ListOptions) (*corev1.NodeList, error) {
+		k.list = func(cli *kubernetes.Clientset,
+			opts metav1.ListOptions) (*corev1.NodeList, error) {
 			return cli.CoreV1().Nodes().List(opts)
 		}
 	}

--- a/tests/jiva/node-selector/node_selector_test.go
+++ b/tests/jiva/node-selector/node_selector_test.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeselector
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	pvc "github.com/openebs/maya/pkg/kubernetes/persistentvolumeclaim/v1alpha1"
+	"github.com/openebs/maya/tests/jiva"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	podList        *corev1.PodList
+	restartCounter = 5
+	readWriteOnce  = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
+	capacity       = "5G"
+	pvcObj         *corev1.PersistentVolumeClaim
+	err            error
+)
+
+var _ = Describe("[jiva] TEST NODE SELECTOR", func() {
+	var (
+		pvcName = "jiva-volume-claim"
+	)
+
+	BeforeEach(func() {
+
+		By("building a pvc")
+		pvcObj, err = pvc.NewBuilder().
+			WithName(pvcName).
+			WithNamespace(namespaceObj.Name).
+			WithStorageClass(scObj.Name).
+			WithAccessModes(readWriteOnce).
+			WithCapacity(capacity).Build()
+		Expect(err).ShouldNot(
+			HaveOccurred(),
+			"while building pvc {%s} in namespace {%s}",
+			pvcName,
+			namespaceObj.Name,
+		)
+
+		By("creating above pvc")
+		_, err = ops.PVCClient.WithNamespace(namespaceObj.Name).Create(pvcObj)
+		Expect(err).To(
+			BeNil(),
+			"while creating pvc {%s} in namespace {%s}",
+			pvcName,
+			namespaceObj.Name,
+		)
+
+		By("verifying controller pod count")
+		controllerPodCount := ops.GetPodRunningCountEventually(
+			namespaceObj.Name,
+			jiva.CtrlLabel,
+			1,
+		)
+		Expect(controllerPodCount).To(Equal(1), "while checking controller pod count")
+
+		By("verifying replica pod count ")
+		replicaPodCount := ops.GetPodRunningCountEventually(
+			namespaceObj.Name,
+			jiva.ReplicaLabel,
+			jiva.ReplicaCount,
+		)
+		Expect(replicaPodCount).To(
+			Equal(jiva.ReplicaCount),
+			"while checking replica pod count",
+		)
+
+		By("verifying status as bound")
+		status := ops.IsPVCBoundEventually(pvcName)
+		Expect(status).To(Equal(true), "while checking status equal to bound")
+
+	})
+
+	AfterEach(func() {
+
+		By("deleting above pvc")
+		err = ops.PVCClient.Delete(pvcName, &metav1.DeleteOptions{})
+		Expect(err).To(
+			BeNil(),
+			"while deleting pvc {%s} in namespace {%s}",
+			pvcName,
+			namespaceObj.Name,
+		)
+
+		By("verifying controller pod count as 0")
+		controllerPodCount := ops.GetPodRunningCountEventually(
+			namespaceObj.Name,
+			jiva.CtrlLabel,
+			0,
+		)
+		Expect(controllerPodCount).To(Equal(0), "while checking controller pod count")
+
+		By("verifying replica pod count as 0")
+		replicaPodCount := ops.GetPodRunningCountEventually(
+			namespaceObj.Name,
+			jiva.ReplicaLabel,
+			0,
+		)
+		Expect(replicaPodCount).To(Equal(0), "while checking replica pod count")
+
+		By("verifying deleted pvc")
+		pvc := ops.IsPVCDeleted(pvcName)
+		Expect(pvc).To(Equal(true), "while trying to get deleted pvc")
+
+	})
+
+	When("replica pod of pvc is restarted", func() {
+		It("should stick to storage node after reconciliation", func() {
+			podList, err = ops.PodClient.
+				WithNamespace(namespaceObj.Name).
+				List(metav1.ListOptions{LabelSelector: jiva.ReplicaLabel})
+			Expect(err).ShouldNot(HaveOccurred(), "while fetching replica pods")
+
+			for i := 0; i < restartCounter; i++ {
+
+				By("deleting a replica pod")
+				err = ops.PodClient.Delete(
+					podList.Items[0].Name,
+					&metav1.DeleteOptions{},
+				)
+				Expect(err).ShouldNot(HaveOccurred(), "while deleting replica pod")
+
+				By("verifying deleted pod is terminated")
+				status := ops.IsPodDeletedEventually(
+					namespaceObj.Name,
+					podList.Items[0].Name,
+				)
+				Expect(status).To(Equal(true), "while checking for deleted pod")
+
+				By("verifying running replica pod count ")
+				replicaPodCount := ops.GetPodRunningCountEventually(
+					namespaceObj.Name,
+					jiva.ReplicaLabel,
+					jiva.ReplicaCount,
+				)
+				Expect(replicaPodCount).To(
+					Equal(jiva.ReplicaCount),
+					"while checking replica pod count",
+				)
+
+				By("verifying replica node selector")
+				podList, err = ops.PodClient.
+					WithNamespace(namespaceObj.Name).
+					List(metav1.ListOptions{LabelSelector: jiva.ReplicaLabel})
+				Expect(err).ShouldNot(HaveOccurred(), "while fetching replica pods")
+
+				Expect(podList.Items[0].Spec.NodeName).To(
+					Equal(storageNode),
+					"checking replica node selector",
+				)
+			}
+		})
+	})
+
+	When("controller pod of pvc is restarted", func() {
+		It("should stick to app node after reconciliation", func() {
+			podList, err = ops.PodClient.
+				WithNamespace(namespaceObj.Name).
+				List(metav1.ListOptions{LabelSelector: jiva.CtrlLabel})
+			Expect(err).ShouldNot(HaveOccurred(), "while fetching controller pods")
+
+			for i := 0; i < restartCounter; i++ {
+
+				By("deleting a controller pod")
+				err = ops.PodClient.Delete(
+					podList.Items[0].Name,
+					&metav1.DeleteOptions{},
+				)
+				Expect(err).ShouldNot(HaveOccurred(), "while deleting controller pod")
+
+				By("verifying deleted pod is terminated")
+				status := ops.IsPodDeletedEventually(
+					namespaceObj.Name,
+					podList.Items[0].Name,
+				)
+				Expect(status).To(Equal(true), "while checking for deleted pod")
+
+				By("verifying running controller pod count ")
+				replicaPodCount := ops.GetPodRunningCountEventually(
+					namespaceObj.Name,
+					jiva.CtrlLabel,
+					1,
+				)
+				Expect(replicaPodCount).To(
+					Equal(1),
+					"while checking controller pod count",
+				)
+
+				By("verifying target node selector")
+				podList, err = ops.PodClient.
+					WithNamespace(namespaceObj.Name).
+					List(metav1.ListOptions{LabelSelector: jiva.CtrlLabel})
+				Expect(err).ShouldNot(HaveOccurred(), "while fetching controller pods")
+
+				Expect(podList.Items[0].Spec.NodeName).To(
+					Equal(appNode),
+					"checking controller node selector",
+				)
+			}
+		})
+	})
+
+})

--- a/tests/jiva/node-selector/suite_test.go
+++ b/tests/jiva/node-selector/suite_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2019 The OpenEBS Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeselector
+
+import (
+	"strconv"
+
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openebs/maya/tests"
+	"github.com/openebs/maya/tests/artifacts"
+	"github.com/openebs/maya/tests/jiva"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	ns "github.com/openebs/maya/pkg/kubernetes/namespace/v1alpha1"
+	sc "github.com/openebs/maya/pkg/kubernetes/storageclass/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
+
+	// auth plugins
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+)
+
+var (
+	namespace             = "jiva-volume-ns"
+	scName                = "jiva-volume-sc"
+	openebsProvisioner    = "openebs.io/provisioner-iscsi"
+	namespaceObj          *corev1.Namespace
+	scObj                 *storagev1.StorageClass
+	nodeList              *corev1.NodeList
+	annotations           = map[string]string{}
+	appNode, storageNode  string
+	openebsCASConfigValue = `- name: ReplicaNodeSelector
+  value: |-
+    nodetype: storage
+- name: TargetNodeSelector
+  value: |-
+    nodetype: app
+- name: ReplicaCount
+  value: `
+)
+
+func TestSource(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test jiva volume node selector")
+}
+
+func init() {
+	jiva.ParseFlags()
+}
+
+var ops *tests.Operations
+
+var _ = BeforeSuite(func() {
+
+	ops = tests.NewOperations(tests.WithKubeConfigPath(jiva.KubeConfigPath))
+
+	annotations[string(apis.CASTypeKey)] = string(apis.JivaVolume)
+	annotations[string(apis.CASConfigKey)] = openebsCASConfigValue + strconv.Itoa(jiva.ReplicaCount)
+
+	By("waiting for maya-apiserver pod to come into running state")
+	podCount := ops.GetPodRunningCountEventually(
+		string(artifacts.OpenebsNamespace),
+		string(artifacts.MayaAPIServerLabelSelector),
+		1,
+	)
+	Expect(podCount).To(Equal(1))
+
+	By("waiting for openebs-provisioner pod to come into running state")
+	podCount = ops.GetPodRunningCountEventually(
+		string(artifacts.OpenebsNamespace),
+		string(artifacts.OpenEBSProvisionerLabelSelector),
+		1,
+	)
+	Expect(podCount).To(Equal(1))
+
+	By("building a namespace")
+	namespaceObj, err = ns.NewBuilder().
+		WithGenerateName(namespace).
+		APIObject()
+	Expect(err).ShouldNot(HaveOccurred(), "while building namespace {%s}", namespace)
+
+	By("building a storageclass")
+	scObj, err = sc.NewBuilder().
+		WithGenerateName(scName).
+		WithAnnotations(annotations).
+		WithProvisioner(openebsProvisioner).Build()
+	Expect(err).ShouldNot(HaveOccurred(), "while building storageclass {%s}", scName)
+
+	By("creating above namespace")
+	namespaceObj, err = ops.NSClient.Create(namespaceObj)
+	Expect(err).To(BeNil(), "while creating namespace {%s}", namespaceObj.GenerateName)
+
+	By("creating above storageclass")
+	scObj, err = ops.SCClient.Create(scObj)
+	Expect(err).To(BeNil(), "while creating storageclass {%s}", scObj.GenerateName)
+
+	By("listing ready nodes")
+	nodeList = ops.GetReadyNodes()
+
+	By("verifying minimum node count to be 2")
+	Expect(len(nodeList.Items)).Should(BeNumerically(">=", 2))
+
+	appNode = nodeList.Items[0].Name
+	By("labeling node 1 as app")
+	_, err = ops.NodeClient.Patch(appNode,
+		types.MergePatchType,
+		[]byte(`{"metadata":{"labels":{"nodetype":"app"}}}`),
+	)
+	Expect(err).ShouldNot(HaveOccurred(), "while patching app node")
+
+	storageNode = nodeList.Items[1].Name
+	By("labeling node 2 as storage")
+	_, err = ops.NodeClient.Patch(storageNode,
+		types.MergePatchType,
+		[]byte(`{"metadata":{"labels":{"nodetype":"storage"}}}`),
+	)
+	Expect(err).ShouldNot(HaveOccurred(), "while patching storage node")
+
+})
+
+var _ = AfterSuite(func() {
+
+	By("removing label from node 1")
+	_, err = ops.NodeClient.Patch(appNode,
+		types.MergePatchType,
+		[]byte(`{"metadata":{"labels":{"nodetype":null}}}`),
+	)
+	Expect(err).ShouldNot(HaveOccurred(), "while removing app node label")
+
+	By("removing label from node 2")
+	_, err = ops.NodeClient.Patch(storageNode,
+		types.MergePatchType,
+		[]byte(`{"metadata":{"labels":{"nodetype":null}}}`),
+	)
+	Expect(err).ShouldNot(HaveOccurred(), "while removing storage node label")
+
+	By("deleting storageclass")
+	err = ops.SCClient.Delete(scObj.Name, &metav1.DeleteOptions{})
+	Expect(err).To(BeNil(), "while deleting storageclass {%s}", scObj.Name)
+
+	By("deleting namespace")
+	err = ops.NSClient.Delete(namespaceObj.Name, &metav1.DeleteOptions{})
+	Expect(err).To(BeNil(), "while deleting namespace {%s}", namespaceObj.Name)
+
+})


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds BDD to check the node selector cas config of storageclass for jiva volume. The BDD restarts the controller and replica pods and verifies whether they come back to the respective labelled nodes or not.

**Sample test output**:
```
user:node-selector$ ginkgo -v -- -kubeconfig=/home/user/.kube/config
Running Suite: Test jiva volume node selector
=============================================
Random Seed: 1560784499
Will run 2 of 2 specs

STEP: waiting for maya-apiserver pod to come into running state
STEP: waiting for openebs-provisioner pod to come into running state
STEP: building a namespace
STEP: building a storageclass
STEP: creating above namespace
STEP: creating above storageclass
STEP: listing nodes
STEP: labeling node 1 as app
STEP: labeling node 2 as storage
[jiva] TEST NODE SELECTOR when replica pod of pvc is restarted 
  should stick to storage node after reconciliation
  /home/user/work/src/github.com/openebs/maya/tests/jiva/node-selector/node_selector_test.go:106
STEP: building a pvc
STEP: creating above pvc
STEP: verifying controller pod count
STEP: verifying replica pod count 
STEP: verifying status as bound
STEP: deleting a replica pod
STEP: verifying deleted pod is terminated
STEP: verifying running replica pod count 
STEP: verifying replica node selector
STEP: deleting a replica pod
STEP: verifying deleted pod is terminated
STEP: verifying running replica pod count 
STEP: verifying replica node selector
STEP: deleting a replica pod
STEP: verifying deleted pod is terminated
STEP: verifying running replica pod count 
STEP: verifying replica node selector
STEP: deleting a replica pod
STEP: verifying deleted pod is terminated
STEP: verifying running replica pod count 
STEP: verifying replica node selector
STEP: deleting a replica pod
STEP: verifying deleted pod is terminated
STEP: verifying running replica pod count 
STEP: verifying replica node selector
STEP: deleting above pvc
STEP: verifying controller pod count as 0
STEP: verifying replica pod count as 0
STEP: verifying deleted pvc

• [SLOW TEST:86.002 seconds]
[jiva] TEST NODE SELECTOR
/home/user/work/src/github.com/openebs/maya/tests/jiva/node-selector/node_selector_test.go:36
  when replica pod of pvc is restarted
  /home/user/work/src/github.com/openebs/maya/tests/jiva/node-selector/node_selector_test.go:105
    should stick to storage node after reconciliation
    /home/user/work/src/github.com/openebs/maya/tests/jiva/node-selector/node_selector_test.go:106
------------------------------
[jiva] TEST NODE SELECTOR when controller pod of pvc is restarted 
  should stick to app node after reconciliation
  /home/user/work/src/github.com/openebs/maya/tests/jiva/node-selector/node_selector_test.go:141
STEP: building a pvc
STEP: creating above pvc
STEP: verifying controller pod count
STEP: verifying replica pod count 
STEP: verifying status as bound
STEP: deleting a controller pod
STEP: verifying deleted pod is terminated
STEP: verifying running controller pod count 
STEP: verifying target node selector
STEP: deleting a controller pod
STEP: verifying deleted pod is terminated
STEP: verifying running controller pod count 
STEP: verifying target node selector
STEP: deleting a controller pod
STEP: verifying deleted pod is terminated
STEP: verifying running controller pod count 
STEP: verifying target node selector
STEP: deleting a controller pod
STEP: verifying deleted pod is terminated
STEP: verifying running controller pod count 
STEP: verifying target node selector
STEP: deleting a controller pod
STEP: verifying deleted pod is terminated
STEP: verifying running controller pod count 
STEP: verifying target node selector
STEP: deleting above pvc
STEP: verifying controller pod count as 0
STEP: verifying replica pod count as 0
STEP: verifying deleted pvc

• [SLOW TEST:69.937 seconds]
[jiva] TEST NODE SELECTOR
/home/user/work/src/github.com/openebs/maya/tests/jiva/node-selector/node_selector_test.go:36
  when controller pod of pvc is restarted
  /home/user/work/src/github.com/openebs/maya/tests/jiva/node-selector/node_selector_test.go:140
    should stick to app node after reconciliation
    /home/user/work/src/github.com/openebs/maya/tests/jiva/node-selector/node_selector_test.go:141
------------------------------
STEP: deleting storageclass
STEP: deleting namespace

Ran 2 of 2 Specs in 159.586 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 2m51.675595131s
Test Suite Passed
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests