### PR TITLE
feat(cstor-operator): filter out released block devices during auto provisioning

### DIFF
--- a/pkg/algorithm/nodeselect/v1alpha1/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node.go
@@ -256,7 +256,7 @@ func (ac *Config) getBlockDevice() (*ndmapis.BlockDeviceList, error) {
 	}
 
 	if ProvisioningType(ac.Spc) == ProvisioningTypeAuto {
-		filterList = append(filterList, blockdevice.FilterNonFSType)
+		filterList = append(filterList, blockdevice.FilterNonFSType, blockdevice.FilterNonRelesedDevices)
 	}
 
 	bdl = bdList.Filter(filterList...)

--- a/pkg/blockdevice/v1alpha1/blockdevice.go
+++ b/pkg/blockdevice/v1alpha1/blockdevice.go
@@ -34,10 +34,11 @@ const (
 	FilterInactive    = "filterInactive"
 	FilterNonInactive = "filterNonInactive"
 	//FilterNonPartitions    = "filterNonPartitions"
-	FilterNonFSType        = "filterNonFSType"
-	FilterSparseDevices    = "filterSparseDevices"
-	FilterNonSparseDevices = "filterNonSparseDevices"
-	InActiveStatus         = "Inactive"
+	FilterNonFSType         = "filterNonFSType"
+	FilterSparseDevices     = "filterSparseDevices"
+	FilterNonSparseDevices  = "filterNonSparseDevices"
+	InActiveStatus          = "Inactive"
+	FilterNonRelesedDevices = "filterNonRelesedDevices"
 )
 
 // DefaultDiskCount is a map containing the default block device count of various raid types.
@@ -113,9 +114,10 @@ var filterOptionFuncMap = map[string]filterOptionFunc{
 	FilterInactive:    filterInactive,
 	FilterNonInactive: filterNonInactive,
 	//FilterNonPartitions:    filterNonPartitions,
-	FilterNonFSType:        filterNonFSType,
-	FilterSparseDevices:    filterSparseDevices,
-	FilterNonSparseDevices: filterNonSparseDevices,
+	FilterNonFSType:         filterNonFSType,
+	FilterSparseDevices:     filterSparseDevices,
+	FilterNonSparseDevices:  filterNonSparseDevices,
+	FilterNonRelesedDevices: filterNonRelesedDevices,
 }
 
 // predicateFailedError returns the predicate error which is provided to this function as an argument
@@ -283,6 +285,19 @@ func filterNonSparseDevices(originalList *BlockDeviceList) *BlockDeviceList {
 	}
 	for _, device := range originalList.Items {
 		if !(device.Spec.Details.DeviceType == string(apis.TypeSparseCPV)) {
+			filteredList.Items = append(filteredList.Items, device)
+		}
+	}
+	return filteredList
+}
+
+func filterNonRelesedDevices(originalList *BlockDeviceList) *BlockDeviceList {
+	filteredList := &BlockDeviceList{
+		BlockDeviceList: &ndm.BlockDeviceList{},
+		errs:            nil,
+	}
+	for _, device := range originalList.Items {
+		if !(device.Status.ClaimState == ndm.BlockDeviceReleased) {
 			filteredList.Items = append(filteredList.Items, device)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds the filter to filter out block devices which are in released state during auto provision mode.
 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests