### PR TITLE
fix(builder, deployment): changed Build function to return api object

### DIFF
--- a/pkg/kubernetes/deployment/appsv1/v1alpha1/deployment_test.go
+++ b/pkg/kubernetes/deployment/appsv1/v1alpha1/deployment_test.go
@@ -32,14 +32,14 @@ func TestBuilderWithName(t *testing.T) {
 		"Test Builder with name": {
 			name: "PVC1",
 			builder: &Builder{deployment: &Deploy{
-				Object: &appsv1.Deployment{},
+				object: &appsv1.Deployment{},
 			}},
 			expectErr: false,
 		},
 		"Test Builder without name": {
 			name: "",
 			builder: &Builder{deployment: &Deploy{
-				Object: &appsv1.Deployment{},
+				object: &appsv1.Deployment{},
 			}},
 			expectErr: true,
 		},
@@ -67,14 +67,14 @@ func TestBuilderWithNamespace(t *testing.T) {
 		"Test Builder with namespace": {
 			namespace: "PVC1",
 			builder: &Builder{deployment: &Deploy{
-				Object: &appsv1.Deployment{},
+				object: &appsv1.Deployment{},
 			}},
 			expectErr: false,
 		},
 		"Test Builder without namespace": {
 			namespace: "",
 			builder: &Builder{deployment: &Deploy{
-				Object: &appsv1.Deployment{},
+				object: &appsv1.Deployment{},
 			}},
 			expectErr: true,
 		},
@@ -103,14 +103,14 @@ func TestBuildWithAnnotations(t *testing.T) {
 			annotations: map[string]string{"persistent-volume": "PV",
 				"application": "percona"},
 			builder: &Builder{deployment: &Deploy{
-				Object: &appsv1.Deployment{},
+				object: &appsv1.Deployment{},
 			}},
 			expectErr: false,
 		},
 		"Test Builderwithout annotations": {
 			annotations: map[string]string{},
 			builder: &Builder{deployment: &Deploy{
-				Object: &appsv1.Deployment{},
+				object: &appsv1.Deployment{},
 			}},
 			expectErr: true,
 		},
@@ -139,14 +139,14 @@ func TestBuildWithAnnotationsNew(t *testing.T) {
 			annotations: map[string]string{"persistent-volume": "PV",
 				"application": "percona"},
 			builder: &Builder{deployment: &Deploy{
-				Object: &appsv1.Deployment{},
+				object: &appsv1.Deployment{},
 			}},
 			expectErr: false,
 		},
 		"Test Builderwithout annotations": {
 			annotations: map[string]string{},
 			builder: &Builder{deployment: &Deploy{
-				Object: &appsv1.Deployment{},
+				object: &appsv1.Deployment{},
 			}},
 			expectErr: true,
 		},
@@ -175,14 +175,14 @@ func TestBuildWithLabels(t *testing.T) {
 			labels: map[string]string{"persistent-volume": "PV",
 				"application": "percona"},
 			builder: &Builder{deployment: &Deploy{
-				Object: &appsv1.Deployment{},
+				object: &appsv1.Deployment{},
 			}},
 			expectErr: false,
 		},
 		"Test Builderwithout labels": {
 			labels: map[string]string{},
 			builder: &Builder{deployment: &Deploy{
-				Object: &appsv1.Deployment{},
+				object: &appsv1.Deployment{},
 			}},
 			expectErr: true,
 		},
@@ -211,14 +211,14 @@ func TestBuildWithLabelsNew(t *testing.T) {
 			labels: map[string]string{"persistent-volume": "PV",
 				"application": "percona"},
 			builder: &Builder{deployment: &Deploy{
-				Object: &appsv1.Deployment{},
+				object: &appsv1.Deployment{},
 			}},
 			expectErr: false,
 		},
 		"Test Builderwithout labels": {
 			labels: map[string]string{},
 			builder: &Builder{deployment: &Deploy{
-				Object: &appsv1.Deployment{},
+				object: &appsv1.Deployment{},
 			}},
 			expectErr: true,
 		},
@@ -247,14 +247,14 @@ func TestBuildWithSelectorMatchLabels(t *testing.T) {
 			matchLabels: map[string]string{"persistent-volume": "PV",
 				"application": "percona"},
 			builder: &Builder{deployment: &Deploy{
-				Object: &appsv1.Deployment{},
+				object: &appsv1.Deployment{},
 			}},
 			expectErr: false,
 		},
 		"Test Builderwithout matchLabels": {
 			matchLabels: map[string]string{},
 			builder: &Builder{deployment: &Deploy{
-				Object: &appsv1.Deployment{},
+				object: &appsv1.Deployment{},
 			}},
 			expectErr: true,
 		},
@@ -283,14 +283,14 @@ func TestBuildWithSelectorMatchLabelsNew(t *testing.T) {
 			matchLabels: map[string]string{"persistent-volume": "PV",
 				"application": "percona"},
 			builder: &Builder{deployment: &Deploy{
-				Object: &appsv1.Deployment{},
+				object: &appsv1.Deployment{},
 			}},
 			expectErr: false,
 		},
 		"Test Builderwithout matchLabels": {
 			matchLabels: map[string]string{},
 			builder: &Builder{deployment: &Deploy{
-				Object: &appsv1.Deployment{},
+				object: &appsv1.Deployment{},
 			}},
 			expectErr: true,
 		},
@@ -320,21 +320,21 @@ func TestBuilderWithReplicas(t *testing.T) {
 		"Test Builder with replicas": {
 			replicas: &samplereplicas,
 			builder: &Builder{deployment: &Deploy{
-				Object: &appsv1.Deployment{},
+				object: &appsv1.Deployment{},
 			}},
 			expectErr: false,
 		},
 		"Test Builder without replicas": {
 			replicas: nil,
 			builder: &Builder{deployment: &Deploy{
-				Object: &appsv1.Deployment{},
+				object: &appsv1.Deployment{},
 			}},
 			expectErr: true,
 		},
 		"Test Builder with invalid replicas": {
 			replicas: &invalidreplicas,
 			builder: &Builder{deployment: &Deploy{
-				Object: &appsv1.Deployment{},
+				object: &appsv1.Deployment{},
 			}},
 			expectErr: true,
 		},
@@ -362,14 +362,14 @@ func TestBuilderWithStrategyType(t *testing.T) {
 		"Test Builder with strategyType": {
 			strategyType: appsv1.RecreateDeploymentStrategyType,
 			builder: &Builder{deployment: &Deploy{
-				Object: &appsv1.Deployment{},
+				object: &appsv1.Deployment{},
 			}},
 			expectErr: false,
 		},
 		"Test Builder without strategyType": {
 			strategyType: appsv1.DeploymentStrategyType(""),
 			builder: &Builder{deployment: &Deploy{
-				Object: &appsv1.Deployment{},
+				object: &appsv1.Deployment{},
 			}},
 			expectErr: true,
 		},
@@ -397,14 +397,14 @@ func TestBuilderWithPodTemplateSpec(t *testing.T) {
 		"Test Builder with templateSpec": {
 			templateSpec: pts.NewBuilder(),
 			builder: &Builder{deployment: &Deploy{
-				Object: &appsv1.Deployment{},
+				object: &appsv1.Deployment{},
 			}},
 			expectErr: false,
 		},
 		"Test Builder without templateSpec": {
 			templateSpec: nil,
 			builder: &Builder{deployment: &Deploy{
-				Object: &appsv1.Deployment{},
+				object: &appsv1.Deployment{},
 			}},
 			expectErr: true,
 		},

--- a/pkg/kubernetes/deployment/appsv1/v1alpha1/kubernetes.go
+++ b/pkg/kubernetes/deployment/appsv1/v1alpha1/kubernetes.go
@@ -122,22 +122,14 @@ func defaultDel(
 // fetch rollout status of a deployment instance from kubernetes
 // cluster
 func defaultRolloutStatus(d *appsv1.Deployment) (*RolloutOutput, error) {
-	b, err := NewBuilderForAPIObject(d).Build()
-	if err != nil {
-		return nil, err
-	}
-
+	b := NewForAPIObject(d)
 	return b.RolloutStatus()
 }
 
 // defaultRolloutStatusf is the default implementation to fetch
 // rollout status of a deployment instance from kubernetes cluster
 func defaultRolloutStatusf(d *appsv1.Deployment) ([]byte, error) {
-	b, err := NewBuilderForAPIObject(d).Build()
-	if err != nil {
-		return nil, err
-	}
-
+	b := NewForAPIObject(d)
 	return b.RolloutStatusRaw()
 }
 

--- a/pkg/kubernetes/deployment/appsv1/v1alpha1/rollout_status.go
+++ b/pkg/kubernetes/deployment/appsv1/v1alpha1/rollout_status.go
@@ -38,25 +38,25 @@ var rolloutStatuses = map[PredicateName]rolloutStatus{
 	// PredicateOlderReplicaActive refer to rolloutStatus for
 	// predicate IsOlderReplicaActive.
 	PredicateOlderReplicaActive: func(d *Deploy) string {
-		if d.Object.Spec.Replicas == nil {
+		if d.object.Spec.Replicas == nil {
 			return "replica update in-progress: some older replicas were updated"
 		}
 		return fmt.Sprintf(
 			"replica update in-progress: %d of %d new replicas were updated",
-			d.Object.Status.UpdatedReplicas, *d.Object.Spec.Replicas)
+			d.object.Status.UpdatedReplicas, *d.object.Spec.Replicas)
 	},
 	// PredicateTerminationInProgress refer rolloutStatus
 	// for predicate IsTerminationInProgress.
 	PredicateTerminationInProgress: func(d *Deploy) string {
 		return fmt.Sprintf(
 			"replica termination in-progress: %d old replicas are pending termination",
-			d.Object.Status.Replicas-d.Object.Status.UpdatedReplicas)
+			d.object.Status.Replicas-d.object.Status.UpdatedReplicas)
 	},
 	// PredicateUpdateInProgress refer to rolloutStatus for predicate IsUpdateInProgress.
 	PredicateUpdateInProgress: func(d *Deploy) string {
 		return fmt.Sprintf(
 			"replica update in-progress: %d of %d updated replicas are available",
-			d.Object.Status.AvailableReplicas, d.Object.Status.UpdatedReplicas)
+			d.object.Status.AvailableReplicas, d.object.Status.UpdatedReplicas)
 	},
 	// PredicateNotSpecSynced refer to status rolloutStatus for predicate IsNotSyncSpec.
 	PredicateNotSpecSynced: func(d *Deploy) string {

--- a/tests/kubernetes/deployment/app_test.go
+++ b/tests/kubernetes/deployment/app_test.go
@@ -22,6 +22,7 @@ import (
 	con "github.com/openebs/maya/pkg/kubernetes/container/v1alpha1"
 	deploy "github.com/openebs/maya/pkg/kubernetes/deployment/appsv1/v1alpha1"
 	pts "github.com/openebs/maya/pkg/kubernetes/podtemplatespec/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -29,7 +30,7 @@ import (
 var (
 	deployName    = "busybox-deploy"
 	label         = "demo=deployment"
-	deployObj     *deploy.Deploy
+	deployObj     *appsv1.Deployment
 	conObj        corev1.Container
 	err           error
 	command       []string
@@ -69,7 +70,8 @@ var _ = Describe("TEST DEPLOYMENT CREATION ", func() {
 			)
 
 			By("creating above deployment")
-			_, err = ops.DeployClient.WithNamespace(namespaceObj.Name).Create(deployObj.Object)
+			_, err = ops.DeployClient.WithNamespace(namespaceObj.Name).
+				Create(deployObj)
 			Expect(err).To(
 				BeNil(),
 				"while creating deployment {%s} in namespace {%s}",
@@ -87,7 +89,8 @@ var _ = Describe("TEST DEPLOYMENT CREATION ", func() {
 		It("should not have any deployment or running pod", func() {
 
 			By("deleting above deployment")
-			err := ops.DeployClient.WithNamespace(namespaceObj.Name).Delete(deployName, &metav1.DeleteOptions{})
+			err := ops.DeployClient.WithNamespace(namespaceObj.Name).
+				Delete(deployName, &metav1.DeleteOptions{})
 			Expect(err).To(
 				BeNil(),
 				"while deleting deployment {%s} in namespace {%s}",

--- a/tests/localpv/hostdevice_test.go
+++ b/tests/localpv/hostdevice_test.go
@@ -24,6 +24,7 @@ import (
 	pvc "github.com/openebs/maya/pkg/kubernetes/persistentvolumeclaim/v1alpha1"
 	pts "github.com/openebs/maya/pkg/kubernetes/podtemplatespec/v1alpha1"
 	volume "github.com/openebs/maya/pkg/kubernetes/volume/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -36,7 +37,7 @@ var _ = Describe("TEST HOSTDEVICE LOCAL PV", func() {
 		deployName    = "busybox-device"
 		label         = "demo=hostdevice-deployment"
 		pvcName       = "pvc-hd"
-		deployObj     *deploy.Deploy
+		deployObj     *appsv1.Deployment
 		labelselector = map[string]string{
 			"demo": "hostdevice-deployment",
 		}
@@ -118,7 +119,8 @@ var _ = Describe("TEST HOSTDEVICE LOCAL PV", func() {
 			)
 
 			By("creating above deployment")
-			_, err = ops.DeployClient.WithNamespace(namespaceObj.Name).Create(deployObj.Object)
+			_, err = ops.DeployClient.WithNamespace(namespaceObj.Name).
+				Create(deployObj)
 			Expect(err).To(
 				BeNil(),
 				"while creating deployment {%s} in namespace {%s}",
@@ -177,7 +179,7 @@ var _ = Describe("[-ve] TEST HOSTDEVICE LOCAL PV", func() {
 		deployName    = "busybox-device"
 		label         = "demo=hostdevice-deployment"
 		pvcName       = "pvc-hd"
-		deployObj     *deploy.Deploy
+		deployObj     *appsv1.Deployment
 		labelselector = map[string]string{
 			"demo": "hostdevice-deployment",
 		}
@@ -186,7 +188,7 @@ var _ = Describe("[-ve] TEST HOSTDEVICE LOCAL PV", func() {
 		existingDeployName    = "existing-busybox-device"
 		existinglabel         = "demo=existing-hostdevice-deployment"
 		existingPVCName       = "existing-pvc-hd"
-		existingDeployObj     *deploy.Deploy
+		existingDeployObj     *appsv1.Deployment
 		existingLabelselector = map[string]string{
 			"demo": "existing-hostdevice-deployment",
 		}
@@ -264,7 +266,8 @@ var _ = Describe("[-ve] TEST HOSTDEVICE LOCAL PV", func() {
 			)
 
 			By("creating above deployment")
-			_, err = ops.DeployClient.WithNamespace(namespaceObj.Name).Create(existingDeployObj.Object)
+			_, err = ops.DeployClient.WithNamespace(namespaceObj.Name).
+				Create(existingDeployObj)
 			Expect(err).To(
 				BeNil(),
 				"while creating deployment {%s} in namespace {%s}",
@@ -352,7 +355,8 @@ var _ = Describe("[-ve] TEST HOSTDEVICE LOCAL PV", func() {
 			)
 
 			By("creating above deployment")
-			_, err = ops.DeployClient.WithNamespace(namespaceObj.Name).Create(deployObj.Object)
+			_, err = ops.DeployClient.WithNamespace(namespaceObj.Name).
+				Create(deployObj)
 			Expect(err).To(
 				BeNil(),
 				"while creating deployment {%s} in namespace {%s}",

--- a/tests/localpv/hostpath_test.go
+++ b/tests/localpv/hostpath_test.go
@@ -24,6 +24,7 @@ import (
 	pvc "github.com/openebs/maya/pkg/kubernetes/persistentvolumeclaim/v1alpha1"
 	pts "github.com/openebs/maya/pkg/kubernetes/podtemplatespec/v1alpha1"
 	volume "github.com/openebs/maya/pkg/kubernetes/volume/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -36,7 +37,7 @@ var _ = Describe("TEST HOSTPATH LOCAL PV", func() {
 		deployName    = "busybox-hostpath"
 		label         = "demo=hostpath-deployment"
 		pvcName       = "pvc-hp"
-		deployObj     *deploy.Deploy
+		deployObj     *appsv1.Deployment
 		labelselector = map[string]string{
 			"demo": "hostpath-deployment",
 		}
@@ -118,7 +119,8 @@ var _ = Describe("TEST HOSTPATH LOCAL PV", func() {
 			)
 
 			By("creating above deployment")
-			_, err = ops.DeployClient.WithNamespace(namespaceObj.Name).Create(deployObj.Object)
+			_, err = ops.DeployClient.WithNamespace(namespaceObj.Name).
+				Create(deployObj)
 			Expect(err).To(
 				BeNil(),
 				"while creating deployment {%s} in namespace {%s}",


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR changes the the `Build()` of deployment builder to return `*apps.Deployment` instead of local `*Deploy` object

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests