### PR TITLE
[cherry-pick] refactor(localpv): move the pv parsing to pv helper package (#1304)

### DIFF
--- a/pkg/kubernetes/persistentvolume/v1alpha1/build.go
+++ b/pkg/kubernetes/persistentvolume/v1alpha1/build.go
@@ -141,7 +141,7 @@ func (b *Builder) WithNodeAffinity(nodeName string) *Builder {
 				{
 					MatchExpressions: []corev1.NodeSelectorRequirement{
 						{
-							Key:      "kubernetes.io/hostname",
+							Key:      KeyNode,
 							Operator: corev1.NodeSelectorOpIn,
 							Values: []string{
 								nodeName,

--- a/pkg/kubernetes/persistentvolume/v1alpha1/build_test.go
+++ b/pkg/kubernetes/persistentvolume/v1alpha1/build_test.go
@@ -305,7 +305,7 @@ func TestBuildHostPath(t *testing.T) {
 								{
 									MatchExpressions: []corev1.NodeSelectorRequirement{
 										{
-											Key:      "kubernetes.io/hostname",
+											Key:      KeyNode,
 											Operator: corev1.NodeSelectorOpIn,
 											Values: []string{
 												"node1",

--- a/pkg/kubernetes/persistentvolume/v1alpha1/kubernetes.go
+++ b/pkg/kubernetes/persistentvolume/v1alpha1/kubernetes.go
@@ -26,6 +26,12 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+const (
+	//KeyNode represents the key values used for specifying the Node Affinity
+	// based on the hostname
+	KeyNode = "kubernetes.io/hostname"
+)
+
 // getClientsetFn is a typed function that
 // abstracts fetching of clientset
 type getClientsetFn func() (clientset *kubernetes.Clientset, err error)


### PR DESCRIPTION
This PR moves the logic to parse the PV attributes to
PV helper pkg.

Signed-off-by: kmova <kiran.mova@mayadata.io>
(cherry picked from commit 4a1a2082084a8054bbd730f5dd171eba709e8672)

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests