### PR TITLE
 fix(csi,bdd): update csi test with latest changes

### DIFF
--- a/pkg/kubernetes/storageclass/v1alpha1/build.go
+++ b/pkg/kubernetes/storageclass/v1alpha1/build.go
@@ -57,6 +57,28 @@ func (b *Builder) WithAnnotations(annotations map[string]string) *Builder {
 	return b
 }
 
+// WithParametersNew resets existing parameters if any with
+// ones that are provided here
+func (b *Builder) WithParametersNew(parameters map[string]string) *Builder {
+	if len(parameters) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build cstorvolume object: no new parameters"),
+		)
+		return b
+	}
+
+	// copy of original map
+	newparameters := map[string]string{}
+	for key, value := range parameters {
+		newparameters[key] = value
+	}
+
+	// override
+	b.sc.object.Parameters = newparameters
+	return b
+}
+
 // WithProvisioner sets the Provisioner field of storageclass with provided argument.
 func (b *Builder) WithProvisioner(provisioner string) *Builder {
 	if len(provisioner) == 0 {

--- a/tests/csi/cstor/volume/provision_test.go
+++ b/tests/csi/cstor/volume/provision_test.go
@@ -66,10 +66,16 @@ var _ = Describe("[cstor] [sparse] TEST VOLUME PROVISIONING", func() {
 			annotations[string(apis.CASTypeKey)] = string(apis.CstorVolume)
 			annotations[string(apis.CASConfigKey)] = CASConfig
 
+			parameters := map[string]string{
+				"replicacount":     "1",
+				"storagePoolClaim": spcObj.Name,
+			}
+
 			By("building a storageclass")
 			scObj, err = sc.NewBuilder().
 				WithGenerateName(scName).
 				WithAnnotations(annotations).
+				WithParametersNew(parameters).
 				WithProvisioner(openebsProvisioner).Build()
 			Expect(err).ShouldNot(HaveOccurred(),
 				"while building storageclass obj with prefix {%s}", scName)

--- a/tests/csi/cstor/volume/suite_test.go
+++ b/tests/csi/cstor/volume/suite_test.go
@@ -47,8 +47,10 @@ var (
 	scObj              *storagev1.StorageClass
 	spcObj             *apis.StoragePoolClaim
 	pvcObj             *corev1.PersistentVolumeClaim
+	podObj             *corev1.Pod
 	targetLabel        = "openebs.io/target=cstor-target"
 	pvcLabel           = "openebs.io/persistent-volume-claim="
+	pvLabel            = "openebs.io/persistent-volume="
 	accessModes        = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
 	capacity           = "5G"
 	annotations        = map[string]string{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- commit update the changes in storageclass parameters required
  for csi BDD tests to run with latest changes.

```
ginkgo -v -- -kubeconfig="$HOME/.kube/config" --cstor-replicas=1 --cstor-maxpools=1
Running Suite: Test cstor volume provisioning
=============================================
Random Seed: 1563432753
Will run 1 of 1 specs

STEP: waiting for maya-apiserver pod to come into running state
STEP: waiting for openebs-provisioner pod to come into running state
STEP: Verifying 'admission-server' pod status as running
STEP: building a namespace
STEP: creating above namespace
[cstor] [sparse] TEST VOLUME PROVISIONING when cstor pvc with replicacount 1 is created 
  should create cstor volume target pod
  /home/payes/gocode/src/github.com/openebs/maya/tests/csi/cstor/volume/provision_test.go:110
STEP: building a storagepoolclaim
STEP: creating above storagepoolclaim
STEP: verifying healthy cstorpool count
STEP: building a CAS Config with generated SPC name
STEP: building a storageclass
STEP: creating above storageclass
STEP: building a pvc
STEP: creating above pvc
STEP: verifying pvc status as bound
STEP: building a busybox app pod using above csi cstor volume
STEP: creating pod with above pvc as volume
STEP: verifying target pod count as 1
STEP: verifying app pod is running
STEP: deleting application pod
STEP: deleting above pvc
STEP: verifying target pod count as 0
STEP: verifying deleted pvc
STEP: verifying if cstorvolume is deleted
STEP: deleting resources created for testing cstor volume provisioning
STEP: deleting storagepoolclaim
STEP: deleting storageclass

• [SLOW TEST:125.400 seconds]
[cstor] [sparse] TEST VOLUME PROVISIONING
/home/payes/gocode/src/github.com/openebs/maya/tests/csi/cstor/volume/provision_test.go:38
  when cstor pvc with replicacount 1 is created
  /home/payes/gocode/src/github.com/openebs/maya/tests/csi/cstor/volume/provision_test.go:109
    should create cstor volume target pod
    /home/payes/gocode/src/github.com/openebs/maya/tests/csi/cstor/volume/provision_test.go:110
------------------------------
STEP: deleting namespace

Ran 1 of 1 Specs in 125.486 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 2m12.912612767s
Test Suite Passed
```

**Special notes for your reviewer**:
- In CSI volume provisioning , target pod is created only after the application is deployed for the first time using the PVC. This is why target pod creation is being verified after deploying the app in the BDD test.

**Checklist:**
- [x] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [x] Commit has integration tests