### PR TITLE
refact(cstor): added last update fields for cstor objects

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
@@ -73,8 +73,9 @@ func (c *CStorPoolController) syncHandler(key string, operation common.QueueOper
 	cspObject.Status.LastUpdateTime = metav1.Now()
 	if cspObject.Status.Phase != apis.CStorPoolPhase(status) {
 		cspObject.Status.LastTransitionTime = cspObject.Status.LastUpdateTime
+		cspObject.Status.Phase = apis.CStorPoolPhase(status)
 	}
-	cspObject.Status.Phase = apis.CStorPoolPhase(status)
+
 	if err != nil {
 		glog.Errorf(err.Error())
 		_, err := c.clientset.OpenebsV1alpha1().CStorPools().Update(cspObject)

--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
@@ -57,7 +57,7 @@ func (c *CStorPoolController) syncHandler(key string, operation common.QueueOper
 	csp, err := newCspLease.Hold()
 	cspObject, ok := csp.(*apis.CStorPool)
 	if !ok {
-		fmt.Errorf("expected csp object but got %#v", cspObject)
+		return fmt.Errorf("expected csp object but got %#v", cspObject)
 	}
 	if err != nil {
 		glog.Errorf("Could not acquire lease on csp object:%v", err)
@@ -70,6 +70,10 @@ func (c *CStorPoolController) syncHandler(key string, operation common.QueueOper
 		glog.Warning("Empty status recieved for csp status in sync handler")
 		return nil
 	}
+	if cspObject.Status.Phase != apis.CStorPoolPhase(status) {
+		cspObject.Status.LastTransitionTime = metav1.Now()
+	}
+	cspObject.Status.LastUpdateTime = metav1.Now()
 	cspObject.Status.Phase = apis.CStorPoolPhase(status)
 	if err != nil {
 		glog.Errorf(err.Error())

--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
@@ -70,10 +70,10 @@ func (c *CStorPoolController) syncHandler(key string, operation common.QueueOper
 		glog.Warning("Empty status recieved for csp status in sync handler")
 		return nil
 	}
-	if cspObject.Status.Phase != apis.CStorPoolPhase(status) {
-		cspObject.Status.LastTransitionTime = metav1.Now()
-	}
 	cspObject.Status.LastUpdateTime = metav1.Now()
+	if cspObject.Status.Phase != apis.CStorPoolPhase(status) {
+		cspObject.Status.LastTransitionTime = cspObject.Status.LastUpdateTime
+	}
 	cspObject.Status.Phase = apis.CStorPoolPhase(status)
 	if err != nil {
 		glog.Errorf(err.Error())

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -86,9 +86,9 @@ func (c *CStorVolumeReplicaController) syncHandler(
 	cvrGot.Status.LastUpdateTime = metav1.Now()
 	if cvrGot.Status.Phase != apis.CStorVolumeReplicaPhase(status) {
 		cvrGot.Status.LastTransitionTime = cvrGot.Status.LastUpdateTime
+		// set phase based on received status
+		cvrGot.Status.Phase = apis.CStorVolumeReplicaPhase(status)
 	}
-	// set phase based on received status
-	cvrGot.Status.Phase = apis.CStorVolumeReplicaPhase(status)
 
 	// need to update cvr before returning this error
 	if err != nil {

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -70,7 +70,10 @@ func (c *CStorVolumeReplicaController) syncHandler(
 		return err
 	}
 	if cvrGot == nil {
-		return merrors.Errorf("failed to reconcile cvr {%s}: object not found", key)
+		return merrors.Errorf(
+			"failed to reconcile cvr {%s}: object not found",
+			key,
+		)
 	}
 
 	status, err := c.cVREventHandler(operation, cvrGot)
@@ -80,7 +83,10 @@ func (c *CStorVolumeReplicaController) syncHandler(
 		// status holds more importance than error
 		return nil
 	}
-
+	if cvrGot.Status.Phase != apis.CStorVolumeReplicaPhase(status) {
+		cvrGot.Status.LastTransitionTime = metav1.Now()
+	}
+	cvrGot.Status.LastUpdateTime = metav1.Now()
 	// set phase based on received status
 	cvrGot.Status.Phase = apis.CStorVolumeReplicaPhase(status)
 
@@ -256,17 +262,31 @@ func (c *CStorVolumeReplicaController) removeFinalizer(
 	return nil
 }
 
-func (c *CStorVolumeReplicaController) cVRAddEventHandler(cVR *apis.CStorVolumeReplica, fullVolName string) (string, error) {
+func (c *CStorVolumeReplicaController) cVRAddEventHandler(
+	cVR *apis.CStorVolumeReplica,
+	fullVolName string,
+) (string, error) {
 	// lock is to synchronize pool and volumereplica. Until certain pool related
 	// operations are over, the volumereplica threads will be held.
 	common.SyncResources.Mux.Lock()
 	if common.SyncResources.IsImported {
 		common.SyncResources.Mux.Unlock()
 		// To check if volume is already imported with pool.
-		importedFlag := common.CheckForInitialImportedPoolVol(common.InitialImportedPoolVol, fullVolName)
+		importedFlag := common.CheckForInitialImportedPoolVol(
+			common.InitialImportedPoolVol,
+			fullVolName,
+		)
 		if importedFlag && !IsEmptyStatus(cVR) {
-			glog.Infof("CStorVolumeReplica %v is already imported", string(cVR.ObjectMeta.UID))
-			c.recorder.Event(cVR, corev1.EventTypeNormal, string(common.SuccessImported), string(common.MessageResourceImported))
+			glog.Infof(
+				"CStorVolumeReplica %v is already imported",
+				string(cVR.ObjectMeta.UID),
+			)
+			c.recorder.Event(
+				cVR,
+				corev1.EventTypeNormal,
+				string(common.SuccessImported),
+				string(common.MessageResourceImported),
+			)
 			return string(apis.CVRStatusOnline), nil
 		}
 	} else {
@@ -277,8 +297,16 @@ func (c *CStorVolumeReplicaController) cVRAddEventHandler(cVR *apis.CStorVolumeR
 	// then it is required to cross-check whether the volume exists or not.
 	existingvol, _ := volumereplica.GetVolumes()
 	if common.CheckIfPresent(existingvol, fullVolName) {
-		glog.Warningf("CStorVolumeReplica %v is already present", string(cVR.GetUID()))
-		c.recorder.Event(cVR, corev1.EventTypeWarning, string(common.AlreadyPresent), string(common.MessageResourceAlreadyPresent))
+		glog.Warningf(
+			"CStorVolumeReplica %v is already present",
+			string(cVR.GetUID()),
+		)
+		c.recorder.Event(
+			cVR,
+			corev1.EventTypeWarning,
+			string(common.AlreadyPresent),
+			string(common.MessageResourceAlreadyPresent),
+		)
 		// If the volume already present then return the cvr status as duplicate
 		return string(apis.CVRStatusErrorDuplicate), nil
 	}
@@ -286,7 +314,9 @@ func (c *CStorVolumeReplicaController) cVRAddEventHandler(cVR *apis.CStorVolumeR
 	// Setting quorum to true for newly creating Volumes.
 	var quorum = true
 	if IsRecreateStatus(cVR) {
-		glog.Infof("Pool is recreated hence creating the volumes by setting off the quorum property")
+		glog.Infof(
+			"Pool is recreated hence creating the volumes by setting off the quorum property",
+		)
 		quorum = false
 	}
 
@@ -297,15 +327,31 @@ func (c *CStorVolumeReplicaController) cVRAddEventHandler(cVR *apis.CStorVolumeR
 			glog.Errorf("cVR creation failure: %v", err.Error())
 			return string(apis.CVRStatusOffline), err
 		}
-		c.recorder.Event(cVR, corev1.EventTypeNormal, string(common.SuccessCreated), string(common.MessageResourceCreated))
-		glog.Infof("cVR creation successful: %v, %v", cVR.ObjectMeta.Name, string(cVR.GetUID()))
+		c.recorder.Event(
+			cVR,
+			corev1.EventTypeNormal,
+			string(common.SuccessCreated),
+			string(common.MessageResourceCreated),
+		)
+		glog.Infof(
+			"cVR creation successful: %v, %v",
+			cVR.ObjectMeta.Name,
+			string(cVR.GetUID()),
+		)
 		return string(apis.CVRStatusOnline), nil
 	}
-	return string(apis.CVRStatusOffline), fmt.Errorf("VolumeReplica offline: %v, %v", cVR.Name, cVR.Labels["cstorvolume.openebs.io/name"])
+	return string(apis.CVRStatusOffline),
+		fmt.Errorf(
+			"VolumeReplica offline: %v, %v",
+			cVR.Name,
+			cVR.Labels["cstorvolume.openebs.io/name"],
+		)
 }
 
 // getVolumeReplicaResource returns object corresponding to the resource key
-func (c *CStorVolumeReplicaController) getVolumeReplicaResource(key string) (*apis.CStorVolumeReplica, error) {
+func (c *CStorVolumeReplicaController) getVolumeReplicaResource(
+	key string,
+) (*apis.CStorVolumeReplica, error) {
 	// Convert the key(namespace/name) string into a distinct name
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
@@ -313,12 +359,19 @@ func (c *CStorVolumeReplicaController) getVolumeReplicaResource(key string) (*ap
 		return nil, nil
 	}
 
-	cStorVolumeReplicaUpdated, err := c.clientset.OpenebsV1alpha1().CStorVolumeReplicas(namespace).Get(name, metav1.GetOptions{})
+	cStorVolumeReplicaUpdated, err := c.clientset.OpenebsV1alpha1().
+		CStorVolumeReplicas(namespace).
+		Get(name, metav1.GetOptions{})
 	if err != nil {
 		// The cStorPool resource may no longer exist, in which case we stop
 		// processing.
 		if errors.IsNotFound(err) {
-			runtime.HandleError(fmt.Errorf("cStorVolumeReplicaUpdated '%s' in work queue no longer exists", key))
+			runtime.HandleError(
+				fmt.Errorf(
+					"cStorVolumeReplicaUpdated '%s' in work queue no longer exists",
+					key,
+				),
+			)
 			return nil, nil
 		}
 		return nil, err
@@ -326,7 +379,8 @@ func (c *CStorVolumeReplicaController) getVolumeReplicaResource(key string) (*ap
 	return cStorVolumeReplicaUpdated, nil
 }
 
-// IsRightCStorVolumeReplica is to check if the cvr request is for particular pod/application.
+// IsRightCStorVolumeReplica is to check if the cvr
+// request is for particular pod/application.
 func IsRightCStorVolumeReplica(cVR *apis.CStorVolumeReplica) bool {
 	if os.Getenv(string(common.OpenEBSIOCStorID)) == string(cVR.ObjectMeta.Labels["cstorpool.openebs.io/uid"]) {
 		return true
@@ -357,14 +411,19 @@ func IsDeletionFailedBefore(cvrObj *apis.CStorVolumeReplica) bool {
 	return cvrObj.Status.Phase == apis.CVRStatusDeletionFailed
 }
 
-// IsStatusOnline is to check if the status of cStorVolumeReplica object is
+// IsOnlineStatus is to check if the status of cStorVolumeReplica object is
 // Healthy.
 func IsOnlineStatus(cVR *apis.CStorVolumeReplica) bool {
 	if string(cVR.Status.Phase) == string(apis.CVRStatusOnline) {
 		glog.Infof("cVR Healthy status: %v", string(cVR.ObjectMeta.UID))
 		return true
 	}
-	glog.Infof("cVR '%s': uid '%s': phase '%s': is_healthy_status: false", string(cVR.ObjectMeta.Name), string(cVR.ObjectMeta.UID), cVR.Status.Phase)
+	glog.Infof(
+		"cVR '%s': uid '%s': phase '%s': is_healthy_status: false",
+		string(cVR.ObjectMeta.Name),
+		string(cVR.ObjectMeta.UID),
+		cVR.Status.Phase,
+	)
 	return false
 }
 
@@ -374,7 +433,12 @@ func IsEmptyStatus(cVR *apis.CStorVolumeReplica) bool {
 		glog.Infof("cVR empty status: %v", string(cVR.ObjectMeta.UID))
 		return true
 	}
-	glog.Infof("cVR '%s': uid '%s': phase '%s': is_empty_status: false", string(cVR.ObjectMeta.Name), string(cVR.ObjectMeta.UID), cVR.Status.Phase)
+	glog.Infof(
+		"cVR '%s': uid '%s': phase '%s': is_empty_status: false",
+		string(cVR.ObjectMeta.Name),
+		string(cVR.ObjectMeta.UID),
+		cVR.Status.Phase,
+	)
 	return false
 }
 
@@ -406,7 +470,9 @@ func IsErrorDuplicate(cvrObj *apis.CStorVolumeReplica) bool {
 }
 
 //  getCVRStatus is a wrapper that fetches the status of cstor volume.
-func (c *CStorVolumeReplicaController) getCVRStatus(cVR *apis.CStorVolumeReplica) (string, error) {
+func (c *CStorVolumeReplicaController) getCVRStatus(
+	cVR *apis.CStorVolumeReplica,
+) (string, error) {
 	volumeName, err := volumereplica.GetVolumeName(cVR)
 	if err != nil {
 		return "", fmt.Errorf("unable to get volume name:%s", err.Error())
@@ -414,7 +480,12 @@ func (c *CStorVolumeReplicaController) getCVRStatus(cVR *apis.CStorVolumeReplica
 	poolStatus, err := volumereplica.Status(volumeName)
 	if err != nil {
 		// ToDO : Put error in event recorder
-		c.recorder.Event(cVR, corev1.EventTypeWarning, string(common.FailureStatusSync), string(common.MessageResourceFailStatusSync))
+		c.recorder.Event(
+			cVR,
+			corev1.EventTypeWarning,
+			string(common.FailureStatusSync),
+			string(common.MessageResourceFailStatusSync),
+		)
 		return "", err
 	}
 	return poolStatus, nil
@@ -426,13 +497,23 @@ func (c *CStorVolumeReplicaController) syncCvr(cvr *apis.CStorVolumeReplica) {
 	volumeName, err := volumereplica.GetVolumeName(cvr)
 	if err != nil {
 		glog.Errorf("Unable to sync CVR capacity: %v", err)
-		c.recorder.Event(cvr, corev1.EventTypeWarning, string(common.FailureCapacitySync), string(common.MessageResourceFailCapacitySync))
+		c.recorder.Event(
+			cvr,
+			corev1.EventTypeWarning,
+			string(common.FailureCapacitySync),
+			string(common.MessageResourceFailCapacitySync),
+		)
 	}
 	// Get capacity of the volume.
 	capacity, err := volumereplica.Capacity(volumeName)
 	if err != nil {
 		glog.Errorf("Unable to sync CVR capacity: %v", err)
-		c.recorder.Event(cvr, corev1.EventTypeWarning, string(common.FailureCapacitySync), string(common.MessageResourceFailCapacitySync))
+		c.recorder.Event(
+			cvr,
+			corev1.EventTypeWarning,
+			string(common.FailureCapacitySync),
+			string(common.MessageResourceFailCapacitySync),
+		)
 	} else {
 		cvr.Status.Capacity = *capacity
 	}

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -83,10 +83,10 @@ func (c *CStorVolumeReplicaController) syncHandler(
 		// status holds more importance than error
 		return nil
 	}
-	if cvrGot.Status.Phase != apis.CStorVolumeReplicaPhase(status) {
-		cvrGot.Status.LastTransitionTime = metav1.Now()
-	}
 	cvrGot.Status.LastUpdateTime = metav1.Now()
+	if cvrGot.Status.Phase != apis.CStorVolumeReplicaPhase(status) {
+		cvrGot.Status.LastTransitionTime = cvrGot.Status.LastUpdateTime
+	}
 	// set phase based on received status
 	cvrGot.Status.Phase = apis.CStorVolumeReplicaPhase(status)
 

--- a/cmd/cstor-volume-mgmt/controller/volume-controller/handler.go
+++ b/cmd/cstor-volume-mgmt/controller/volume-controller/handler.go
@@ -18,10 +18,11 @@ package volumecontroller
 
 import (
 	"fmt"
-	pkg_errors "github.com/pkg/errors"
 	"os"
 	"reflect"
 	"time"
+
+	pkg_errors "github.com/pkg/errors"
 
 	"strings"
 
@@ -30,7 +31,7 @@ import (
 	"github.com/openebs/maya/cmd/cstor-volume-mgmt/volume"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	"github.com/openebs/maya/pkg/client/k8s"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -38,9 +39,12 @@ import (
 )
 
 // syncHandler compares the actual state with the desired, and attempts to
-// converge the two. It then updates the Status block of the cStorVolumeUpdated resource
-// with the current status of the resource.
-func (c *CStorVolumeController) syncHandler(key string, operation common.QueueOperation) error {
+// converge the two. It then updates the Status block of the cStorVolumeUpdated
+// resource with the current status of the resource.
+func (c *CStorVolumeController) syncHandler(
+	key string,
+	operation common.QueueOperation,
+) error {
 	glog.V(4).Infof("Handling %v operation for resource : %s ", operation, key)
 	cStorVolumeGot, err := c.getVolumeResource(key)
 	if err != nil {
@@ -50,23 +54,41 @@ func (c *CStorVolumeController) syncHandler(key string, operation common.QueueOp
 	if status == common.CVStatusIgnore {
 		return nil
 	}
+	if cStorVolumeGot.Status.Phase != apis.CStorVolumePhase(status) {
+		cStorVolumeGot.Status.LastTransitionTime = metav1.Now()
+	}
+	cStorVolumeGot.Status.LastUpdateTime = metav1.Now()
 	cStorVolumeGot.Status.Phase = apis.CStorVolumePhase(status)
 	if err != nil {
 		glog.Errorf(err.Error())
 		glog.Infof("cStorVolume:%v, %v; Status: %v", cStorVolumeGot.Name,
 			string(cStorVolumeGot.GetUID()), cStorVolumeGot.Status.Phase)
 
-		_, err1 := c.clientset.OpenebsV1alpha1().CStorVolumes(cStorVolumeGot.Namespace).Update(cStorVolumeGot)
+		_, err1 := c.clientset.OpenebsV1alpha1().
+			CStorVolumes(cStorVolumeGot.Namespace).
+			Update(cStorVolumeGot)
 		if err1 != nil {
-			return pkg_errors.Wrapf(err1, "failed to update cStorVolume:%v, %v; Status: %v err: %v", cStorVolumeGot.Name,
-				string(cStorVolumeGot.GetUID()), cStorVolumeGot.Status.Phase, err)
+			return pkg_errors.Wrapf(
+				err1,
+				"failed to update cStorVolume:%v, %v; Status: %v err: %v",
+				cStorVolumeGot.Name,
+				string(cStorVolumeGot.GetUID()),
+				cStorVolumeGot.Status.Phase,
+				err,
+			)
 		}
 		return err
 	}
-	_, err = c.clientset.OpenebsV1alpha1().CStorVolumes(cStorVolumeGot.Namespace).Update(cStorVolumeGot)
+	_, err = c.clientset.OpenebsV1alpha1().
+		CStorVolumes(cStorVolumeGot.Namespace).
+		Update(cStorVolumeGot)
 	if err != nil {
-		return pkg_errors.Wrapf(err, "failed to update cStorVolume:%v, %v; Status: %v", cStorVolumeGot.Name,
-			string(cStorVolumeGot.GetUID()), cStorVolumeGot.Status.Phase)
+		return pkg_errors.Wrapf(
+			err, "failed to update cStorVolume:%v, %v; Status: %v",
+			cStorVolumeGot.Name,
+			string(cStorVolumeGot.GetUID()),
+			cStorVolumeGot.Status.Phase,
+		)
 	}
 	glog.V(4).Infof("cStorVolume:%v, %v; Status: %v", cStorVolumeGot.Name,
 		string(cStorVolumeGot.GetUID()), cStorVolumeGot.Status.Phase)
@@ -75,8 +97,15 @@ func (c *CStorVolumeController) syncHandler(key string, operation common.QueueOp
 }
 
 // cStorVolumeEventHandler is to handle cstor volume related events.
-func (c *CStorVolumeController) cStorVolumeEventHandler(operation common.QueueOperation, cStorVolumeGot *apis.CStorVolume) (common.CStorVolumeStatus, error) {
-	glog.V(4).Infof("%v event received for volume : %v ", operation, cStorVolumeGot.Name)
+func (c *CStorVolumeController) cStorVolumeEventHandler(
+	operation common.QueueOperation,
+	cStorVolumeGot *apis.CStorVolume,
+) (common.CStorVolumeStatus, error) {
+	glog.V(4).Infof(
+		"%v event received for volume : %v ",
+		operation,
+		cStorVolumeGot.Name,
+	)
 	switch operation {
 	case common.QOpAdd:
 		// CheckValidVolume is to check if volume attributes are correct.
@@ -110,16 +139,26 @@ func (c *CStorVolumeController) cStorVolumeEventHandler(operation common.QueueOp
 		volStatus, err := volume.GetVolumeStatus(cStorVolumeGot)
 		if err != nil {
 			glog.Errorf("Error in getting volume status: %s", err.Error())
-			cStorVolumeGot.Status.Phase = apis.CStorVolumePhase(common.CVStatusError)
+			cStorVolumeGot.Status.Phase = apis.CStorVolumePhase(
+				common.CVStatusError,
+			)
 		} else {
 			cStorVolumeGot.Status.Phase = apis.CStorVolumePhase(volStatus.Status)
 			// if replicas are zero set the status as init
 			if len(volStatus.ReplicaStatuses) == 0 {
-				cStorVolumeGot.Status.Phase = apis.CStorVolumePhase(common.CVStatusInit)
+				cStorVolumeGot.Status.Phase = apis.CStorVolumePhase(
+					common.CVStatusInit,
+				)
 			}
 		}
+		if cStorVolumeGot.Status.Phase != lastKnownPhase {
+			cStorVolumeGot.Status.LastTransitionTime = metav1.Now()
+		}
+		cStorVolumeGot.Status.LastUpdateTime = metav1.Now()
 		cStorVolumeGot.Status.ReplicaStatuses = volStatus.ReplicaStatuses
-		updatedCstorVolume, err := c.clientset.OpenebsV1alpha1().CStorVolumes(cStorVolumeGot.Namespace).Update(cStorVolumeGot)
+		updatedCstorVolume, err := c.clientset.OpenebsV1alpha1().
+			CStorVolumes(cStorVolumeGot.Namespace).
+			Update(cStorVolumeGot)
 		if err != nil {
 			glog.Errorf("Error updating cStorVolume object: %s", err)
 			return common.CVStatusIgnore, nil
@@ -131,28 +170,37 @@ func (c *CStorVolumeController) cStorVolumeEventHandler(operation common.QueueOp
 				glog.Errorf("Error creating event : %s", err.Error())
 			}
 		}
-		// Update already made above with latest status. We return ignore from here so that
-		// caller does not re-attempt to update status with older resource version
+		// Update already made above with latest status.
+		// We return ignore from here so that caller does not
+		// re-attempt to update status with older resource version
 		return common.CVStatusIgnore, nil
 	case common.QOpDestroy:
 		return common.CVStatusIgnore, nil
 	}
 
-	glog.Infof("Ignoring changes for volume %s for operation %v", cStorVolumeGot.Name, operation)
+	glog.Infof(
+		"Ignoring changes for volume %s for operation %v",
+		cStorVolumeGot.Name,
+		operation,
+	)
 	return common.CVStatusIgnore, nil
 }
 
 // getEventType returns the event type based on the passed CStorVolumeStatus
 func getEventType(phase common.CStorVolumeStatus) string {
 	// It is normal event only when phase is Running or Degraded
-	if phase == common.CVStatusInit || phase == common.CVStatusHealthy || phase == common.CVStatusDegraded {
+	if phase == common.CVStatusInit ||
+		phase == common.CVStatusHealthy ||
+		phase == common.CVStatusDegraded {
 		return v1.EventTypeNormal
 	}
 	return v1.EventTypeWarning
 }
 
 // createEventObj creates an object of v1.Event based on the CstorVolume
-func (c *CStorVolumeController) createEventObj(cstorVolume *apis.CStorVolume) *v1.Event {
+func (c *CStorVolumeController) createEventObj(
+	cstorVolume *apis.CStorVolume,
+) *v1.Event {
 	return &v1.Event{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cstorVolume.Name + "." + string(cstorVolume.Status.Phase),
@@ -182,9 +230,13 @@ func (c *CStorVolumeController) createEventObj(cstorVolume *apis.CStorVolume) *v
 // createSyncUpdateEvent tries to get the eventGot if present it updates
 // the lastTimestamp to current time and increases count by one,
 // if absent, creates the given eventGot
-func (c *CStorVolumeController) createSyncUpdateEvent(eventGot *v1.Event) (err error) {
+func (c *CStorVolumeController) createSyncUpdateEvent(
+	eventGot *v1.Event,
+) (err error) {
 	client := c.kubeclientset
-	event, err := client.CoreV1().Events(eventGot.Namespace).Get(eventGot.Name, metav1.GetOptions{})
+	event, err := client.CoreV1().
+		Events(eventGot.Namespace).
+		Get(eventGot.Name, metav1.GetOptions{})
 	// error could be due to missing object or some other reason
 	// we ignore error if it is due to missing object
 	if err != nil && !strings.Contains(err.Error(), "not found") {
@@ -203,14 +255,21 @@ func (c *CStorVolumeController) createSyncUpdateEvent(eventGot *v1.Event) (err e
 	return
 }
 
-// enqueueCstorVolume takes a CStorVolume resource and converts it into a namespace/name
-// string which is then put onto the work queue. This method should *not* be
-// passed resources of any type other than CStorVolumes.
-func (c *CStorVolumeController) enqueueCStorVolume(obj *apis.CStorVolume, q common.QueueLoad) {
+// enqueueCstorVolume takes a CStorVolume resource and converts it into a
+// namespace/name string which is then put onto the work queue. This method
+// should *not* be passed resources of any type other than CStorVolumes.
+func (c *CStorVolumeController) enqueueCStorVolume(
+	obj *apis.CStorVolume,
+	q common.QueueLoad,
+) {
 	var key string
 	var err error
 	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
-		glog.Errorf("Failed to enqueue %v operation for CStorVolume resource %s", q.Operation, q.Key)
+		glog.Errorf(
+			"Failed to enqueue %v operation for CStorVolume resource %s",
+			q.Operation,
+			q.Key,
+		)
 		runtime.HandleError(err)
 		return
 	}
@@ -219,11 +278,15 @@ func (c *CStorVolumeController) enqueueCStorVolume(obj *apis.CStorVolume, q comm
 }
 
 // getVolumeResource returns object corresponding to the resource key
-func (c *CStorVolumeController) getVolumeResource(key string) (*apis.CStorVolume, error) {
+func (c *CStorVolumeController) getVolumeResource(
+	key string,
+) (*apis.CStorVolume, error) {
 	// Convert the key(namespace/name) string into a distinct name
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
-		runtime.HandleError(fmt.Errorf("Invalid resource key: %s, err: %v", key, err))
+		runtime.HandleError(
+			fmt.Errorf("Invalid resource key: %s, err: %v", key, err),
+		)
 		return nil, err
 	}
 
@@ -231,12 +294,19 @@ func (c *CStorVolumeController) getVolumeResource(key string) (*apis.CStorVolume
 		namespace = string(common.DefaultNameSpace)
 	}
 
-	cStorVolumeGot, err := c.clientset.OpenebsV1alpha1().CStorVolumes(namespace).Get(name, metav1.GetOptions{})
+	cStorVolumeGot, err := c.clientset.OpenebsV1alpha1().
+		CStorVolumes(namespace).
+		Get(name, metav1.GetOptions{})
 	if err != nil {
 		// The cStorVolume resource may no longer exist, in which case we stop
 		// processing.
 		if errors.IsNotFound(err) {
-			runtime.HandleError(fmt.Errorf("cStorVolumeGot '%s' in work queue no longer exists", key))
+			runtime.HandleError(
+				fmt.Errorf(
+					"cStorVolumeGot '%s' in work queue no longer exists",
+					key,
+				),
+			)
 			return nil, err
 		}
 
@@ -245,20 +315,30 @@ func (c *CStorVolumeController) getVolumeResource(key string) (*apis.CStorVolume
 	return cStorVolumeGot, nil
 }
 
-// IsValidCStorVolumeMgmt is to check if the volume request is for particular pod/application.
+// IsValidCStorVolumeMgmt is to check if the volume request
+// is for particular pod/application.
 func IsValidCStorVolumeMgmt(cStorVolume *apis.CStorVolume) bool {
 	if os.Getenv(string(common.OpenEBSIOCStorVolumeID)) == string(cStorVolume.UID) {
-		glog.V(2).Infof("Right watcher for the cstor volume resource with id : %s", cStorVolume.UID)
+		glog.V(2).Infof(
+			"Right watcher for the cstor volume resource with id : %s",
+			cStorVolume.UID,
+		)
 		return true
 	}
-	glog.V(2).Infof("Wrong watcher for the cstor volume resource with id : %s", cStorVolume.UID)
+	glog.V(2).Infof(
+		"Wrong watcher for the cstor volume resource with id : %s",
+		cStorVolume.UID,
+	)
 	return false
 }
 
 // IsDestroyEvent is to check if the call is for cStorVolume destroy.
 func IsDestroyEvent(cStorVolume *apis.CStorVolume) bool {
 	if cStorVolume.ObjectMeta.DeletionTimestamp != nil {
-		glog.Infof("CStor volume destroy event for volume : %s", cStorVolume.Name)
+		glog.Infof(
+			"CStor volume destroy event for volume : %s",
+			cStorVolume.Name,
+		)
 		return true
 	}
 	glog.Infof("CStor volume modify event for volume : %s", cStorVolume.Name)
@@ -269,7 +349,10 @@ func IsDestroyEvent(cStorVolume *apis.CStorVolume) bool {
 func IsOnlyStatusChange(oldCStorVolume, newCStorVolume *apis.CStorVolume) bool {
 	if reflect.DeepEqual(oldCStorVolume.Spec, newCStorVolume.Spec) &&
 		!reflect.DeepEqual(oldCStorVolume.Status, newCStorVolume.Status) {
-		glog.Infof("Only status changed for cstor volume : %s", newCStorVolume.Name)
+		glog.Infof(
+			"Only status changed for cstor volume : %s",
+			newCStorVolume.Name,
+		)
 		return true
 	}
 	glog.Infof("No status changed for cstor volume : %s", newCStorVolume.Name)

--- a/cmd/cstor-volume-mgmt/controller/volume-controller/handler.go
+++ b/cmd/cstor-volume-mgmt/controller/volume-controller/handler.go
@@ -54,10 +54,10 @@ func (c *CStorVolumeController) syncHandler(
 	if status == common.CVStatusIgnore {
 		return nil
 	}
-	if cStorVolumeGot.Status.Phase != apis.CStorVolumePhase(status) {
-		cStorVolumeGot.Status.LastTransitionTime = metav1.Now()
-	}
 	cStorVolumeGot.Status.LastUpdateTime = metav1.Now()
+	if cStorVolumeGot.Status.Phase != apis.CStorVolumePhase(status) {
+		cStorVolumeGot.Status.LastTransitionTime = cStorVolumeGot.Status.LastUpdateTime
+	}
 	cStorVolumeGot.Status.Phase = apis.CStorVolumePhase(status)
 	if err != nil {
 		glog.Errorf(err.Error())
@@ -151,10 +151,11 @@ func (c *CStorVolumeController) cStorVolumeEventHandler(
 				)
 			}
 		}
-		if cStorVolumeGot.Status.Phase != lastKnownPhase {
-			cStorVolumeGot.Status.LastTransitionTime = metav1.Now()
-		}
 		cStorVolumeGot.Status.LastUpdateTime = metav1.Now()
+		if cStorVolumeGot.Status.Phase != lastKnownPhase {
+			cStorVolumeGot.Status.LastTransitionTime = cStorVolumeGot.Status.LastUpdateTime
+		}
+
 		cStorVolumeGot.Status.ReplicaStatuses = volStatus.ReplicaStatuses
 		updatedCstorVolume, err := c.clientset.OpenebsV1alpha1().
 			CStorVolumes(cStorVolumeGot.Namespace).

--- a/pkg/apis/openebs.io/v1alpha1/cstor_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_pool.go
@@ -109,11 +109,12 @@ const (
 
 // CStorPoolStatus is for handling status of pool.
 type CStorPoolStatus struct {
-	Phase              CStorPoolPhase        `json:"phase"`
-	Capacity           CStorPoolCapacityAttr `json:"capacity"`
-	LastTransitionTime metav1.Time           `json:"lastTransitionTime,omitempty"`
-	LastUpdateTime     metav1.Time           `json:"lastUpdateTime,omitempty"`
-	Message            string                `json:"message,omitempty"`
+	Phase    CStorPoolPhase        `json:"phase"`
+	Capacity CStorPoolCapacityAttr `json:"capacity"`
+	// LastTransitionTime refers to the time when the phase changes
+	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
+	LastUpdateTime     metav1.Time `json:"lastUpdateTime,omitempty"`
+	Message            string      `json:"message,omitempty"`
 }
 
 // CStorPoolCapacityAttr stores the pool capacity related attributes.

--- a/pkg/apis/openebs.io/v1alpha1/cstor_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_pool.go
@@ -109,10 +109,14 @@ const (
 
 // CStorPoolStatus is for handling status of pool.
 type CStorPoolStatus struct {
-	Phase    CStorPoolPhase        `json:"phase"`
-	Capacity CStorPoolCapacityAttr `json:"capacity"`
+	Phase              CStorPoolPhase        `json:"phase"`
+	Capacity           CStorPoolCapacityAttr `json:"capacity"`
+	LastTransitionTime metav1.Time           `json:"lastTransitionTime,omitempty"`
+	LastUpdateTime     metav1.Time           `json:"lastUpdateTime,omitempty"`
+	Message            string                `json:"message,omitempty"`
 }
 
+// CStorPoolCapacityAttr stores the pool capacity related attributes.
 type CStorPoolCapacityAttr struct {
 	Total string `json:"total"`
 	Free  string `json:"free"`

--- a/pkg/apis/openebs.io/v1alpha1/cstor_volume.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_volume.go
@@ -51,8 +51,11 @@ type CStorVolumePhase string
 
 // CStorVolumeStatus is for handling status of cvr.
 type CStorVolumeStatus struct {
-	Phase           CStorVolumePhase `json:"phase"`
-	ReplicaStatuses []ReplicaStatus  `json:"replicaStatuses,omitempty"`
+	Phase              CStorVolumePhase `json:"phase"`
+	ReplicaStatuses    []ReplicaStatus  `json:"replicaStatuses,omitempty"`
+	LastTransitionTime metav1.Time      `json:"lastTransitionTime,omitempty"`
+	LastUpdateTime     metav1.Time      `json:"lastUpdateTime,omitempty"`
+	Message            string           `json:"message,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/openebs.io/v1alpha1/cstor_volume.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_volume.go
@@ -51,11 +51,12 @@ type CStorVolumePhase string
 
 // CStorVolumeStatus is for handling status of cvr.
 type CStorVolumeStatus struct {
-	Phase              CStorVolumePhase `json:"phase"`
-	ReplicaStatuses    []ReplicaStatus  `json:"replicaStatuses,omitempty"`
-	LastTransitionTime metav1.Time      `json:"lastTransitionTime,omitempty"`
-	LastUpdateTime     metav1.Time      `json:"lastUpdateTime,omitempty"`
-	Message            string           `json:"message,omitempty"`
+	Phase           CStorVolumePhase `json:"phase"`
+	ReplicaStatuses []ReplicaStatus  `json:"replicaStatuses,omitempty"`
+	// LastTransitionTime refers to the time when the phase changes
+	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
+	LastUpdateTime     metav1.Time `json:"lastUpdateTime,omitempty"`
+	Message            string      `json:"message,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
@@ -87,8 +87,11 @@ const (
 
 // CStorVolumeReplicaStatus is for handling status of cvr.
 type CStorVolumeReplicaStatus struct {
-	Phase    CStorVolumeReplicaPhase `json:"phase"`
-	Capacity CStorVolumeCapacityAttr `json:"capacity"`
+	Phase              CStorVolumeReplicaPhase `json:"phase"`
+	Capacity           CStorVolumeCapacityAttr `json:"capacity"`
+	LastTransitionTime metav1.Time             `json:"lastTransitionTime,omitempty"`
+	LastUpdateTime     metav1.Time             `json:"lastUpdateTime,omitempty"`
+	Message            string                  `json:"message,omitempty"`
 }
 
 // CStorVolumeCapacityAttr is for storing the volume capacity.

--- a/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
@@ -87,11 +87,12 @@ const (
 
 // CStorVolumeReplicaStatus is for handling status of cvr.
 type CStorVolumeReplicaStatus struct {
-	Phase              CStorVolumeReplicaPhase `json:"phase"`
-	Capacity           CStorVolumeCapacityAttr `json:"capacity"`
-	LastTransitionTime metav1.Time             `json:"lastTransitionTime,omitempty"`
-	LastUpdateTime     metav1.Time             `json:"lastUpdateTime,omitempty"`
-	Message            string                  `json:"message,omitempty"`
+	Phase    CStorVolumeReplicaPhase `json:"phase"`
+	Capacity CStorVolumeCapacityAttr `json:"capacity"`
+	// LastTransitionTime refers to the time when the phase changes
+	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
+	LastUpdateTime     metav1.Time `json:"lastUpdateTime,omitempty"`
+	Message            string      `json:"message,omitempty"`
 }
 
 // CStorVolumeCapacityAttr is for storing the volume capacity.

--- a/pkg/apis/openebs.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/openebs.io/v1alpha1/zz_generated.deepcopy.go
@@ -415,7 +415,7 @@ func (in *CStorPool) DeepCopyInto(out *CStorPool) {
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	in.Spec.DeepCopyInto(&out.Spec)
-	out.Status = in.Status
+	in.Status.DeepCopyInto(&out.Status)
 	return
 }
 
@@ -646,6 +646,8 @@ func (in *CStorPoolSpec) DeepCopy() *CStorPoolSpec {
 func (in *CStorPoolStatus) DeepCopyInto(out *CStorPoolStatus) {
 	*out = *in
 	out.Capacity = in.Capacity
+	in.LastTransitionTime.DeepCopyInto(&out.LastTransitionTime)
+	in.LastUpdateTime.DeepCopyInto(&out.LastUpdateTime)
 	return
 }
 
@@ -961,7 +963,7 @@ func (in *CStorVolumeReplica) DeepCopyInto(out *CStorVolumeReplica) {
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	out.Spec = in.Spec
-	out.Status = in.Status
+	in.Status.DeepCopyInto(&out.Status)
 	return
 }
 
@@ -1036,6 +1038,8 @@ func (in *CStorVolumeReplicaSpec) DeepCopy() *CStorVolumeReplicaSpec {
 func (in *CStorVolumeReplicaStatus) DeepCopyInto(out *CStorVolumeReplicaStatus) {
 	*out = *in
 	out.Capacity = in.Capacity
+	in.LastTransitionTime.DeepCopyInto(&out.LastTransitionTime)
+	in.LastUpdateTime.DeepCopyInto(&out.LastUpdateTime)
 	return
 }
 
@@ -1073,6 +1077,8 @@ func (in *CStorVolumeStatus) DeepCopyInto(out *CStorVolumeStatus) {
 		*out = make([]ReplicaStatus, len(*in))
 		copy(*out, *in)
 	}
+	in.LastTransitionTime.DeepCopyInto(&out.LastTransitionTime)
+	in.LastUpdateTime.DeepCopyInto(&out.LastUpdateTime)
 	return
 }
 


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds the `LastUpdatedTime` and `LastTransitionTime` field for the status of `cstorvolume`, `cstorvolumereplica` and `cstorpool`.

sample csp :
```
apiVersion: openebs.io/v1alpha1
  kind: CStorPool
  metadata:
    annotations:
      openebs.io/csp-lease: '{"holder":"openebs/cstor-sparse-pool-8y6d-7fb44586c6-xfphf","leaderTransition":1}'
    creationTimestamp: "2019-07-03T06:51:17Z"
    generation: 60
    labels:
      kubernetes.io/hostname: minikube
      openebs.io/cas-template-name: cstor-pool-create-default-1.1.0
      openebs.io/cas-type: cstor
      openebs.io/storage-pool-claim: cstor-sparse-pool
      openebs.io/version: 1.1.0
    name: cstor-sparse-pool-8y6d
    ownerReferences:
    - apiVersion: openebs.io/v1alpha1
      blockOwnerDeletion: true
      controller: true
      kind: StoragePoolClaim
      name: cstor-sparse-pool
      uid: f4340f70-9d5e-11e9-907e-54e1ad5e8320
    resourceVersion: "8899"
    selfLink: /apis/openebs.io/v1alpha1/cstorpools/cstor-sparse-pool-8y6d
    uid: f52e9cc8-9d5e-11e9-907e-54e1ad5e8320
  spec:
    group:
    - blockDevice:
      - deviceID: /var/openebs/sparse/1-ndm-sparse.img
        inUseByPool: true
        name: sparse-089efd60dca9408ff135f4a2f5ebb545
    poolSpec:
      cacheFile: ""
      overProvisioning: false
      poolType: striped
  status:
    capacity:
      free: 9.94G
      total: 9.94G
      used: 1.64M
    lastTransitionTime: "2019-07-03T06:51:33Z"
    lastUpdateTime: "2019-07-03T07:20:00Z"
    phase: Healthy
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```
sample cvr:
```
apiVersion: openebs.io/v1alpha1
  kind: CStorVolumeReplica
  metadata:
    annotations:
      cstorpool.openebs.io/hostname: minikube
      isRestoreVol: "false"
      openebs.io/storage-class-ref: |
        name: openebs-cstor-sparse
        resourceVersion: 974
    creationTimestamp: "2019-07-03T07:43:07Z"
    finalizers:
    - cstorvolumereplica.openebs.io/finalizer
    generation: 9
    labels:
      cstorpool.openebs.io/name: cstor-sparse-pool-8y6d
      cstorpool.openebs.io/uid: f52e9cc8-9d5e-11e9-907e-54e1ad5e8320
      cstorvolume.openebs.io/name: pvc-31799907-9d66-11e9-885e-54e1ad5e8320
      openebs.io/cas-template-name: cstor-volume-create-default-1.1.0
      openebs.io/persistent-volume: pvc-31799907-9d66-11e9-885e-54e1ad5e8320
      openebs.io/version: 1.1.0
    name: pvc-31799907-9d66-11e9-885e-54e1ad5e8320-cstor-sparse-pool-8y6d
    namespace: openebs
    resourceVersion: "11516"
    selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/cstorvolumereplicas/pvc-31799907-9d66-11e9-885e-54e1ad5e8320-cstor-sparse-pool-8y6d
    uid: 32f0f48c-9d66-11e9-885e-54e1ad5e8320
  spec:
    capacity: 4G
    targetIP: 10.97.224.174
    zvolWorkers: ""
  status:
    capacity:
      totalAllocated: 6K
      used: 6K
    lastTransitionTime: "2019-07-03T07:43:55Z"
    lastUpdateTime: "2019-07-03T07:45:57Z"
    phase: Healthy
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```

sample cv:
```
apiVersion: openebs.io/v1alpha1
  kind: CStorVolume
  metadata:
    annotations:
      openebs.io/fs-type: ext4
      openebs.io/lun: "0"
      openebs.io/storage-class-ref: |
        name: openebs-cstor-sparse
        resourceVersion: 974
    creationTimestamp: "2019-07-03T07:43:07Z"
    generation: 6
    labels:
      openebs.io/cas-template-name: cstor-volume-create-default-1.1.0
      openebs.io/persistent-volume: pvc-31799907-9d66-11e9-885e-54e1ad5e8320
      openebs.io/version: 1.1.0
    name: pvc-31799907-9d66-11e9-885e-54e1ad5e8320
    namespace: openebs
    resourceVersion: "11499"
    selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/cstorvolumes/pvc-31799907-9d66-11e9-885e-54e1ad5e8320
    uid: 32cff794-9d66-11e9-885e-54e1ad5e8320
  spec:
    capacity: 4G
    consistencyFactor: 1
    iqn: iqn.2016-09.com.openebs.cstor:pvc-31799907-9d66-11e9-885e-54e1ad5e8320
    nodeBase: iqn.2016-09.com.openebs.cstor
    replicationFactor: 1
    status: Init
    targetIP: 10.97.224.174
    targetPort: "3260"
    targetPortal: 10.97.224.174:3260
  status:
    lastTransitionTime: "2019-07-03T07:43:51Z"
    lastUpdateTime: "2019-07-03T07:45:51Z"
    phase: Healthy
    replicaStatuses:
    - checkpointedIOSeq: "0"
      inflightRead: "0"
      inflightSync: "0"
      inflightWrite: "0"
      mode: Healthy
      quorum: "1"
      replicaId: "753706992609146025"
      upTime: 142
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests