### PR TITLE
[cherry-pick] fix(import): importing pools with dev directory option 

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler_test.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/openebs/maya/cmd/cstor-pool-mgmt/controller/common"
+	pool "github.com/openebs/maya/cmd/cstor-pool-mgmt/pool"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	openebsFakeClientset "github.com/openebs/maya/pkg/client/generated/clientset/versioned/fake"
 	informers "github.com/openebs/maya/pkg/client/generated/informers/externalversions"
@@ -388,6 +389,24 @@ func TestIsOnlyStatusChange(t *testing.T) {
 		if obtainedOutput != ut.expectedOutput {
 			t.Fatalf("Desc:%v, Expected:%v, Got:%v", desc, ut.expectedOutput,
 				obtainedOutput)
+		}
+	}
+}
+
+func TestGetDevPath(t *testing.T) {
+	testGetDevPath := map[string]string{
+		"abcd":             "abcd",
+		"/dev":             "",
+		"/dev/":            "/dev",
+		"/dev/disk":        "/dev",
+		"/dev/disk/":       "/dev/disk",
+		"/dev/by-id/disk":  "/dev/by-id",
+		"/dev/by-id/disk/": "/dev/by-id/disk",
+	}
+	for ip, op := range testGetDevPath {
+		obtainedOutput := pool.GetDevPath(ip)
+		if obtainedOutput != op {
+			t.Fatalf("IP:%v, OP:%v, Got:%v", ip, op, obtainedOutput)
 		}
 	}
 }

--- a/cmd/cstor-pool-mgmt/pool/pool_test.go
+++ b/cmd/cstor-pool-mgmt/pool/pool_test.go
@@ -411,7 +411,9 @@ func TestImportPool(t *testing.T) {
 	}
 	RunnerVar = TestRunner{}
 	for desc, ut := range testPoolResource {
-		obtainedErr := ImportPool(ut.test, ut.cachefileFlag)
+		var importOptions ImportOptions
+		importOptions.CachefileFlag = ut.cachefileFlag
+		_, obtainedErr := ImportPool(ut.test, &importOptions)
 		if ut.expectedError != obtainedErr {
 			t.Fatalf("desc:%v, Expected: %v, Got: %v", desc, ut.expectedError, obtainedErr)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR is cherry-pick of #1372 
cstor-pool-mgmt, currently, imports pool with and without cache file. If both of them fails, it creates the pool based on CSP status.
This PR adds another option for importing pool i.e., dev directory. It gets the devices directory path from the path of one of the deviceIDs in the CSP.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests