### PR TITLE
fix(import): importing pools with dev directory option

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
@@ -162,6 +162,7 @@ func (c *CStorPoolController) cStorPoolEventHandler(operation common.QueueOperat
 	return string(apis.CStorPoolStatusInvalid), nil
 }
 
+// GetDevPath gets the path from given deviceID
 func GetDevPath(devid string) string {
 	lastindex := strings.LastIndexByte(devid, '/')
 	if lastindex == -1 {
@@ -256,6 +257,8 @@ func (c *CStorPoolController) cStorPoolAddEvent(cStorPoolGot *apis.CStorPool) (s
 	}
 
 	devPath := GetDevPath(devIDList[0])
+
+	// Trigger import with dev path
 	status, importPoolErr = c.triggerImportPool(cStorPoolGot, false, devPath)
 	if status == string(apis.CStorPoolStatusOnline) {
 		return status, nil

--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
@@ -177,6 +177,10 @@ func (c *CStorPoolController) cStorPoolAddEvent(cStorPoolGot *apis.CStorPool) (s
 		return string(apis.CStorPoolStatusOffline), fmt.Errorf("Poolname/UID cannot be empty")
 	}
 
+	if cStorPoolGot.Spec.PoolSpec.CacheFile == "" {
+		cStorPoolGot.Spec.PoolSpec.CacheFile = "/tmp/pool1.cache"
+	}
+
 	/* 	If pool is already present.
 	Pool CR status is online. This means pool (main car) is running successfully,
 	but watcher container got restarted.

--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler_test.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler_test.go
@@ -392,6 +392,24 @@ func TestIsOnlyStatusChange(t *testing.T) {
 	}
 }
 
+func TestGetDevPath(t *testing.T) {
+	testGetDevPath := map[string]string{
+		"abcd":             "abcd",
+		"/dev":             "",
+		"/dev/":            "/dev",
+		"/dev/disk":        "/dev",
+		"/dev/disk/":       "/dev/disk",
+		"/dev/by-id/disk":  "/dev/by-id",
+		"/dev/by-id/disk/": "/dev/by-id/disk",
+	}
+	for ip, op := range testGetDevPath {
+		obtainedOutput := GetDevPath(ip)
+		if obtainedOutput != op {
+			t.Fatalf("IP:%v, OP:%v, Got:%v", ip, op, obtainedOutput)
+		}
+	}
+}
+
 // TestIsEmptyStatus is to check if status is empty.
 func TestIsEmptyStatus(t *testing.T) {
 	deletionTimeStamp := metav1.Now()

--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler_test.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	pool "github.com/openebs/maya/cmd/cstor-pool-mgmt/pool"
 )
 
 // TestGetPoolResource checks if pool resource created is successfully got.
@@ -403,7 +404,7 @@ func TestGetDevPath(t *testing.T) {
 		"/dev/by-id/disk/": "/dev/by-id/disk",
 	}
 	for ip, op := range testGetDevPath {
-		obtainedOutput := GetDevPath(ip)
+		obtainedOutput := pool.GetDevPath(ip)
 		if obtainedOutput != op {
 			t.Fatalf("IP:%v, OP:%v, Got:%v", ip, op, obtainedOutput)
 		}

--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler_test.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/openebs/maya/cmd/cstor-pool-mgmt/controller/common"
+	pool "github.com/openebs/maya/cmd/cstor-pool-mgmt/pool"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	openebsFakeClientset "github.com/openebs/maya/pkg/client/generated/clientset/versioned/fake"
 	informers "github.com/openebs/maya/pkg/client/generated/informers/externalversions"
@@ -28,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
-	pool "github.com/openebs/maya/cmd/cstor-pool-mgmt/pool"
 )
 
 // TestGetPoolResource checks if pool resource created is successfully got.

--- a/cmd/cstor-pool-mgmt/pool/pool.go
+++ b/cmd/cstor-pool-mgmt/pool/pool.go
@@ -67,6 +67,9 @@ var RunnerVar util.Runner
 // ImportPool imports cStor pool if already present.
 func ImportPool(cStorPool *apis.CStorPool, cachefileFlag bool, devPath string) error {
 	var importAttr []string
+
+	// import takes either cachefile or devPath, not both.
+	// here, prioritizing devPath
 	if devPath != "" {
 		importAttr = importPoolBuilder(cStorPool, false, devPath)
 	} else {
@@ -79,7 +82,7 @@ func ImportPool(cStorPool *apis.CStorPool, cachefileFlag bool, devPath string) e
 		return err
 	}
 
-	glog.Info("Importing Pool Successful with %v %v", cachefileFlag, devPath)
+	glog.Infof("Importing Pool Successful with %v %v", cachefileFlag, devPath)
 	return nil
 }
 

--- a/cmd/cstor-pool-mgmt/pool/pool.go
+++ b/cmd/cstor-pool-mgmt/pool/pool.go
@@ -61,6 +61,7 @@ const (
 	PoolPrefix PoolNamePrefix = "cstor-"
 )
 
+// ImportOptions contains the options to build import command
 type ImportOptions struct {
 	// CachefileFlag option to use cachefile for import
 	CachefileFlag bool
@@ -148,10 +149,7 @@ func checkForPoolExistence(cStorPool *apis.CStorPool, blockDeviceList []string) 
 	importOptions.dontImport = true
 	stdoutStderr, _ := ImportPool(cStorPool, &importOptions)
 	glog.Infof("checkForPoolExistence output: %v", stdoutStderr)
-	if strings.Contains(stdoutStderr, string(PoolPrefix)+string(cStorPool.ObjectMeta.UID)) {
-		return true
-	}
-	return false
+	return strings.Contains(stdoutStderr, string(PoolPrefix)+string(cStorPool.ObjectMeta.UID))
 }
 
 // CreatePool creates a new cStor pool.

--- a/cmd/cstor-pool-mgmt/pool/pool.go
+++ b/cmd/cstor-pool-mgmt/pool/pool.go
@@ -94,7 +94,7 @@ func ImportPool(cStorPool *apis.CStorPool, importOptions *ImportOptions) (string
 		importOptions.CachefileFlag, importOptions.DevPath, importOptions.dontImport,
 		importAttr, string(stdoutStderr))
 
-	poolName := string(PoolPrefix)+string(cStorPool.ObjectMeta.UID)
+	poolName := string(PoolPrefix) + string(cStorPool.ObjectMeta.UID)
 	statusPoolStr := []string{"status", poolName}
 	stdoutStderr1, err1 := RunnerVar.RunCombinedOutput(zpool.PoolOperator, statusPoolStr...)
 	if err1 != nil {

--- a/cmd/cstor-pool-mgmt/pool/pool_test.go
+++ b/cmd/cstor-pool-mgmt/pool/pool_test.go
@@ -411,7 +411,7 @@ func TestImportPool(t *testing.T) {
 	}
 	RunnerVar = TestRunner{}
 	for desc, ut := range testPoolResource {
-		obtainedErr := ImportPool(ut.test, ut.cachefileFlag)
+		obtainedErr := ImportPool(ut.test, ut.cachefileFlag, "")
 		if ut.expectedError != obtainedErr {
 			t.Fatalf("desc:%v, Expected: %v, Got: %v", desc, ut.expectedError, obtainedErr)
 		}

--- a/cmd/cstor-pool-mgmt/pool/pool_test.go
+++ b/cmd/cstor-pool-mgmt/pool/pool_test.go
@@ -411,7 +411,7 @@ func TestImportPool(t *testing.T) {
 	}
 	RunnerVar = TestRunner{}
 	for desc, ut := range testPoolResource {
-		obtainedErr := ImportPool(ut.test, ut.cachefileFlag, "")
+		obtainedErr := ImportPool(ut.test, ut.CachefileFlag, "")
 		if ut.expectedError != obtainedErr {
 			t.Fatalf("desc:%v, Expected: %v, Got: %v", desc, ut.expectedError, obtainedErr)
 		}

--- a/cmd/cstor-pool-mgmt/pool/pool_test.go
+++ b/cmd/cstor-pool-mgmt/pool/pool_test.go
@@ -411,7 +411,9 @@ func TestImportPool(t *testing.T) {
 	}
 	RunnerVar = TestRunner{}
 	for desc, ut := range testPoolResource {
-		obtainedErr := ImportPool(ut.test, ut.CachefileFlag, "")
+		var importOptions ImportOptions
+		importOptions.CachefileFlag = ut.cachefileFlag
+		_, obtainedErr := ImportPool(ut.test, &importOptions)
 		if ut.expectedError != obtainedErr {
 			t.Fatalf("desc:%v, Expected: %v, Got: %v", desc, ut.expectedError, obtainedErr)
 		}


### PR DESCRIPTION
Signed-off-by: Vitta <vitta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
cstor-pool-mgmt, currently, imports pool with and without cache file. If both of them fails, it creates the pool based on CSP status.
This PR adds another option for importing pool i.e., dev directory. It gets the devices directory path from the path of one of the deviceIDs in the CSP.

Added unit testcase for a util fn.
TODO: Will add BDD
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests