### PR TITLE
cherry-pick(cstor-operator, spc): honour cachefile value on spc yaml

### DIFF
--- a/cmd/maya-apiserver/cstor-operator/spc/storagepool_create.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/storagepool_create.go
@@ -71,6 +71,7 @@ func (pc *PoolCreateConfig) getCasPool(spc *apis.StoragePoolClaim) (*apis.CasPoo
 		withCasTemplateName(spc.Annotations[string(v1alpha1.CreatePoolCASTemplateKey)]).
 		withDiskType(spc.Spec.Type).
 		withPoolType(spc.Spec.PoolSpec.PoolType).
+		withPoolCacheFile(spc.Spec.PoolSpec.CacheFile).
 		withAnnotations(spc.Annotations).
 		withMaxPool(spc).
 		Build()
@@ -110,6 +111,11 @@ func (cb *CasPoolBuilder) withSpcName(name string) *CasPoolBuilder {
 
 func (cb *CasPoolBuilder) withPoolType(poolType string) *CasPoolBuilder {
 	cb.CasPool.PoolType = poolType
+	return cb
+}
+
+func (cb *CasPoolBuilder) withPoolCacheFile(poolCacheFile string) *CasPoolBuilder {
+	cb.CasPool.PoolCacheFile = poolCacheFile
 	return cb
 }
 

--- a/pkg/apis/openebs.io/v1alpha1/cas_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_pool.go
@@ -92,6 +92,9 @@ type CasPool struct {
 	// PoolType is the type of pool to be provisioned e.g. striped or mirrored
 	PoolType string
 
+	// PoolCacheFile is cache file which used at the time of importing a pool
+	PoolCacheFile string
+
 	// MaxPool is the maximum number of pool that should be provisioned
 	MaxPools int
 

--- a/pkg/apis/openebs.io/v1alpha1/cas_template_keys.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_template_keys.go
@@ -129,6 +129,8 @@ const (
 	PoolTypeCTP StoragePoolTLPProperty = "poolType"
 	// InitPhaseCTP is the init phase for the cstorpool CR that will be ceated
 	InitPhaseCTP StoragePoolTLPProperty = "phase"
+	// PoolCacheFileCTP is the cache file used in case of imporitng pool
+	PoolCacheFileCTP StoragePoolTLPProperty = "poolCacheFile"
 )
 
 // VolumeTLPProperty is used to define properties that comes

--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -154,6 +154,7 @@ spec:
         {{- end }}
       poolSpec:
         poolType: {{$blockDeviceIdList.poolType}}
+        cacheFile: {{$blockDeviceIdList.poolCacheFile}}
         overProvisioning: false
     status:
       phase: Init

--- a/pkg/storagepool/storagepool.go
+++ b/pkg/storagepool/storagepool.go
@@ -98,6 +98,7 @@ func (v *casPoolOperation) Create() (*v1alpha1.CasPool, error) {
 			string(v1alpha1.NodeNameCTP):          v.pool.NodeName,
 			string(v1alpha1.PoolTypeCTP):          v.pool.PoolType,
 			string(v1alpha1.BlockDeviceIDListCTP): v.pool.DeviceID,
+			string(v1alpha1.PoolCacheFileCTP):     v.pool.PoolCacheFile,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR propagate cacheFile value which is set on spc to csp during csp creation. This is cherry-pick of #1366 

When user applied below spc yaml
```yaml
apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: cstor-sparse
spec:
  name: cstor-sparse
  type: sparse
  poolSpec:
    poolType: striped
    cacheFile: /tmp/pool1.cache
  maxPools: 1
```
cstor-operator will propagate cache file to csp
```yaml
apiVersion: openebs.io/v1alpha1
kind: CStorPool
metadata:
    annotations:
      openebs.io/csp-lease: '{"holder":"openebs/cstor-sparse-s8ke-7c6f597fc7-kvkbp","leaderTransition":1}'
    creationTimestamp: "2019-07-24T06:14:16Z"
    generation: 1
    labels:
      kubernetes.io/hostname: 127.0.0.1
      openebs.io/cas-template-name: cstor-pool-create-default-1.1.0
      openebs.io/cas-type: cstor
      openebs.io/storage-pool-claim: cstor-sparse
      openebs.io/version: 1.1.0
    name: cstor-sparse-s8ke
    ownerReferences:
    - apiVersion: openebs.io/v1alpha1
      blockOwnerDeletion: true
      controller: true
      kind: StoragePoolClaim
      name: cstor-sparse
      uid: 435c7489-adda-11e9-90a5-54e1ad4a9dd4
    resourceVersion: "1021"
    selfLink: /apis/openebs.io/v1alpha1/cstorpools/cstor-sparse-s8ke
    uid: 43b066a9-adda-11e9-90a5-54e1ad4a9dd4
spec:
    group:
    - blockDevice:
      - deviceID: /var/openebs/sparse/0-ndm-sparse.img
        inUseByPool: true
        name: sparse-5a92ced3e2ee21eac7b930f670b5eab5
    poolSpec:
      cacheFile: /tmp/pool1.cache
      overProvisioning: false
      poolType: striped
  status:
    capacity:
      free: ""
      total: ""
      used: ""
    lastTransitionTime: "2019-07-24T06:14:27Z"
    lastUpdateTime: "2019-07-24T06:14:27Z"
    phase: Offline
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests