### PR TITLE
chore(gosimple): fix lint issue.

### DIFF
--- a/cmd/maya-apiserver/cstor-operator/cspc/operations.go
+++ b/cmd/maya-apiserver/cstor-operator/cspc/operations.go
@@ -151,7 +151,7 @@ func isRaidGroupPresentOnCSP(group *apis.RaidGroup, csp *apis.NewTestCStorPool) 
 }
 
 // getAddedBlockDevicesInGroup returns the added block device list
-func getAddedBlockDevicesInGroup(groupOnCSPC *apis.RaidGroup, groupOnCSP *apis.RaidGroup) ([]string, error) {
+func getAddedBlockDevicesInGroup(groupOnCSPC, groupOnCSP *apis.RaidGroup) ([]string, error) {
 	var addedBlockDevices []string
 
 	// bdPresentOnCSP is a map whose key is block devices


### PR DESCRIPTION
Two or more consecutive named function parameters share a type,
omit the type from all but the last.

Signed-off-by: Ashutosh Kumar <ashutosh.kumar@openebs.io>