### PR TITLE
feat(cvc-controller) randomize usable pools before distributing CVR 

### DIFF
--- a/cmd/cstorvolumeclaim/start.go
+++ b/cmd/cstorvolumeclaim/start.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cstorvolumeclaim
 
 import (
+	"sync"
+
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 
@@ -38,7 +40,7 @@ var (
 )
 
 // Start starts the cstor-operator.
-func Start() error {
+func Start(controllerMtx *sync.RWMutex) error {
 	// set up signals so we handle the first shutdown signal gracefully
 	stopCh := signals.SetupSignalHandler()
 
@@ -68,6 +70,13 @@ func Start() error {
 
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, time.Second*30)
 	cvcInformerFactory := informers.NewSharedInformerFactory(openebsClient, time.Second*30)
+	// Build() fn of all controllers calls AddToScheme to adds all types of this
+	// clientset into the given scheme.
+	// If multiple controllers happen to call this AddToScheme same time,
+	// it causes panic with error saying concurrent map access.
+	// This lock is used to serialize the AddToScheme call of all controllers.
+	controllerMtx.Lock()
+
 	controller, err := NewCVCControllerBuilder().
 		withKubeClient(kubeClient).
 		withOpenEBSClient(openebsClient).
@@ -81,6 +90,10 @@ func Start() error {
 		withRecorder(kubeClient).
 		withEventHandler(cvcInformerFactory).
 		withWorkqueueRateLimiting().Build()
+
+	// blocking call, can't use defer to release the lock
+	controllerMtx.Unlock()
+
 	if err != nil {
 		return errors.Wrapf(err, "error building controller instance")
 	}

--- a/cmd/maya-apiserver/cstor-operator/cspc/start.go
+++ b/cmd/maya-apiserver/cstor-operator/cspc/start.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cspc
 
 import (
+	"sync"
+
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 
@@ -37,7 +39,7 @@ var (
 )
 
 // Start starts the cstor-operator.
-func Start() error {
+func Start(controllerMtx *sync.RWMutex) error {
 	// set up signals so we handle the first shutdown signal gracefully
 	stopCh := signals.SetupSignalHandler()
 
@@ -67,6 +69,13 @@ func Start() error {
 
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, time.Second*30)
 	spcInformerFactory := informers.NewSharedInformerFactory(openebsClient, time.Second*30)
+	// Build() fn of all controllers calls AddToScheme to adds all types of this
+	// clientset into the given scheme.
+	// If multiple controllers happen to call this AddToScheme same time,
+	// it causes panic with error saying concurrent map access.
+	// This lock is used to serialize the AddToScheme call of all controllers.
+	controllerMtx.Lock()
+
 	controller, err := NewControllerBuilder().
 		withKubeClient(kubeClient).
 		withOpenEBSClient(openebsClient).
@@ -76,6 +85,10 @@ func Start() error {
 		withRecorder(kubeClient).
 		withEventHandler(spcInformerFactory).
 		withWorkqueueRateLimiting().Build()
+
+	// blocking call, can't use defer to release the lock
+	controllerMtx.Unlock()
+
 	if err != nil {
 		return errors.Wrapf(err, "error building controller instance")
 	}

--- a/cmd/maya-apiserver/cstor-operator/cspc/start_test.go
+++ b/cmd/maya-apiserver/cstor-operator/cspc/start_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cspc
 
 import (
+	"sync"
 	"testing"
 	"time"
 )
@@ -24,7 +25,8 @@ func TestStart(t *testing.T) {
 	var err error
 	var errchannel = make(chan error)
 	go func() {
-		err = Start()
+		var mux = sync.RWMutex{}
+		err = Start(&mux)
 		errchannel <- err
 	}()
 	select {

--- a/cmd/maya-apiserver/cstor-operator/spc/start_test.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/start_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package spc
 
 import (
+	"sync"
 	"testing"
 	"time"
 )
@@ -24,7 +25,8 @@ func TestStart(t *testing.T) {
 	var err error
 	var errchannel = make(chan error)
 	go func() {
-		err := Start()
+		var mux = sync.RWMutex{}
+		err = Start(&mux)
 		errchannel <- err
 	}()
 	select {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- PR randomize the poollist to distribute the cstorvolumereplicas.
- Go's concurrency mechanisms don't prevent race conditions, so having a mutex lock here to prevent it 
   from race conditions.
  Build() fn of all controllers calls AddToScheme to adds all types of this clientset into the given scheme.
  If multiple controllers happen to call this AddToScheme same time,
  it causes panic with error saying concurrent map access. This lock is used to serialize the AddToScheme call of all controllers.
