### PR TITLE
fix(apis): change ndm apis

### DIFF
--- a/pkg/apis/openebs.io/ndm/v1alpha1/blockdevice_types.go
+++ b/pkg/apis/openebs.io/ndm/v1alpha1/blockdevice_types.go
@@ -73,10 +73,14 @@ type DeviceStatus struct {
 type DeviceClaimState string
 
 const (
-	// BlockDeviceUnclaimed represents that the block device is not bound to any BDC
-	BlockDeviceUnclaimed = "Unclaimed"
+	// BlockDeviceUnclaimed represents that the block device is not bound to any BDC,
+	// all cleanup jobs have been completed and is available for claiming.
+	BlockDeviceUnclaimed DeviceClaimState = "Unclaimed"
+	// BlockDeviceReleased represents that the block device is released from the BDC,
+	// pending cleanup jobs
+	BlockDeviceReleased DeviceClaimState = "Released"
 	// BlockDeviceClaimed represents that the block device is bound to a BDC
-	BlockDeviceClaimed = "Claimed"
+	BlockDeviceClaimed DeviceClaimState = "Claimed"
 )
 
 // +genclient

--- a/pkg/apis/openebs.io/ndm/v1alpha1/blockdeviceclaim_types.go
+++ b/pkg/apis/openebs.io/ndm/v1alpha1/blockdeviceclaim_types.go
@@ -69,10 +69,26 @@ const (
 
 // DeviceClaimDetails defines the details of the block device that should be claimed
 type DeviceClaimDetails struct {
-	DeviceFormat   string `json:"formatType,omitempty"`     //Format of the device required, eg:ext4, xfs
-	MountPoint     string `json:"mountPoint,omitempty"`     //MountPoint of the device required. Claim device from the specified mountpoint.
-	AllowPartition bool   `json:"allowPartition,omitempty"` //AllowPartition represents whether to claim a full block device or a device that is a partition
+	// BlockVolumeMode represents whether to claim a device in Block mode or Filesystem mode.
+	// These are use cases of BlockVolumeMode:
+	// 1) Not specified: VolumeMode check will not be effective
+	// 2) VolumeModeBlock: BD should not have any filesystem or mountpoint
+	// 3) VolumeModeFileSystem: BD should have a filesystem and mountpoint. If DeviceFormat is
+	//    specified then the format should match with the FSType in BD
+	BlockVolumeMode BlockDeviceVolumeMode `json:"blockVolumeMode,omitempty"`
+	DeviceFormat    string                `json:"formatType,omitempty"`     //Format of the device required, eg:ext4, xfs
+	AllowPartition  bool                  `json:"allowPartition,omitempty"` //AllowPartition represents whether to claim a full block device or a device that is a partition
 }
+
+// BlockDeviceVolumeMode specifies the type in which the BlockDevice can be used
+type BlockDeviceVolumeMode string
+
+const (
+	// VolumeModeBlock specifies that the block device needs to be used as a raw block
+	VolumeModeBlock BlockDeviceVolumeMode = "Block"
+	// VolumeModeFileSystem specifies that block device will be used with a filesystem already existing
+	VolumeModeFileSystem BlockDeviceVolumeMode = "FileSystem"
+)
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/openebs.io/ndm/v1alpha1/blockdeviceclaim_types.go
+++ b/pkg/apis/openebs.io/ndm/v1alpha1/blockdeviceclaim_types.go
@@ -76,8 +76,12 @@ type DeviceClaimDetails struct {
 	// 3) VolumeModeFileSystem: BD should have a filesystem and mountpoint. If DeviceFormat is
 	//    specified then the format should match with the FSType in BD
 	BlockVolumeMode BlockDeviceVolumeMode `json:"blockVolumeMode,omitempty"`
-	DeviceFormat    string                `json:"formatType,omitempty"`     //Format of the device required, eg:ext4, xfs
-	AllowPartition  bool                  `json:"allowPartition,omitempty"` //AllowPartition represents whether to claim a full block device or a device that is a partition
+
+	//Format of the device required, eg:ext4, xfs
+	DeviceFormat string `json:"formatType,omitempty"`
+
+	//AllowPartition represents whether to claim a full block device or a device that is a partition
+	AllowPartition bool `json:"allowPartition,omitempty"`
 }
 
 // BlockDeviceVolumeMode specifies the type in which the BlockDevice can be used
@@ -86,7 +90,9 @@ type BlockDeviceVolumeMode string
 const (
 	// VolumeModeBlock specifies that the block device needs to be used as a raw block
 	VolumeModeBlock BlockDeviceVolumeMode = "Block"
-	// VolumeModeFileSystem specifies that block device will be used with a filesystem already existing
+
+	// VolumeModeFileSystem specifies that block device will be used with a filesystem
+	// already existing
 	VolumeModeFileSystem BlockDeviceVolumeMode = "FileSystem"
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Changed BlockDevice and BlockDeviceClaim APIs

1. Introduced a new state `Released` in BlockDevice `ClaimState`. A BD will be in `Released` state once the associated BDC is deleted, and cleanup jobs are being performed on the BD. Once the cleanup job is successful, BD will be marked as `Unclaimed` and can be claimed by other BDCs
2. Removed `Mountpoint` from BDC. The field is irrevelant because it is not possible to create a claim with a particular mount point, since it involves iterating through all the BDs. 
`BlockVolumeMode` is introduced which is used to specify the type of BD to claim. Depending on the volume mode, either unformatted device or BD with a filesystem can be claimed

State transition of `claimState` for a block device
**1.** Sample BD in unclaimed state
```yaml
apiVersion: openebs.io/v1alpha1
kind: BlockDevice
metadata:
  creationTimestamp: "2019-06-18T09:27:24Z"
  generation: 7
  labels:
    kubernetes.io/hostname: minikube
    ndm.io/blockdevice-type: blockdevice
    ndm.io/managed: "true"
  name: sparse-92afc63c6788baf4b268e63d96be1e0d
  namespace: default
  resourceVersion: "31508"
  selfLink: /apis/openebs.io/v1alpha1/namespaces/default/blockdevices/sparse-92afc63c6788baf4b268e63d96be1e0d
  uid: 47edf7c3-91ab-11e9-bea0-9840bb3de22d
spec:
  capacity:
    logicalSectorSize: 0
    physicalSectorSize: 0
    storage: 1073741824
  details:
    compliance: ""
    deviceType: sparse
    firmwareRevision: ""
    model: ""
    serial: ""
    vendor: ""
  devlinks: []
  filesystem: {}
  partitioned: "No"
  path: /var/openebs/sparse/0-ndm-sparse.img
status:
  claimState: Unclaimed
  state: Active
```

**2.** When a BDC is created, the BD will be in claimed state
```yaml
apiVersion: openebs.io/v1alpha1
kind: BlockDevice
metadata:
  creationTimestamp: "2019-06-18T09:27:24Z"
  generation: 8
  labels:
    kubernetes.io/hostname: minikube
    ndm.io/blockdevice-type: blockdevice
    ndm.io/managed: "true"
  name: sparse-92afc63c6788baf4b268e63d96be1e0d
  namespace: default
  resourceVersion: "32135"
  selfLink: /apis/openebs.io/v1alpha1/namespaces/default/blockdevices/sparse-92afc63c6788baf4b268e63d96be1e0d
  uid: 47edf7c3-91ab-11e9-bea0-9840bb3de22d
spec:
  capacity:
    logicalSectorSize: 0
    physicalSectorSize: 0
    storage: 1073741824
  claimRef:
    apiVersion: openebs.io/v1alpha1
    kind: BlockDeviceClaim
    name: test-blockdeviceclaim
    namespace: default
    resourceVersion: "32134"
    uid: 982b4c87-91cb-11e9-bea0-9840bb3de22d
  details:
    compliance: ""
    deviceType: sparse
    firmwareRevision: ""
    model: ""
    serial: ""
    vendor: ""
  devlinks: []
  filesystem: {}
  partitioned: "No"
  path: /var/openebs/sparse/0-ndm-sparse.img
status:
  claimState: Claimed
  state: Active
```

**3.** Deleting BDC, changes the `claimState` of BD to `Released`, which means the BD is not being bound to any BDC, but some cleanup jobs are being performed on the BD.
```yaml
apiVersion: openebs.io/v1alpha1
kind: BlockDevice
metadata:
  creationTimestamp: "2019-06-18T09:27:24Z"
  generation: 9
  labels:
    kubernetes.io/hostname: minikube
    ndm.io/blockdevice-type: blockdevice
    ndm.io/managed: "true"
  name: sparse-92afc63c6788baf4b268e63d96be1e0d
  namespace: default
  resourceVersion: "32280"
  selfLink: /apis/openebs.io/v1alpha1/namespaces/default/blockdevices/sparse-92afc63c6788baf4b268e63d96be1e0d
  uid: 47edf7c3-91ab-11e9-bea0-9840bb3de22d
spec:
  capacity:
    logicalSectorSize: 0
    physicalSectorSize: 0
    storage: 1073741824
  details:
    compliance: ""
    deviceType: sparse
    firmwareRevision: ""
    model: ""
    serial: ""
    vendor: ""
  devlinks: []
  filesystem: {}
  partitioned: "No"
  path: /var/openebs/sparse/0-ndm-sparse.img
status:
  claimState: Released
  state: Active
```

**4.** When the cleanup job is finished, the BD will be marked as `Unclaimed`
```yaml
apiVersion: openebs.io/v1alpha1
kind: BlockDevice
metadata:
  creationTimestamp: "2019-06-18T09:27:24Z"
  generation: 10
  labels:
    kubernetes.io/hostname: minikube
    ndm.io/blockdevice-type: blockdevice
    ndm.io/managed: "true"
  name: sparse-92afc63c6788baf4b268e63d96be1e0d
  namespace: default
  resourceVersion: "32342"
  selfLink: /apis/openebs.io/v1alpha1/namespaces/default/blockdevices/sparse-92afc63c6788baf4b268e63d96be1e0d
  uid: 47edf7c3-91ab-11e9-bea0-9840bb3de22d
spec:
  capacity:
    logicalSectorSize: 0
    physicalSectorSize: 0
    storage: 1073741824
  details:
    compliance: ""
    deviceType: sparse
    firmwareRevision: ""
    model: ""
    serial: ""
    vendor: ""
  devlinks: []
  filesystem: {}
  partitioned: "No"
  path: /var/openebs/sparse/0-ndm-sparse.img
status:
  claimState: Unclaimed
  state: Active
```
**Special notes for your reviewer**:
There is no change in autogen code, as only constants have been added to the APIs