### PR TITLE
refactor(kubeclient): add singleton instance to upgraderesult kubeclient

### DIFF
--- a/pkg/kubernetes/client/v1alpha1/client.go
+++ b/pkg/kubernetes/client/v1alpha1/client.go
@@ -142,9 +142,9 @@ var (
 
 // Instance returns a singleton instance of
 // this client
-func Instance() *Client {
+func Instance(opts ...OptionFn) *Client {
 	once.Do(func() {
-		instance = New()
+		instance = New(opts...)
 	})
 
 	return instance

--- a/pkg/kubernetes/client/v1alpha1/client_test.go
+++ b/pkg/kubernetes/client/v1alpha1/client_test.go
@@ -309,3 +309,10 @@ func TestConfigForPath(t *testing.T) {
 		})
 	}
 }
+
+func TestInstance(t *testing.T) {
+	c := Instance()
+	if c == nil {
+		t.Fatalf("test failed: expected non nil client instance got nil")
+	}
+}


### PR DESCRIPTION
This commit adds function that exposes creating a singleton instance for upgraderesult's kubeclient. This helps the caller code while creating a kubeclient instance since most of the properties of a kubeclient instance need to be set once in the lifetime of the process.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests