### PR TITLE
[WIP]feat(leader-election): add lease API with leader election for cvc-controller

### DIFF
--- a/cmd/cstorvolumeclaim/controller.go
+++ b/cmd/cstorvolumeclaim/controller.go
@@ -69,8 +69,7 @@ type Patch struct {
 }
 
 // syncHandler compares the actual state with the desired, and attempts to
-// converge the two. It then updates the Status block of the spcPoolUpdated resource
-// with the current status of the resource.
+// converge the two. syncHandler processes items from cvc Queue.
 func (c *CVCController) syncHandler(key string) error {
 	startTime := time.Now()
 	glog.V(4).Infof("Started syncing cstorvolumeclaim %q (%v)", key, startTime)
@@ -127,17 +126,9 @@ func (c *CVCController) enqueueCVC(obj interface{}) {
 }
 
 // synCVC is the function which tries to converge to a desired state for the
-// CStorVolumeClaims
+// CStorVolumeClaims. It then updates the Status block of the CStorVolumes claim
+// resource with the bound status once the required resources has been created.
 func (c *CVCController) syncCVC(cvc *apis.CStorVolumeClaim) error {
-	//	var newCVCLease Leaser
-	//	newCVCLease = &Lease{cvc, cvcLeaseKey, c.clientset, c.kubeclientset}
-	//	err := newCVCLease.Hold()
-	//	if err != nil {
-	//		return errors.Wrapf(err, "Could not acquire lease on cvc object")
-	//	}
-	//	glog.V(4).Infof("Lease acquired successfully on CStorVolumeClaims %s ", spc.Name)
-	//	defer newCVCLease.Release()
-
 	// CStor Volume Claim should be deleted. Check if deletion timestamp is set
 	// and remove finalizer.
 	if c.isClaimDeletionCandidate(cvc) {

--- a/pkg/kubernetes/leaderelection/v1alpha1/leader_election.go
+++ b/pkg/kubernetes/leaderelection/v1alpha1/leader_election.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2019 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/tools/record"
+)
+
+const (
+	defaultLeaseDuration = 15 * time.Second
+	defaultRenewDeadline = 10 * time.Second
+	defaultRetryPeriod   = 5 * time.Second
+)
+
+// leaderElection is a convenience wrapper around client-go's leader election library.
+type leaderElection struct {
+	runFunc func(ctx context.Context)
+
+	// the lockName identifies the leader election config and should be shared across all members
+	lockName string
+	// the identity is the unique identity of the currently running member
+	identity string
+	// the namespace to store the lock resource
+	namespace string
+	// resourceLock defines the type of leaderelection that should be used
+	// valid options are resourcelock.LeasesResourceLock, resourcelock.EndpointsResourceLock,
+	// and resourcelock.ConfigMapsResourceLock
+	resourceLock string
+
+	leaseDuration time.Duration
+	renewDeadline time.Duration
+	retryPeriod   time.Duration
+
+	clientset kubernetes.Interface
+}
+
+// NewLeaderElection returns the default & preferred leader election type
+func NewLeaderElection(clientset kubernetes.Interface, lockName string, runFunc func(ctx context.Context)) *leaderElection {
+	return NewLeaderElectionWithLeases(clientset, lockName, runFunc)
+}
+
+// NewLeaderElectionWithLeases returns an implementation of leader election using Leases
+func NewLeaderElectionWithLeases(clientset kubernetes.Interface, lockName string, runFunc func(ctx context.Context)) *leaderElection {
+	return &leaderElection{
+		runFunc:       runFunc,
+		lockName:      lockName,
+		resourceLock:  resourcelock.LeasesResourceLock,
+		leaseDuration: defaultLeaseDuration,
+		renewDeadline: defaultRenewDeadline,
+		retryPeriod:   defaultRetryPeriod,
+		clientset:     clientset,
+	}
+}
+
+// NewLeaderElectionWithEndpoints returns an implementation of leader election using Endpoints
+func NewLeaderElectionWithEndpoints(clientset kubernetes.Interface, lockName string, runFunc func(ctx context.Context)) *leaderElection {
+	return &leaderElection{
+		runFunc:       runFunc,
+		lockName:      lockName,
+		resourceLock:  resourcelock.EndpointsResourceLock,
+		leaseDuration: defaultLeaseDuration,
+		renewDeadline: defaultRenewDeadline,
+		retryPeriod:   defaultRetryPeriod,
+		clientset:     clientset,
+	}
+}
+
+// NewLeaderElectionWithConfigMaps returns an implementation of leader election using ConfigMaps
+func NewLeaderElectionWithConfigMaps(clientset kubernetes.Interface, lockName string, runFunc func(ctx context.Context)) *leaderElection {
+	return &leaderElection{
+		runFunc:       runFunc,
+		lockName:      lockName,
+		resourceLock:  resourcelock.ConfigMapsResourceLock,
+		leaseDuration: defaultLeaseDuration,
+		renewDeadline: defaultRenewDeadline,
+		retryPeriod:   defaultRetryPeriod,
+		clientset:     clientset,
+	}
+}
+
+func (l *leaderElection) WithIdentity(identity string) {
+	l.identity = identity
+}
+
+func (l *leaderElection) WithNamespace(namespace string) {
+	l.namespace = namespace
+}
+
+func (l *leaderElection) WithLeaseDuration(leaseDuration time.Duration) {
+	l.leaseDuration = leaseDuration
+}
+
+func (l *leaderElection) WithRenewDeadline(renewDeadline time.Duration) {
+	l.renewDeadline = renewDeadline
+}
+
+func (l *leaderElection) WithRetryPeriod(retryPeriod time.Duration) {
+	l.retryPeriod = retryPeriod
+}
+
+func (l *leaderElection) Run() error {
+	if l.identity == "" {
+		id, err := defaultLeaderElectionIdentity()
+		if err != nil {
+			return fmt.Errorf("error getting the default leader identity: %v", err)
+		}
+
+		l.identity = id
+	}
+
+	if l.namespace == "" {
+		l.namespace = inClusterNamespace()
+	}
+
+	broadcaster := record.NewBroadcaster()
+	broadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: l.clientset.CoreV1().Events(l.namespace)})
+	eventRecorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: fmt.Sprintf("%s/%s", l.lockName, string(l.identity))})
+
+	rlConfig := resourcelock.ResourceLockConfig{
+		Identity:      sanitizeName(l.identity),
+		EventRecorder: eventRecorder,
+	}
+
+	lock, err := resourcelock.New(l.resourceLock, l.namespace, sanitizeName(l.lockName), l.clientset.CoreV1(), l.clientset.CoordinationV1(), rlConfig)
+	if err != nil {
+		return err
+	}
+
+	leaderConfig := leaderelection.LeaderElectionConfig{
+		Lock:          lock,
+		LeaseDuration: l.leaseDuration,
+		RenewDeadline: l.renewDeadline,
+		RetryPeriod:   l.retryPeriod,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(ctx context.Context) {
+				glog.V(2).Info("became leader, starting")
+				l.runFunc(ctx)
+			},
+			OnStoppedLeading: func() {
+				glog.Fatal("stopped leading")
+			},
+			OnNewLeader: func(identity string) {
+				glog.V(3).Infof("new leader detected, current leader: %s", identity)
+			},
+		},
+	}
+
+	leaderelection.RunOrDie(context.TODO(), leaderConfig)
+	return nil // should never reach here
+}
+
+func defaultLeaderElectionIdentity() (string, error) {
+	return os.Hostname()
+}
+
+// sanitizeName sanitizes the provided string so it can be consumed by leader election library
+func sanitizeName(name string) string {
+	re := regexp.MustCompile("[^a-zA-Z0-9-]")
+	name = re.ReplaceAllString(name, "-")
+	if name[len(name)-1] == '-' {
+		// name must not end with '-'
+		name = name + "X"
+	}
+	return name
+}
+
+// inClusterNamespace returns the namespace in which the pod is running in by checking
+// the env var POD_NAMESPACE, then the file /var/run/secrets/kubernetes.io/serviceaccount/namespace.
+// if neither returns a valid namespace, the "openebs" namespace is returned
+func inClusterNamespace() string {
+	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
+		return ns
+	}
+
+	if data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
+			return ns
+		}
+	}
+
+	return "openebs"
+}

--- a/pkg/kubernetes/leaderelection/v1alpha1/leader_election_test.go
+++ b/pkg/kubernetes/leaderelection/v1alpha1/leader_election_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+)
+
+func Test_sanitizeName(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		output string
+	}{
+		{
+			"requires no change",
+			"test-driver",
+			"test-driver",
+		},
+		{
+			"has characters that should be replaced",
+			"test!driver/foo",
+			"test-driver-foo",
+		},
+		{
+			"has trailing space",
+			"driver\\",
+			"driver-X",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			output := sanitizeName(test.input)
+			if output != test.output {
+				t.Logf("expected name: %q", test.output)
+				t.Logf("actual name: %q", output)
+				t.Errorf("unexpected santized name")
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This commits adds the leader_election API with lease for cvc-controller.

Leader election, in simple words, is the mechanism that guarantees that only one instance of the cvc-controller — or one instance of the maya-apiserver — is actively making decisions, while all the other instances are inactive, but ready to take leadership if something happens to the active one.

**Special notes for your reviewer**:

PR changes depends on PR #1333


Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

