### PR TITLE
feat(upgrade): added upgrade files for 1.0.0-1.1.0 jivaVolume, pools and cstorVolume upgrades

### DIFF
--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/csp_upgrade.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/csp_upgrade.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"fmt"
+	"text/template"
+
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
+)
+
+type cspDeployPatchDetails struct {
+	UpgradeVersion, PoolImage, PoolMgmtImage, MExporterImage string
+}
+
+func getCSPDeployPatchDetails(
+	d *appsv1.Deployment,
+) (*cspDeployPatchDetails, error) {
+	patchDetails := &cspDeployPatchDetails{}
+	cstorPoolImage, err := getBaseImage(d, "cstor-pool")
+	if err != nil {
+		return nil, err
+	}
+	cstorPoolMgmtImage, err := getBaseImage(d, "cstor-pool-mgmt")
+	if err != nil {
+		return nil, err
+	}
+	MExporterImage, err := getBaseImage(d, "maya-exporter")
+	if err != nil {
+		return nil, err
+	}
+	patchDetails.PoolImage = cstorPoolImage
+	patchDetails.PoolMgmtImage = cstorPoolMgmtImage
+	patchDetails.MExporterImage = MExporterImage
+	return patchDetails, nil
+}
+
+func cspUpgrade(cspName, openebsNamespace string) error {
+	if cspName == "" {
+		return errors.Errorf("missing csp name")
+	}
+	if openebsNamespace == "" {
+		return errors.Errorf("missing openebs namespace")
+	}
+
+	cspObj, err := cspClient.Get(cspName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	cspVersion := cspObj.Labels["openebs.io/version"]
+	if (cspVersion != currentVersion) && (cspVersion != upgradeVersion) {
+		return errors.Errorf(
+			"cstor pool version %s is neither %s nor %s\n",
+			cspVersion,
+			currentVersion,
+			upgradeVersion,
+		)
+	}
+	cspLabel := "openebs.io/cstor-pool=" + cspName
+	cspDeployObj, err := getDeployment(cspLabel, openebsNamespace)
+	if err != nil {
+		return err
+	}
+	if cspDeployObj.Name == "" {
+		return errors.Errorf("missing deployment name for csp %s", cspName)
+	}
+	cspDeployVersion, err := getOpenEBSVersion(cspDeployObj)
+	if err != nil {
+		return err
+	}
+	if (cspDeployVersion != currentVersion) && (cspDeployVersion != upgradeVersion) {
+		return errors.Errorf(
+			"cstor pool version %s is neither %s nor %s\n",
+			cspVersion,
+			currentVersion,
+			upgradeVersion,
+		)
+	}
+	if cspVersion == currentVersion {
+		tmpl, err := template.New("cspPatch").Parse(openebsVersionPatchTemplate)
+		if err != nil {
+			return err
+		}
+		err = tmpl.Execute(&buffer, upgradeVersion)
+		if err != nil {
+			return err
+		}
+		cspPatch := buffer.String()
+		buffer.Reset()
+		_, err = cspClient.Patch(
+			cspName,
+			types.MergePatchType,
+			[]byte(cspPatch),
+		)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("patched csp %s\n", cspName)
+	} else {
+		fmt.Printf("csp %s already in %s version\n", cspName, upgradeVersion)
+	}
+
+	if cspDeployVersion == currentVersion {
+		patchDetails, err := getCSPDeployPatchDetails(cspDeployObj)
+		if err != nil {
+			return err
+		}
+		patchDetails.UpgradeVersion = upgradeVersion
+		tmpl, err := template.New("cspDeployPatch").Parse(cspDeployPatchTemplate)
+		if err != nil {
+			return err
+		}
+		err = tmpl.Execute(&buffer, patchDetails)
+		if err != nil {
+			return err
+		}
+		cspDeployPatch := buffer.String()
+		buffer.Reset()
+		err = patchDelpoyment(
+			cspDeployObj.Name,
+			openebsNamespace,
+			types.StrategicMergePatchType,
+			[]byte(cspDeployPatch),
+		)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("patched csp deployment %s\n", cspName)
+	} else {
+		fmt.Printf("csp deployment %s already in %s version\n",
+			cspDeployObj.Name,
+			upgradeVersion,
+		)
+	}
+	fmt.Println("Upgrade Successful for csp", cspName)
+	return nil
+}

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/cstor_volume_upgrade.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/cstor_volume_upgrade.go
@@ -123,7 +123,7 @@ func patchTargetDeploy(d *appsv1.Deployment, ns string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Println(d.Name, " patched")
+		fmt.Printf("target deployment %s patched\n", d.Name)
 	} else {
 		fmt.Printf("target deployment already in %s version\n", upgradeVersion)
 	}
@@ -171,7 +171,7 @@ func patchCV(pvLabel, namespace string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Println(cvObject.Items[0].Name, " patched")
+		fmt.Printf("cstorvolume %s patched\n", cvObject.Items[0].Name)
 	} else {
 		fmt.Printf("cstorvolume already in %s version\n", upgradeVersion)
 	}
@@ -212,7 +212,7 @@ func patchCVR(cvrName, namespace string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Println(cvrObject.Name, " patched")
+		fmt.Printf("cstorvolumereplica %s patched\n", cvrObject.Name)
 	} else {
 		fmt.Printf("cstorvolume replica already in %s version\n", upgradeVersion)
 	}
@@ -261,7 +261,7 @@ func patchService(targetServiceLabel, namespace string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Println(targetServiceName, "patched")
+		fmt.Printf("targetservice %s patched\n", targetServiceName)
 	} else {
 		fmt.Printf("service already in %s version\n", upgradeVersion)
 	}

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/cstor_volume_upgrade.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/cstor_volume_upgrade.go
@@ -1,0 +1,326 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"fmt"
+	"text/template"
+
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
+)
+
+type cstorTargetPatchDetails struct {
+	UpgradeVersion, IstgtImage, MExporterImage, VolumeMgmtImage string
+}
+
+func verifyCSPVersion(pvLabel, namespace string) error {
+	cvrList, err := cvrClient.List(
+		metav1.ListOptions{
+			LabelSelector: pvLabel,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	for _, cvrObj := range cvrList.Items {
+		cspName := cvrObj.Labels["cstorpool.openebs.io/name"]
+		if cspName == "" {
+			return errors.Errorf("missing csp name for %s", cvrObj.Name)
+		}
+		cspDeployObj, err := deployClient.WithNamespace(namespace).
+			Get(cspName)
+		if err != nil {
+			return err
+		}
+		if cspDeployObj.Labels["openebs.io/version"] != upgradeVersion {
+			return errors.Errorf(
+				"csp deployment %s not in %s version",
+				cspDeployObj.Name,
+				upgradeVersion,
+			)
+		}
+	}
+	return nil
+}
+
+func getTargetDeployPatchDetails(
+	d *appsv1.Deployment,
+) (*cstorTargetPatchDetails, error) {
+	patchDetails := &cstorTargetPatchDetails{}
+	if d.Name == "" {
+		return nil, errors.Errorf("missing deployment name")
+	}
+	istgtImage, err := getBaseImage(d, "cstor-istgt")
+	if err != nil {
+		return nil, err
+	}
+	patchDetails.IstgtImage = istgtImage
+	mexporterImage, err := getBaseImage(d, "maya-volume-exporter")
+	if err != nil {
+		return nil, err
+	}
+	patchDetails.MExporterImage = mexporterImage
+	volumeMgmtImage, err := getBaseImage(d, "cstor-volume-mgmt")
+	if err != nil {
+		return nil, err
+	}
+	patchDetails.VolumeMgmtImage = volumeMgmtImage
+	return patchDetails, nil
+}
+
+func patchTargetDeploy(d *appsv1.Deployment, ns string) error {
+	version, err := getOpenEBSVersion(d)
+	if err != nil {
+		return err
+	}
+	if (version != currentVersion) && (version != upgradeVersion) {
+		return errors.Errorf(
+			"target deployment version %s is neither %s nor %s\n",
+			version,
+			currentVersion,
+			upgradeVersion,
+		)
+	}
+	if version == currentVersion {
+		tmpl, err := template.New("targetPatch").Parse(cstorTargetPatchTemplate)
+		if err != nil {
+			return err
+		}
+		patchDetails, err := getTargetDeployPatchDetails(d)
+		if err != nil {
+			return err
+		}
+		patchDetails.UpgradeVersion = upgradeVersion
+		err = tmpl.Execute(&buffer, patchDetails)
+		if err != nil {
+			return err
+		}
+		replicaPatch := buffer.String()
+		buffer.Reset()
+		err = patchDelpoyment(
+			d.Name,
+			ns,
+			types.StrategicMergePatchType,
+			[]byte(replicaPatch),
+		)
+		if err != nil {
+			return err
+		}
+		fmt.Println(d.Name, " patched")
+	} else {
+		fmt.Printf("target deployment already in %s version\n", upgradeVersion)
+	}
+	return nil
+}
+
+func patchCV(pvLabel, namespace string) error {
+	cvObject, err := cvClient.WithNamespace(namespace).List(
+		metav1.ListOptions{
+			LabelSelector: pvLabel,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	if len(cvObject.Items) == 0 {
+		return errors.Errorf("cstorvolume not found")
+	}
+	version := cvObject.Items[0].Labels["openebs.io/version"]
+	if (version != currentVersion) && (version != upgradeVersion) {
+		return errors.Errorf(
+			"cstorvolume version %s is neither %s nor %s\n",
+			version,
+			currentVersion,
+			upgradeVersion,
+		)
+	}
+	if version == currentVersion {
+		tmpl, err := template.New("cvPatch").Parse(openebsVersionPatchTemplate)
+		if err != nil {
+			return err
+		}
+		err = tmpl.Execute(&buffer, upgradeVersion)
+		if err != nil {
+			return err
+		}
+		cvPatch := buffer.String()
+		buffer.Reset()
+		_, err = cvClient.WithNamespace(namespace).Patch(
+			cvObject.Items[0].Name,
+			namespace,
+			types.MergePatchType,
+			[]byte(cvPatch),
+		)
+		if err != nil {
+			return err
+		}
+		fmt.Println(cvObject.Items[0].Name, " patched")
+	} else {
+		fmt.Printf("cstorvolume already in %s version\n", upgradeVersion)
+	}
+	return nil
+}
+
+func patchCVR(cvrName, namespace string) error {
+	cvrObject, err := cvrClient.WithNamespace(namespace).Get(cvrName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	version := cvrObject.Labels["openebs.io/version"]
+	if (version != currentVersion) && (version != upgradeVersion) {
+		return errors.Errorf(
+			"cstorvolume version %s is neither %s nor %s\n",
+			version,
+			currentVersion,
+			upgradeVersion,
+		)
+	}
+	if version == currentVersion {
+		tmpl, err := template.New("cvPatch").Parse(openebsVersionPatchTemplate)
+		if err != nil {
+			return err
+		}
+		err = tmpl.Execute(&buffer, upgradeVersion)
+		if err != nil {
+			return err
+		}
+		cvPatch := buffer.String()
+		buffer.Reset()
+		_, err = cvrClient.WithNamespace(namespace).Patch(
+			cvrObject.Name,
+			namespace,
+			types.MergePatchType,
+			[]byte(cvPatch),
+		)
+		if err != nil {
+			return err
+		}
+		fmt.Println(cvrObject.Name, " patched")
+	} else {
+		fmt.Printf("cstorvolume replica already in %s version\n", upgradeVersion)
+	}
+	return nil
+}
+
+func patchService(targetServiceLabel, namespace string) error {
+	targetServiceObj, err := serviceClient.WithNamespace(namespace).List(
+		metav1.ListOptions{
+			LabelSelector: targetServiceLabel,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	targetServiceName := targetServiceObj.Items[0].Name
+	if targetServiceName == "" {
+		return errors.Errorf("missing service name")
+	}
+	version := targetServiceObj.Items[0].
+		Labels["openebs.io/version"]
+	if version != currentVersion && version != upgradeVersion {
+		return errors.Errorf(
+			"service version %s is neither %s nor %s\n",
+			version,
+			currentVersion,
+			upgradeVersion,
+		)
+	}
+	if version == currentVersion {
+		tmpl, err := template.New("servicePatch").Parse(openebsVersionPatchTemplate)
+		if err != nil {
+			return err
+		}
+		err = tmpl.Execute(&buffer, upgradeVersion)
+		if err != nil {
+			return err
+		}
+		servicePatch := buffer.String()
+		buffer.Reset()
+		_, err = serviceClient.WithNamespace(namespace).Patch(
+			targetServiceName,
+			types.StrategicMergePatchType,
+			[]byte(servicePatch),
+		)
+		if err != nil {
+			return err
+		}
+		fmt.Println(targetServiceName, "patched")
+	} else {
+		fmt.Printf("service already in %s version\n", upgradeVersion)
+	}
+	return nil
+}
+
+func cstorVolumeUpgrade(pvName, openebsNamespace string) error {
+	pvLabel := "openebs.io/persistent-volume=" + pvName
+	targetLabel := pvLabel + ",openebs.io/target=cstor-target"
+	targetServiceLabel := pvLabel + ",openebs.io/target-service=cstor-target-svc"
+
+	err := verifyCSPVersion(pvLabel, openebsNamespace)
+	if err != nil {
+		return err
+	}
+
+	ns, err := getPVCDeploymentsNamespace(pvName, pvLabel, openebsNamespace)
+	if err != nil {
+		return err
+	}
+
+	targetDeployObj, err := getDeployment(targetLabel, ns)
+	if err != nil {
+		return err
+	}
+
+	err = patchTargetDeploy(targetDeployObj, ns)
+	if err != nil {
+		return err
+	}
+
+	err = patchService(targetServiceLabel, ns)
+	if err != nil {
+		return err
+	}
+
+	err = patchCV(pvLabel, ns)
+	if err != nil {
+		return err
+	}
+
+	cvrList, err := cvrClient.WithNamespace(openebsNamespace).List(
+		metav1.ListOptions{
+			LabelSelector: pvLabel,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	for _, cvrObj := range cvrList.Items {
+		if cvrObj.Name == "" {
+			return errors.Errorf("missing cvr name")
+		}
+		err = patchCVR(cvrObj.Name, openebsNamespace)
+		if err != nil {
+			return err
+		}
+
+	}
+
+	return nil
+}

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/exec.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/exec.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2019 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"bytes"
+
+	csp "github.com/openebs/maya/pkg/cstor/pool/v1alpha3"
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
+	deploy "github.com/openebs/maya/pkg/kubernetes/deployment/appsv1/v1alpha1"
+	pv "github.com/openebs/maya/pkg/kubernetes/persistentvolume/v1alpha1"
+	svc "github.com/openebs/maya/pkg/kubernetes/service/v1alpha1"
+)
+
+var (
+	upgradeVersion = "1.1.0-RC1"
+	currentVersion = "1.0.0"
+
+	replicaPatchTemplate = `{
+		"metadata": {
+		   "labels": {
+			  "openebs.io/version": "{{.UpgradeVersion}}",
+			  "openebs.io/persistent-volume": "{{.PVName}}",
+			  "openebs.io/replica": "jiva-replica"
+		   }
+		},
+		"spec": {
+			"selector": {
+				"matchLabels":{
+					"openebs.io/persistent-volume": "{{.PVName}}",
+					"openebs.io/replica": "jiva-replica"
+				}
+			},
+		   "template": {
+			   "metadata": {
+				   "labels": {
+					   "openebs.io/version": "{{.UpgradeVersion}}",
+					   "openebs.io/persistent-volume": "{{.PVName}}",
+					   "openebs.io/replica": "jiva-replica"
+				   }
+			   },
+			  "spec": {
+				 "containers": [
+					{
+					   "name": "{{.ReplicaContainerName}}",
+					   "image": "{{.ReplicaImage}}:{{.UpgradeVersion}}"
+					}
+				 ],
+				 "affinity": {
+					 "podAntiAffinity": {
+						 "requiredDuringSchedulingIgnoredDuringExecution": [
+							 {
+								 "labelSelector": {
+									 "matchLabels": {
+										 "openebs.io/persistent-volume": "{{.PVName}}",
+										 "openebs.io/replica": "jiva-replica"
+									 }
+								 },
+					 "topologyKey": "kubernetes.io/hostname"
+							 }
+						 ]
+					 }
+				 }
+			  }
+		   }
+		}
+	 }`
+
+	targetPatchTemplate = `{
+		"metadata": {
+		   "labels": {
+			 "openebs.io/version": "{{.UpgradeVersion}}"
+		   }
+		},
+		"spec": {
+		   "template": {
+			  "metadata": {
+				 "labels":{
+					"openebs.io/version": "{{.UpgradeVersion}}"
+				 }
+			  },
+			 "spec": {
+			   "containers": [
+				 {
+					"name": "{{.ControllerContainerName}}",
+					"image": "{{.ControllerImage}}:{{.UpgradeVersion}}"
+				 },
+				 {
+					"name": "maya-volume-exporter",
+					"image": "{{.MExporterImage}}:{{.UpgradeVersion}}"
+				 }
+			   ]
+			 }
+		   }
+		}
+	  }`
+
+	openebsVersionPatchTemplate = `{
+		"metadata": {
+		   "labels": {
+			  "openebs.io/version": "{{.}}"
+		   }
+		}
+	 }`
+
+	cspDeployPatchTemplate = `{
+		"metadata": {
+		   "labels": {
+			  "openebs.io/version": "{{.UpgradeVersion}}"
+		   }
+		},
+		"spec": {
+		   "template": {
+			  "metadata": {
+				 "labels": {
+					"openebs.io/version": "{{.UpgradeVersion}}"
+				 }
+			  },
+			  "spec": {
+				 "containers": [
+					{
+					   "name": "cstor-pool",
+					   "image": "{{.PoolImage}}:{{.UpgradeVersion}}"
+					},
+					{
+					  "name": "cstor-pool-mgmt",
+					  "image": "{{.PoolMgmtImage}}:{{.UpgradeVersion}}"
+					},
+					{
+					  "name": "maya-exporter",
+					  "image": "{{.MExporterImage}}:{{.UpgradeVersion}}"
+					}
+				]
+			  }
+		   }
+		}
+	  }`
+
+	buffer bytes.Buffer
+
+	deployClient  = deploy.NewKubeClient()
+	serviceClient = svc.NewKubeClient()
+	pvClient      = pv.NewKubeClient()
+	cspClient     = csp.KubeClient()
+)
+
+// Exec ...
+func Exec(kind, name, openebsNamespace string) error {
+
+	switch kind {
+	case "jivaVolume":
+		err := jivaUpgrade(name, openebsNamespace)
+		if err != nil {
+			return err
+		}
+	case "storagePoolClaim":
+		err := spcUpgrade(name, openebsNamespace)
+		if err != nil {
+			return err
+		}
+	case "cstorPool":
+		err := cspUpgrade(name, openebsNamespace)
+		if err != nil {
+			return err
+		}
+	default:
+		return errors.Errorf("Invalid kind for upgrade")
+	}
+	return nil
+}

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/exec.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/exec.go
@@ -160,7 +160,8 @@ var (
 
 // Exec ...
 func Exec(kind, name, openebsNamespace string) error {
-
+	// TODO
+	// verify openebs namespace and check maya-apiserver version
 	switch kind {
 	case "jivaVolume":
 		err := jivaUpgrade(name, openebsNamespace)

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/jiva_upgrade.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/jiva_upgrade.go
@@ -1,0 +1,408 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"fmt"
+	"strings"
+	"text/template"
+	"time"
+
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
+	retry "github.com/openebs/maya/pkg/util/retry"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
+
+	// auth plugins
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+)
+
+type replicaPatchDetails struct {
+	UpgradeVersion, PVName, ReplicaContainerName, ReplicaImage string
+}
+
+type controllerPatchDetails struct {
+	UpgradeVersion, ControllerContainerName, ControllerImage, MExporterImage string
+}
+
+type replicaDetails struct {
+	patchDetails  *replicaPatchDetails
+	version, name string
+}
+
+type controllerDetails struct {
+	patchDetails  *controllerPatchDetails
+	version, name string
+}
+
+func getOpenEBSVersion(d *appsv1.Deployment) (string, error) {
+	if d.Labels["openebs.io/version"] == "" {
+		return "", errors.Errorf("missing openebs version")
+	}
+	return d.Labels["openebs.io/version"], nil
+}
+
+func getDeployment(labels, namespace string) (*appsv1.Deployment, error) {
+	deployList, err := deployClient.WithNamespace(namespace).List(
+		&metav1.ListOptions{
+			LabelSelector: labels,
+		})
+	if err != nil {
+		return nil, err
+	}
+	if len(deployList.Items) == 0 {
+		return nil, errors.Errorf("no deployments found for %s", labels)
+	}
+	return &(deployList.Items[0]), nil
+}
+
+func getReplicaPatchDetails(d *appsv1.Deployment) (
+	*replicaPatchDetails,
+	error,
+) {
+	rd := &replicaPatchDetails{}
+	// verify delpoyment name
+	if d.Name == "" {
+		return nil, errors.New("missing deployment name")
+	}
+	name, err := getContainerName(d)
+	if err != nil {
+		return nil, err
+	}
+	rd.ReplicaContainerName = name
+	image, err := getBaseImage(d, rd.ReplicaContainerName)
+	if err != nil {
+		return nil, err
+	}
+	rd.ReplicaImage = image
+	return rd, nil
+}
+
+func getControllerPatchDetails(d *appsv1.Deployment) (
+	*controllerPatchDetails,
+	error,
+) {
+	rd := &controllerPatchDetails{}
+	// verify delpoyment name
+	if d.Name == "" {
+		return nil, errors.New("missing deployment name")
+	}
+	name, err := getContainerName(d)
+	if err != nil {
+		return nil, err
+	}
+	rd.ControllerContainerName = name
+	image, err := getBaseImage(d, rd.ControllerContainerName)
+	if err != nil {
+		return nil, err
+	}
+	rd.ControllerImage = image
+	image, err = getBaseImage(d, "maya-volume-exporter")
+	if err != nil {
+		return nil, err
+	}
+	rd.MExporterImage = image
+	return rd, nil
+}
+
+func patchDelpoyment(
+	deployName,
+	namespace string,
+	pt types.PatchType,
+	data []byte,
+) error {
+	_, err := deployClient.WithNamespace(namespace).Patch(
+		deployName,
+		pt,
+		data,
+	)
+	if err != nil {
+		return err
+	}
+
+	err = retry.
+		Times(60).
+		Wait(5 * time.Second).
+		Try(func(attempt uint) error {
+			rolloutStatus, err1 := deployClient.WithNamespace(namespace).
+				RolloutStatus(deployName)
+			if err != nil {
+				return err1
+			}
+			if !rolloutStatus.IsRolledout {
+				return errors.Errorf("failed to rollout %s", rolloutStatus.Message)
+			}
+			return nil
+		})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func getContainerName(d *appsv1.Deployment) (string, error) {
+	containerList := d.Spec.Template.Spec.Containers
+	// verify length of container list
+	if len(containerList) == 0 {
+		return "", errors.New("missing container")
+	}
+	name := containerList[0].Name
+	// verify replica container name
+	if name == "" {
+		return "", errors.New("missing container name")
+	}
+	return name, nil
+}
+
+func getBaseImage(deployObj *appsv1.Deployment, name string) (string, error) {
+	for _, con := range deployObj.Spec.Template.Spec.Containers {
+		if con.Name == name {
+			return strings.Split(con.Image, ":")[0], nil
+		}
+	}
+	return "", errors.Errorf("image not found for %s", name)
+}
+
+func getReplica(replicaLabel, namespace string) (*replicaDetails, error) {
+	replicaObj := &replicaDetails{}
+	deployObj, err := getDeployment(replicaLabel, namespace)
+	if err != nil {
+		return nil, errors.Errorf("failed to get replica deployment")
+	}
+	if deployObj.Name == "" {
+		return nil, errors.Errorf("missing deployment name for replica")
+	}
+	replicaObj.name = deployObj.Name
+	version, err := getOpenEBSVersion(deployObj)
+	if err != nil {
+		return nil, err
+	}
+	if (version != currentVersion) && (version != upgradeVersion) {
+		return nil, errors.Errorf(
+			"replica version %s is neither %s nor %s\n",
+			version,
+			currentVersion,
+			upgradeVersion,
+		)
+	}
+	replicaObj.version = version
+	patchDetails, err := getReplicaPatchDetails(deployObj)
+	if err != nil {
+		return nil, err
+	}
+	replicaObj.patchDetails = patchDetails
+	replicaObj.patchDetails.UpgradeVersion = upgradeVersion
+	return replicaObj, nil
+}
+
+func getController(controllerLabel, namespace string) (*controllerDetails, error) {
+	controllerObj := &controllerDetails{}
+	deployObj, err := getDeployment(controllerLabel, namespace)
+	if err != nil {
+		return nil, err
+	}
+	if deployObj.Name == "" {
+		return nil, errors.Errorf("missing deployment name for controller")
+	}
+	controllerObj.name = deployObj.Name
+	version, err := getOpenEBSVersion(deployObj)
+	if err != nil {
+		return nil, err
+	}
+	if (version != currentVersion) && (version != upgradeVersion) {
+		return nil, errors.Errorf(
+			"controller version %s is neither %s nor %s\n",
+			version,
+			currentVersion,
+			upgradeVersion,
+		)
+	}
+	controllerObj.version = version
+	patchDetails, err := getControllerPatchDetails(deployObj)
+	if err != nil {
+		return nil, err
+	}
+	controllerObj.patchDetails = patchDetails
+	controllerObj.patchDetails.UpgradeVersion = upgradeVersion
+	return controllerObj, nil
+}
+
+func patchReplica(replicaObj *replicaDetails, namespace string) error {
+	if replicaObj.version == currentVersion {
+		tmpl, err := template.New("replicaPatch").Parse(replicaPatchTemplate)
+		if err != nil {
+			return err
+		}
+		err = tmpl.Execute(&buffer, replicaObj.patchDetails)
+		if err != nil {
+			return err
+		}
+		replicaPatch := buffer.String()
+		err = patchDelpoyment(
+			replicaObj.name,
+			namespace,
+			types.StrategicMergePatchType,
+			[]byte(replicaPatch),
+		)
+		if err != nil {
+			return err
+		}
+		fmt.Println(replicaObj.name, " patched")
+	} else {
+		fmt.Printf("replica deployment already in %s version\n", upgradeVersion)
+	}
+	return nil
+}
+
+func patchController(controllerObj *controllerDetails, namespace string) error {
+	if controllerObj.version == currentVersion {
+		tmpl, err := template.New("controllerPatch").Parse(targetPatchTemplate)
+		if err != nil {
+			return err
+		}
+		err = tmpl.Execute(&buffer, controllerObj.patchDetails)
+		if err != nil {
+			return err
+		}
+		controllerPatch := buffer.String()
+
+		err = patchDelpoyment(
+			controllerObj.name,
+			namespace,
+			types.StrategicMergePatchType,
+			[]byte(controllerPatch),
+		)
+		if err != nil {
+			return err
+		}
+		fmt.Println(controllerObj.name, " patched")
+	} else {
+		fmt.Printf("controller deployment already in %s version\n", upgradeVersion)
+	}
+	return nil
+}
+
+func jivaUpgrade(pvName, openebsNamespace string) error {
+
+	var (
+		pvLabel         = "openebs.io/persistent-volume=" + pvName
+		replicaLabel    = "openebs.io/replica=jiva-replica," + pvLabel
+		controllerLabel = "openebs.io/controller=jiva-controller," + pvLabel
+		ns              string
+		err             error
+	)
+
+	pvObj, err := pvClient.Get(pvName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	// verifying whether the pvc is deployed with DeployInOpenebsNamespace cas config
+	deployInOpenebs, err := deployClient.WithNamespace(openebsNamespace).List(
+		&metav1.ListOptions{
+			LabelSelector: pvLabel,
+		})
+	if err != nil {
+		return err
+	}
+	// check whether pvc pods are openebs namespace or not
+	if len(deployInOpenebs.Items) > 0 {
+		ns = openebsNamespace
+	} else {
+		// if pvc pods are not in openebs namespace take the namespace of pvc
+		if pvObj.Spec.ClaimRef.Namespace == "" {
+			return errors.Errorf("namespace missing for pv %s", pvName)
+		}
+		ns = pvObj.Spec.ClaimRef.Namespace
+	}
+
+	// fetching replica deployment details
+	replicaObj, err := getReplica(replicaLabel, ns)
+	if err != nil {
+		return err
+	}
+	replicaObj.patchDetails.PVName = pvName
+
+	// fetching controller deployment details
+	controllerObj, err := getController(controllerLabel, ns)
+	if err != nil {
+		return err
+	}
+	// fetching controller service details
+	controllerServiceList, err := serviceClient.WithNamespace(ns).List(
+		metav1.ListOptions{
+			LabelSelector: pvLabel,
+		})
+	if err != nil {
+		return err
+	}
+	// controllerServiceObj := controllerServiceList.Items[0]
+	controllerServiceName := controllerServiceList.Items[0].Name
+	controllerServiceVersion := controllerServiceList.Items[0].
+		Labels["openebs.io/version"]
+	if controllerServiceVersion != currentVersion &&
+		controllerServiceVersion != upgradeVersion {
+		return errors.Errorf(
+			"controller service version %s is neither %s nor %s\n",
+			controllerServiceVersion,
+			currentVersion,
+			upgradeVersion,
+		)
+	}
+
+	// replica patch
+	err = patchReplica(replicaObj, ns)
+	if err != nil {
+		return err
+	}
+	buffer.Reset()
+
+	// controller patch
+	err = patchController(controllerObj, ns)
+	if err != nil {
+		return err
+	}
+	buffer.Reset()
+
+	// service patch
+	if controllerServiceVersion == currentVersion {
+		tmpl, err := template.New("servicePatch").Parse(openebsVersionPatchTemplate)
+		if err != nil {
+			return err
+		}
+		err = tmpl.Execute(&buffer, upgradeVersion)
+		if err != nil {
+			return err
+		}
+		servicePatch := buffer.String()
+		_, err = serviceClient.WithNamespace(ns).Patch(
+			controllerServiceName,
+			types.StrategicMergePatchType,
+			[]byte(servicePatch),
+		)
+		if err != nil {
+			return err
+		}
+		fmt.Println(controllerServiceName, "patched")
+	} else {
+		fmt.Printf("controller service already in %s version\n", upgradeVersion)
+	}
+
+	fmt.Println("Upgrade Successful for", pvName)
+	return nil
+}

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/spc_upgrade.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/spc_upgrade.go
@@ -29,7 +29,9 @@ func spcUpgrade(spcName, openebsNamespace string) error {
 	cspList, err := cspClient.List(metav1.ListOptions{
 		LabelSelector: spcLabel,
 	})
-
+	if err != nil {
+		return err
+	}
 	for _, cspObj := range cspList.Items {
 		if cspObj.Name == "" {
 			return errors.Errorf("missing csp name")

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/spc_upgrade.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/spc_upgrade.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"fmt"
+
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func spcUpgrade(spcName, openebsNamespace string) error {
+
+	spcLabel := "openebs.io/storage-pool-claim=" + spcName
+	cspList, err := cspClient.List(metav1.ListOptions{
+		LabelSelector: spcLabel,
+	})
+
+	for _, cspObj := range cspList.Items {
+		if cspObj.Name == "" {
+			return errors.Errorf("missing csp name")
+		}
+		err = cspUpgrade(cspObj.Name, openebsNamespace)
+		if err != nil {
+			return err
+		}
+	}
+	fmt.Println("Upgrade Successful for spc", spcName)
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds to upgrade functions for jiva volumes and cstor pools .
The pool upgrade has both the option of passing csp or spc as input.
**Sample pool upgrade output:**
```
user:maya$ upgrade 1.0.0 1.1.0-RC1 jivaVolume pvc-b32839ee-ade5-11e9-a5a1-42010a800144 openebs
pvc-b32839ee-ade5-11e9-a5a1-42010a800144-rep  patched
pvc-b32839ee-ade5-11e9-a5a1-42010a800144-ctrl  patched
pvc-b32839ee-ade5-11e9-a5a1-42010a800144-ctrl-svc patched
Upgrade Successful for pvc-b32839ee-ade5-11e9-a5a1-42010a800144

user:maya$ upgrade 1.0.0 1.1.0-RC1 cstorPool sparse-claim-auto-tpp2 openebs
patched csp sparse-claim-auto-tpp2
patched csp deployment sparse-claim-auto-tpp2
Upgrade Successful for csp sparse-claim-auto-tpp2

user:maya$ upgrade 1.0.0 1.1.0-RC1 storagePoolClaim sparse-claim-auto openebs
csp sparse-claim-auto-tpp2 already in 1.1.0-RC1 version
csp deployment sparse-claim-auto-tpp2 already in 1.1.0-RC1 version
Upgrade Successful for csp sparse-claim-auto-tpp2
patched csp sparse-claim-auto-xng2
patched csp deployment sparse-claim-auto-xng2
Upgrade Successful for csp sparse-claim-auto-xng2
Upgrade Successful for spc sparse-claim-auto

user:maya$ upgrade 1.0.0 1.1.0-RC1 cstorVolume pvc-3d3e569d-ae0a-11e9-a5a1-42010a800144 openebs
pvc-3d3e569d-ae0a-11e9-a5a1-42010a800144-target  patched
pvc-3d3e569d-ae0a-11e9-a5a1-42010a800144 patched
pvc-3d3e569d-ae0a-11e9-a5a1-42010a800144  patched
pvc-3d3e569d-ae0a-11e9-a5a1-42010a800144-sparse-claim-auto-0ovt  patched
pvc-3d3e569d-ae0a-11e9-a5a1-42010a800144-sparse-claim-auto-dtz7  patched
pvc-3d3e569d-ae0a-11e9-a5a1-42010a800144-sparse-claim-auto-ye3u  patched

```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests