### PR TITLE
cherry-pick(exporter): add jiva target client status (#1340)

### DIFF
--- a/cmd/maya-exporter/app/collector/collector.go
+++ b/cmd/maya-exporter/app/collector/collector.go
@@ -72,6 +72,7 @@ func (c *collector) collectors() []prometheus.Collector {
 		c.degradedReplicaCounter,
 		c.healthyReplicaCounter,
 		c.volumeUpTime,
+		c.isClientConnected,
 	}
 }
 
@@ -179,6 +180,7 @@ func (c *collector) set(volStats stats) {
 	c.healthyReplicaCounter.Set(volStats.healthyReplicaCount)
 
 	c.volumeStatus.Set(float64(volStats.getVolumeStatus()))
+	c.isClientConnected.Set(volStats.isClientConnected)
 
 	return
 }

--- a/cmd/maya-exporter/app/collector/jiva.go
+++ b/cmd/maya-exporter/app/collector/jiva.go
@@ -119,6 +119,11 @@ func (j *jiva) parse(volStats v1.VolumeStats, metrics *metrics) stats {
 	url = strings.TrimPrefix(url, protocol)
 	stats.address = url
 	stats.iqn = jivaIQN + volStats.Name
+	if volStats.IsClientConnected {
+		stats.isClientConnected = 1
+	} else {
+		stats.isClientConnected = 0
+	}
 
 	return stats
 }

--- a/cmd/maya-exporter/app/collector/metrics.go
+++ b/cmd/maya-exporter/app/collector/metrics.go
@@ -66,6 +66,7 @@ type metrics struct {
 	healthyReplicaCounter  prometheus.Gauge
 	degradedReplicaCounter prometheus.Gauge
 	totalReplicaCounter    prometheus.Gauge
+	isClientConnected      prometheus.Gauge
 	volumeUpTime           *prometheus.GaugeVec
 }
 
@@ -92,6 +93,7 @@ type stats struct {
 	healthyReplicaCount  float64
 	degradedReplicaCount float64
 	offlineReplicaCount  float64
+	isClientConnected    float64
 	name                 string
 	replicas             []v1.Replica
 	status               v1.TargetMode
@@ -248,6 +250,14 @@ func Metrics(cas string) metrics {
 				Namespace: "openebs",
 				Name:      "total_replica_count",
 				Help:      "Total no of replicas connected to cas",
+			},
+		),
+
+		isClientConnected: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "openebs",
+				Name:      "iscsi_initiator_login_status",
+				Help:      "iSCSI Initiator to jiva target login status: (0, 1): {Not Logged In, Logged In}",
 			},
 		),
 	}

--- a/pkg/stats/v1alpha1/stats.go
+++ b/pkg/stats/v1alpha1/stats.go
@@ -95,6 +95,9 @@ type VolumeStats struct {
 	Replicas []Replica `json:"Replicas"`
 	// Target status is the status of the target (RW/RO)
 	TargetStatus TargetMode `json:"Status"`
+	// IsClientConnected is the status of initiator whether it
+	// is connected to target or not.
+	IsClientConnected bool `json:"IsClientConnected"`
 }
 
 // Replica is used to store the info about the replicas


### PR DESCRIPTION
Add client status in exporter metrics, this is useful in identifying
whether a client is connected to jiva target or not.

Depends on: openebs/jiva#233, openebs/gotgt#22

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests