### PR TITLE
 chore(spc, bdc finalizer): finalizer handling on BDCs via spc

### DIFF
--- a/pkg/algorithm/nodeselect/v1alpha1/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node.go
@@ -326,6 +326,7 @@ func (ac *Config) ClaimBlockDevice(nodeBDs *nodeBlockDevice, spc *apis.StoragePo
 				WithLabels(labels).
 				WithBlockDeviceName(bdName).
 				WithHostName(hostName).
+				WithFinalizer(spcv1alpha1.SPCFinalizer).
 				WithCapacity(capacity).
 				WithOwnerReference(spc).
 				Build()

--- a/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim.go
+++ b/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim.go
@@ -127,6 +127,13 @@ func (bdcl *BlockDeviceClaimList) GetBlockDeviceNamesByNode() map[string][]strin
 func RemoveFinalizersOnBDCList(namespace, label, finalizer string) error {
 	bdcClient := NewKubeClient().WithNamespace(namespace)
 	bdcObjList, err := bdcClient.List(metav1.ListOptions{LabelSelector: label})
+	if err != nil {
+		return errors.Wrapf(
+			err,
+			"failed to list BDC related to label %s",
+			label,
+		)
+	}
 	for _, bdcObj := range bdcObjList.Items {
 		bdcObj := bdcObj
 		// If BDC doesn't contain finalizer continue

--- a/pkg/cstor/pool/v1alpha2/kubernetes_test.go
+++ b/pkg/cstor/pool/v1alpha2/kubernetes_test.go
@@ -71,6 +71,16 @@ func fakeDeleteOk(cs *clientset.Clientset, name string,
 	return nil
 }
 
+func fakeDeleteCollectionOk(cs *clientset.Clientset, listOpts metav1.ListOptions,
+	deleteOpts *metav1.DeleteOptions) error {
+	return nil
+}
+
+func fakeDeleteCollectionErr(cs *clientset.Clientset, listOpts metav1.ListOptions,
+	deleteOpts *metav1.DeleteOptions) error {
+	return errors.New("fake error")
+}
+
 func fakeDeleteErr(cs *clientset.Clientset, name string,
 	opt *metav1.DeleteOptions) error {
 	return errors.New("some error")
@@ -183,12 +193,12 @@ func TestGetClientOrCached(t *testing.T) {
 	}{
 		// Positive tests
 		"When clientset is nil": {&Kubeclient{nil,
-			fakeGetClientsetNil, fakeListOk, fakeGetOk, fakeCreateOk, fakePatchOk, fakeDeleteOk}, false},
+			fakeGetClientsetNil, fakeListOk, fakeGetOk, fakeCreateOk, fakePatchOk, fakeDeleteOk, fakeDeleteCollectionOk}, false},
 		"When clientset is not nil": {&Kubeclient{&clientset.Clientset{},
-			fakeGetClientsetOk, fakeListOk, fakeGetOk, fakeCreateOk, fakePatchOk, fakeDeleteOk}, false},
+			fakeGetClientsetOk, fakeListOk, fakeGetOk, fakeCreateOk, fakePatchOk, fakeDeleteOk, nil}, false},
 		// Negative tests
 		"When getting clientset throws error": {&Kubeclient{nil,
-			fakeGetClientsetErr, fakeListOk, fakeGetOk, fakeCreateOk, fakePatchOk, fakeDeleteOk}, true},
+			fakeGetClientsetErr, fakeListOk, fakeGetOk, fakeCreateOk, fakePatchOk, fakeDeleteOk, fakeDeleteCollectionErr}, true},
 	}
 
 	for name, mock := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
1) This PR adds the finalizer on storagepoolclaim(spc) and blockdeviceclaim(bdc) 
during creation time of cstor pools. When the spc is deleted it will do below things
1. Delete all the csp related to spc.
2. Removes the finalizer added by spc controller.
3. When above steps are successful then spc controller will  remove the spc finalizer.

 TODO:
1. Need to test

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests