### PR TITLE
cherry-pick(apis): change ndm apis

### DIFF
--- a/pkg/apis/openebs.io/ndm/v1alpha1/blockdevice_types.go
+++ b/pkg/apis/openebs.io/ndm/v1alpha1/blockdevice_types.go
@@ -73,10 +73,14 @@ type DeviceStatus struct {
 type DeviceClaimState string
 
 const (
-	// BlockDeviceUnclaimed represents that the block device is not bound to any BDC
-	BlockDeviceUnclaimed = "Unclaimed"
+	// BlockDeviceUnclaimed represents that the block device is not bound to any BDC,
+	// all cleanup jobs have been completed and is available for claiming.
+	BlockDeviceUnclaimed DeviceClaimState = "Unclaimed"
+	// BlockDeviceReleased represents that the block device is released from the BDC,
+	// pending cleanup jobs
+	BlockDeviceReleased DeviceClaimState = "Released"
 	// BlockDeviceClaimed represents that the block device is bound to a BDC
-	BlockDeviceClaimed = "Claimed"
+	BlockDeviceClaimed DeviceClaimState = "Claimed"
 )
 
 // +genclient

--- a/pkg/apis/openebs.io/ndm/v1alpha1/blockdeviceclaim_types.go
+++ b/pkg/apis/openebs.io/ndm/v1alpha1/blockdeviceclaim_types.go
@@ -69,10 +69,32 @@ const (
 
 // DeviceClaimDetails defines the details of the block device that should be claimed
 type DeviceClaimDetails struct {
-	DeviceFormat   string `json:"formatType,omitempty"`     //Format of the device required, eg:ext4, xfs
-	MountPoint     string `json:"mountPoint,omitempty"`     //MountPoint of the device required. Claim device from the specified mountpoint.
-	AllowPartition bool   `json:"allowPartition,omitempty"` //AllowPartition represents whether to claim a full block device or a device that is a partition
+	// BlockVolumeMode represents whether to claim a device in Block mode or Filesystem mode.
+	// These are use cases of BlockVolumeMode:
+	// 1) Not specified: VolumeMode check will not be effective
+	// 2) VolumeModeBlock: BD should not have any filesystem or mountpoint
+	// 3) VolumeModeFileSystem: BD should have a filesystem and mountpoint. If DeviceFormat is
+	//    specified then the format should match with the FSType in BD
+	BlockVolumeMode BlockDeviceVolumeMode `json:"blockVolumeMode,omitempty"`
+
+	//Format of the device required, eg:ext4, xfs
+	DeviceFormat string `json:"formatType,omitempty"`
+
+	//AllowPartition represents whether to claim a full block device or a device that is a partition
+	AllowPartition bool `json:"allowPartition,omitempty"`
 }
+
+// BlockDeviceVolumeMode specifies the type in which the BlockDevice can be used
+type BlockDeviceVolumeMode string
+
+const (
+	// VolumeModeBlock specifies that the block device needs to be used as a raw block
+	VolumeModeBlock BlockDeviceVolumeMode = "Block"
+
+	// VolumeModeFileSystem specifies that block device will be used with a filesystem
+	// already existing
+	VolumeModeFileSystem BlockDeviceVolumeMode = "FileSystem"
+)
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
Changed BlockDevice and BlockDeviceClaim APIs

Introduced a new state Released in BlockDevice ClaimState. A BD will be in Released state once the associated BDC is deleted, and cleanup jobs are being performed on the BD. Once the cleanup job is successful, BD will be marked as Unclaimed and can be claimed by other BDCs

Removed Mountpoint from BDC. The field is irrevelant because it is not possible to create a claim with a particular mount point, since it involves iterating through all the BDs.

BlockVolumeMode is introduced which is used to specify the type of BD to claim. Depending on the volume mode, either unformatted device or BD with a filesystem can be claimed

Cherry-pick #1302 

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>