### PR TITLE
feat(spc, cspc): add support to create cspc from auto spc

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1096,6 +1096,7 @@
     "k8s.io/client-go/kubernetes/typed/core/v1",
     "k8s.io/client-go/kubernetes/typed/extensions/v1beta1",
     "k8s.io/client-go/kubernetes/typed/storage/v1",
+    "k8s.io/client-go/listers/core/v1",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/client-go/rest",
     "k8s.io/client-go/testing",

--- a/cmd/maya-apiserver/cstor-operator/spc/controller.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/controller.go
@@ -201,7 +201,6 @@ func (c *Controller) updateSpc(oldSpc, newSpc interface{}) {
 	// Currently we are reconciling based on maxPool count
 	glog.V(4).Infof("Queuing SPC %s for update event", spc.Name)
 	c.enqueueSpc(newSpc)
-	return
 }
 
 // deleteSpc is the delete event handler for spc.

--- a/cmd/maya-apiserver/cstor-operator/spc/controller.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/controller.go
@@ -177,10 +177,8 @@ func (c *Controller) updateSpc(oldSpc, newSpc interface{}) {
 		c.recorder.Event(spc, corev1.EventTypeWarning, "Update", message)
 		return
 	}
-	// Enqueue spc only when there is a pending pool to be created.
-	if c.isPoolPending(spc) {
-		c.enqueueSpc(newSpc)
-	}
+	// Don't reconcile on spc
+	return
 }
 
 // deleteSpc is the delete event handler for spc.

--- a/cmd/maya-apiserver/cstor-operator/spc/handler.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/handler.go
@@ -271,6 +271,10 @@ func (c *Controller) isPoolSpecPending(spc *apis.StoragePoolClaim) bool {
 	if len(cspcObjList) == 0 {
 		return true
 	}
+	if len(cspcObjList) > 1 {
+		glog.Errorf("got more than one cspc using spc %s", spc.Name, namespace)
+		return false
+	}
 	//TODO: should we support down scale of pools
 	if len(cspcObjList[0].Spec.Pools) >= *spc.Spec.MaxPools {
 		return false

--- a/cmd/maya-apiserver/cstor-operator/spc/handler.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/handler.go
@@ -259,6 +259,10 @@ func (c *Controller) isPoolSpecPending(spc *apis.StoragePoolClaim) bool {
 		return false
 	}
 	namespace := env.Get(env.OpenEBSNamespace)
+	if namespace == "" {
+		glog.Errorf("failed to get namespace for openebs from env variable")
+		return false
+	}
 	customSPCObj := &spcv1alpha1.SPC{Object: spc}
 	selector := klabels.SelectorFromSet(customSPCObj.GetDefaultSPCLabels())
 	cspcObjList, err := c.cspcLister.
@@ -272,7 +276,7 @@ func (c *Controller) isPoolSpecPending(spc *apis.StoragePoolClaim) bool {
 		return true
 	}
 	if len(cspcObjList) > 1 {
-		glog.Errorf("got more than one cspc using spc %s", spc.Name, namespace)
+		glog.Errorf("got more than one cspc using spc %s", spc.Name)
 		return false
 	}
 	//TODO: should we support down scale of pools

--- a/cmd/maya-apiserver/cstor-operator/spc/handler_test.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/handler_test.go
@@ -521,6 +521,7 @@ func TestIsPoolPending(t *testing.T) {
 		withNDMClient(fakeNDMClient).
 		withspcSynced(openebsInformerFactory).
 		withSpcLister(openebsInformerFactory).
+		withCSPCLister(openebsInformerFactory).
 		withRecorder(fakeKubeClient).
 		withWorkqueueRateLimiting().
 		withEventHandler(openebsInformerFactory).

--- a/cmd/maya-apiserver/cstor-operator/spc/handler_test.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/handler_test.go
@@ -22,6 +22,7 @@ import (
 	openebsFakeClientset "github.com/openebs/maya/pkg/client/generated/clientset/versioned/fake"
 	informers "github.com/openebs/maya/pkg/client/generated/informers/externalversions"
 	ndmFakeClientset "github.com/openebs/maya/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset/fake"
+	env "github.com/openebs/maya/pkg/env/v1alpha1"
 	spcv1alpha1 "github.com/openebs/maya/pkg/storagepoolclaim/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -630,6 +631,7 @@ func TestIsPoolSpecPening(t *testing.T) {
 		name := name
 		test := test
 		t.Run(name, func(t *testing.T) {
+			_ = env.Set(env.OpenEBSNamespace, "openebs")
 			gotBool := controller.isPoolSpecPending(test.spc)
 			if gotBool != test.expectedIsPending {
 				t.Errorf("%q test case failed as expected %v but got %v", name, test.expectedIsPending, gotBool)

--- a/cmd/maya-apiserver/cstor-operator/spc/spc_lease.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/spc_lease.go
@@ -121,7 +121,7 @@ func (sl *Lease) Release() {
 		newErr := fmt.Errorf("Lease could not be removed:%v", err)
 		runtime.HandleError(newErr)
 	}
-	glog.Info("Lease removed successfully on storagepoolclaim")
+	glog.V(4).Info("Lease removed successfully on storagepoolclaim")
 }
 
 func (sl *Lease) getPodName() string {

--- a/cmd/maya-apiserver/cstor-operator/spc/start.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/start.go
@@ -74,6 +74,8 @@ func Start() error {
 		withNDMClient(ndmClient).
 		withspcSynced(spcInformerFactory).
 		withSpcLister(spcInformerFactory).
+		withCSPCLister(spcInformerFactory).
+		withNodeLister(kubeInformerFactory).
 		withRecorder(kubeClient).
 		withEventHandler(spcInformerFactory).
 		withWorkqueueRateLimiting().Build()

--- a/cmd/maya-apiserver/cstor-operator/spc/storagepool_create.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/storagepool_create.go
@@ -103,6 +103,12 @@ func (pc *PoolCreateConfig) createCStorPoolCluster(
 	updatedSPC := pc.Spc
 	if !slice.ContainsString(pc.Spc.ObjectMeta.Finalizers, spcv1alpha1.SPCFinalizer, nil) {
 		updatedSPC, err = pc.patchSPCWithFinalizers()
+		if err != nil {
+			return errors.Wrapf(
+				err,
+				"failed to patch spc %s", pc.Spc.Name,
+			)
+		}
 	}
 	pc.Spc = updatedSPC
 	spc := pc.Spc

--- a/pkg/algorithm/nodeselect/v1alpha1/config.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/config.go
@@ -56,6 +56,8 @@ type Config struct {
 	CspClient cstorpool.CstorpoolInterface
 	// ProvisioningType tells the type of provisioning i.e. manual or auto.
 	ProvisioningType string
+	// Namespace where OpenEBS setup is installed
+	Namespace string
 }
 
 // getNDMK8sClient returns an instance of kubernetes client for NDM.
@@ -109,6 +111,7 @@ func NewConfig(spc *apis.StoragePoolClaim) *Config {
 	// Since provisioning type is auto kubernetes blockdevice client
 	bdClient = getNDMK8sClient()
 
+	namespace := env.Get(env.OpenEBSNamespace)
 	cspK8sClient := getCspK8sClient()
 	spK8sClient := getSpK8sClient()
 	pT := ProvisioningType(spc)
@@ -118,6 +121,7 @@ func NewConfig(spc *apis.StoragePoolClaim) *Config {
 		CspClient:         cspK8sClient,
 		SpClient:          spK8sClient,
 		ProvisioningType:  pT,
+		Namespace:         namespace,
 	}
 	return ac
 }

--- a/pkg/algorithm/nodeselect/v1alpha1/config.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/config.go
@@ -58,8 +58,8 @@ type Config struct {
 	ProvisioningType string
 }
 
-// getDiskK8sClient returns an instance of kubernetes client for Disk.
-func getBlockDeviceK8sClient() *blockdevice.KubernetesClient {
+// getNDMK8sClient returns an instance of kubernetes client for NDM.
+func getNDMK8sClient() *blockdevice.KubernetesClient {
 	namespace := env.Get(env.OpenEBSNamespace)
 	newClient, _ := k8s.NewK8sClient("")
 	K8sClient := &blockdevice.KubernetesClient{
@@ -75,7 +75,7 @@ func getBlockDeviceK8sClient() *blockdevice.KubernetesClient {
 // This client is used in manual provisioning of SPC.
 func getBlockDeviceSpcClient(spc *apis.StoragePoolClaim) *blockdevice.SpcObjectClient {
 	K8sClient := &blockdevice.SpcObjectClient{
-		KubernetesClient: getBlockDeviceK8sClient(),
+		KubernetesClient: getNDMK8sClient(),
 		Spc:              spc,
 	}
 	return K8sClient
@@ -106,14 +106,8 @@ func getCspK8sClient() *cstorpool.KubernetesClient {
 func NewConfig(spc *apis.StoragePoolClaim) *Config {
 	var bdClient blockdevice.BlockDeviceInterface
 
-	// If provisioning type is manual blockdeviceClient is assigned SPC
-	// blockdevice client
-	// else it is assigned kubernetes blockdevice client.
-	if ProvisioningType(spc) == ProvisioningTypeManual {
-		bdClient = getBlockDeviceSpcClient(spc)
-	} else {
-		bdClient = getBlockDeviceK8sClient()
-	}
+	// Since provisioning type is auto kubernetes blockdevice client
+	bdClient = getNDMK8sClient()
 
 	cspK8sClient := getCspK8sClient()
 	spK8sClient := getSpK8sClient()

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node.go
@@ -154,16 +154,9 @@ func (ac *Config) getUsedCSPCNodeMap() (map[string]bool, error) {
 	customNodeList := node.NewListBuilder().
 		WithAPIList(nodeList)
 	for _, pool := range cspcObj.Spec.Pools {
-		foundNode := false
-		for key, value := range pool.NodeSelector {
-			nodeName := customNodeList.GetLabeledNode(key, value).GetNodeName()
-			if nodeName != "" {
-				usedNodeMap[nodeName] = true
-				foundNode = true
-			}
-			if foundNode {
-				break
-			}
+		nodeName := customNodeList.GetNodeNameFromLabels(pool.NodeSelector)
+		if nodeName != "" {
+			usedNodeMap[nodeName] = true
 		}
 	}
 	return usedNodeMap, nil

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node.go
@@ -241,7 +241,8 @@ func (ac *Config) getCandidateNodeBlockDevices(
 		} else {
 			// Add the current blockdevice to the existing listbuilder of
 			// blockdevice
-			listBuilder = listBuilder.ListBuilderForObject(cspcBDObj)
+			listBuilderObj := listBuilder.ListBuilderForObject(cspcBDObj)
+			nodeBlockDeviceMap[hostName] = listBuilderObj
 		}
 	}
 	if len(nodeBlockDeviceMap) == 0 {

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node.go
@@ -147,14 +147,19 @@ func (ac *Config) getUsedCSPCNodeMap() (map[string]bool, error) {
 		)
 	}
 	cspcObj := cspcList.Items[0]
-	nodeList, err := node.NewKubeClient().List(metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-	customNodeList := node.NewListBuilder().
-		WithAPIList(nodeList)
+	// TODO: Remove below code after getting review comments
+	//nodeList, err := node.NewKubeClient().List(metav1.ListOptions{})
+	//if err != nil {
+	//	return nil, err
+	//}
+	//customNodeList := node.NewListBuilder().
+	//	WithAPIList(nodeList)
 	for _, pool := range cspcObj.Spec.Pools {
-		nodeName := customNodeList.GetNodeNameFromLabels(pool.NodeSelector)
+		//nodeName := customNodeList.GetNodeNameFromLabels(pool.NodeSelector)
+		nodeName, err := node.GetNodeFromLabelSelector(pool.NodeSelector)
+		if err != nil {
+			return nil, err
+		}
 		if nodeName != "" {
 			usedNodeMap[nodeName] = true
 		}
@@ -201,6 +206,9 @@ func (ac *Config) getCandidateNodeBlockDevices(
 		bd := blockdevice.BlockDevice{
 			BlockDevice: &blockDevice,
 		}
+		//TODO: Update below code when ndm fixes bug
+		// i.e updating value of kubernetes.io/hostName as node name instead of
+		// putting host name
 		hostName := bd.BlockDevice.Labels[string(apis.HostNameCPK)]
 		listBuilder := nodeBlockDeviceMap[hostName]
 		capacity := bd.BlockDevice.Spec.Capacity.Storage

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node.go
@@ -207,8 +207,8 @@ func (ac *Config) getCandidateNodeBlockDevices(
 			BlockDevice: &blockDevice,
 		}
 		//TODO: Update below code when ndm fixes bug
-		// i.e updating value of kubernetes.io/hostName as node name instead of
-		// putting host name
+		// i.e updating value of kubernetes.io/hostName as host name instead of
+		// putting node name
 		hostName := bd.BlockDevice.Labels[string(apis.HostNameCPK)]
 		listBuilder := nodeBlockDeviceMap[hostName]
 		capacity := bd.BlockDevice.Spec.Capacity.Storage

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node.go
@@ -45,10 +45,6 @@ type ClaimedBDDetails struct {
 	BlockDeviceList []BDDetails
 }
 
-type bdCapacityRepetition struct {
-	sizeRepetitions map[uint64]int
-}
-
 // NodeBlockDeviceSelector selects required node and block devices attached to
 // the node
 func (ac *Config) NodeBlockDeviceSelector() (map[string]*cspcbd.ListBuilder, error) {
@@ -216,7 +212,7 @@ func (ac *Config) getCandidateNodeBlockDevices(
 		listBuilder := nodeBlockDeviceMap[hostName]
 		capacity := bd.BlockDevice.Spec.Capacity.Storage
 		// If node is already in use by cspc then continue
-		if usedCSPCNodes[hostName] == true {
+		if usedCSPCNodes[hostName] {
 			continue
 		}
 		// If enough blockdevices are selected from the node then continue

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node_test.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node_test.go
@@ -74,7 +74,16 @@ func FakeDiskCreator(bd *blockdevice.KubernetesClient) {
 				Details: ndmapis.DeviceDetails{
 					DeviceType: deviceType,
 				},
+				Capacity: ndmapis.DeviceCapacity{
+					Storage: 10737418240,
+				},
 				Partitioned: "NO",
+				DevLinks: []ndmapis.DeviceDevLink{
+					ndmapis.DeviceDevLink{
+						Kind:  "by-ID",
+						Links: []string{"/dev/sda"},
+					},
+				},
 			},
 			Status: ndmapis.DeviceStatus{
 				State: DiskStateActive,
@@ -195,10 +204,14 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 					PoolSpec: v1alpha1.CStorPoolAttr{
 						PoolType: "striped",
 					},
+					MaxPools: func() *int {
+						count := 1
+						return &count
+					}(),
 				},
 			},
 			expectedDiskListLength: 1,
-			expectedErr:            true,
+			expectedErr:            false,
 		},
 		// Test Case #2
 		"autoSPC2": {
@@ -208,10 +221,14 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 					PoolSpec: v1alpha1.CStorPoolAttr{
 						PoolType: "mirrored",
 					},
+					MaxPools: func() *int {
+						count := 3
+						return &count
+					}(),
 				},
 			},
-			expectedDiskListLength: 2,
-			expectedErr:            true,
+			expectedDiskListLength: 6,
+			expectedErr:            false,
 		},
 		// Test Case #3
 		"autoSPC3": {
@@ -221,23 +238,31 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 					PoolSpec: v1alpha1.CStorPoolAttr{
 						PoolType: "striped",
 					},
+					MaxPools: func() *int {
+						count := 4
+						return &count
+					}(),
 				},
 			},
-			expectedDiskListLength: 1,
-			expectedErr:            true,
+			expectedDiskListLength: 4,
+			expectedErr:            false,
 		},
 		// Test Case #4
 		"autoSPC4": {
 			fakeCasPool: &v1alpha1.StoragePoolClaim{
 				Spec: v1alpha1.StoragePoolClaimSpec{
-					Type: "sparse",
+					Type: "disk",
 					PoolSpec: v1alpha1.CStorPoolAttr{
-						PoolType: "mirrored",
+						PoolType: "raidz2",
 					},
+					MaxPools: func() *int {
+						count := 3
+						return &count
+					}(),
 				},
 			},
-			expectedDiskListLength: 2,
-			expectedErr:            true,
+			expectedDiskListLength: 18,
+			expectedErr:            false,
 		},
 		//Test Case #5
 		// blockdevice0, blockdevice1 are of sparse type
@@ -254,7 +279,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 				},
 			},
 			expectedDiskListLength: 1,
-			expectedErr:            false,
+			expectedErr:            true,
 		},
 		// Test Case #6
 		"manualSPC6": {
@@ -270,7 +295,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 				},
 			},
 			expectedDiskListLength: 2,
-			expectedErr:            false,
+			expectedErr:            true,
 		},
 		// Test Case #7
 		"manualSPC7": {
@@ -286,7 +311,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 				},
 			},
 			expectedDiskListLength: 0,
-			expectedErr:            false,
+			expectedErr:            true,
 		},
 		// Test Case #8
 		"manualSPC8": {
@@ -302,7 +327,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 				},
 			},
 			expectedDiskListLength: 4,
-			expectedErr:            false,
+			expectedErr:            true,
 		},
 		// Test Case #8
 		"manualSPC9": {
@@ -318,7 +343,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 				},
 			},
 			expectedDiskListLength: 2,
-			expectedErr:            false,
+			expectedErr:            true,
 		},
 		// Test Case #10
 		"manualSPC10Raidz": {
@@ -334,7 +359,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 				},
 			},
 			expectedDiskListLength: 3,
-			expectedErr:            false,
+			expectedErr:            true,
 		},
 		// Test Case #11
 		"manualSPC11Raidz": {
@@ -350,7 +375,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 				},
 			},
 			expectedDiskListLength: 0,
-			expectedErr:            false,
+			expectedErr:            true,
 		},
 		// Test Case #12
 		"manualSPC12Raidz": {
@@ -366,7 +391,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 				},
 			},
 			expectedDiskListLength: 3,
-			expectedErr:            false,
+			expectedErr:            true,
 		},
 		// Test Case #13
 		"manualSPC13Raidz": {
@@ -382,7 +407,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 				},
 			},
 			expectedDiskListLength: 3,
-			expectedErr:            false,
+			expectedErr:            true,
 		},
 		// Test Case #14
 		"manualSPC14Raidz": {
@@ -398,7 +423,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 				},
 			},
 			expectedDiskListLength: 0,
-			expectedErr:            false,
+			expectedErr:            true,
 		},
 		// Test Case #15
 		"manualSPC15Raidz2": {
@@ -414,7 +439,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 				},
 			},
 			expectedDiskListLength: 0,
-			expectedErr:            false,
+			expectedErr:            true,
 		},
 		// Test Case #16
 		"manualSPC16Raidz2": {
@@ -430,7 +455,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 				},
 			},
 			expectedDiskListLength: 0,
-			expectedErr:            false,
+			expectedErr:            true,
 		},
 		// Test Case #17
 		"manualSPC17Raidz2": {
@@ -446,7 +471,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 				},
 			},
 			expectedDiskListLength: 0,
-			expectedErr:            false,
+			expectedErr:            true,
 		},
 		// Test Case #18
 		"manualSPC18Raidz2": {
@@ -462,7 +487,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 				},
 			},
 			expectedDiskListLength: 6,
-			expectedErr:            false,
+			expectedErr:            true,
 		},
 		// Test Case #19
 		"manualSPC19Raidz2": {
@@ -478,7 +503,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 				},
 			},
 			expectedDiskListLength: 12,
-			expectedErr:            false,
+			expectedErr:            true,
 		},
 		// Test Case #20
 		"manualSPC20Raidz2": {
@@ -494,7 +519,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 				},
 			},
 			expectedDiskListLength: 6,
-			expectedErr:            false,
+			expectedErr:            true,
 		},
 		// Test Case #21
 		"manualSPC21Raidz2": {
@@ -510,7 +535,7 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 				},
 			},
 			expectedDiskListLength: 0,
-			expectedErr:            false,
+			expectedErr:            true,
 		},
 		// Test Case #22
 		"manualSPC22Raidz2": {
@@ -533,16 +558,28 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 	for name, test := range tests {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
+			//hostName := "gke-ashu-cstor-default-pool-a4065fd6-vxsh0"
 			ac := fakeAlgorithmConfig(test.fakeCasPool)
-			blockdeviceList, err := ac.NodeBlockDeviceSelector()
+			//blockdeviceList, err := ac.NodeBlockDeviceSelector()
+			selectedNodeBDs, err := ac.NodeBlockDeviceSelector()
 			if test.expectedErr && err == nil {
 				t.Fatalf("Test case failed expected error not to be nil")
 			}
 			if !test.expectedErr && err != nil {
-				t.Fatalf("Test case failed expected error to be nil")
+				t.Fatalf(
+					"Test case failed expected error to be nil but got error %v",
+					err,
+				)
 			}
-			if err == nil && len(blockdeviceList.BlockDevices.Items) != test.expectedDiskListLength {
-				t.Errorf("Test case failed as the expected blockdevice list length is %d but got %d", test.expectedDiskListLength, len(blockdeviceList.BlockDevices.Items))
+			if err == nil {
+				gotLen := 0
+				for _, val := range selectedNodeBDs {
+					val, _ := val.ToObjectList()
+					gotLen += len(val)
+				}
+				if gotLen != test.expectedDiskListLength {
+					t.Errorf("%q test case failed as the expected blockdevice list length is %d but got %d", name, test.expectedDiskListLength, gotLen)
+				}
 			}
 		})
 	}

--- a/pkg/algorithm/nodeselect/v1alpha2/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha2/select_node.go
@@ -39,7 +39,7 @@ func (ac *Config) SelectNode() (*apis.PoolSpec, string, error) {
 	for _, pool := range ac.CSPC.Spec.Pools {
 		// pin it
 		pool := pool
-		nodeName, err := GetNodeFromLabelSelector(pool.NodeSelector)
+		nodeName, err := nodeapis.GetNodeFromLabelSelector(pool.NodeSelector)
 		if err != nil || nodeName == "" {
 			glog.Errorf("could not use node for selectors {%v}", pool.NodeSelector)
 			continue
@@ -56,31 +56,6 @@ func (ac *Config) SelectNode() (*apis.PoolSpec, string, error) {
 
 	}
 	return nil, "", errors.New("no node qualified for pool creation")
-}
-
-// GetNodeFromLabelSelector returns the node name selected by provided labels
-// TODO : Move it to node package
-func GetNodeFromLabelSelector(labels map[string]string) (string, error) {
-	nodeList, err := nodeapis.NewKubeClient().List(metav1.ListOptions{LabelSelector: getLabelSelectorString(labels)})
-	if err != nil {
-		return "", errors.Wrap(err, "failed to get node list from the node selector")
-	}
-	if len(nodeList.Items) != 1 {
-		return "", errors.Errorf("could not get a unique node from the given node selectors")
-	}
-	return nodeList.Items[0].Name, nil
-}
-
-// getLabelSelectorString returns a string of label selector form label map to be used in
-// list options.
-// TODO : Move it to node package
-func getLabelSelectorString(selector map[string]string) string {
-	var selectorString string
-	for key, value := range selector {
-		selectorString = selectorString + key + "=" + value + ","
-	}
-	selectorString = selectorString[:len(selectorString)-len(",")]
-	return selectorString
 }
 
 // GetUsedNode returns a map of node for which pool has already been created.

--- a/pkg/apiutil/apiutil.go
+++ b/pkg/apiutil/apiutil.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+//TODO: Get better home from reviews
+package apiutil
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+)
+
+// RemoveFinalizer will removes the finalizer from object meta
+func RemoveFinalizer(
+	objMeta *metav1.ObjectMeta,
+	removeFinalizers ...string) {
+	objFinalizers := objMeta.GetFinalizers()
+	if len(objFinalizers) == 0 || len(removeFinalizers) == 0 {
+		return
+	}
+	updatedFinalizerList := RemoveSlices(objFinalizers, removeFinalizers)
+	objMeta.SetFinalizers(updatedFinalizerList)
+}
+
+// RemoveSlices will remove removeList from originalList
+func RemoveSlices(originalList, removeList []string) []string {
+	removeListMap := map[string]bool{}
+	resultList := []string{}
+	for _, value := range removeList {
+		removeListMap[value] = true
+	}
+	for _, value := range originalList {
+		if !removeListMap[value] {
+			resultList = append(resultList, value)
+		}
+	}
+	return resultList
+}
+
+// GetPatchData returns byte difference in object
+func GetPatchData(oldObj, newObj interface{}) ([]byte, error) {
+	oldData, err := json.Marshal(oldObj)
+	if err != nil {
+		return nil, errors.Wrapf(err, "marshal old object failed")
+	}
+	newData, err := json.Marshal(newObj)
+	if err != nil {
+		return nil, errors.Wrapf(err, "mashal new object failed")
+	}
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, oldObj)
+	if err != nil {
+		return nil, errors.Wrapf(err, "CreateTwoWayMergePatch failed")
+	}
+	return patchBytes, nil
+}

--- a/pkg/blockdevice/v1alpha1/blockdevice.go
+++ b/pkg/blockdevice/v1alpha1/blockdevice.go
@@ -39,6 +39,7 @@ const (
 	FilterNonSparseDevices  = "filterNonSparseDevices"
 	InActiveStatus          = "Inactive"
 	FilterNonRelesedDevices = "filterNonRelesedDevices"
+	FilterUnclaimedDevices  = "filterUnclaimedDevices"
 )
 
 // DefaultDiskCount is a map containing the default block device count of various raid types.
@@ -118,6 +119,7 @@ var filterOptionFuncMap = map[string]filterOptionFunc{
 	FilterSparseDevices:     filterSparseDevices,
 	FilterNonSparseDevices:  filterNonSparseDevices,
 	FilterNonRelesedDevices: filterNonRelesedDevices,
+	FilterUnclaimedDevices:  filterUnclaimedDevices,
 }
 
 // predicateFailedError returns the predicate error which is provided to this function as an argument
@@ -298,6 +300,19 @@ func filterNonRelesedDevices(originalList *BlockDeviceList) *BlockDeviceList {
 	}
 	for _, device := range originalList.Items {
 		if !(device.Status.ClaimState == ndm.BlockDeviceReleased) {
+			filteredList.Items = append(filteredList.Items, device)
+		}
+	}
+	return filteredList
+}
+
+func filterUnclaimedDevices(originalList *BlockDeviceList) *BlockDeviceList {
+	filteredList := &BlockDeviceList{
+		BlockDeviceList: &ndm.BlockDeviceList{},
+		errs:            nil,
+	}
+	for _, device := range originalList.Items {
+		if device.Status.ClaimState == ndm.BlockDeviceUnclaimed {
 			filteredList.Items = append(filteredList.Items, device)
 		}
 	}

--- a/pkg/cstor/poolcluster/v1alpha1/build.go
+++ b/pkg/cstor/poolcluster/v1alpha1/build.go
@@ -33,6 +33,11 @@ func NewBuilder() *Builder {
 	return &Builder{cspc: &CSPC{object: &apisv1alpha1.CStorPoolCluster{}}}
 }
 
+// BuilderFromCSPC returns new instance of Builder with cspc object
+func BuilderFromCSPC(cspc *CSPC) *Builder {
+	return &Builder{cspc: cspc}
+}
+
 // WithName sets the Name field of CSPC with provided value.
 func (b *Builder) WithName(name string) *Builder {
 	if len(name) == 0 {
@@ -40,6 +45,37 @@ func (b *Builder) WithName(name string) *Builder {
 		return b
 	}
 	b.cspc.object.Name = name
+	return b
+}
+
+// WithLabelsNew resets existing labels if any with
+// ones that are provided here
+func (b *Builder) WithLabelsNew(labels map[string]string) *Builder {
+	if len(labels) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build service object: no new labels"),
+		)
+		return b
+	}
+
+	newlbls := map[string]string{}
+	for key, value := range labels {
+		newlbls[key] = value
+	}
+
+	// override
+	b.cspc.object.Labels = newlbls
+	return b
+}
+
+// WithFinalizersNew sets the finalizer field of CSPC with provided value
+func (b *Builder) WithFinalizersNew(finalizers []string) *Builder {
+	if len(finalizers) == 0 {
+		b.errs = append(b.errs, errors.New("failed to build CSPC object: missing CSPC finalizers"))
+		return b
+	}
+	b.cspc.object.Finalizers = append(b.cspc.object.Finalizers, finalizers...)
 	return b
 }
 

--- a/pkg/cstor/poolcluster/v1alpha1/build.go
+++ b/pkg/cstor/poolcluster/v1alpha1/build.go
@@ -43,6 +43,16 @@ func (b *Builder) WithName(name string) *Builder {
 	return b
 }
 
+// WithNamespace sets the Namespace field of CSPC with provided value
+func (b *Builder) WithNamespace(namespace string) *Builder {
+	if len(namespace) == 0 {
+		b.errs = append(b.errs, errors.New("failed to build CSPC object: missing CSPC namespace"))
+		return b
+	}
+	b.cspc.object.Namespace = namespace
+	return b
+}
+
 // WithPoolSpecBuilder adds a pool to this cspc object.
 //
 // NOTE:

--- a/pkg/cstor/poolcluster/v1alpha1/cstorpoolblockdevice/build.go
+++ b/pkg/cstor/poolcluster/v1alpha1/cstorpoolblockdevice/build.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cstorpoolclusterblockdevice
+
+import (
+	"github.com/pkg/errors"
+
+	apisv1alpha1 "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+)
+
+// Builder is the builder object for CSPC blockdevices
+type Builder struct {
+	cspcbd *CSPCBlockDevice
+	errs   []error
+}
+
+// NewBuilder returns new instance of Builder
+func NewBuilder() *Builder {
+	return &Builder{
+		cspcbd: &CSPCBlockDevice{
+			object: &apisv1alpha1.CStorPoolClusterBlockDevice{},
+		},
+	}
+}
+
+// WithBlockDeviceName sets the BlockDeviceName field of
+// cstorpoolclusterblockdevice
+func (b *Builder) WithBlockDeviceName(name string) *Builder {
+	if len(name) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build cspc blockdeviceobject: missing blockdevice name"),
+		)
+		return b
+	}
+	b.cspcbd.object.BlockDeviceName = name
+	return b
+}
+
+// WithCapacity sets the capacity field of cstorpoolclusterblockdevice
+func (b *Builder) WithCapacity(capacity string) *Builder {
+	if len(capacity) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build cspc blockdeviceobject: missing blockdevice capacity"),
+		)
+		return b
+	}
+	b.cspcbd.object.Capacity = capacity
+	return b
+}
+
+// WithDevLink sets the devLink field of cstorpoolclusterblockdevice
+func (b *Builder) WithDevLink(devLink string) *Builder {
+	if len(devLink) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build cspc blockdeviceobject: missing blockdevice devLink"),
+		)
+		return b
+	}
+	b.cspcbd.object.DevLink = devLink
+	return b
+}
+
+// Build returns the CStorPoolClusterBlockDevice API instance
+func (b *Builder) Build() (*CSPCBlockDevice, error) {
+	if len(b.errs) > 0 {
+		return nil, errors.Errorf("%+v", b.errs)
+	}
+	return b.cspcbd, nil
+}
+
+// ToAPI  returns the cstorpoolclusterblockdevice api object from the builder object.
+func (cspcbd *CSPCBlockDevice) ToAPI() *apisv1alpha1.CStorPoolClusterBlockDevice {
+	return cspcbd.object
+}

--- a/pkg/cstor/poolcluster/v1alpha1/cstorpoolblockdevice/buildlist.go
+++ b/pkg/cstor/poolcluster/v1alpha1/cstorpoolblockdevice/buildlist.go
@@ -53,7 +53,7 @@ func ListBuilderForObjectNew(cspcBD *CSPCBlockDevice) *ListBuilder {
 	if cspcBD == nil {
 		lb.errs = append(
 			lb.errs,
-			errors.New("failed to build cspc blockdevice list: missing object cspc blockdevice"),
+			errors.New("failed to build cspc blockdevice list: no new cspc blockdevice"),
 		)
 		return lb
 	}

--- a/pkg/cstor/poolcluster/v1alpha1/cstorpoolblockdevice/buildlist.go
+++ b/pkg/cstor/poolcluster/v1alpha1/cstorpoolblockdevice/buildlist.go
@@ -70,6 +70,9 @@ func (lb *ListBuilder) ListBuilderForObject(cspcBD *CSPCBlockDevice) *ListBuilde
 		)
 		return lb
 	}
+	if lb == nil {
+		return ListBuilderForObjectNew(cspcBD)
+	}
 	lb.list.items = append(lb.list.items, cspcBD)
 	return lb
 }
@@ -92,6 +95,9 @@ func (lb *ListBuilder) Len() int {
 	return lb.list.Len()
 }
 
+//TODO: Get good function name from reviews
+
+// ToObjectList converts the ListBuilder object into array of custom objects
 func (lb *ListBuilder) ToObjectList() ([]*CSPCBlockDevice, error) {
 	if len(lb.errs) > 0 {
 		return nil, errors.Errorf("%+v", lb.errs)

--- a/pkg/cstor/poolcluster/v1alpha1/cstorpoolblockdevice/buildlist.go
+++ b/pkg/cstor/poolcluster/v1alpha1/cstorpoolblockdevice/buildlist.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cstorpoolclusterblockdevice
+
+import (
+	"github.com/pkg/errors"
+)
+
+// ListBuilder enables building an instance of
+// CSPCBlockDevices
+type ListBuilder struct {
+	list *CSPCBlockDeviceList
+	errs []error
+}
+
+// NewListBuilder returns an instance of ListBuilder
+func NewListBuilder() *ListBuilder {
+	return &ListBuilder{list: &CSPCBlockDeviceList{}}
+}
+
+// ListBuilderForObjectList builds the ListBuilder object based on CSPCList
+func ListBuilderForObjectList(cspcBDList *CSPCBlockDeviceList) *ListBuilder {
+	b := NewListBuilder()
+	if cspcBDList == nil {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build cspc blockdevice list: missing object list"),
+		)
+		return b
+	}
+	b.list = cspcBDList
+	return b
+}
+
+// ListBuilderForObjectNew builds the new ListBuilder object
+// based on CSPCBlockDevice
+func ListBuilderForObjectNew(cspcBD *CSPCBlockDevice) *ListBuilder {
+	lb := &ListBuilder{list: &CSPCBlockDeviceList{}}
+	if cspcBD == nil {
+		lb.errs = append(
+			lb.errs,
+			errors.New("failed to build cspc blockdevice list: missing object cspc blockdevice"),
+		)
+		return lb
+	}
+	lb.list.items = append(lb.list.items, cspcBD)
+	return lb
+}
+
+// ListBuilderForObject adds the CSPCBlockDevice to existing ListBuilder
+func (lb *ListBuilder) ListBuilderForObject(cspcBD *CSPCBlockDevice) *ListBuilder {
+	if cspcBD == nil {
+		lb.errs = append(
+			lb.errs,
+			errors.New("failed to build cspc blockdevice list: missing object cspc blockdevice"),
+		)
+		return lb
+	}
+	lb.list.items = append(lb.list.items, cspcBD)
+	return lb
+}
+
+// GetRequiredBlockDevices returns the n number of blockdevices
+func (lb *ListBuilder) GetRequiredBlockDevices(count int) *ListBuilder {
+	newListBuilder := &ListBuilder{list: &CSPCBlockDeviceList{}}
+	for i, obj := range lb.list.items {
+		obj := obj
+		newListBuilder.list.items = append(newListBuilder.list.items, obj)
+		if i == count {
+			break
+		}
+	}
+	return newListBuilder
+}
+
+// Len returns the count of CSPC blockdevices
+func (lb *ListBuilder) Len() int {
+	return lb.list.Len()
+}
+
+func (lb *ListBuilder) ToObjectList() ([]*CSPCBlockDevice, error) {
+	if len(lb.errs) > 0 {
+		return nil, errors.Errorf("%+v", lb.errs)
+	}
+	return lb.list.items, nil
+}

--- a/pkg/cstor/poolcluster/v1alpha1/cstorpoolblockdevice/cstorpoolblockdevice.go
+++ b/pkg/cstor/poolcluster/v1alpha1/cstorpoolblockdevice/cstorpoolblockdevice.go
@@ -20,10 +20,14 @@ import (
 	apisv1alpha1 "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 )
 
+// CSPCBlockDevice is a wrapper over cstorpoolcluster blockdevice api
+// object. It provides build, validations and other common
+// logic to be used by various feature specific callers.
 type CSPCBlockDevice struct {
 	object *apisv1alpha1.CStorPoolClusterBlockDevice
 }
 
+// CSPCBlockDeviceList holds the list of cspc blockdevice instances
 type CSPCBlockDeviceList struct {
 	items []*CSPCBlockDevice
 }

--- a/pkg/cstor/poolcluster/v1alpha1/cstorpoolblockdevice/cstorpoolblockdevice.go
+++ b/pkg/cstor/poolcluster/v1alpha1/cstorpoolblockdevice/cstorpoolblockdevice.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cstorpoolclusterblockdevice
+
+import (
+	apisv1alpha1 "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+)
+
+type CSPCBlockDevice struct {
+	object *apisv1alpha1.CStorPoolClusterBlockDevice
+}
+
+type CSPCBlockDeviceList struct {
+	items []*CSPCBlockDevice
+}
+
+// Len returns the number of items present
+// in the PSList
+func (c *CSPCBlockDeviceList) Len() int {
+	return len(c.items)
+}

--- a/pkg/cstor/poolcluster/v1alpha1/cstorpoolcluster.go
+++ b/pkg/cstor/poolcluster/v1alpha1/cstorpoolcluster.go
@@ -100,3 +100,7 @@ func (b *ListBuilder) WithFilter(pred ...Predicate) *ListBuilder {
 	b.filters = append(b.filters, pred...)
 	return b
 }
+
+func (c *CSPC) ToAPI() *apisv1alpha1.CStorPoolCluster {
+	return c.object
+}

--- a/pkg/cstor/poolcluster/v1alpha1/cstorpoolcluster.go
+++ b/pkg/cstor/poolcluster/v1alpha1/cstorpoolcluster.go
@@ -19,6 +19,7 @@ import (
 )
 
 const (
+	// CSPCFinalizer represents finalizer value on cspc
 	CSPCFinalizer = "cstorpoolcluster.openebs.io/finalizer"
 )
 
@@ -105,6 +106,7 @@ func (b *ListBuilder) WithFilter(pred ...Predicate) *ListBuilder {
 	return b
 }
 
+// ToAPI converts CSPC to API CSP
 func (c *CSPC) ToAPI() *apisv1alpha1.CStorPoolCluster {
 	return c.object
 }

--- a/pkg/cstor/poolcluster/v1alpha1/cstorpoolcluster.go
+++ b/pkg/cstor/poolcluster/v1alpha1/cstorpoolcluster.go
@@ -18,6 +18,10 @@ import (
 	apisv1alpha1 "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 )
 
+const (
+	CSPCFinalizer = "cstorpoolcluster.openebs.io/finalizer"
+)
+
 // CSPC is a wrapper over cstorpoolcluster api
 // object. It provides build, validations and other common
 // logic to be used by various feature specific callers.

--- a/pkg/cstor/poolcluster/v1alpha1/cstorpoolspecs/build.go
+++ b/pkg/cstor/poolcluster/v1alpha1/cstorpoolspecs/build.go
@@ -39,13 +39,31 @@ func (b *Builder) AppendErrorToBuilder(err error) *Builder {
 	return b
 }
 
+// WithNodeSelectorNew sets the node selector with provided value
+func (b *Builder) WithNodeSelectorNew(nodeSelector map[string]string) *Builder {
+	if len(nodeSelector) == 0 {
+		b.errs = append(b.errs, errors.New("failed to build pool spec object: missing node selector"))
+		return b
+	}
+	b.ps.object.NodeSelector = map[string]string{}
+	for key, value := range nodeSelector {
+		b.ps.object.NodeSelector[key] = value
+	}
+	return b
+}
+
 // WithNodeSelector sets the node selector with provided value.
 func (b *Builder) WithNodeSelector(nodeSelector map[string]string) *Builder {
 	if len(nodeSelector) == 0 {
 		b.errs = append(b.errs, errors.New("failed to build pool spec object: missing node selector"))
 		return b
 	}
-	b.ps.object.NodeSelector = nodeSelector
+	if b.ps.object.NodeSelector == nil {
+		return b.WithNodeSelector(nodeSelector)
+	}
+	for key, value := range nodeSelector {
+		b.ps.object.NodeSelector[key] = value
+	}
 	return b
 }
 
@@ -60,12 +78,12 @@ func (b *Builder) WithCacheFilePath(cacheFile string) *Builder {
 }
 
 // WithDefaultRaidGroupType sets the cacheFile field of pool spec with provided value.
-func (b *Builder) WithDefaultRaidGroupType(cacheFile string) *Builder {
-	if len(cacheFile) == 0 {
-		b.errs = append(b.errs, errors.New("failed to build pool spec object: missing cache file path"))
+func (b *Builder) WithDefaultRaidGroupType(raidType string) *Builder {
+	if len(raidType) == 0 {
+		b.errs = append(b.errs, errors.New("failed to build pool spec object: missing raidType name"))
 		return b
 	}
-	b.ps.object.PoolConfig.CacheFile = cacheFile
+	b.ps.object.PoolConfig.DefaultRaidGroupType = raidType
 	return b
 }
 

--- a/pkg/cstor/poolcluster/v1alpha1/raidgroups/build.go
+++ b/pkg/cstor/poolcluster/v1alpha1/raidgroups/build.go
@@ -71,6 +71,7 @@ func (b *Builder) WithReadCache() *Builder {
 	return b
 }
 
+// WithCSPCBlockDeviceList sets the blockdevices field with provided value
 func (b *Builder) WithCSPCBlockDeviceList(listBuilderCSPCBD *cspcbd.ListBuilder) *Builder {
 	if listBuilderCSPCBD == nil {
 		b.errs = append(

--- a/pkg/cstor/poolcluster/v1alpha1/raidgroups/build.go
+++ b/pkg/cstor/poolcluster/v1alpha1/raidgroups/build.go
@@ -18,6 +18,7 @@ package raidgroups
 
 import (
 	apisv1alpha1 "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	cspcbd "github.com/openebs/maya/pkg/cstor/poolcluster/v1alpha1/cstorpoolblockdevice"
 	"github.com/pkg/errors"
 )
 
@@ -67,6 +68,28 @@ func (b *Builder) WithSpare() *Builder {
 // WithReadCache flags the IsReadCache field of raid group.
 func (b *Builder) WithReadCache() *Builder {
 	b.rg.object.IsReadCache = true
+	return b
+}
+
+func (b *Builder) WithCSPCBlockDeviceList(listBuilderCSPCBD *cspcbd.ListBuilder) *Builder {
+	if listBuilderCSPCBD == nil {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build raid group object: nil cspc blockdevice lisr"),
+		)
+		return b
+	}
+	cspcBDList, err := listBuilderCSPCBD.ToObjectList()
+	if err != nil {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build raid group object: failed to get blockdevice custom object list"),
+		)
+	}
+	for _, obj := range cspcBDList {
+		obj := obj.ToAPI()
+		b.rg.object.BlockDevices = append(b.rg.object.BlockDevices, *obj)
+	}
 	return b
 }
 

--- a/pkg/kubernetes/deployment/appsv1/v1alpha1/deployment.go
+++ b/pkg/kubernetes/deployment/appsv1/v1alpha1/deployment.go
@@ -80,6 +80,7 @@ func NewBuilder() *Builder {
 		deployment: &Deploy{
 			object: &appsv1.Deployment{},
 		},
+		errors: []error{},
 	}
 }
 

--- a/pkg/kubernetes/node/v1alpha1/node.go
+++ b/pkg/kubernetes/node/v1alpha1/node.go
@@ -91,6 +91,24 @@ func (b *ListBuilder) WithAPIObject(nodes ...corev1.Node) *ListBuilder {
 	return b
 }
 
+// GetNodeNameFromLabels returns node name if any node has all labels else
+// return empty value
+func (b *ListBuilder) GetNodeNameFromLabels(labels map[string]string) string {
+	for _, node := range b.list.items {
+		hasAllLabels := true
+		for key, value := range labels {
+			if !node.HasLabel(key, value) {
+				hasAllLabels = false
+				break
+			}
+		}
+		if hasAllLabels {
+			return node.object.Name
+		}
+	}
+	return ""
+}
+
 // GetLabeledNode return custom node instance if provided
 // key and value are present in any of the node instance
 func (b *ListBuilder) GetLabeledNode(key, value string) *Node {

--- a/pkg/kubernetes/node/v1alpha1/node.go
+++ b/pkg/kubernetes/node/v1alpha1/node.go
@@ -91,6 +91,35 @@ func (b *ListBuilder) WithAPIObject(nodes ...corev1.Node) *ListBuilder {
 	return b
 }
 
+// GetLabeledNode return custom node instance if provided
+// key and value are present in any of the node instance
+func (b *ListBuilder) GetLabeledNode(key, value string) *Node {
+	for _, node := range b.list.items {
+		if node.HasLabel(key, value) {
+			return node
+		}
+	}
+	return nil
+}
+
+// HasLabel return true if provided key and value are
+// present in the node instance
+func (n *Node) HasLabel(key, value string) bool {
+	val, ok := n.object.GetLabels()[key]
+	if ok {
+		return val == value
+	}
+	return false
+}
+
+// GetNodeName returns name of the node instance
+func (n *Node) GetNodeName() string {
+	if n == nil {
+		return ""
+	}
+	return n.object.Name
+}
+
 // List returns the list of node instances that was built by this builder
 func (b *ListBuilder) List() *NodeList {
 	if b.filters == nil && len(b.filters) == 0 {

--- a/pkg/storagepoolclaim/v1alpha1/storagepoolclaim.go
+++ b/pkg/storagepoolclaim/v1alpha1/storagepoolclaim.go
@@ -24,6 +24,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+const (
+	SPCFinalizer = "storagepoolclaim.openebs.io/finalizer"
+)
+
 // SupportedDiskTypes is a map containing the valid disk type
 var SupportedDiskTypes = map[apis.CasPoolValString]bool{
 	apis.TypeSparseCPV: true,
@@ -143,6 +147,12 @@ func (sb *Builder) WithPoolType(poolType string) *Builder {
 	return sb
 }
 
+// WithFinalizersNew sets the finalizer field of CSPC with provided value
+func (sb *Builder) WithFinalizersNew(finalizers ...string) *Builder {
+	sb.Spc.Object.Finalizers = append(sb.Spc.Object.Finalizers, finalizers...)
+	return sb
+}
+
 // WithOverProvisioning sets the OverProvisioning field of spc with provided argument value.
 func (sb *Builder) WithOverProvisioning(val bool) *Builder {
 	sb.Spc.Object.Spec.PoolSpec.OverProvisioning = val
@@ -231,4 +241,11 @@ func (l *SPCList) GetPoolUIDs() []string {
 		uids = append(uids, string(pool.GetUID()))
 	}
 	return uids
+}
+
+// GetDefaultSPCLabels returns deafult spc label to filter resources
+func (s *SPC) GetDefaultSPCLabels() map[string]string {
+	return map[string]string{
+		string(apis.StoragePoolClaimCPK): s.Object.Name,
+	}
 }

--- a/pkg/storagepoolclaim/v1alpha1/storagepoolclaim.go
+++ b/pkg/storagepoolclaim/v1alpha1/storagepoolclaim.go
@@ -25,6 +25,7 @@ import (
 )
 
 const (
+	// SPCFinalizer represents finalizer value on spc
 	SPCFinalizer = "storagepoolclaim.openebs.io/finalizer"
 )
 


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR add support to create cspc from auto spc
sample auto spc yaml:
```yaml
apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: cstor-sparse
spec:
  name: cstor-sparse
  type: sparse
  poolSpec:
    poolType: raidz
  maxPools: 1
```
When the user applied above spc maya-apiserver(spc-controller) will internally convert to cspc(aka cstorpoolcluster). If cspc creation is successful then spc is patched with finalizer(to make proper cleanup).
```yaml
apiVersion: v1
items:
- apiVersion: openebs.io/v1alpha1
  kind: CStorPoolCluster
  metadata:
    creationTimestamp: "2019-07-05T20:08:39Z"
    finalizers:
    - cstorpoolcluster.openebs.io/finalizer 
    generation: 1
    name: cstor-sparse
    namespace: openebs
    resourceVersion: "6373"
    selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/cstorpoolclusters/cstor-sparse
    uid: adc9c22c-9f60-11e9-95b5-54e1ad4a9dd4
  spec:
    pools:
    - nodeSelector:
        kubernetes.io/hostname: 127.0.0.1
      poolConfig:
        cacheFile: ""
        compression: "off"
        defaultRaidGroupType: raidz
        overProvisioning: false
      raidGroups:
      - blockDevices:
        - blockDeviceName: sparse-177b6bc2ae2dd332c7a384a02179368b
          capacity: 10G
          devLink: /var/openebs/sparse/6-ndm-sparse.img
        - blockDeviceName: sparse-b6ffc62c1e15edd30c1b4150d897d5cb
          capacity: 10G
          devLink: /var/openebs/sparse/2-ndm-sparse.img
        - blockDeviceName: sparse-c1f2bcd14c0c74e492f74651893eecee
          capacity: 10G
          devLink: /var/openebs/sparse/5-ndm-sparse.img
        isReadCache: false
        isSpare: false
        isWriteCache: false
        name: group-1
        type: raidz
  status:
    phase: ""
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```
When user needs to delete cstor-pool related resources which are provisioned in auto mode he needs to delete spc (for proper cleaning of cstor pool resources)

**Internal workflow:**
When spc delete request received from controller
1) SPC controller removes finalizers from cspc and delete cspc object.
2) If above step is successful then SPC controller will removes the finalizers from spc.

Auto Provisioning of pools is supported via auto spc(yaml).

**Note**
1) Down scaling pool is not supported.
2) Manual testing is done on single node and multi node cluster.  
3) For travis fix PR #https://github.com/openebs/maya/pull/1328 needs to check in. 

**TODO**
1) Working on UnitTest cases. 


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests