### PR TITLE
chore(cstor-operator): fix BD claim, pool resource naming and creation and node reprocessing

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1077,6 +1077,7 @@
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/intstr",
     "k8s.io/apimachinery/pkg/util/json",
+    "k8s.io/apimachinery/pkg/util/rand",
     "k8s.io/apimachinery/pkg/util/runtime",
     "k8s.io/apimachinery/pkg/util/strategicpatch",
     "k8s.io/apimachinery/pkg/util/uuid",

--- a/cmd/maya-apiserver/cstor-operator/cspc/cspc_lease.go
+++ b/cmd/maya-apiserver/cstor-operator/cspc/cspc_lease.go
@@ -126,7 +126,7 @@ func (sl *Lease) Release() {
 		newErr := fmt.Errorf("Lease could not be removed:%v", err)
 		runtime.HandleError(newErr)
 	}
-	glog.Info("Lease removed successfully on cstorpoolcluster")
+	glog.V(5).Info("Lease removed successfully on cstorpoolcluster")
 }
 
 func (sl *Lease) getPodName() string {

--- a/cmd/maya-apiserver/cstor-operator/cspc/storagepool_create.go
+++ b/cmd/maya-apiserver/cstor-operator/cspc/storagepool_create.go
@@ -76,13 +76,13 @@ func (pc *PoolConfig) CreateStoragePool() error {
 	if err != nil {
 		return errors.Wrap(err, "failed to get CSP spec")
 	}
-	err = pc.createCSP(cspObj)
+	gotCSP, err := pc.createCSP(cspObj)
 
 	if err != nil {
 		return errors.Wrapf(err, "failed to create csp for cspc {%s}", pc.AlgorithmConfig.CSPC.Name)
 	}
 
-	poolDeployObj, err := pc.GetPoolDeploySpec(cspObj)
+	poolDeployObj, err := pc.GetPoolDeploySpec(gotCSP)
 	if err != nil {
 		return err
 	}
@@ -93,9 +93,9 @@ func (pc *PoolConfig) CreateStoragePool() error {
 	return nil
 }
 
-func (pc *PoolConfig) createCSP(csp *apis.NewTestCStorPool) error {
-	_, err := apiscsp.NewKubeClient().WithNamespace(pc.AlgorithmConfig.Namespace).Create(csp)
-	return err
+func (pc *PoolConfig) createCSP(csp *apis.NewTestCStorPool) (*apis.NewTestCStorPool, error) {
+	gotCSP, err := apiscsp.NewKubeClient().WithNamespace(pc.AlgorithmConfig.Namespace).Create(csp)
+	return gotCSP, err
 }
 
 func (pc *PoolConfig) createPoolDeployment(deployObj *appsv1.Deployment) error {

--- a/pkg/algorithm/nodeselect/v1alpha2/build_csp.go
+++ b/pkg/algorithm/nodeselect/v1alpha2/build_csp.go
@@ -51,7 +51,7 @@ func (ac *Config) GetCSPSpec() (*apis.NewTestCStorPool, error) {
 
 	err = ac.ClaimBDsForNode(ac.GetBDListForNode(poolSpec))
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to claim block devices for node selector {%v}", poolSpec.NodeSelector)
+		return nil, errors.Wrapf(err, "failed to claim block devices for node {%s}", nodeName)
 	}
 	return cspObj.Object, nil
 }

--- a/pkg/algorithm/nodeselect/v1alpha2/build_csp.go
+++ b/pkg/algorithm/nodeselect/v1alpha2/build_csp.go
@@ -39,6 +39,7 @@ func (ac *Config) GetCSPSpec() (*apis.NewTestCStorPool, error) {
 	csplabels := ac.buildLabelsForCSP(nodeName)
 	cspObj, err := apiscsp.NewBuilder().
 		WithName(ac.CSPC.Name + "-" + rand.String(4)).
+		WithNamespace(ac.Namespace).
 		WithNodeSelectorByReference(poolSpec.NodeSelector).
 		WithNodeName(nodeName).
 		WithPoolConfig(&poolSpec.PoolConfig).

--- a/pkg/algorithm/nodeselect/v1alpha2/build_csp.go
+++ b/pkg/algorithm/nodeselect/v1alpha2/build_csp.go
@@ -32,7 +32,7 @@ const (
 // block device present in the CSP spec
 func (ac *Config) GetCSPSpec() (*apis.NewTestCStorPool, error) {
 	poolSpec, nodeName, err := ac.SelectNode()
-	if err != nil {
+	if err != nil || nodeName == "" {
 		return nil, errors.Wrap(err, "failed to select a node")
 	}
 	csplabels := ac.buildLabelsForCSP(nodeName)

--- a/pkg/algorithm/nodeselect/v1alpha2/build_csp.go
+++ b/pkg/algorithm/nodeselect/v1alpha2/build_csp.go
@@ -21,6 +21,7 @@ import (
 	apiscsp "github.com/openebs/maya/pkg/cstor/newpool/v1alpha3"
 	"github.com/openebs/maya/pkg/version"
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 const (
@@ -37,7 +38,7 @@ func (ac *Config) GetCSPSpec() (*apis.NewTestCStorPool, error) {
 	}
 	csplabels := ac.buildLabelsForCSP(nodeName)
 	cspObj, err := apiscsp.NewBuilder().
-		WithName(ac.CSPC.Name).
+		WithName(ac.CSPC.Name + rand.String(4)).
 		WithNodeSelectorByReference(poolSpec.NodeSelector).
 		WithNodeName(nodeName).
 		WithPoolConfig(&poolSpec.PoolConfig).

--- a/pkg/algorithm/nodeselect/v1alpha2/build_csp.go
+++ b/pkg/algorithm/nodeselect/v1alpha2/build_csp.go
@@ -38,7 +38,7 @@ func (ac *Config) GetCSPSpec() (*apis.NewTestCStorPool, error) {
 	}
 	csplabels := ac.buildLabelsForCSP(nodeName)
 	cspObj, err := apiscsp.NewBuilder().
-		WithName(ac.CSPC.Name + rand.String(4)).
+		WithName(ac.CSPC.Name + "-" + rand.String(4)).
 		WithNodeSelectorByReference(poolSpec.NodeSelector).
 		WithNodeName(nodeName).
 		WithPoolConfig(&poolSpec.PoolConfig).

--- a/pkg/algorithm/nodeselect/v1alpha2/config.go
+++ b/pkg/algorithm/nodeselect/v1alpha2/config.go
@@ -32,6 +32,9 @@ type Config struct {
 	CSPC *apis.CStorPoolCluster
 	// Namespace is the namespace where openebs is installed.
 	Namespace string
+	// VisitedNodes is a map which contains the node names which has already been
+	// processed for pool provisioning
+	VisitedNodes map[string]bool
 }
 
 // Builder embeds the Config object.
@@ -44,8 +47,9 @@ type Builder struct {
 func NewBuilder() *Builder {
 	return &Builder{
 		ConfigObj: &Config{
-			CSPC:      &apis.CStorPoolCluster{},
-			Namespace: "",
+			CSPC:         &apis.CStorPoolCluster{},
+			Namespace:    "",
+			VisitedNodes: make(map[string]bool),
 		},
 	}
 }

--- a/pkg/algorithm/nodeselect/v1alpha2/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha2/select_node.go
@@ -40,14 +40,15 @@ func (ac *Config) SelectNode() (*apis.PoolSpec, string, error) {
 		// pin it
 		pool := pool
 		nodeName, err := GetNodeFromLabelSelector(pool.NodeSelector)
+		if err != nil || nodeName == "" {
+			glog.Errorf("could not use node for selectors {%v}", pool.NodeSelector)
+			continue
+		}
 		if ac.VisitedNodes[nodeName] {
 			continue
 		} else {
 			ac.VisitedNodes[nodeName] = true
-			if err != nil {
-				glog.Errorf("could not use node for selectors {%v}", pool.NodeSelector)
-				continue
-			}
+
 			if !usedNodes[nodeName] {
 				return &pool, nodeName, nil
 			}
@@ -146,7 +147,7 @@ func (ac *Config) ClaimBDsForNode(BD []string) error {
 	}
 
 	if pendingClaim > 0 {
-		return errors.New("block devices are pending to be claimed")
+		return errors.Errorf("%d block device claims are pending", pendingClaim)
 	}
 	return nil
 }

--- a/pkg/kubernetes/deployment/appsv1/v1alpha1/deployment.go
+++ b/pkg/kubernetes/deployment/appsv1/v1alpha1/deployment.go
@@ -381,10 +381,11 @@ func NewForAPIObject(
 // Build returns a deployment instance
 func (b *Builder) Build() (*appsv1.Deployment, error) {
 	err := b.validate()
+	// TODO: err in Wrapf is not logged. Fix is required
 	if err != nil {
 		return nil, errors.Wrapf(err,
 			"failed to build a deployment: %s",
-			b.deployment.object)
+			b.deployment.object.Name)
 	}
 	return b.deployment.object, nil
 }
@@ -392,7 +393,7 @@ func (b *Builder) Build() (*appsv1.Deployment, error) {
 func (b *Builder) validate() error {
 	if len(b.errors) != 0 {
 		return errors.Errorf(
-			"failed to validate: build errors were found: %v",
+			"failed to validate: build errors were found: %+v",
 			b.errors,
 		)
 	}


### PR DESCRIPTION
This commit will do following:

1. Once BDC has been created for BD ( for pool provisioning), a CSP
   will not be created once all the BDs are in *Claimed* state.
   This means, more then one event will be rquired for a CSP to be created.
   For the first time during pool provisioning, BD will be cheked for Claimed
   state and if not claimed, BDC for them will be created and program shall
   return.
   In the next event, again the BDs will be checked for claimed state and if
   claimed pool provisioning shall proceed else program shall return and so on.

2. In a single event, when a node has been visited for pool creation, in either
   case success or failure, that node will not be revisited for pool creation.
   This is required as one dirty node causing pool provisioning failure can stop
   other subsequent nodes from being pool provisioned on them.

3. Pool resources i.e. CSP and Pool Dpeloyment will have names that is suffixed by 
    char alphanumeric random string.

4. Pool deployment build was failing due to missing namespace. This PR contains a fix
    for this.

Signed-off-by: Ashutosh Kumar <ashutosh.kumar@openebs.io>
