### PR TITLE
fix(cspc,csp): fix pool destroy functionality using finalizers

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/new-pool-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/new-pool-controller/handler.go
@@ -117,6 +117,7 @@ func (c *CStorPoolController) destroy(csp *apis.NewTestCStorPool) error {
 		phase = apis.CStorPoolStatusDeletionFailed
 		goto updatestatus
 	}
+	glog.Infof("Pool %s deleted successfully", csp.Name)
 	return nil
 
 updatestatus:
@@ -223,7 +224,6 @@ func (c *CStorPoolController) removeFinalizer(csp *apis.NewTestCStorPool) error 
 	if len(csp.Finalizers) == 0 {
 		return nil
 	}
-
 	csp.Finalizers = []string{}
 	_, err := c.clientset.
 		OpenebsV1alpha1().

--- a/cmd/cstor-pool-mgmt/controller/new-pool-controller/new_pool_controller.go
+++ b/cmd/cstor-pool-mgmt/controller/new-pool-controller/new_pool_controller.go
@@ -122,10 +122,6 @@ func NewCStorPoolController(
 			}
 			controller.enqueueCStorPool(csp)
 		},
-		DeleteFunc: func(obj interface{}) {
-			csp := obj.(*apis.NewTestCStorPool)
-			glog.Infof("cStorPool Resource deleted event: %v, %v", csp.ObjectMeta.Name, string(csp.ObjectMeta.UID))
-		},
 	})
 
 	return controller

--- a/cmd/maya-apiserver/cstor-operator/cspc/handler.go
+++ b/cmd/maya-apiserver/cstor-operator/cspc/handler.go
@@ -273,7 +273,7 @@ func (pc *PoolConfig) handleCSPCDeletion() error {
 
 	cspcBuilderObj, err := apiscspc.BuilderForAPIObject(pc.AlgorithmConfig.CSPC).Build()
 	if err != nil {
-		glog.Errorf("Failed to build CSPC api object %s", pc.AlgorithmConfig.CSPC.Name)
+		glog.Errorf("Failed to build CSPC api object %s:%s", pc.AlgorithmConfig.CSPC.Name,err.Error())
 		return nil
 	}
 

--- a/cmd/maya-apiserver/cstor-operator/cspc/handler.go
+++ b/cmd/maya-apiserver/cstor-operator/cspc/handler.go
@@ -273,7 +273,7 @@ func (pc *PoolConfig) handleCSPCDeletion() error {
 
 	cspcBuilderObj, err := apiscspc.BuilderForAPIObject(pc.AlgorithmConfig.CSPC).Build()
 	if err != nil {
-		glog.Errorf("Failed to build CSPC api object %s:%s", pc.AlgorithmConfig.CSPC.Name,err.Error())
+		glog.Errorf("Failed to build CSPC api object %s:%s", pc.AlgorithmConfig.CSPC.Name, err.Error())
 		return nil
 	}
 

--- a/cmd/maya-apiserver/cstor-operator/cspc/handler.go
+++ b/cmd/maya-apiserver/cstor-operator/cspc/handler.go
@@ -18,12 +18,8 @@ package cspc
 
 import (
 	"fmt"
-	ndmapis "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
 	bdc "github.com/openebs/maya/pkg/blockdeviceclaim/v1alpha1"
-	blockdeviceclaim "github.com/openebs/maya/pkg/blockdeviceclaim/v1alpha1"
-	"github.com/openebs/maya/pkg/cstor/poolcluster/v1alpha1"
 	apiscspc "github.com/openebs/maya/pkg/cstor/poolcluster/v1alpha1"
-	"github.com/openebs/maya/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apiscsp "github.com/openebs/maya/pkg/cstor/newpool/v1alpha3"
@@ -144,7 +140,7 @@ func (c *Controller) syncCSPC(cspcGot *apis.CStorPoolCluster) error {
 
 	// If CSPC is deleted -- handle the deletion.
 	if !cspcGot.DeletionTimestamp.IsZero() {
-		err := pc.handleCSPCDeletion()
+		err = pc.handleCSPCDeletion()
 		if err != nil {
 			glog.Errorf("Failed to sync CSPC for deletion:%s", err.Error())
 		}
@@ -160,15 +156,6 @@ func (c *Controller) syncCSPC(cspcGot *apis.CStorPoolCluster) error {
 	cspc, err := cspcBuilderObj.AddFinalizer(apiscspc.CSPCFinalizer)
 	if err != nil {
 		glog.Errorf("Failed to add finalizer on CSPC %s:%s", cspcGot.Name, err.Error())
-		return nil
-	}
-
-	if !cspc.DeletionTimestamp.IsZero() {
-		// if returns error, we will log the error instead of re-queueing
-		err = c.handleDeletion(cspc, openebsNameSpace)
-		if err != nil {
-			glog.Errorf("Could not remove finalizers: %s", err.Error())
-		}
 		return nil
 	}
 
@@ -267,92 +254,6 @@ func (pc *PoolConfig) createDeployForCSP(csp *apis.NewTestCStorPool) error {
 	if err != nil {
 		return errors.Wrapf(err, "could not create deployment for csp {%s}", csp.Name)
 	}
-	return nil
-}
-
-// getUsedBDCs returns BDCList that is associated with the given cspc
-func (c *Controller) getUsedBDCs(cspc *apis.CStorPoolCluster, namespace string) (*ndmapis.BlockDeviceClaimList, error) {
-	bdcList, err := c.ndmclientset.OpenebsV1alpha1().BlockDeviceClaims(namespace).
-		List(metav1.ListOptions{LabelSelector: string(apis.CStorPoolClusterCPK) + "=" + cspc.Name})
-	if err != nil {
-		return nil, errors.Wrapf(err, "could not list BDCs for CSPC %v", cspc.Name)
-	}
-	return bdcList, nil
-}
-
-// handleDeletion is used to remove finalizers on the associated BDCs
-// and CSPC when the delete timestamp is set on the cspc object
-func (c *Controller) handleDeletion(cspc *apis.CStorPoolCluster, namespace string) error {
-	// get all the BDCs associated with the cspc
-	bdcList, err := c.getUsedBDCs(cspc, namespace)
-	if err != nil {
-		return errors.Wrapf(err, "failed to remove finalizer on bdcs and cspc")
-	}
-
-	// iterate over the bdcs and remove the finalizer
-	for _, bdc := range bdcList.Items {
-		bdc := bdc
-		err = c.removeBDCFinalizer(&bdc, v1alpha1.CSPCFinalizer)
-		if err != nil {
-			return errors.Wrapf(err, "failed to remove finalizer on bdcs and cspc")
-		}
-	}
-
-	// remove finalizer on cspc
-	err = c.removeCSPCFinalizer(cspc, v1alpha1.CSPCFinalizer)
-	if err != nil {
-		return errors.Wrapf(err, "failed to remove finalizer on cspc object")
-	}
-
-	// if finalizer is removed successfully, then object will
-	// be removed and no need to reconcile further
-	return nil
-}
-
-// removeBDCFinalizer removes the given finalizer from the BDC
-func (c *Controller) removeBDCFinalizer(bdcObj *ndmapis.BlockDeviceClaim, finalizer string) error {
-	if len(bdcObj.Finalizers) == 0 {
-		return nil
-	}
-
-	bdcObj.Finalizers = util.RemoveString(bdcObj.Finalizers, finalizer)
-
-	// Update is used instead of patch, because when there were 2 finalizers in the object
-	// and tried to remove the first finalizer using patch operation , it was not working. The
-	// patch operation didn't return any error but the object was not getting patched.
-	// using Update() it was possible to remove the finalizer on the BDC
-	_, err := blockdeviceclaim.NewKubeClient().
-		WithNamespace(bdcObj.Namespace).
-		Update(bdcObj)
-	if err != nil {
-		return errors.Wrapf(err, "failed to remove finalizer from BDC %v", bdcObj.Name)
-	}
-	return nil
-}
-
-// removeCSPCFinalizer will remove finalizer on cspc
-func (c *Controller) removeCSPCFinalizer(cspcObj *apis.CStorPoolCluster, finalizer string) error {
-	if len(cspcObj.Finalizers) == 0 {
-		return nil
-	}
-
-	// if the cspc object does not contain the finalizer string set
-	// by cstor operator then we will return nil. This will avoid an
-	// un-necessary API call.
-	if !util.ContainsString(cspcObj.Finalizers, finalizer) {
-		glog.V(2).Infof("finalizer %s is already removed", finalizer)
-		return nil
-	}
-
-	cspcObj.Finalizers = util.RemoveString(cspcObj.Finalizers, finalizer)
-
-	_, err := v1alpha1.NewKubeClient().
-		WithNamespace(cspcObj.Namespace).
-		Update(cspcObj)
-	if err != nil {
-		return errors.Wrapf(err, "failed to remove finalizers from cspc %v", cspcObj.Name)
-	}
-	glog.Infof("finalizer %s is successfully removed from cspc %s", finalizer, cspcObj.Name)
 	return nil
 }
 

--- a/pkg/algorithm/nodeselect/v1alpha2/build_csp.go
+++ b/pkg/algorithm/nodeselect/v1alpha2/build_csp.go
@@ -19,6 +19,7 @@ package v1alpha2
 import (
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	apiscsp "github.com/openebs/maya/pkg/cstor/newpool/v1alpha3"
+	apicspsc "github.com/openebs/maya/pkg/cstor/poolcluster/v1alpha1"
 	"github.com/openebs/maya/pkg/version"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -46,6 +47,7 @@ func (ac *Config) GetCSPSpec() (*apis.NewTestCStorPool, error) {
 		WithRaidGroups(poolSpec.RaidGroups).
 		WithCSPCOwnerReference(ac.CSPC).
 		WithLabelsNew(csplabels).
+		WithFinalizer(apicspsc.CSPCFinalizer).
 		Build()
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to build CSP object for node selector {%v}", poolSpec.NodeSelector)

--- a/pkg/cstor/newpool/v1alpha3/build.go
+++ b/pkg/cstor/newpool/v1alpha3/build.go
@@ -220,6 +220,19 @@ func (b *Builder) WithRaidGroups(raidGroup []apis.RaidGroup) *Builder {
 	return b
 }
 
+// WithFinalizer sets the finalizer field in the BDC
+func (b *Builder) WithFinalizer(finalizers ...string) *Builder {
+	if len(finalizers) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build CSP object: missing finalizer"),
+		)
+		return b
+	}
+	b.CSP.Object.Finalizers = append(b.CSP.Object.Finalizers, finalizers...)
+	return b
+}
+
 // WithOwnerReference sets the OwnerReference field in CSP with required
 //fields
 func (b *Builder) WithOwnerReference(spc *apis.StoragePoolClaim) *Builder {

--- a/pkg/cstor/poolcluster/v1alpha1/buildlist_test.go
+++ b/pkg/cstor/poolcluster/v1alpha1/buildlist_test.go
@@ -43,7 +43,7 @@ func fakeCSPCList(cspcNames []string) []*CSPC {
 	for _, name := range cspcNames {
 		cspc := apisv1alpha1.CStorPoolCluster{}
 		cspc.SetName(name)
-		plist = append(plist, &CSPC{&cspc})
+		plist = append(plist, &CSPC{&cspc, ""})
 	}
 	return plist
 }

--- a/pkg/cstor/poolcluster/v1alpha1/cstorpoolcluster.go
+++ b/pkg/cstor/poolcluster/v1alpha1/cstorpoolcluster.go
@@ -127,53 +127,53 @@ func HasFinalizer(finalizer string) Predicate {
 }
 
 // HasFinalizer returns true if the provided finalizer is present on the object.
-func (cspc *CSPC) HasFinalizer(finalizer string) bool {
-	finalizersList := cspc.object.GetFinalizers()
+func (c *CSPC) HasFinalizer(finalizer string) bool {
+	finalizersList := c.object.GetFinalizers()
 	return util.ContainsString(finalizersList, finalizer)
 }
 
 // RemoveFinalizer removes the given finalizer from the object.
-func (cspc *CSPC) RemoveFinalizer(finalizer string) error {
-	if len(cspc.object.Finalizers) == 0 {
-		glog.V(2).Infof("no finalizer present on CSPC %s", cspc.object.Name)
+func (c *CSPC) RemoveFinalizer(finalizer string) error {
+	if len(c.object.Finalizers) == 0 {
+		glog.V(2).Infof("no finalizer present on CSPC %s", c.object.Name)
 		return nil
 	}
 
-	if !cspc.HasFinalizer(finalizer) {
-		glog.V(2).Infof("finalizer %s is already removed on CSPC %s", finalizer, cspc.object.Name)
+	if !c.HasFinalizer(finalizer) {
+		glog.V(2).Infof("finalizer %s is already removed on CSPC %s", finalizer, c.object.Name)
 		return nil
 	}
 
-	cspc.object.Finalizers = util.RemoveString(cspc.object.Finalizers, finalizer)
+	c.object.Finalizers = util.RemoveString(c.object.Finalizers, finalizer)
 
-	_, err := NewKubeClient(WithKubeConfigPath(cspc.configPath)).
-		WithNamespace(cspc.object.Namespace).
-		Update(cspc.object)
+	_, err := NewKubeClient(WithKubeConfigPath(c.configPath)).
+		WithNamespace(c.object.Namespace).
+		Update(c.object)
 	if err != nil {
 		return errors.Wrap(err, "failed to update object while removing finalizer")
 	}
-	glog.Infof("Finalizer %s removed successfully from CSPC %s", finalizer, cspc.object.Name)
+	glog.Infof("Finalizer %s removed successfully from CSPC %s", finalizer, c.object.Name)
 	return nil
 }
 
 // AddFinalizer adds the given finalizer to the object.
-func (cspc *CSPC) AddFinalizer(finalizer string) (*apisv1alpha1.CStorPoolCluster, error) {
-	if cspc.HasFinalizer(finalizer) {
-		glog.V(2).Infof("finalizer %s is already present on CSPC %s", finalizer, cspc.object.Name)
-		return cspc.object, nil
+func (c *CSPC) AddFinalizer(finalizer string) (*apisv1alpha1.CStorPoolCluster, error) {
+	if c.HasFinalizer(finalizer) {
+		glog.V(2).Infof("finalizer %s is already present on CSPC %s", finalizer, c.object.Name)
+		return c.object, nil
 	}
 
-	cspc.object.Finalizers = append(cspc.object.Finalizers, finalizer)
+	c.object.Finalizers = append(c.object.Finalizers, finalizer)
 
-	cspcAPIObj, err := NewKubeClient(WithKubeConfigPath(cspc.configPath)).
-		WithNamespace(cspc.object.Namespace).
-		Update(cspc.object)
+	cspcAPIObj, err := NewKubeClient(WithKubeConfigPath(c.configPath)).
+		WithNamespace(c.object.Namespace).
+		Update(c.object)
 
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to update CSPC %s while adding finalizer %s",
-			cspc.object.Name, finalizer)
+			c.object.Name, finalizer)
 	}
 
-	glog.Infof("Finalizer %s added on CSPC %s", finalizer, cspc.object.Name)
+	glog.Infof("Finalizer %s added on CSPC %s", finalizer, c.object.Name)
 	return cspcAPIObj, nil
 }


### PR DESCRIPTION
This PR does the following:

1. Add CSPC finalizer on CSPC resources.
2. Add CSPC finalizer on CSP resource.
3. Handle finalizer removal for CSPC resource deletion.

Signed-off-by: Ashutosh Kumar <ashutosh.kumar@openebs.io>