### PR TITLE
feat(install): add flag to disable default config creation

### DIFF
--- a/pkg/install/v1alpha1/cstor_sparse_pool_claim.go
+++ b/pkg/install/v1alpha1/cstor_sparse_pool_claim.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The OpenEBS Authors
+Copyright 2018-2019 The OpenEBS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,12 +17,6 @@ limitations under the License.
 // TODO
 // Rename this file by removing the version suffix information
 package v1alpha1
-
-import (
-	"strconv"
-
-	menv "github.com/openebs/maya/pkg/env/v1alpha1"
-)
 
 const cstorSparsePoolYamls = `
 ---
@@ -80,13 +74,6 @@ spec:
     poolType: striped
 ---
 `
-
-// IsCstorSparsePoolEnabled reads from env variable to check whether cstor sparse pool
-// should be created by default or not.
-func IsCstorSparsePoolEnabled() (enabled bool) {
-	enabled, _ = strconv.ParseBool(menv.Get(DefaultCstorSparsePool))
-	return
-}
 
 // CstorSparsePoolArtifacts returns sparse pool artifacts corresponding to
 // latest version if cstor sparse pool creation is enabled

--- a/pkg/install/v1alpha1/cstor_sparse_pool_claim_test.go
+++ b/pkg/install/v1alpha1/cstor_sparse_pool_claim_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The OpenEBS Authors
+Copyright 2018-2019 The OpenEBS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,36 +26,49 @@ import (
 func TestIsCstorSparsePool(t *testing.T) {
 	tests := map[string]struct {
 		value     string
+		defConf   string
 		isenabled bool
 		iserr     bool
 	}{
+		"with true, default config false": {
+			value:     "true",
+			defConf:   "false",
+			isenabled: false,
+			iserr:     false,
+		},
 		"with true": {
 			value:     "true",
+			defConf:   "true",
 			isenabled: true,
 			iserr:     false,
 		},
 		"with 1": {
 			value:     "1",
+			defConf:   "true",
 			isenabled: true,
 			iserr:     false,
 		},
 		"with false": {
 			value:     "false",
+			defConf:   "true",
 			isenabled: false,
 			iserr:     false,
 		},
 		"with 0": {
 			value:     "0",
+			defConf:   "true",
 			isenabled: false,
 			iserr:     false,
 		},
 		"with junk": {
 			value:     "junk",
+			defConf:   "true",
 			isenabled: false,
 			iserr:     false,
 		},
 		"with special chars": {
 			value:     "abc:123-123",
+			defConf:   "true",
 			isenabled: false,
 			iserr:     true,
 		},
@@ -63,14 +76,20 @@ func TestIsCstorSparsePool(t *testing.T) {
 
 	for name, mock := range tests {
 		t.Run(name, func(t *testing.T) {
+			os.Unsetenv(string(CreateDefaultStorageConfig))
+			errDef := os.Setenv(string(CreateDefaultStorageConfig), mock.defConf)
+			if errDef != nil {
+				t.Fatalf("Test '%s' failed %+v", name, errDef)
+			}
 			os.Unsetenv(string(DefaultCstorSparsePool))
 			err := os.Setenv(string(DefaultCstorSparsePool), mock.value)
 			if err != nil {
 				t.Fatalf("Test '%s' failed %+v", name, err)
 			}
 			actual := IsCstorSparsePoolEnabled()
+			actualStgConfig := IsDefaultStorageConfigEnabled()
 			if actual != mock.isenabled {
-				t.Fatalf("Test '%s' failed: expected '%t' actual '%t' ", name, actual, mock.isenabled)
+				t.Fatalf("Test '%s' failed: expected '%t' actual '%t' : storage-config '%t' ", name, actual, mock.isenabled, actualStgConfig)
 			}
 			os.Unsetenv(string(DefaultCstorSparsePool))
 		})

--- a/pkg/install/v1alpha1/cstor_sparse_pool_claim_test.go
+++ b/pkg/install/v1alpha1/cstor_sparse_pool_claim_test.go
@@ -75,6 +75,8 @@ func TestIsCstorSparsePool(t *testing.T) {
 	}
 
 	for name, mock := range tests {
+		name := name
+		mock := mock
 		t.Run(name, func(t *testing.T) {
 			os.Unsetenv(string(CreateDefaultStorageConfig))
 			errDef := os.Setenv(string(CreateDefaultStorageConfig), mock.defConf)
@@ -99,43 +101,57 @@ func TestIsCstorSparsePool(t *testing.T) {
 func TestCstorSparsePoolSpc070(t *testing.T) {
 	tests := map[string]struct {
 		value    string
+		defConf  string
 		expected int
 		iserr    bool
 	}{
 		"with 1": {
 			value:    "1",
+			defConf:  "true",
 			expected: 2,
 			iserr:    false,
 		},
 		"with true": {
 			value:    "true",
+			defConf:  "true",
 			expected: 2,
 			iserr:    false,
 		},
 		"with 0": {
 			value:    "0",
+			defConf:  "true",
 			expected: 0,
 			iserr:    false,
 		},
 		"with false": {
 			value:    "false",
+			defConf:  "true",
 			expected: 0,
 			iserr:    false,
 		},
 		"with junk": {
 			value:    "junk",
+			defConf:  "true",
 			expected: 0,
 			iserr:    false,
 		},
 		"with special chars": {
 			value:    "abc:123-123",
+			defConf:  "true",
 			expected: 0,
 			iserr:    false,
 		},
 	}
 
 	for name, mock := range tests {
+		name := name
+		mock := mock
 		t.Run(name, func(t *testing.T) {
+			os.Unsetenv(string(CreateDefaultStorageConfig))
+			errDef := os.Setenv(string(CreateDefaultStorageConfig), mock.defConf)
+			if errDef != nil {
+				t.Fatalf("Test '%s' failed %+v", name, errDef)
+			}
 			os.Unsetenv(string(DefaultCstorSparsePool))
 			err := os.Setenv(string(DefaultCstorSparsePool), mock.value)
 			if err != nil {

--- a/pkg/install/v1alpha1/env.go
+++ b/pkg/install/v1alpha1/env.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The OpenEBS Authors
+Copyright 2018-2019 The OpenEBS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -28,4 +28,11 @@ const (
 	// installed/configured else for "false" it will
 	// not be configured
 	DefaultCstorSparsePool menv.ENVKey = "OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL"
+
+	// CreateDefaultStorageConfig is the environment
+	// variable that flags if default storage pools and/or storage
+	// classes should be created.
+	//
+	// Default is "true"
+	CreateDefaultStorageConfig menv.ENVKey = "OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG"
 )

--- a/pkg/install/v1alpha1/env_setter.go
+++ b/pkg/install/v1alpha1/env_setter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The OpenEBS Authors
+Copyright 2018-2019 The OpenEBS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -202,6 +202,10 @@ func (e *envInstall) List() (l *envList, err error) {
 	l.Items = append(l.Items, &env{
 		Key:   menv.OpenEBSVersion,
 		Value: ver.Current(),
+	})
+	l.Items = append(l.Items, &env{
+		Key:   CreateDefaultStorageConfig,
+		Value: "true",
 	})
 	l.Items = append(l.Items, &env{
 		Key:   DefaultCstorSparsePool,

--- a/pkg/install/v1alpha1/env_setter_test.go
+++ b/pkg/install/v1alpha1/env_setter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The OpenEBS Authors
+Copyright 2018-2019 The OpenEBS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ func TestEnvInstallCount(t *testing.T) {
 	tests := map[string]struct {
 		expectedCount int
 	}{
-		"101": {19},
+		"101": {20},
 	}
 
 	for name, mock := range tests {

--- a/pkg/install/v1alpha1/flags.go
+++ b/pkg/install/v1alpha1/flags.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	menv "github.com/openebs/maya/pkg/env/v1alpha1"
+	"strconv"
+)
+
+// IsDefaultStorageConfigEnabled reads from env variable to check
+// whether default storage configuration should be created or not.
+func IsDefaultStorageConfigEnabled() (enabled bool) {
+	enabled, _ = strconv.ParseBool(menv.Get(CreateDefaultStorageConfig))
+	return
+}
+
+// IsCstorSparsePoolEnabled reads from env variable to check
+// whether cstor sparse pool should be created by default or not.
+// In addition, cstor sparse pool should be created only if the
+// creation of default storage configuration is enabled.
+func IsCstorSparsePoolEnabled() bool {
+	enabled, _ := strconv.ParseBool(menv.Get(DefaultCstorSparsePool))
+	return IsDefaultStorageConfigEnabled() && enabled
+}

--- a/pkg/install/v1alpha1/jiva_pool.go
+++ b/pkg/install/v1alpha1/jiva_pool.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The OpenEBS Authors
+Copyright 2018-2019 The OpenEBS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ provisioner: openebs.io/provisioner-iscsi
 // JivaPoolArtifacts returns the default jiva pool and storage
 // class related artifacts corresponding to latest version
 func JivaPoolArtifacts() (list artifactList) {
-	list.Items = append(list.Items, ParseArtifactListFromMultipleYamls(jivaPools{})...)
+	list.Items = append(list.Items, ParseArtifactListFromMultipleYamlsIf(jivaPools{}, IsDefaultStorageConfigEnabled)...)
 	return
 }
 

--- a/pkg/install/v1alpha1/localpv_sc.go
+++ b/pkg/install/v1alpha1/localpv_sc.go
@@ -61,7 +61,7 @@ reclaimPolicy: Delete
 // LocalPVArtifacts returns the default Local PV storage
 // class related artifacts corresponding to latest version
 func LocalPVArtifacts() (list artifactList) {
-	list.Items = append(list.Items, ParseArtifactListFromMultipleYamls(localPVSCs{})...)
+	list.Items = append(list.Items, ParseArtifactListFromMultipleYamlsIf(localPVSCs{}, IsDefaultStorageConfigEnabled)...)
 	return
 }
 


### PR DESCRIPTION
Refer: https://github.com/openebs/openebs/issues/2665

The default storage pool and storage classes installed
by openebs-apiserer can't be customized by the user.

While further thoughts have to go into what aspects of
the storage configuration needs to be customized, this
PR allows to disable the creation of the default
storage classes/pools.

The new logic for creation of default config is as follows:
(a) if default config is enabled, create:
    - jiva storage pool and jiva default storage class
    - local pv storage classes for hostpath and device

(b) if default config is enabled and cstor sparse is enabled:
    - create cstor sparse pool claim and its storage class

By default:
- config creation is enabled.
- cstor sparse is disabled

Note that the openebs snapshot promoter storage class
is installed and managed by openebs apiserver, as there
are no customization supported by this storage class.

Signed-off-by: kmova <kiran.mova@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [x] Fixes #<issue number>
- [x] Labelled this PR & related issue with `documentation` tag
- [x] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests