### PR TITLE
feat(cstor, BDD): cstor volume provision using target node selector

### DIFF
--- a/tests/cstor/node-selector/suite_test.go
+++ b/tests/cstor/node-selector/suite_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2019 The OpenEBS Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeselector
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openebs/maya/tests"
+	"github.com/openebs/maya/tests/cstor"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	ns "github.com/openebs/maya/pkg/kubernetes/namespace/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	// auth plugins
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+)
+
+var (
+	openebsNamespace      = "openebs"
+	nsName                = "test-cstor-volume-selector"
+	scName                = "test-cstor-volume-selector-sc"
+	openebsCASConfigValue = `
+- name: ReplicaCount
+  value: $count
+- name: StoragePoolClaim
+  value: $spcName
+- name: TargetNodeSelector
+  value: |-
+    nodetype: storage
+`
+	openebsProvisioner = "openebs.io/provisioner-iscsi"
+	spcName            = "test-cstor-selector-sparse-pool-auto"
+	nsObj              *corev1.Namespace
+	scObj              *storagev1.StorageClass
+	spcObj             *apis.StoragePoolClaim
+	pvcObj             *corev1.PersistentVolumeClaim
+	nodeList           *corev1.NodeList
+	pvLabel            = "openebs.io/persistent-volume="
+	pvcLabel           = "openebs.io/persistent-volume-claim="
+	accessModes        = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
+	capacity           = "5G"
+	storageNode        string
+	annotations        = map[string]string{}
+)
+
+func TestSource(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test cstor volume provisioning using target Node selector")
+}
+
+func init() {
+	cstor.ParseFlags()
+}
+
+var ops *tests.Operations
+
+var _ = BeforeSuite(func() {
+
+	ops = tests.NewOperations(tests.WithKubeConfigPath(cstor.KubeConfigPath)).VerifyOpenebs(1)
+	var err error
+
+	By("building a namespace")
+	nsObj, err = ns.NewBuilder().
+		WithGenerateName(nsName).
+		APIObject()
+	Expect(err).ShouldNot(HaveOccurred(), "while building namespace {%s}", nsName)
+
+	By("creating a namespace")
+	nsObj, err = ops.NSClient.Create(nsObj)
+	Expect(err).To(BeNil(), "while creating namespace {%s}", nsObj.Name)
+
+	By("listing ready nodes")
+	nodeList = ops.GetReadyNodes()
+
+	By("verifying minimum node count to be 1")
+	Expect(len(nodeList.Items)).Should(BeNumerically(">=", 1))
+
+	storageNode = nodeList.Items[0].Name
+	By("labeling node as 'nodetype:storage' ")
+	_, err = ops.NodeClient.Patch(storageNode,
+		types.MergePatchType,
+		[]byte(`{"metadata":{"labels":{"nodetype":"storage"}}}`),
+	)
+	Expect(err).ShouldNot(HaveOccurred(), "while patching storage node")
+
+})
+
+var _ = AfterSuite(func() {
+
+	By("deleting namespace")
+	err := ops.NSClient.Delete(nsObj.Name, &metav1.DeleteOptions{})
+	Expect(err).To(BeNil(), "while deleting namespace {%s}", nsObj.Name)
+
+	By("remove selector label from labeled nodes")
+	_, err = ops.NodeClient.Patch(storageNode,
+		types.MergePatchType,
+		[]byte(`{"metadata":{"labels":{"nodetype": null }}}`),
+	)
+	Expect(err).ShouldNot(HaveOccurred(), "while patching storage node")
+
+})

--- a/tests/cstor/node-selector/volume_selector_test.go
+++ b/tests/cstor/node-selector/volume_selector_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeselector
+
+import (
+	"strconv"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	pvc "github.com/openebs/maya/pkg/kubernetes/persistentvolumeclaim/v1alpha1"
+	sc "github.com/openebs/maya/pkg/kubernetes/storageclass/v1alpha1"
+	spc "github.com/openebs/maya/pkg/storagepoolclaim/v1alpha1"
+	"github.com/openebs/maya/tests/cstor"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("[cstor] TEST VOLUME PROVISIONING USING TARGET AND REPLICA SELECTOR",
+	func() {
+		var (
+			err     error
+			pvcName = "cstor-volume-claim"
+		)
+
+		BeforeEach(func() {
+			When(" creating a cstor based volume", func() {
+				By("building spc object")
+				spcObj = spc.NewBuilder().
+					WithGenerateName(spcName).
+					WithDiskType(string(apis.TypeSparseCPV)).
+					WithMaxPool(cstor.PoolCount).
+					WithOverProvisioning(false).
+					WithPoolType(string(apis.PoolTypeStripedCPV)).
+					Build().Object
+
+				By("creating storagepoolclaim")
+				spcObj, err = ops.SPCClient.Create(spcObj)
+				Expect(err).To(BeNil(), "while creating spc", spcName)
+
+				By("verifying healthy csp count")
+				cspCount := ops.GetHealthyCSPCountEventually(spcObj.Name, cstor.PoolCount)
+				Expect(cspCount).To(Equal(true), "while checking cstorpool health status")
+
+				By("building a CAS Config with generated SPC name")
+				CASConfig := strings.Replace(openebsCASConfigValue, "$spcName", spcObj.Name, 1)
+				CASConfig = strings.Replace(CASConfig, "$count", strconv.Itoa(cstor.ReplicaCount), 1)
+				annotations[string(apis.CASTypeKey)] = string(apis.CstorVolume)
+				annotations[string(apis.CASConfigKey)] = CASConfig
+
+				By("building object of storageclass")
+				scObj, err = sc.NewBuilder().
+					WithGenerateName(scName).
+					WithAnnotations(annotations).
+					WithProvisioner(openebsProvisioner).Build()
+				Expect(err).ShouldNot(HaveOccurred(), "while building storageclass obj for storageclass {%s}", scName)
+
+				By("creating storageclass")
+				scObj, err = ops.SCClient.Create(scObj)
+				Expect(err).To(BeNil(), "while creating storageclass", scName)
+
+			})
+		})
+
+		AfterEach(func() {
+			By("deleting resources created for testing cstor volume provisioning", func() {
+
+				By("deleting storagepoolclaim")
+				_, err = ops.SPCClient.Delete(spcObj.Name, &metav1.DeleteOptions{})
+				Expect(err).To(BeNil(), "while deleting the spc's {%s}", spcName)
+
+				By("deleting storageclass")
+				err = ops.SCClient.Delete(scObj.Name, &metav1.DeleteOptions{})
+				Expect(err).To(BeNil(), "while deleting storageclass", scName)
+
+			})
+		})
+
+		When("cstor pvc with replicacount 1 is created", func() {
+			It("should create cstor volume target pod", func() {
+
+				By("building a pvc")
+				pvcObj, err = pvc.NewBuilder().
+					WithName(pvcName).
+					WithNamespace(nsObj.Name).
+					WithStorageClass(scObj.Name).
+					WithAccessModes(accessModes).
+					WithCapacity(capacity).Build()
+				Expect(err).ShouldNot(
+					HaveOccurred(),
+					"while building pvc {%s} in namespace {%s}",
+					pvcName,
+					nsObj.Name,
+				)
+
+				By("creating above pvc")
+				pvcObj, err = ops.PVCClient.WithNamespace(nsObj.Name).Create(pvcObj)
+				Expect(err).To(
+					BeNil(),
+					"while creating pvc {%s} in namespace {%s}",
+					pvcName,
+					nsObj.Name,
+				)
+
+				By("verifying target pod count as 1")
+				targetVolumeLabel := pvcLabel + pvcObj.Name
+				controllerPodCount := ops.GetPodRunningCountEventually(openebsNamespace, targetVolumeLabel, 1)
+				Expect(controllerPodCount).To(Equal(1), "while checking controller pod count")
+
+				pvcObj, err = ops.PVCClient.WithNamespace(nsObj.Name).Get(pvcName, metav1.GetOptions{})
+				Expect(err).To(
+					BeNil(),
+					"while getting pvc {%s} in namespace {%s}",
+					pvcName,
+					nsObj.Name,
+				)
+
+				By("verifying cstorvolume replica count")
+				cvrLabel := pvLabel + pvcObj.Spec.VolumeName
+				cvrCount := ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, cvrLabel, cstor.ReplicaCount)
+				Expect(cvrCount).To(Equal(true), "while checking cstorvolume replica count")
+
+				By("verifying pvc status as bound")
+				status := ops.IsPVCBound(pvcName)
+				Expect(status).To(Equal(true), "while checking status equal to bound")
+
+				By("deleting above pvc")
+				err := ops.PVCClient.Delete(pvcName, &metav1.DeleteOptions{})
+				Expect(err).To(
+					BeNil(),
+					"while deleting pvc {%s} in namespace {%s}",
+					pvcName,
+					nsObj.Name,
+				)
+
+				By("verifying target pod count as 0")
+				controllerPodCount = ops.GetPodRunningCountEventually(openebsNamespace, targetVolumeLabel, 0)
+				Expect(controllerPodCount).To(Equal(0), "while checking controller pod count")
+
+				By("verifying deleted pvc")
+				pvc := ops.IsPVCDeleted(pvcName)
+				Expect(pvc).To(Equal(true), "while trying to get deleted pvc")
+
+				By("verifying if cstorvolume is deleted")
+				cvLabel := pvLabel + pvcObj.Spec.VolumeName
+				cvCount := ops.GetCstorVolumeCountEventually(openebsNamespace, cvLabel, 0)
+				Expect(cvCount).To(Equal(true), "while checking cstorvolume count")
+			})
+		})
+
+	})


### PR DESCRIPTION
**What this PR does / why we need it**:
  TargetNodeSelector allows you to specify the nodes where openebs targets have to be scheduled.
  Test requires minimum 1 Node in k8s cluster, any available ready Node will be labeled using k8s patch 
  with "nodetype: storage" to schedule the target volume pod to  above matched labeled Node.

TargetNodeSelector cas config label has been set using StorageClass
   as below

```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  annotations:
    cas.openebs.io/config: |
      - name: ReplicaCount
        value: 1
      - name: StoragePoolClaim
        value: test-cstor-selector-sparse-pool-auto-1560848294807552442
      - name: TargetNodeSelector
        value: |-
          nodetype: storage
    openebs.io/cas-type: cstor
  name: test-cstor-volume-selector-sc-7pcz6
```
```go
 ginkgo -v -- --kubeconfig=/var/run/kubernetes/admin.kubeconfig --cstor-replicas=1 --cstor-maxpools=1
Running Suite: Test cstor volume provisioning using target Node selector
========================================================================
Random Seed: 1560849930
Will run 1 of 1 specs

STEP: waiting for maya-apiserver pod to come into running state
STEP: waiting for openebs-provisioner pod to come into running state
STEP: Verifying 'admission-server' pod status as running
STEP: building a namespace
STEP: creating a namespace
STEP: listing ready nodes
STEP: verifying minimum node count to be 1
STEP: labeling node as 'nodetype:storage' 
[cstor] TEST VOLUME PROVISIONING USING TARGET AND REPLICA SELECTOR when cstor pvc with replicacount 1 is created 
  should create cstor volume target pod
  /home/prateek/gocode/src/github.com/openebs/maya/tests/cstor/node-selector/volume_selector_test.go:95
STEP: building spc object
STEP: creating storagepoolclaim
STEP: verifying healthy csp count
STEP: building a CAS Config with generated SPC name
STEP: building object of storageclass
STEP: creating storageclass
STEP: building a pvc
STEP: creating above pvc
STEP: verifying target pod count as 1
STEP: verifying cstorvolume replica count
STEP: verifying pvc status as bound
STEP: deleting above pvc
STEP: verifying target pod count as 0
STEP: verifying deleted pvc
STEP: verifying if cstorvolume is deleted
STEP: deleting resources created for testing cstor volume provisioning
STEP: deleting storagepoolclaim
STEP: deleting storageclass

• [SLOW TEST:81.799 seconds]
[cstor] TEST VOLUME PROVISIONING USING TARGET AND REPLICA SELECTOR
/home/prateek/gocode/src/github.com/openebs/maya/tests/cstor/node-selector/volume_selector_test.go:34
  when cstor pvc with replicacount 1 is created
  /home/prateek/gocode/src/github.com/openebs/maya/tests/cstor/node-selector/volume_selector_test.go:94
    should create cstor volume target pod
    /home/prateek/gocode/src/github.com/openebs/maya/tests/cstor/node-selector/volume_selector_test.go:95
------------------------------
STEP: deleting namespace
STEP: remove selector label from labeled nodes

Ran 1 of 1 Specs in 81.889 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 1m25.10182007s
Test Suite Passed


```


Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->



**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests