### PR TITLE
(cherry-pick)fix(cvr, delete): ensure cvr gets deleted during reconcile (#1263)

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/common/common.go
+++ b/cmd/cstor-pool-mgmt/controller/common/common.go
@@ -125,7 +125,9 @@ const (
 // InitialImportedPoolVol is to store pool-volume names while pod restart.
 var InitialImportedPoolVol []string
 
-// QueueLoad is for storing the key and type of operation before entering workqueue
+// QueueLoad represents the payload of the workqueue
+//
+// It stores the key and corresponding type of operation
 type QueueLoad struct {
 	Key       string
 	Operation QueueOperation
@@ -139,15 +141,19 @@ const (
 	OpenEBSIOCStorID Environment = "OPENEBS_IO_CSTOR_ID"
 )
 
-//QueueOperation represents the type of operation on resource
+// QueueOperation determines the type of operation
+// that needs to be executed on the watched resource
 type QueueOperation string
 
-//Different type of operations on the controller
+// Different type of operations that can be
+// supported by the controller/watcher logic
 const (
 	QOpAdd     QueueOperation = "add"
 	QOpDestroy QueueOperation = "destroy"
 	QOpModify  QueueOperation = "modify"
-	// QOpSync is the operation for syncing(reconciling) on cstor pool object.
+
+	// QOpSync is the operation to reconcile
+	// cstor pool resource
 	QOpSync QueueOperation = "Sync"
 )
 

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -351,13 +351,10 @@ func IsOnlyStatusChange(oldCVR, newCVR *apis.CStorVolumeReplica) bool {
 	return false
 }
 
-// IsDeletionFailedBefore is to make sure no other operation should happen if the
-// status of CStorVolumeReplica is deletion-failed.
-func IsDeletionFailedBefore(cVR *apis.CStorVolumeReplica) bool {
-	if cVR.Status.Phase == apis.CVRStatusDeletionFailed {
-		return true
-	}
-	return false
+// IsDeletionFailedBefore flags if status of
+// cvr is CVRStatusDeletionFailed
+func IsDeletionFailedBefore(cvrObj *apis.CStorVolumeReplica) bool {
+	return cvrObj.Status.Phase == apis.CVRStatusDeletionFailed
 }
 
 // IsStatusOnline is to check if the status of cStorVolumeReplica object is
@@ -402,14 +399,10 @@ func IsRecreateStatus(cVR *apis.CStorVolumeReplica) bool {
 	return false
 }
 
-// IsErrorDuplicate is to check if the status of cStorVolumeReplica object is error-duplicate.
-func IsErrorDuplicate(cVR *apis.CStorVolumeReplica) bool {
-	if string(cVR.Status.Phase) == string(apis.CVRStatusErrorDuplicate) {
-		glog.Infof("cVR duplication error: %v", string(cVR.ObjectMeta.UID))
-		return true
-	}
-	glog.V(4).Infof("Not error duplicate status: %v", string(cVR.ObjectMeta.UID))
-	return false
+// IsErrorDuplicate flags if cvr resource is a duplicate
+// entry
+func IsErrorDuplicate(cvrObj *apis.CStorVolumeReplica) bool {
+	return cvrObj.Status.Phase == apis.CVRStatusErrorDuplicate
 }
 
 //  getCVRStatus is a wrapper that fetches the status of cstor volume.


### PR DESCRIPTION
This commit has following changes:
- remove the check where reconcile was avoided in case
of previous delete failures
- reduce instances of log flooding
- improve log messages
- modify & indent code to make it more readable

Related PR(s):
- https://github.com/openebs/maya/pull/1256
This commit tries to fix the symptom 2 talked in PR 1256

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests