### PR TITLE
chore(cvc-controller): refactor CVC schema and CVR distribution logic

### DIFF
--- a/cmd/cstorvolumeclaim/controller.go
+++ b/cmd/cstorvolumeclaim/controller.go
@@ -351,7 +351,7 @@ func (c *CVCController) getCurrentReplicaCount(cvc *apis.CStorVolumeClaim) (int,
 	//	CVRs, err := c.cvrLister.CStorVolumeReplicas(cvc.Namespace).
 	//		List(klabels.Set(pvLabel).AsSelector())
 
-	pvLabel := pvAnnotaion + cvc.Name
+	pvLabel := pvSelector + "=" + cvc.Name
 
 	cvrList, err := c.clientset.
 		OpenebsV1alpha1().

--- a/cmd/cstorvolumeclaim/cstorvolumeclaim.go
+++ b/cmd/cstorvolumeclaim/cstorvolumeclaim.go
@@ -40,7 +40,6 @@ const (
 	cvKind  = "CStorVolume"
 
 	cstorpoolNameLabel = "cstorpool.openebs.io/name"
-	pvAnnotaion        = "openebs.io/persistent-volume="
 	// spcAnnotation annotation for spc for listing cstor pools created for
 	// a StoragePool Claim
 	spcAnnotation = "openebs.io/storage-pool-claim="
@@ -406,7 +405,7 @@ func getUsedPoolNames(cvrList *apis.CStorVolumeReplicaList) map[string]bool {
 func getUsablePoolList(pvName string, poolList *apis.CStorPoolList) *apis.CStorPoolList {
 	usablePoolList := &apis.CStorPoolList{}
 
-	pvLabel := pvAnnotaion + pvName
+	pvLabel := pvSelector + "=" + pvName
 	cvrList, err := cvr.NewKubeclient(cvr.WithNamespace(getNamespace())).List(metav1.ListOptions{
 		LabelSelector: pvLabel,
 	})

--- a/cmd/cstorvolumeclaim/cstorvolumeclaim.go
+++ b/cmd/cstorvolumeclaim/cstorvolumeclaim.go
@@ -173,13 +173,12 @@ func getNamespace() string {
 	return menv.Get(menv.OpenEBSNamespace)
 }
 
-// getSPC gets storagePoolClaim from
-// storageclass parameter
+// getSPC gets storagePoolClaim from cstorvolumeclaim resource
 func getSPC(
 	claim *apis.CStorVolumeClaim,
 ) string {
 
-	spcName := claim.Annotations["openebs.io/cspc-name"]
+	spcName := claim.Labels[string(apis.StoragePoolClaimCPK)]
 	return spcName
 }
 

--- a/pkg/apis/openebs.io/v1alpha1/cas_keys.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_keys.go
@@ -72,8 +72,8 @@ const (
 	// StorageClassKey is the key to fetch name of StorageClass
 	StorageClassKey CASKey = "openebs.io/storageclass"
 
-	// StorageConfigClassKey is the key to fetch name of StorageClass
-	StorageConfigClassKey CASKey = "openebs.io/config-class"
+	// ConfigClassKey is the key to fetch name of CStorVolume ConfigClass
+	ConfigClassKey CASKey = "openebs.io/config-class"
 
 	// CASTypeKey is the key to fetch storage engine for the volume
 	CASTypeKey CASKey = "openebs.io/cas-type"

--- a/pkg/apis/openebs.io/v1alpha1/cstor_volume_claim.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_volume_claim.go
@@ -49,6 +49,9 @@ type CStorVolumeClaimSpec struct {
 	// Capacity represents the actual resources of the underlying
 	// cstor volume.
 	Capacity corev1.ResourceList `json:"capacity"`
+	// ReplicaCount represents the actual replica count for the underlying
+	// cstor volume
+	ReplicaCount int `json:"replicaCount"`
 	// CStorVolumeRef has the information about where CstorVolumeClaim
 	// is created from.
 	CStorVolumeRef *corev1.ObjectReference `json:"cstorVolumeRef,omitempty"`
@@ -57,8 +60,8 @@ type CStorVolumeClaimSpec struct {
 // CStorVolumeClaimPublish contains info related to attachment of a volume to a node.
 // i.e. NodeId etc.
 type CStorVolumeClaimPublish struct {
-	// NodeId contains publish info related to attachment of a volume to a node.
-	NodeId string `json:"nodeId,omitempty"`
+	// NodeID contains publish info related to attachment of a volume to a node.
+	NodeID string `json:"nodeId,omitempty"`
 }
 
 // CStorVolumeClaimPhase represents the current phase of CStorVolumeClaim.


### PR DESCRIPTION
**What this PR does / why we need it**:

- Update CVC schema struct with `ReplicaCount` type.
- Add StoragePoolClaim (CstorPoolClusterClaim) name in CVC annotations
- Refactor controller to get replicaCount from the
  cstorvolumeclaim schema instead of annotations.

1. CStorVolumeClaim

```yaml
apiVersion: openebs.io/v1alpha1
kind: CStorVolumeClaim
metadata:
  annotations:
    openebs.io/config-class: openebs-cstor-sparse-auto
    openebs.io/volumeID: pvc-d030e3e4-a700-11e9-b527-42010a800279
  creationTimestamp: "2019-07-15T13:02:34Z"
  finalizers:
  - cvc.openebs.io/finalizer
  generation: 3
  labels:
    openebs.io/storage-pool-claim: cstor-sparse-pool
  name: pvc-d030e3e4-a700-11e9-b527-42010a800279
  namespace: openebs
  resourceVersion: "5114188"
  selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/cstorvolumeclaims/pvc-d030e3e4-a700-11e9-b527-42010a800279
  uid: d03bfcae-a700-11e9-b527-42010a800279
publish:
  nodeId: gke-prateek-helm-pool-1-38b7cbfe-rn9q
spec:
  capacity:
    storage: "5368709120"
  cstorVolumeRef:
    apiVersion: openebs.io/v1alpha1
    kind: CStorVolume
    name: pvc-d030e3e4-a700-11e9-b527-42010a800279
    namespace: openebs
    resourceVersion: "5114169"
    uid: e6cabbe3-a700-11e9-b527-42010a800279
  replicaCount: 3
status:
  phase: Bound
```

2. StorageClass:

```yaml

apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-cstor-sparse-auto
parameters:
  configClass: openebs-cstor-sparse-auto
  replicaCount: "1"
  storagePoolClaim: sparse-claim-auto
provisioner: openebs-csi.openebs.io
reclaimPolicy: Delete
volumeBindingMode: Immediate

```
Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->


