### PR TITLE
refact(builder) added new methods to deploymet builder

### DIFF
--- a/pkg/kubernetes/deployment/appsv1/v1alpha1/deployment_test.go
+++ b/pkg/kubernetes/deployment/appsv1/v1alpha1/deployment_test.go
@@ -1,0 +1,424 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	pts "github.com/openebs/maya/pkg/kubernetes/podtemplatespec/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func TestBuilderWithName(t *testing.T) {
+	tests := map[string]struct {
+		name      string
+		builder   *Builder
+		expectErr bool
+	}{
+		"Test Builder with name": {
+			name: "PVC1",
+			builder: &Builder{deployment: &Deploy{
+				Object: &appsv1.Deployment{},
+			}},
+			expectErr: false,
+		},
+		"Test Builder without name": {
+			name: "",
+			builder: &Builder{deployment: &Deploy{
+				Object: &appsv1.Deployment{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithName(mock.name)
+			if mock.expectErr && len(b.errors) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errors) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuilderWithNamespace(t *testing.T) {
+	tests := map[string]struct {
+		namespace string
+		builder   *Builder
+		expectErr bool
+	}{
+		"Test Builder with namespace": {
+			namespace: "PVC1",
+			builder: &Builder{deployment: &Deploy{
+				Object: &appsv1.Deployment{},
+			}},
+			expectErr: false,
+		},
+		"Test Builder without namespace": {
+			namespace: "",
+			builder: &Builder{deployment: &Deploy{
+				Object: &appsv1.Deployment{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithNamespace(mock.namespace)
+			if mock.expectErr && len(b.errors) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errors) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuildWithAnnotations(t *testing.T) {
+	tests := map[string]struct {
+		annotations map[string]string
+		builder     *Builder
+		expectErr   bool
+	}{
+		"Test Builderwith annotations": {
+			annotations: map[string]string{"persistent-volume": "PV",
+				"application": "percona"},
+			builder: &Builder{deployment: &Deploy{
+				Object: &appsv1.Deployment{},
+			}},
+			expectErr: false,
+		},
+		"Test Builderwithout annotations": {
+			annotations: map[string]string{},
+			builder: &Builder{deployment: &Deploy{
+				Object: &appsv1.Deployment{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithAnnotations(mock.annotations)
+			if mock.expectErr && len(b.errors) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errors) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuildWithAnnotationsNew(t *testing.T) {
+	tests := map[string]struct {
+		annotations map[string]string
+		builder     *Builder
+		expectErr   bool
+	}{
+		"Test Builderwith annotations": {
+			annotations: map[string]string{"persistent-volume": "PV",
+				"application": "percona"},
+			builder: &Builder{deployment: &Deploy{
+				Object: &appsv1.Deployment{},
+			}},
+			expectErr: false,
+		},
+		"Test Builderwithout annotations": {
+			annotations: map[string]string{},
+			builder: &Builder{deployment: &Deploy{
+				Object: &appsv1.Deployment{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithAnnotationsNew(mock.annotations)
+			if mock.expectErr && len(b.errors) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errors) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuildWithLabels(t *testing.T) {
+	tests := map[string]struct {
+		labels    map[string]string
+		builder   *Builder
+		expectErr bool
+	}{
+		"Test Builderwith labels": {
+			labels: map[string]string{"persistent-volume": "PV",
+				"application": "percona"},
+			builder: &Builder{deployment: &Deploy{
+				Object: &appsv1.Deployment{},
+			}},
+			expectErr: false,
+		},
+		"Test Builderwithout labels": {
+			labels: map[string]string{},
+			builder: &Builder{deployment: &Deploy{
+				Object: &appsv1.Deployment{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithLabels(mock.labels)
+			if mock.expectErr && len(b.errors) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errors) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuildWithLabelsNew(t *testing.T) {
+	tests := map[string]struct {
+		labels    map[string]string
+		builder   *Builder
+		expectErr bool
+	}{
+		"Test Builderwith labels": {
+			labels: map[string]string{"persistent-volume": "PV",
+				"application": "percona"},
+			builder: &Builder{deployment: &Deploy{
+				Object: &appsv1.Deployment{},
+			}},
+			expectErr: false,
+		},
+		"Test Builderwithout labels": {
+			labels: map[string]string{},
+			builder: &Builder{deployment: &Deploy{
+				Object: &appsv1.Deployment{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithLabelsNew(mock.labels)
+			if mock.expectErr && len(b.errors) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errors) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuildWithSelectorMatchLabels(t *testing.T) {
+	tests := map[string]struct {
+		matchLabels map[string]string
+		builder     *Builder
+		expectErr   bool
+	}{
+		"Test Builderwith matchLabels": {
+			matchLabels: map[string]string{"persistent-volume": "PV",
+				"application": "percona"},
+			builder: &Builder{deployment: &Deploy{
+				Object: &appsv1.Deployment{},
+			}},
+			expectErr: false,
+		},
+		"Test Builderwithout matchLabels": {
+			matchLabels: map[string]string{},
+			builder: &Builder{deployment: &Deploy{
+				Object: &appsv1.Deployment{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithSelectorMatchLabels(mock.matchLabels)
+			if mock.expectErr && len(b.errors) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errors) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuildWithSelectorMatchLabelsNew(t *testing.T) {
+	tests := map[string]struct {
+		matchLabels map[string]string
+		builder     *Builder
+		expectErr   bool
+	}{
+		"Test Builderwith matchLabels": {
+			matchLabels: map[string]string{"persistent-volume": "PV",
+				"application": "percona"},
+			builder: &Builder{deployment: &Deploy{
+				Object: &appsv1.Deployment{},
+			}},
+			expectErr: false,
+		},
+		"Test Builderwithout matchLabels": {
+			matchLabels: map[string]string{},
+			builder: &Builder{deployment: &Deploy{
+				Object: &appsv1.Deployment{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithSelectorMatchLabelsNew(mock.matchLabels)
+			if mock.expectErr && len(b.errors) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errors) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuilderWithReplicas(t *testing.T) {
+	samplereplicas := int32(3)
+	invalidreplicas := int32(-1)
+	tests := map[string]struct {
+		replicas  *int32
+		builder   *Builder
+		expectErr bool
+	}{
+		"Test Builder with replicas": {
+			replicas: &samplereplicas,
+			builder: &Builder{deployment: &Deploy{
+				Object: &appsv1.Deployment{},
+			}},
+			expectErr: false,
+		},
+		"Test Builder without replicas": {
+			replicas: nil,
+			builder: &Builder{deployment: &Deploy{
+				Object: &appsv1.Deployment{},
+			}},
+			expectErr: true,
+		},
+		"Test Builder with invalid replicas": {
+			replicas: &invalidreplicas,
+			builder: &Builder{deployment: &Deploy{
+				Object: &appsv1.Deployment{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithReplicas(mock.replicas)
+			if mock.expectErr && len(b.errors) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errors) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuilderWithStrategyType(t *testing.T) {
+	tests := map[string]struct {
+		strategyType appsv1.DeploymentStrategyType
+		builder      *Builder
+		expectErr    bool
+	}{
+		"Test Builder with strategyType": {
+			strategyType: appsv1.RecreateDeploymentStrategyType,
+			builder: &Builder{deployment: &Deploy{
+				Object: &appsv1.Deployment{},
+			}},
+			expectErr: false,
+		},
+		"Test Builder without strategyType": {
+			strategyType: appsv1.DeploymentStrategyType(""),
+			builder: &Builder{deployment: &Deploy{
+				Object: &appsv1.Deployment{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithStrategyType(mock.strategyType)
+			if mock.expectErr && len(b.errors) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errors) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuilderWithPodTemplateSpec(t *testing.T) {
+	tests := map[string]struct {
+		templateSpec *pts.Builder
+		builder      *Builder
+		expectErr    bool
+	}{
+		"Test Builder with templateSpec": {
+			templateSpec: pts.NewBuilder(),
+			builder: &Builder{deployment: &Deploy{
+				Object: &appsv1.Deployment{},
+			}},
+			expectErr: false,
+		},
+		"Test Builder without templateSpec": {
+			templateSpec: nil,
+			builder: &Builder{deployment: &Deploy{
+				Object: &appsv1.Deployment{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithPodTemplateSpecBuilder(mock.templateSpec)
+			if mock.expectErr && len(b.errors) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errors) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}

--- a/pkg/kubernetes/podtemplatespec/v1alpha1/podtemplatespec.go
+++ b/pkg/kubernetes/podtemplatespec/v1alpha1/podtemplatespec.go
@@ -1,0 +1,278 @@
+// Copyright © 2018-2019 The OpenEBS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
+	container "github.com/openebs/maya/pkg/kubernetes/container/v1alpha1"
+	volume "github.com/openebs/maya/pkg/kubernetes/volume/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// PodTemplateSpec holds the api's podtemplatespec objects
+type PodTemplateSpec struct {
+	Object *corev1.PodTemplateSpec
+}
+
+// Builder is the builder object for Pod
+type Builder struct {
+	podtemplatespec *PodTemplateSpec
+	errs            []error
+}
+
+// NewBuilder returns new instance of Builder
+func NewBuilder() *Builder {
+	return &Builder{
+		podtemplatespec: &PodTemplateSpec{
+			Object: &corev1.PodTemplateSpec{},
+		},
+	}
+}
+
+// WithName sets the Name field of podtemplatespec with provided value.
+func (b *Builder) WithName(name string) *Builder {
+	if len(name) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build podtemplatespec object: missing name"),
+		)
+		return b
+	}
+	b.podtemplatespec.Object.Name = name
+	return b
+}
+
+// WithNamespace sets the Namespace field of PodTemplateSpec with provided value.
+func (b *Builder) WithNamespace(namespace string) *Builder {
+	if len(namespace) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build podtemplatespec object: missing namespace",
+			),
+		)
+		return b
+	}
+	b.podtemplatespec.Object.Namespace = namespace
+	return b
+}
+
+// WithAnnotationsNew sets the annotation field of podtemplatespec
+func (b *Builder) WithAnnotationsNew(annotations map[string]string) *Builder {
+	if len(annotations) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build podtemplatespec object: missing annotations",
+			),
+		)
+		return b
+	}
+
+	// copy of original map
+	newannotations := map[string]string{}
+	for key, value := range annotations {
+		newannotations[key] = value
+	}
+
+	// override
+	b.podtemplatespec.Object.Annotations = newannotations
+	return b
+}
+
+// WithLabelsNew sets the labels field of podtemplatespec
+func (b *Builder) WithLabelsNew(labels map[string]string) *Builder {
+	if len(labels) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build podtemplatespec object: missing labels",
+			),
+		)
+		return b
+	}
+
+	// copy of original map
+	newlbls := map[string]string{}
+	for key, value := range labels {
+		newlbls[key] = value
+	}
+
+	// override
+	b.podtemplatespec.Object.Labels = newlbls
+	return b
+}
+
+// WithNodeSelectorNew sets the nodeselector field of podtemplatespec
+func (b *Builder) WithNodeSelectorNew(nodeselectors map[string]string) *Builder {
+	if len(nodeselectors) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build podtemplatespec object: missing nodeselectors",
+			),
+		)
+		return b
+	}
+
+	// copy of original map
+	newnodeselectors := map[string]string{}
+	for key, value := range nodeselectors {
+		newnodeselectors[key] = value
+	}
+
+	// override
+	b.podtemplatespec.Object.Spec.NodeSelector = newnodeselectors
+	return b
+}
+
+// WithServiceAccountName sets the ServiceAccountnNme field of podtemplatespec
+func (b *Builder) WithServiceAccountName(serviceAccountnNme string) *Builder {
+	if len(serviceAccountnNme) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build podtemplatespec object: missing serviceaccountname",
+			),
+		)
+		return b
+	}
+
+	b.podtemplatespec.Object.Spec.ServiceAccountName = serviceAccountnNme
+	return b
+}
+
+// WithAffinity sets the affinity field of podtemplatespec
+func (b *Builder) WithAffinity(affinity *corev1.Affinity) *Builder {
+	if affinity == nil {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build podtemplatespec object: missing affinity",
+			),
+		)
+		return b
+	}
+
+	// copy of original pointer
+	newaffinitylist := *affinity
+
+	b.podtemplatespec.Object.Spec.Affinity = &newaffinitylist
+	return b
+}
+
+// WithTolerationsNew sets the tolerations field of podtemplatespec
+func (b *Builder) WithTolerationsNew(tolerations ...corev1.Toleration) *Builder {
+	if len(tolerations) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build podtemplatespec object: missing tolerations",
+			),
+		)
+		return b
+	}
+
+	// copy of original slice
+	newtolerations := []corev1.Toleration{}
+	newtolerations = append(newtolerations, tolerations...)
+
+	b.podtemplatespec.Object.Spec.Tolerations = newtolerations
+
+	return b
+}
+
+// WithContainerBuilders builds the list of containerbuilder
+// provided and sets the containers field of the podtemplatespec
+func (b *Builder) WithContainerBuilders(
+	containerBuilderList ...*container.Builder,
+) *Builder {
+	if containerBuilderList == nil {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build podtemplatespec: nil containerbuilder"),
+		)
+	}
+	for _, containerBuilder := range containerBuilderList {
+		containerObj, err := containerBuilder.Build()
+		if err != nil {
+			b.errs = append(
+				b.errs,
+				errors.Wrap(
+					err,
+					"failed to build podtemplatespec: unable to build container",
+				),
+			)
+			return b
+		}
+		b.podtemplatespec.Object.Spec.Containers = append(
+			b.podtemplatespec.Object.Spec.Containers,
+			containerObj,
+		)
+	}
+	return b
+}
+
+// WithVolumeBuilders builds the list of volumebuilders provided
+// and sets Volumes field of podtemplatespec.
+func (b *Builder) WithVolumeBuilders(
+	volumeBuilderList ...*volume.Builder,
+) *Builder {
+	if volumeBuilderList == nil {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build podtemplatespec: nil volumeBuilderList"),
+		)
+	}
+	for _, volumeBuilder := range volumeBuilderList {
+		vol, err := volumeBuilder.Build()
+		if err != nil {
+			b.errs = append(
+				b.errs,
+				errors.Wrap(err, "failed to build podtemplatespec"),
+			)
+			return b
+		}
+		newvol := *vol
+		b.podtemplatespec.Object.Spec.Volumes = append(
+			b.podtemplatespec.Object.Spec.Volumes,
+			newvol,
+		)
+	}
+	return b
+}
+
+// Build returns a deployment instance
+func (b *Builder) Build() (*PodTemplateSpec, error) {
+	err := b.validate()
+	if err != nil {
+		return nil, errors.Wrapf(
+			err,
+			"failed to build a podtemplatespec: %s",
+			b.podtemplatespec.Object,
+		)
+	}
+	return b.podtemplatespec, nil
+}
+
+func (b *Builder) validate() error {
+	if len(b.errs) != 0 {
+		return errors.Errorf(
+			"failed to validate: build errors were found: %v",
+			b.errs,
+		)
+	}
+	return nil
+}

--- a/pkg/kubernetes/podtemplatespec/v1alpha1/podtemplatespec_test.go
+++ b/pkg/kubernetes/podtemplatespec/v1alpha1/podtemplatespec_test.go
@@ -1,0 +1,421 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	conatiner "github.com/openebs/maya/pkg/kubernetes/container/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestBuilderWithName(t *testing.T) {
+	tests := map[string]struct {
+		name      string
+		builder   *Builder
+		expectErr bool
+	}{
+		"Test Builder with name": {
+			name: "PVC1",
+			builder: &Builder{podtemplatespec: &PodTemplateSpec{
+				Object: &corev1.PodTemplateSpec{},
+			}},
+			expectErr: false,
+		},
+		"Test Builder without name": {
+			name: "",
+			builder: &Builder{podtemplatespec: &PodTemplateSpec{
+				Object: &corev1.PodTemplateSpec{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithName(mock.name)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuilderWithNamespace(t *testing.T) {
+	tests := map[string]struct {
+		namespace string
+		builder   *Builder
+		expectErr bool
+	}{
+		"Test Builder with namespace": {
+			namespace: "PVC1",
+			builder: &Builder{podtemplatespec: &PodTemplateSpec{
+				Object: &corev1.PodTemplateSpec{},
+			}},
+			expectErr: false,
+		},
+		"Test Builder without namespace": {
+			namespace: "",
+			builder: &Builder{podtemplatespec: &PodTemplateSpec{
+				Object: &corev1.PodTemplateSpec{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithNamespace(mock.namespace)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuildWithAnnotations(t *testing.T) {
+	tests := map[string]struct {
+		annotations map[string]string
+		builder     *Builder
+		expectErr   bool
+	}{
+		"Test Builderwith annotations": {
+			annotations: map[string]string{"persistent-volume": "PV",
+				"application": "percona"},
+			builder: &Builder{podtemplatespec: &PodTemplateSpec{
+				Object: &corev1.PodTemplateSpec{},
+			}},
+			expectErr: false,
+		},
+		"Test Builder without annotations": {
+			annotations: map[string]string{},
+			builder: &Builder{podtemplatespec: &PodTemplateSpec{
+				Object: &corev1.PodTemplateSpec{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithAnnotations(mock.annotations)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuildWithAnnotationsNew(t *testing.T) {
+	tests := map[string]struct {
+		annotations map[string]string
+		builder     *Builder
+		expectErr   bool
+	}{
+		"Test Builderwith annotations": {
+			annotations: map[string]string{"persistent-volume": "PV",
+				"application": "percona"},
+			builder: &Builder{podtemplatespec: &PodTemplateSpec{
+				Object: &corev1.PodTemplateSpec{},
+			}},
+			expectErr: false,
+		},
+		"Test Builder without annotations": {
+			annotations: map[string]string{},
+			builder: &Builder{podtemplatespec: &PodTemplateSpec{
+				Object: &corev1.PodTemplateSpec{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithAnnotationsNew(mock.annotations)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuildWithLabels(t *testing.T) {
+	tests := map[string]struct {
+		labels    map[string]string
+		builder   *Builder
+		expectErr bool
+	}{
+		"Test Builderwith labels": {
+			labels: map[string]string{"persistent-volume": "PV",
+				"application": "percona"},
+			builder: &Builder{podtemplatespec: &PodTemplateSpec{
+				Object: &corev1.PodTemplateSpec{},
+			}},
+			expectErr: false,
+		},
+		"Test Builder without labels": {
+			labels: map[string]string{},
+			builder: &Builder{podtemplatespec: &PodTemplateSpec{
+				Object: &corev1.PodTemplateSpec{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithLabels(mock.labels)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuildWithLabelsNew(t *testing.T) {
+	tests := map[string]struct {
+		labels    map[string]string
+		builder   *Builder
+		expectErr bool
+	}{
+		"Test Builderwith labels": {
+			labels: map[string]string{"persistent-volume": "PV",
+				"application": "percona"},
+			builder: &Builder{podtemplatespec: &PodTemplateSpec{
+				Object: &corev1.PodTemplateSpec{},
+			}},
+			expectErr: false,
+		},
+		"Test Builder without labels": {
+			labels: map[string]string{},
+			builder: &Builder{podtemplatespec: &PodTemplateSpec{
+				Object: &corev1.PodTemplateSpec{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithLabelsNew(mock.labels)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuildWithAffinity(t *testing.T) {
+	tests := map[string]struct {
+		affinity  *corev1.Affinity
+		builder   *Builder
+		expectErr bool
+	}{
+		"Test Builder with affinity": {
+			affinity: &corev1.Affinity{},
+			builder: &Builder{podtemplatespec: &PodTemplateSpec{
+				Object: &corev1.PodTemplateSpec{},
+			}},
+			expectErr: false,
+		},
+		"Test Builder without affinity": {
+			affinity: nil,
+			builder: &Builder{podtemplatespec: &PodTemplateSpec{
+				Object: &corev1.PodTemplateSpec{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithAffinity(mock.affinity)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuildWithContainerBuilders(t *testing.T) {
+	tests := map[string]struct {
+		conBuilders []*conatiner.Builder
+		builder     *Builder
+		expectErr   bool
+	}{
+		"Test Builder with containerBuilders": {
+			conBuilders: []*conatiner.Builder{
+				conatiner.NewBuilder(),
+			},
+			builder: &Builder{podtemplatespec: &PodTemplateSpec{
+				Object: &corev1.PodTemplateSpec{},
+			}},
+			expectErr: false,
+		},
+		"Test Builder without containerBuilders": {
+			conBuilders: nil,
+			builder: &Builder{podtemplatespec: &PodTemplateSpec{
+				Object: &corev1.PodTemplateSpec{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithContainerBuilders(mock.conBuilders...)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuilderWithContainerBuildersNew(t *testing.T) {
+	tests := map[string]struct {
+		conBuilders []*conatiner.Builder
+		builder     *Builder
+		expectErr   bool
+	}{
+		"Test Builder with containerBuilders": {
+			conBuilders: []*conatiner.Builder{
+				conatiner.NewBuilder(),
+			},
+			builder: &Builder{podtemplatespec: &PodTemplateSpec{
+				Object: &corev1.PodTemplateSpec{},
+			}},
+			expectErr: false,
+		},
+		"Test Builder without containerBuilders": {
+			conBuilders: nil,
+			builder: &Builder{podtemplatespec: &PodTemplateSpec{
+				Object: &corev1.PodTemplateSpec{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithContainerBuildersNew(mock.conBuilders...)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuilderWithTolerations(t *testing.T) {
+	tests := map[string]struct {
+		tolerations []corev1.Toleration
+		builder     *Builder
+		expectErr   bool
+	}{
+		"Test Builder with tolerations": {
+			tolerations: []corev1.Toleration{
+				corev1.Toleration{},
+			},
+			builder: &Builder{podtemplatespec: &PodTemplateSpec{
+				Object: &corev1.PodTemplateSpec{},
+			}},
+			expectErr: false,
+		},
+		"Test Builder without tolerations": {
+			tolerations: []corev1.Toleration{},
+			builder: &Builder{podtemplatespec: &PodTemplateSpec{
+				Object: &corev1.PodTemplateSpec{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithTolerations(mock.tolerations...)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
+func TestBuilderWithTolerationsNew(t *testing.T) {
+	tests := map[string]struct {
+		tolerations []corev1.Toleration
+		builder     *Builder
+		expectErr   bool
+	}{
+		"Test Builder with tolerations": {
+			tolerations: []corev1.Toleration{
+				corev1.Toleration{},
+			},
+			builder: &Builder{podtemplatespec: &PodTemplateSpec{
+				Object: &corev1.PodTemplateSpec{},
+			}},
+			expectErr: false,
+		},
+		"Test Builder without tolerations": {
+			tolerations: []corev1.Toleration{},
+			builder: &Builder{podtemplatespec: &PodTemplateSpec{
+				Object: &corev1.PodTemplateSpec{},
+			}},
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder.WithTolerationsNew(mock.tolerations...)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}

--- a/pkg/kubernetes/service/v1alpha1/build.go
+++ b/pkg/kubernetes/service/v1alpha1/build.go
@@ -174,7 +174,7 @@ func (b *Builder) WithSelectors(selectors map[string]string) *Builder {
 	}
 
 	if b.service.object.Spec.Selector == nil {
-		return b.WithLabelsNew(selectors)
+		return b.WithSelectorsNew(selectors)
 	}
 
 	for key, value := range selectors {

--- a/tests/kubernetes/deployment/app_test.go
+++ b/tests/kubernetes/deployment/app_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 	con "github.com/openebs/maya/pkg/kubernetes/container/v1alpha1"
 	deploy "github.com/openebs/maya/pkg/kubernetes/deployment/appsv1/v1alpha1"
+	pts "github.com/openebs/maya/pkg/kubernetes/podtemplatespec/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -48,12 +49,16 @@ var _ = Describe("TEST DEPLOYMENT CREATION ", func() {
 			deployObj, err = deploy.NewBuilder().
 				WithName(deployName).
 				WithNamespace(namespaceObj.Name).
-				WithLabelSelector(labelselector).
-				WithContainerBuilder(
-					con.NewBuilder().
-						WithName("busybox").
-						WithImage("busybox").
-						WithCommandNew(command),
+				WithLabelsNew(labelselector).
+				WithSelectorMatchLabelsNew(labelselector).
+				WithPodTemplateSpecBuilder(
+					pts.NewBuilder().
+						WithContainerBuildersNew(
+							con.NewBuilder().
+								WithName("busybox").
+								WithImage("busybox").
+								WithCommandNew(command),
+						),
 				).
 				Build()
 			Expect(err).ShouldNot(

--- a/tests/localpv/hostdevice_test.go
+++ b/tests/localpv/hostdevice_test.go
@@ -22,6 +22,7 @@ import (
 	container "github.com/openebs/maya/pkg/kubernetes/container/v1alpha1"
 	deploy "github.com/openebs/maya/pkg/kubernetes/deployment/appsv1/v1alpha1"
 	pvc "github.com/openebs/maya/pkg/kubernetes/persistentvolumeclaim/v1alpha1"
+	pts "github.com/openebs/maya/pkg/kubernetes/podtemplatespec/v1alpha1"
 	volume "github.com/openebs/maya/pkg/kubernetes/volume/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,30 +80,34 @@ var _ = Describe("TEST HOSTDEVICE LOCAL PV", func() {
 			deployObj, err = deploy.NewBuilder().
 				WithName(deployName).
 				WithNamespace(namespaceObj.Name).
-				WithLabelSelector(labelselector).
-				WithContainerBuilder(
-					container.NewBuilder().
-						WithName("busybox").
-						WithImage("busybox").
-						WithCommandNew(
-							[]string{
-								"sleep",
-								"3600",
-							},
+				WithLabelsNew(labelselector).
+				WithSelectorMatchLabelsNew(labelselector).
+				WithPodTemplateSpecBuilder(
+					pts.NewBuilder().
+						WithContainerBuildersNew(
+							container.NewBuilder().
+								WithName("busybox").
+								WithImage("busybox").
+								WithCommandNew(
+									[]string{
+										"sleep",
+										"3600",
+									},
+								).
+								WithVolumeMountsNew(
+									[]corev1.VolumeMount{
+										corev1.VolumeMount{
+											Name:      "demo-vol2",
+											MountPath: "/mnt/store1",
+										},
+									},
+								),
 						).
-						WithVolumeMountsNew(
-							[]corev1.VolumeMount{
-								corev1.VolumeMount{
-									Name:      "demo-vol2",
-									MountPath: "/mnt/store1",
-								},
-							},
+						WithVolumeBuildersNew(
+							volume.NewBuilder().
+								WithName("demo-vol2").
+								WithPVCSource(pvcName),
 						),
-				).
-				WithVolumeBuilder(
-					volume.NewBuilder().
-						WithName("demo-vol2").
-						WithPVCSource(pvcName),
 				).
 				Build()
 			Expect(err).ShouldNot(
@@ -221,30 +226,34 @@ var _ = Describe("[-ve] TEST HOSTDEVICE LOCAL PV", func() {
 			existingDeployObj, err = deploy.NewBuilder().
 				WithName(existingDeployName).
 				WithNamespace(namespaceObj.Name).
-				WithLabelSelector(existingLabelselector).
-				WithContainerBuilder(
-					container.NewBuilder().
-						WithName("busybox").
-						WithImage("busybox").
-						WithCommandNew(
-							[]string{
-								"sleep",
-								"3600",
-							},
+				WithLabelsNew(existingLabelselector).
+				WithSelectorMatchLabelsNew(existingLabelselector).
+				WithPodTemplateSpecBuilder(
+					pts.NewBuilder().
+						WithContainerBuildersNew(
+							container.NewBuilder().
+								WithName("busybox").
+								WithImage("busybox").
+								WithCommandNew(
+									[]string{
+										"sleep",
+										"3600",
+									},
+								).
+								WithVolumeMountsNew(
+									[]corev1.VolumeMount{
+										corev1.VolumeMount{
+											Name:      "demo-vol3",
+											MountPath: "/mnt/store1",
+										},
+									},
+								),
 						).
-						WithVolumeMountsNew(
-							[]corev1.VolumeMount{
-								corev1.VolumeMount{
-									Name:      "demo-vol3",
-									MountPath: "/mnt/store1",
-								},
-							},
+						WithVolumeBuildersNew(
+							volume.NewBuilder().
+								WithName("demo-vol3").
+								WithPVCSource(existingPVCName),
 						),
-				).
-				WithVolumeBuilder(
-					volume.NewBuilder().
-						WithName("demo-vol3").
-						WithPVCSource(existingPVCName),
 				).
 				Build()
 			Expect(err).ShouldNot(
@@ -305,30 +314,34 @@ var _ = Describe("[-ve] TEST HOSTDEVICE LOCAL PV", func() {
 			deployObj, err = deploy.NewBuilder().
 				WithName(deployName).
 				WithNamespace(namespaceObj.Name).
-				WithLabelSelector(labelselector).
-				WithContainerBuilder(
-					container.NewBuilder().
-						WithName("busybox").
-						WithImage("busybox").
-						WithCommandNew(
-							[]string{
-								"sleep",
-								"3600",
-							},
+				WithLabelsNew(labelselector).
+				WithSelectorMatchLabelsNew(labelselector).
+				WithPodTemplateSpecBuilder(
+					pts.NewBuilder().
+						WithContainerBuildersNew(
+							container.NewBuilder().
+								WithName("busybox").
+								WithImage("busybox").
+								WithCommandNew(
+									[]string{
+										"sleep",
+										"3600",
+									},
+								).
+								WithVolumeMountsNew(
+									[]corev1.VolumeMount{
+										corev1.VolumeMount{
+											Name:      "demo-vol2",
+											MountPath: "/mnt/store1",
+										},
+									},
+								),
 						).
-						WithVolumeMountsNew(
-							[]corev1.VolumeMount{
-								corev1.VolumeMount{
-									Name:      "demo-vol2",
-									MountPath: "/mnt/store1",
-								},
-							},
+						WithVolumeBuildersNew(
+							volume.NewBuilder().
+								WithName("demo-vol2").
+								WithPVCSource(pvcName),
 						),
-				).
-				WithVolumeBuilder(
-					volume.NewBuilder().
-						WithName("demo-vol2").
-						WithPVCSource(pvcName),
 				).
 				Build()
 			Expect(err).ShouldNot(

--- a/tests/localpv/hostpath_test.go
+++ b/tests/localpv/hostpath_test.go
@@ -22,6 +22,7 @@ import (
 	container "github.com/openebs/maya/pkg/kubernetes/container/v1alpha1"
 	deploy "github.com/openebs/maya/pkg/kubernetes/deployment/appsv1/v1alpha1"
 	pvc "github.com/openebs/maya/pkg/kubernetes/persistentvolumeclaim/v1alpha1"
+	pts "github.com/openebs/maya/pkg/kubernetes/podtemplatespec/v1alpha1"
 	volume "github.com/openebs/maya/pkg/kubernetes/volume/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,30 +80,34 @@ var _ = Describe("TEST HOSTPATH LOCAL PV", func() {
 			deployObj, err = deploy.NewBuilder().
 				WithName(deployName).
 				WithNamespace(namespaceObj.Name).
-				WithLabelSelector(labelselector).
-				WithContainerBuilder(
-					container.NewBuilder().
-						WithName("busybox").
-						WithImage("busybox").
-						WithCommandNew(
-							[]string{
-								"sleep",
-								"3600",
-							},
+				WithLabelsNew(labelselector).
+				WithSelectorMatchLabelsNew(labelselector).
+				WithPodTemplateSpecBuilder(
+					pts.NewBuilder().
+						WithContainerBuildersNew(
+							container.NewBuilder().
+								WithName("busybox").
+								WithImage("busybox").
+								WithCommandNew(
+									[]string{
+										"sleep",
+										"3600",
+									},
+								).
+								WithVolumeMountsNew(
+									[]corev1.VolumeMount{
+										corev1.VolumeMount{
+											Name:      "demo-vol1",
+											MountPath: "/mnt/store1",
+										},
+									},
+								),
 						).
-						WithVolumeMountsNew(
-							[]corev1.VolumeMount{
-								corev1.VolumeMount{
-									Name:      "demo-vol1",
-									MountPath: "/mnt/store1",
-								},
-							},
+						WithVolumeBuilders(
+							volume.NewBuilder().
+								WithName("demo-vol1").
+								WithPVCSource(pvcName),
 						),
-				).
-				WithVolumeBuilder(
-					volume.NewBuilder().
-						WithName("demo-vol1").
-						WithPVCSource(pvcName),
 				).
 				Build()
 			Expect(err).ShouldNot(


### PR DESCRIPTION
 Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR 
 - added a podtemplatespec builder to decouple the template and deployment builder.
   It helps to avoid repeating functions like `WithLabels` in the same file.
 - added function required to create target deployment for cstor volume.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests