### PR TITLE
[WIP]fix(cstor-pool): delete sock file before deleting for cstor-pool container

### DIFF
--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -280,6 +280,13 @@ spec:
               postStart:
                  exec:
                     command: ["/bin/sh", "-c", "sleep 2"]
+              # Removes the sock file that is used for communication between
+              # cstor-pool and cstor-pool-mgmt containers, so that, cstor-pool-mgmt
+              # of new pool pod instance will NOT communicate with cstor-pool
+              # container of terminating pod instance.
+              preStop:
+                 exec:
+                    command: ["/bin/bash", "-c", "rm /tmp/uzfs.sock"]
           - name: cstor-pool-mgmt
             image: {{ .Config.CstorPoolMgmtImage.value }}
             resources:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR deletes the unix.sock file (which is shared between the
cstor-pool-mgmt and cstor-pool). This is deleted during cstor-pool container
deletion phase via a preStop hook.

(https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/)
In other words, before triggering kill of cstor-pool container, kubernetes will
execute this preStop hook.

This fix avoids RPC between cstor-pool-mgmt container of a new pod and
cstor-pool container of the terminating pod i.e. old pod.

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>