### PR TITLE
refact(upgrade): refactor the cli for upgrade

### DIFF
--- a/cmd/upgrade/executor/cstor_spc.go
+++ b/cmd/upgrade/executor/cstor_spc.go
@@ -30,7 +30,7 @@ import (
 
 // CStorSPCOptions stores information required for cstor SPC upgrade
 type CStorSPCOptions struct {
-	cstorSPCName string
+	spcName string
 }
 
 var (
@@ -58,9 +58,9 @@ func NewUpgradeCStorSPCJob() *cobra.Command {
 
 	options.resourceKind = "storagePoolClaim"
 
-	cmd.Flags().StringVarP(&options.cstorSPCName,
+	cmd.Flags().StringVarP(&options.cstorSPC.spcName,
 		"spc-name", "",
-		options.cstorSPCName,
+		options.cstorSPC.spcName,
 		"cstor SPC name to be upgraded. Run \"kubectl get spc\", to get spc-name")
 
 	return cmd
@@ -68,7 +68,7 @@ func NewUpgradeCStorSPCJob() *cobra.Command {
 
 // RunCStorSPCUpgradeChecks will ensure the sanity of the cstor SPC upgrade options
 func (u *UpgradeOptions) RunCStorSPCUpgradeChecks(cmd *cobra.Command) error {
-	if len(strings.TrimSpace(u.cstorSPCName)) == 0 {
+	if len(strings.TrimSpace(u.cstorSPC.spcName)) == 0 {
 		return errors.Errorf("Cannot execute upgrade job: cstor spc name is missing")
 	}
 
@@ -85,23 +85,23 @@ func (u *UpgradeOptions) RunCStorSPCUpgrade(cmd *cobra.Command) error {
 	case "0.9.0-1.0.0":
 		fmt.Println("Upgrading to 1.0.0")
 		err := upgrade090to100.Exec(u.resourceKind,
-			u.cstorSPCName,
+			u.cstorSPC.spcName,
 			u.openebsNamespace)
 		if err != nil {
 			fmt.Println(err)
-			return errors.Errorf("Failed to upgrade cStor SPC %v:", u.cstorSPCName)
+			return errors.Errorf("Failed to upgrade cStor SPC %v:", u.cstorSPC.spcName)
 		}
 	case "1.0.0-1.1.0":
 		fmt.Println("Upgrading to 1.1.0")
 		err := upgrade100to110.Exec(u.fromVersion, u.toVersion,
 			u.resourceKind,
-			u.cstorSPCName,
+			u.cstorSPC.spcName,
 			u.openebsNamespace,
 			u.imageURLPrefix,
 			u.toVersionImageTag)
 		if err != nil {
 			fmt.Println(err)
-			return errors.Errorf("Failed to upgrade cStor SPC %v:", u.cstorSPCName)
+			return errors.Errorf("Failed to upgrade cStor SPC %v:", u.cstorSPC.spcName)
 		}
 	default:
 		return errors.Errorf("Invalid from version %s or to version %s", u.fromVersion, u.toVersion)

--- a/cmd/upgrade/executor/cstor_spc.go
+++ b/cmd/upgrade/executor/cstor_spc.go
@@ -49,14 +49,13 @@ func NewUpgradeCStorSPCJob() *cobra.Command {
 		Long:    cstorSPCUpgradeCmdHelpText,
 		Example: `upgrade cstor-spc --spc-name <spc-name>`,
 		Run: func(cmd *cobra.Command, args []string) {
+			options.resourceKind = "storagePoolClaim"
 			util.CheckErr(options.RunPreFlightChecks(cmd), util.Fatal)
 			util.CheckErr(options.RunCStorSPCUpgradeChecks(cmd), util.Fatal)
 			util.CheckErr(options.InitializeDefaults(cmd), util.Fatal)
 			util.CheckErr(options.RunCStorSPCUpgrade(cmd), util.Fatal)
 		},
 	}
-
-	options.resourceKind = "storagePoolClaim"
 
 	cmd.Flags().StringVarP(&options.cstorSPC.spcName,
 		"spc-name", "",

--- a/cmd/upgrade/executor/cstor_spc.go
+++ b/cmd/upgrade/executor/cstor_spc.go
@@ -41,7 +41,8 @@ Usage: upgrade cstor-spc --spc-name <spc-name> --options...
 `
 )
 
-// NewUpgradeCStorSPCJob upgrade a Jiva Volume
+// NewUpgradeCStorSPCJob upgrades all the cStor Pools associated with
+// a given Storage Pool Claim
 func NewUpgradeCStorSPCJob() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "cstor-spc",

--- a/cmd/upgrade/executor/cstor_spc.go
+++ b/cmd/upgrade/executor/cstor_spc.go
@@ -28,55 +28,55 @@ import (
 	upgrade100to110 "github.com/openebs/maya/pkg/upgrade/1.0.0-1.1.0/v1alpha1"
 )
 
-// JivaVolumeOptions stores information required for jiva volume upgrade
-type JivaVolumeOptions struct {
-	jivaPVName string
+// CStorSPCOptions stores information required for cstor SPC upgrade
+type cStorSPCOptions struct {
+	cstorSPCName string
 }
 
 var (
-	jivaVolumeUpgradeCmdHelpText = `
-This command upgrades the Jiva Persistent Volume
+	cstorSPCUpgradeCmdHelpText = `
+This command upgrades the cStor SPC 
 
-Usage: upgrade jiva-volume --volname <pv-name> --options...
+Usage: upgrade cstor-spc --spc-name <spc-name> --options...
 `
 )
 
-// NewUpgradeJivaVolumeJob upgrade a Jiva Volume
-func NewUpgradeJivaVolumeJob() *cobra.Command {
+// NewUpgradeCStorSPCJob upgrade a Jiva Volume
+func NewUpgradeCStorSPCJob() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "jiva-volume",
-		Short:   "Upgrade Jiva Volume",
-		Long:    jivaVolumeUpgradeCmdHelpText,
-		Example: `upgrade jiva-volume --pv-name <pv-name>`,
+		Use:     "cstor-spc",
+		Short:   "Upgrade cStor SPC",
+		Long:    cstorSPCUpgradeCmdHelpText,
+		Example: `upgrade cstor-spc --spc-name <spc-name>`,
 		Run: func(cmd *cobra.Command, args []string) {
 			util.CheckErr(options.RunPreFlightChecks(cmd), util.Fatal)
-			util.CheckErr(options.RunJivaVolumeUpgradeChecks(cmd), util.Fatal)
+			util.CheckErr(options.RunCStorSPCUpgradeChecks(cmd), util.Fatal)
 			util.CheckErr(options.InitializeDefaults(cmd), util.Fatal)
-			util.CheckErr(options.RunJivaVolumeUpgrade(cmd), util.Fatal)
+			util.CheckErr(options.RunCStorSPCUpgrade(cmd), util.Fatal)
 		},
 	}
 
-	options.resourceKind = "jivaVolume"
+	options.resourceKind = "storagePoolClaim"
 
-	cmd.Flags().StringVarP(&options.jivaPVName,
-		"pv-name", "",
-		options.jivaPVName,
-		"jiva persistent volume name to be upgraded, as obtained using: kubectl get pv")
+	cmd.Flags().StringVarP(&options.cstorSPCName,
+		"spc-name", "",
+		options.cstorSPCName,
+		"cstor SPC name to be upgraded. Run \"kubectl get spc\", to get spc-name")
 
 	return cmd
 }
 
-// RunJivaVolumeUpgradeChecks will ensure the sanity of the jiva upgrade options
-func (u *UpgradeOptions) RunJivaVolumeUpgradeChecks(cmd *cobra.Command) error {
-	if len(strings.TrimSpace(u.jivaPVName)) == 0 {
-		return errors.Errorf("Cannot execute upgrade job: jiva pv name is missing")
+// RunCStorSPCUpgradeChecks will ensure the sanity of the cstor SPC upgrade options
+func (u *UpgradeOptions) RunCStorSPCUpgradeChecks(cmd *cobra.Command) error {
+	if len(strings.TrimSpace(u.cstorSPCName)) == 0 {
+		return errors.Errorf("Cannot execute upgrade job: cstor spc name is missing")
 	}
 
 	return nil
 }
 
-// RunJivaVolumeUpgrade upgrades the given Jiva Volume.
-func (u *UpgradeOptions) RunJivaVolumeUpgrade(cmd *cobra.Command) error {
+// RunCStorSPCUpgrade upgrades the given Jiva Volume.
+func (u *UpgradeOptions) RunCStorSPCUpgrade(cmd *cobra.Command) error {
 
 	from := strings.Split(u.fromVersion, "-")[0]
 	to := strings.Split(u.toVersion, "-")[0]
@@ -85,23 +85,23 @@ func (u *UpgradeOptions) RunJivaVolumeUpgrade(cmd *cobra.Command) error {
 	case "0.9.0-1.0.0":
 		fmt.Println("Upgrading to 1.0.0")
 		err := upgrade090to100.Exec(u.resourceKind,
-			u.jivaPVName,
+			u.cstorSPCName,
 			u.openebsNamespace)
 		if err != nil {
 			fmt.Println(err)
-			return errors.Errorf("Failed to upgrade Jiva Volume %v:", u.jivaPVName)
+			return errors.Errorf("Failed to upgrade cStor SPC %v:", u.cstorSPCName)
 		}
 	case "1.0.0-1.1.0":
 		fmt.Println("Upgrading to 1.1.0")
 		err := upgrade100to110.Exec(u.fromVersion, u.toVersion,
 			u.resourceKind,
-			u.jivaPVName,
+			u.cstorSPCName,
 			u.openebsNamespace,
 			u.imageURLPrefix,
 			u.toVersionImageTag)
 		if err != nil {
 			fmt.Println(err)
-			return errors.Errorf("Failed to upgrade Jiva Volume %v:", u.jivaPVName)
+			return errors.Errorf("Failed to upgrade cStor SPC %v:", u.cstorSPCName)
 		}
 	default:
 		return errors.Errorf("Invalid from version %s or to version %s", u.fromVersion, u.toVersion)

--- a/cmd/upgrade/executor/cstor_volume.go
+++ b/cmd/upgrade/executor/cstor_volume.go
@@ -49,14 +49,13 @@ func NewUpgradeCStorVolumeJob() *cobra.Command {
 		Long:    cstorVolumeUpgradeCmdHelpText,
 		Example: `upgrade cstor-volume --pv-name <pv-name>`,
 		Run: func(cmd *cobra.Command, args []string) {
+			options.resourceKind = "cstorVolume"
 			util.CheckErr(options.RunPreFlightChecks(cmd), util.Fatal)
 			util.CheckErr(options.RunCStorVolumeUpgradeChecks(cmd), util.Fatal)
 			util.CheckErr(options.InitializeDefaults(cmd), util.Fatal)
 			util.CheckErr(options.RunCStorVolumeUpgrade(cmd), util.Fatal)
 		},
 	}
-
-	options.resourceKind = "cstorVolume"
 
 	cmd.Flags().StringVarP(&options.cstorVolume.pvName,
 		"pv-name", "",

--- a/cmd/upgrade/executor/cstor_volume.go
+++ b/cmd/upgrade/executor/cstor_volume.go
@@ -30,7 +30,7 @@ import (
 
 // CStorVolumeOptions stores information required for cstor volume upgrade
 type CStorVolumeOptions struct {
-	cstorPVName string
+	pvName string
 }
 
 var (
@@ -58,9 +58,9 @@ func NewUpgradeCStorVolumeJob() *cobra.Command {
 
 	options.resourceKind = "cstorVolume"
 
-	cmd.Flags().StringVarP(&options.cstorPVName,
+	cmd.Flags().StringVarP(&options.cstorVolume.pvName,
 		"pv-name", "",
-		options.cstorPVName,
+		options.cstorVolume.pvName,
 		"cstor persistent volume name. Run \"kubectl get pv\" to get pv-name.")
 
 	return cmd
@@ -68,7 +68,7 @@ func NewUpgradeCStorVolumeJob() *cobra.Command {
 
 // RunCStorVolumeUpgradeChecks will ensure the sanity of the cstor upgrade options
 func (u *UpgradeOptions) RunCStorVolumeUpgradeChecks(cmd *cobra.Command) error {
-	if len(strings.TrimSpace(u.cstorPVName)) == 0 {
+	if len(strings.TrimSpace(u.cstorVolume.pvName)) == 0 {
 		return errors.Errorf("Cannot execute upgrade job: cstor pv name is missing")
 	}
 
@@ -85,23 +85,23 @@ func (u *UpgradeOptions) RunCStorVolumeUpgrade(cmd *cobra.Command) error {
 	case "0.9.0-1.0.0":
 		fmt.Println("Upgrading to 1.0.0")
 		err := upgrade090to100.Exec(u.resourceKind,
-			u.cstorPVName,
+			u.cstorVolume.pvName,
 			u.openebsNamespace)
 		if err != nil {
 			fmt.Println(err)
-			return errors.Errorf("Failed to upgrade CStor Volume %v:", u.cstorPVName)
+			return errors.Errorf("Failed to upgrade CStor Volume %v:", u.cstorVolume.pvName)
 		}
 	case "1.0.0-1.1.0":
 		fmt.Println("Upgrading to 1.1.0")
 		err := upgrade100to110.Exec(u.fromVersion, u.toVersion,
 			u.resourceKind,
-			u.cstorPVName,
+			u.cstorVolume.pvName,
 			u.openebsNamespace,
 			u.imageURLPrefix,
 			u.toVersionImageTag)
 		if err != nil {
 			fmt.Println(err)
-			return errors.Errorf("Failed to upgrade CStor Volume %v:", u.cstorPVName)
+			return errors.Errorf("Failed to upgrade CStor Volume %v:", u.cstorVolume.pvName)
 		}
 	default:
 		return errors.Errorf("Invalid from version %s or to version %s", u.fromVersion, u.toVersion)

--- a/cmd/upgrade/executor/cstor_volume.go
+++ b/cmd/upgrade/executor/cstor_volume.go
@@ -28,55 +28,55 @@ import (
 	upgrade100to110 "github.com/openebs/maya/pkg/upgrade/1.0.0-1.1.0/v1alpha1"
 )
 
-// CStorSPCOptions stores information required for cstor SPC upgrade
-type CStorSPCOptions struct {
-	cstorSPCName string
+// CStorVolumeOptions stores information required for cstor volume upgrade
+type CStorVolumeOptions struct {
+	cstorPVName string
 }
 
 var (
-	cstorSPCUpgradeCmdHelpText = `
-This command upgrades the cStor SPC 
+	cstorVolumeUpgradeCmdHelpText = `
+This command upgrades the CStor Persistent Volume
 
-Usage: upgrade cstor-spc --spc-name <spc-name> --options...
+Usage: upgrade cstor-volume --volname <pv-name> --options...
 `
 )
 
-// NewUpgradeCStorSPCJob upgrade a Jiva Volume
-func NewUpgradeCStorSPCJob() *cobra.Command {
+// NewUpgradeCStorVolumeJob upgrade a CStor Volume
+func NewUpgradeCStorVolumeJob() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "cstor-spc",
-		Short:   "Upgrade cStor SPC",
-		Long:    cstorSPCUpgradeCmdHelpText,
-		Example: `upgrade cstor-spc --spc-name <spc-name>`,
+		Use:     "cstor-volume",
+		Short:   "Upgrade CStor Volume",
+		Long:    cstorVolumeUpgradeCmdHelpText,
+		Example: `upgrade cstor-volume --pv-name <pv-name>`,
 		Run: func(cmd *cobra.Command, args []string) {
 			util.CheckErr(options.RunPreFlightChecks(cmd), util.Fatal)
-			util.CheckErr(options.RunCStorSPCUpgradeChecks(cmd), util.Fatal)
+			util.CheckErr(options.RunCStorVolumeUpgradeChecks(cmd), util.Fatal)
 			util.CheckErr(options.InitializeDefaults(cmd), util.Fatal)
-			util.CheckErr(options.RunCStorSPCUpgrade(cmd), util.Fatal)
+			util.CheckErr(options.RunCStorVolumeUpgrade(cmd), util.Fatal)
 		},
 	}
 
-	options.resourceKind = "storagePoolClaim"
+	options.resourceKind = "cstorVolume"
 
-	cmd.Flags().StringVarP(&options.cstorSPCName,
-		"spc-name", "",
-		options.cstorSPCName,
-		"cstor SPC name to be upgraded. Run \"kubectl get spc\", to get spc-name")
+	cmd.Flags().StringVarP(&options.cstorPVName,
+		"pv-name", "",
+		options.cstorPVName,
+		"cstor persistent volume name. Run \"kubectl get pv\" to get pv-name.")
 
 	return cmd
 }
 
-// RunCStorSPCUpgradeChecks will ensure the sanity of the cstor SPC upgrade options
-func (u *UpgradeOptions) RunCStorSPCUpgradeChecks(cmd *cobra.Command) error {
-	if len(strings.TrimSpace(u.cstorSPCName)) == 0 {
-		return errors.Errorf("Cannot execute upgrade job: cstor spc name is missing")
+// RunCStorVolumeUpgradeChecks will ensure the sanity of the cstor upgrade options
+func (u *UpgradeOptions) RunCStorVolumeUpgradeChecks(cmd *cobra.Command) error {
+	if len(strings.TrimSpace(u.cstorPVName)) == 0 {
+		return errors.Errorf("Cannot execute upgrade job: cstor pv name is missing")
 	}
 
 	return nil
 }
 
-// RunCStorSPCUpgrade upgrades the given Jiva Volume.
-func (u *UpgradeOptions) RunCStorSPCUpgrade(cmd *cobra.Command) error {
+// RunCStorVolumeUpgrade upgrades the given CStor Volume.
+func (u *UpgradeOptions) RunCStorVolumeUpgrade(cmd *cobra.Command) error {
 
 	from := strings.Split(u.fromVersion, "-")[0]
 	to := strings.Split(u.toVersion, "-")[0]
@@ -85,23 +85,23 @@ func (u *UpgradeOptions) RunCStorSPCUpgrade(cmd *cobra.Command) error {
 	case "0.9.0-1.0.0":
 		fmt.Println("Upgrading to 1.0.0")
 		err := upgrade090to100.Exec(u.resourceKind,
-			u.cstorSPCName,
+			u.cstorPVName,
 			u.openebsNamespace)
 		if err != nil {
 			fmt.Println(err)
-			return errors.Errorf("Failed to upgrade cStor SPC %v:", u.cstorSPCName)
+			return errors.Errorf("Failed to upgrade CStor Volume %v:", u.cstorPVName)
 		}
 	case "1.0.0-1.1.0":
 		fmt.Println("Upgrading to 1.1.0")
 		err := upgrade100to110.Exec(u.fromVersion, u.toVersion,
 			u.resourceKind,
-			u.cstorSPCName,
+			u.cstorPVName,
 			u.openebsNamespace,
 			u.imageURLPrefix,
 			u.toVersionImageTag)
 		if err != nil {
 			fmt.Println(err)
-			return errors.Errorf("Failed to upgrade cStor SPC %v:", u.cstorSPCName)
+			return errors.Errorf("Failed to upgrade CStor Volume %v:", u.cstorPVName)
 		}
 	default:
 		return errors.Errorf("Invalid from version %s or to version %s", u.fromVersion, u.toVersion)

--- a/cmd/upgrade/executor/env.go
+++ b/cmd/upgrade/executor/env.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The OpenEBS Authors.
+Copyright 2019 The OpenEBS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,18 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package executor
 
 import (
-	"github.com/openebs/maya/cmd/upgrade/executor"
-	mlogger "github.com/openebs/maya/pkg/logs"
+	menv "github.com/openebs/maya/pkg/env/v1alpha1"
 )
 
-func main() {
-	// Init logging
-	mlogger.InitLogs()
-	defer mlogger.FlushLogs()
+//This file defines the environement variable names that are specific
+// to this provisioner. In addition to the variables defined in this file,
+// provisioner also uses the following:
+//   OPENEBS_NAMESPACE
 
-	err := executor.NewJob().Execute()
-	executor.CheckError(err)
+func getOpenEBSNamespace() string {
+	return menv.Get(menv.OpenEBSNamespace)
 }

--- a/cmd/upgrade/executor/error.go
+++ b/cmd/upgrade/executor/error.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The OpenEBS Authors.
+Copyright 2019 The OpenEBS Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,18 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package executor
 
 import (
-	"github.com/openebs/maya/cmd/upgrade/executor"
-	mlogger "github.com/openebs/maya/pkg/logs"
+	"context"
+	"fmt"
+	"os"
 )
 
-func main() {
-	// Init logging
-	mlogger.InitLogs()
-	defer mlogger.FlushLogs()
-
-	err := executor.NewJob().Execute()
-	executor.CheckError(err)
+// CheckError prints err to stderr and exits with code 1 if err is not nil. Otherwise, it is a
+// no-op.
+func CheckError(err error) {
+	if err != nil {
+		if err != context.Canceled {
+			fmt.Fprintf(os.Stderr, fmt.Sprintf("An error occurred: %v\n", err))
+		}
+		os.Exit(1)
+	}
 }

--- a/cmd/upgrade/executor/jiva_volume.go
+++ b/cmd/upgrade/executor/jiva_volume.go
@@ -30,7 +30,7 @@ import (
 
 // JivaVolumeOptions stores information required for jiva volume upgrade
 type JivaVolumeOptions struct {
-	jivaPVName string
+	pvName string
 }
 
 var (
@@ -58,9 +58,9 @@ func NewUpgradeJivaVolumeJob() *cobra.Command {
 
 	options.resourceKind = "jivaVolume"
 
-	cmd.Flags().StringVarP(&options.jivaPVName,
+	cmd.Flags().StringVarP(&options.jivaVolume.pvName,
 		"pv-name", "",
-		options.jivaPVName,
+		options.jivaVolume.pvName,
 		"jiva persistent volume name to be upgraded, as obtained using: kubectl get pv")
 
 	return cmd
@@ -68,7 +68,7 @@ func NewUpgradeJivaVolumeJob() *cobra.Command {
 
 // RunJivaVolumeUpgradeChecks will ensure the sanity of the jiva upgrade options
 func (u *UpgradeOptions) RunJivaVolumeUpgradeChecks(cmd *cobra.Command) error {
-	if len(strings.TrimSpace(u.jivaPVName)) == 0 {
+	if len(strings.TrimSpace(u.jivaVolume.pvName)) == 0 {
 		return errors.Errorf("Cannot execute upgrade job: jiva pv name is missing")
 	}
 
@@ -85,23 +85,23 @@ func (u *UpgradeOptions) RunJivaVolumeUpgrade(cmd *cobra.Command) error {
 	case "0.9.0-1.0.0":
 		fmt.Println("Upgrading to 1.0.0")
 		err := upgrade090to100.Exec(u.resourceKind,
-			u.jivaPVName,
+			u.jivaVolume.pvName,
 			u.openebsNamespace)
 		if err != nil {
 			fmt.Println(err)
-			return errors.Errorf("Failed to upgrade Jiva Volume %v:", u.jivaPVName)
+			return errors.Errorf("Failed to upgrade Jiva Volume %v:", u.jivaVolume.pvName)
 		}
 	case "1.0.0-1.1.0":
 		fmt.Println("Upgrading to 1.1.0")
 		err := upgrade100to110.Exec(u.fromVersion, u.toVersion,
 			u.resourceKind,
-			u.jivaPVName,
+			u.jivaVolume.pvName,
 			u.openebsNamespace,
 			u.imageURLPrefix,
 			u.toVersionImageTag)
 		if err != nil {
 			fmt.Println(err)
-			return errors.Errorf("Failed to upgrade Jiva Volume %v:", u.jivaPVName)
+			return errors.Errorf("Failed to upgrade Jiva Volume %v:", u.jivaVolume.pvName)
 		}
 	default:
 		return errors.Errorf("Invalid from version %s or to version %s", u.fromVersion, u.toVersion)

--- a/cmd/upgrade/executor/jiva_volume.go
+++ b/cmd/upgrade/executor/jiva_volume.go
@@ -49,14 +49,13 @@ func NewUpgradeJivaVolumeJob() *cobra.Command {
 		Long:    jivaVolumeUpgradeCmdHelpText,
 		Example: `upgrade jiva-volume --pv-name <pv-name>`,
 		Run: func(cmd *cobra.Command, args []string) {
+			options.resourceKind = "jivaVolume"
 			util.CheckErr(options.RunPreFlightChecks(cmd), util.Fatal)
 			util.CheckErr(options.RunJivaVolumeUpgradeChecks(cmd), util.Fatal)
 			util.CheckErr(options.InitializeDefaults(cmd), util.Fatal)
 			util.CheckErr(options.RunJivaVolumeUpgrade(cmd), util.Fatal)
 		},
 	}
-
-	options.resourceKind = "jivaVolume"
 
 	cmd.Flags().StringVarP(&options.jivaVolume.pvName,
 		"pv-name", "",

--- a/cmd/upgrade/executor/jiva_volume.go
+++ b/cmd/upgrade/executor/jiva_volume.go
@@ -28,6 +28,11 @@ import (
 	upgrade100to110 "github.com/openebs/maya/pkg/upgrade/1.0.0-1.1.0/v1alpha1"
 )
 
+// JivaVolumeOptions stores information required for jiva volume upgrade
+type JivaVolumeOptions struct {
+	jivaPVName string
+}
+
 var (
 	jivaVolumeUpgradeCmdHelpText = `
 This command upgrades the Jiva Persistent Volume
@@ -42,30 +47,37 @@ func NewUpgradeJivaVolumeJob() *cobra.Command {
 		Use:     "jiva-volume",
 		Short:   "Upgrade Jiva Volume",
 		Long:    jivaVolumeUpgradeCmdHelpText,
-		Example: `upgrade jiva-volume --volname <pv-name>`,
+		Example: `upgrade jiva-volume --pv-name <pv-name>`,
 		Run: func(cmd *cobra.Command, args []string) {
 			util.CheckErr(options.RunPreFlightChecks(cmd), util.Fatal)
 			util.CheckErr(options.RunJivaVolumeUpgradeChecks(cmd), util.Fatal)
+			util.CheckErr(options.InitializeJivaDefaults(cmd), util.Fatal)
 			util.CheckErr(options.RunJivaVolumeUpgrade(cmd), util.Fatal)
 		},
 	}
 
 	options.resourceKind = "jivaVolume"
 
-	cmd.Flags().StringVarP(&options.resourceName,
-		"volname", "",
-		options.resourceName,
+	cmd.Flags().StringVarP(&options.jivaPVName,
+		"pv-name", "",
+		options.jivaPVName,
 		"jiva persistent volume name to be upgraded, as obtained using: kubectl get pv")
 
 	return cmd
 }
 
-// RunJivaVolumeUpgradeChecks will ensure the sanity of the common upgrade options
+// RunJivaVolumeUpgradeChecks will ensure the sanity of the jiva upgrade options
 func (u *UpgradeOptions) RunJivaVolumeUpgradeChecks(cmd *cobra.Command) error {
-	if len(strings.TrimSpace(u.resourceName)) == 0 {
+	if len(strings.TrimSpace(u.jivaPVName)) == 0 {
 		return errors.Errorf("Cannot execute upgrade job: jiva pv name is missing")
 	}
 
+	return nil
+}
+
+// InitializeJivaDefaults will ensure the default values for optional options are
+// set.
+func (u *UpgradeOptions) InitializeJivaDefaults(cmd *cobra.Command) error {
 	if len(strings.TrimSpace(u.toVersionImageTag)) == 0 {
 		u.toVersionImageTag = u.toVersion
 	}
@@ -75,33 +87,34 @@ func (u *UpgradeOptions) RunJivaVolumeUpgradeChecks(cmd *cobra.Command) error {
 
 // RunJivaVolumeUpgrade upgrades the given Jiva Volume.
 func (u *UpgradeOptions) RunJivaVolumeUpgrade(cmd *cobra.Command) error {
-	from := u.fromVersion
-	to := u.toVersion
-	kind := u.resourceKind
-	name := u.resourceName
-	openebsNamespace := u.namespace
-	urlPrefix := u.imageURLPrefix
-	imageTag := u.toVersionImageTag
 
-	fromVersion := strings.Split(from, "-")[0]
-	toVersion := strings.Split(to, "-")[0]
+	from := strings.Split(u.fromVersion, "-")[0]
+	to := strings.Split(u.toVersion, "-")[0]
 
-	switch fromVersion + "-" + toVersion {
+	switch from + "-" + to {
 	case "0.9.0-1.0.0":
 		fmt.Println("Upgrading to 1.0.0")
-		err := upgrade090to100.Exec(kind, name, openebsNamespace)
+		err := upgrade090to100.Exec(u.resourceKind,
+			u.jivaPVName,
+			u.openebsNamespace)
 		if err != nil {
-			return errors.Errorf("Failed to upgrade Jiva Volume %v:", name)
+			fmt.Println(err)
+			return errors.Errorf("Failed to upgrade Jiva Volume %v:", u.jivaPVName)
 		}
 	case "1.0.0-1.1.0":
 		fmt.Println("Upgrading to 1.1.0")
-		err := upgrade100to110.Exec(from, to, kind, name, openebsNamespace, urlPrefix, imageTag)
+		err := upgrade100to110.Exec(u.fromVersion, u.toVersion,
+			u.resourceKind,
+			u.jivaPVName,
+			u.openebsNamespace,
+			u.imageURLPrefix,
+			u.toVersionImageTag)
 		if err != nil {
 			fmt.Println(err)
-			return errors.Errorf("Failed to upgrade Jiva Volume %v:", name)
+			return errors.Errorf("Failed to upgrade Jiva Volume %v:", u.jivaPVName)
 		}
 	default:
-		return errors.Errorf("Invalid from version %s or to version %s", from, to)
+		return errors.Errorf("Invalid from version %s or to version %s", u.fromVersion, u.toVersion)
 	}
 	return nil
 }

--- a/cmd/upgrade/executor/jiva_volume.go
+++ b/cmd/upgrade/executor/jiva_volume.go
@@ -61,7 +61,7 @@ func NewUpgradeJivaVolumeJob() *cobra.Command {
 }
 
 // RunJivaVolumeUpgradeChecks will ensure the sanity of the common upgrade options
-func (u *UpgradeOptions) RunJivaVolumeUpgradeChecks( cmd *cobra.Command ) error {
+func (u *UpgradeOptions) RunJivaVolumeUpgradeChecks(cmd *cobra.Command) error {
 	if len(strings.TrimSpace(u.resourceName)) == 0 {
 		return errors.Errorf("Cannot execute upgrade job: jiva pv name is missing")
 	}
@@ -97,7 +97,7 @@ func (u *UpgradeOptions) RunJivaVolumeUpgrade(cmd *cobra.Command) error {
 		fmt.Println("Upgrading to 1.1.0")
 		err := upgrade100to110.Exec(from, to, kind, name, openebsNamespace, urlPrefix, imageTag)
 		if err != nil {
-			fmt.Println( err )
+			fmt.Println(err)
 			return errors.Errorf("Failed to upgrade Jiva Volume %v:", name)
 		}
 	default:

--- a/cmd/upgrade/executor/jiva_volume.go
+++ b/cmd/upgrade/executor/jiva_volume.go
@@ -17,9 +17,10 @@ limitations under the License.
 package executor
 
 import (
-	"fmt"
+	//"fmt"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/openebs/maya/pkg/util"
 	"github.com/spf13/cobra"
 
@@ -80,18 +81,26 @@ func (u *UpgradeOptions) RunJivaVolumeUpgrade(cmd *cobra.Command) error {
 	from := strings.Split(u.fromVersion, "-")[0]
 	to := strings.Split(u.toVersion, "-")[0]
 
+	glog.V(4).Infof("Started upgrading %s{%s} from %s to %s",
+		u.resourceKind,
+		u.jivaVolume.pvName,
+		u.fromVersion,
+		u.toVersion)
+
 	switch from + "-" + to {
 	case "0.9.0-1.0.0":
-		fmt.Println("Upgrading to 1.0.0")
+		glog.Infof("Upgrading to 1.0.0")
 		err := upgrade090to100.Exec(u.resourceKind,
 			u.jivaVolume.pvName,
 			u.openebsNamespace)
 		if err != nil {
-			fmt.Println(err)
-			return errors.Errorf("Failed to upgrade Jiva Volume %v:", u.jivaVolume.pvName)
+			glog.Error(err)
+			return errors.Wrapf(err, "Failed to upgrade %s{%s}",
+				u.resourceKind,
+				u.jivaVolume.pvName)
 		}
 	case "1.0.0-1.1.0":
-		fmt.Println("Upgrading to 1.1.0")
+		glog.Infof("Upgrading to 1.1.0")
 		err := upgrade100to110.Exec(u.fromVersion, u.toVersion,
 			u.resourceKind,
 			u.jivaVolume.pvName,
@@ -99,11 +108,14 @@ func (u *UpgradeOptions) RunJivaVolumeUpgrade(cmd *cobra.Command) error {
 			u.imageURLPrefix,
 			u.toVersionImageTag)
 		if err != nil {
-			fmt.Println(err)
-			return errors.Errorf("Failed to upgrade Jiva Volume %v:", u.jivaVolume.pvName)
+			glog.Error(err)
+			return errors.Wrapf(err, "Failed to upgrade %s{%s}",
+				u.resourceKind,
+				u.jivaVolume.pvName)
 		}
 	default:
 		return errors.Errorf("Invalid from version %s or to version %s", u.fromVersion, u.toVersion)
 	}
+	glog.Infof("Upgraded successfully")
 	return nil
 }

--- a/cmd/upgrade/executor/jiva_volume.go
+++ b/cmd/upgrade/executor/jiva_volume.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2019 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executor
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openebs/maya/pkg/util"
+	"github.com/spf13/cobra"
+
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
+	upgrade090to100 "github.com/openebs/maya/pkg/upgrade/0.9.0-1.0.0/v1alpha1"
+	upgrade100to110 "github.com/openebs/maya/pkg/upgrade/1.0.0-1.1.0/v1alpha1"
+)
+
+var (
+	jivaVolumeUpgradeCmdHelpText = `
+This command upgrades the Jiva Persistent Volume
+
+Usage: upgrade jiva-volume --volname <pv-name> --options...
+`
+)
+
+// NewUpgradeJivaVolumeJob upgrade a Jiva Volume
+func NewUpgradeJivaVolumeJob() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "jiva-volume",
+		Short:   "Upgrade Jiva Volume",
+		Long:    jivaVolumeUpgradeCmdHelpText,
+		Example: `upgrade jiva-volume --volname <pv-name>`,
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(options.RunPreFlightChecks(cmd), util.Fatal)
+			util.CheckErr(options.RunJivaVolumeUpgradeChecks(cmd), util.Fatal)
+			util.CheckErr(options.RunJivaVolumeUpgrade(cmd), util.Fatal)
+		},
+	}
+
+	options.resourceKind = "jivaVolume"
+
+	cmd.Flags().StringVarP(&options.resourceName,
+		"volname", "",
+		options.resourceName,
+		"jiva persistent volume name to be upgraded, as obtained using: kubectl get pv")
+
+	return cmd
+}
+
+// RunJivaVolumeUpgradeChecks will ensure the sanity of the common upgrade options
+func (u *UpgradeOptions) RunJivaVolumeUpgradeChecks( cmd *cobra.Command ) error {
+	if len(strings.TrimSpace(u.resourceName)) == 0 {
+		return errors.Errorf("Cannot execute upgrade job: jiva pv name is missing")
+	}
+
+	if len(strings.TrimSpace(u.toVersionImageTag)) == 0 {
+		u.toVersionImageTag = u.toVersion
+	}
+
+	return nil
+}
+
+// RunJivaVolumeUpgrade upgrades the given Jiva Volume.
+func (u *UpgradeOptions) RunJivaVolumeUpgrade(cmd *cobra.Command) error {
+	from := u.fromVersion
+	to := u.toVersion
+	kind := u.resourceKind
+	name := u.resourceName
+	openebsNamespace := u.namespace
+	urlPrefix := u.imageUrlPrefix
+	imageTag := u.toVersionImageTag
+
+	fromVersion := strings.Split(from, "-")[0]
+	toVersion := strings.Split(to, "-")[0]
+
+	switch fromVersion + "-" + toVersion {
+	case "0.9.0-1.0.0":
+		fmt.Println("Upgrading to 1.0.0")
+		err := upgrade090to100.Exec(kind, name, openebsNamespace)
+		if err != nil {
+			return errors.Errorf("Failed to upgrade Jiva Volume %v:", name)
+		}
+	case "1.0.0-1.1.0":
+		fmt.Println("Upgrading to 1.1.0")
+		err := upgrade100to110.Exec(from, to, kind, name, openebsNamespace, urlPrefix, imageTag)
+		if err != nil {
+			fmt.Println( err )
+			return errors.Errorf("Failed to upgrade Jiva Volume %v:", name)
+		}
+	default:
+		return errors.Errorf("Invalid from version %s or to version %s", from, to)
+	}
+	return nil
+}

--- a/cmd/upgrade/executor/jiva_volume.go
+++ b/cmd/upgrade/executor/jiva_volume.go
@@ -80,7 +80,7 @@ func (u *UpgradeOptions) RunJivaVolumeUpgrade(cmd *cobra.Command) error {
 	kind := u.resourceKind
 	name := u.resourceName
 	openebsNamespace := u.namespace
-	urlPrefix := u.imageUrlPrefix
+	urlPrefix := u.imageURLPrefix
 	imageTag := u.toVersionImageTag
 
 	fromVersion := strings.Split(from, "-")[0]

--- a/cmd/upgrade/executor/options.go
+++ b/cmd/upgrade/executor/options.go
@@ -30,9 +30,9 @@ type UpgradeOptions struct {
 	imageURLPrefix    string
 	toVersionImageTag string
 	resourceKind      string
-	JivaVolumeOptions
-	CStorSPCOptions
-	CStorVolumeOptions
+	jivaVolume        JivaVolumeOptions
+	cstorSPC          CStorSPCOptions
+	cstorVolume       CStorVolumeOptions
 }
 
 var (

--- a/cmd/upgrade/executor/options.go
+++ b/cmd/upgrade/executor/options.go
@@ -29,14 +29,14 @@ type UpgradeOptions struct {
 	fromVersion       string
 	toVersion         string
 	namespace         string
-	imageUrlPrefix    string
+	imageURLPrefix    string
 	toVersionImageTag string
 }
 
 var (
 	options = &UpgradeOptions{
 		namespace:      "openebs",
-		imageUrlPrefix: "quay.io/openebs/",
+		imageURLPrefix: "quay.io/openebs/",
 	}
 )
 

--- a/cmd/upgrade/executor/options.go
+++ b/cmd/upgrade/executor/options.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executor
+
+import (
+	"strings"
+	"github.com/spf13/cobra"
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
+)
+
+// UpgradeOptions stores information required for upgrade
+type UpgradeOptions struct {
+	resourceName      string
+	resourceKind      string
+	fromVersion       string
+	toVersion         string
+	namespace         string
+	imageUrlPrefix    string
+	toVersionImageTag string
+}
+
+var (
+	options = &UpgradeOptions{
+		namespace:      "openebs",
+		imageUrlPrefix: "quay.io/openebs/",
+	}
+)
+
+// RunPreFlightChecks will ensure the sanity of the common upgrade options
+func (u *UpgradeOptions) RunPreFlightChecks( cmd *cobra.Command ) error {
+	if len(strings.TrimSpace(u.namespace)) != 0 {
+		return errors.Errorf("Cannot execute upgrade job: namespace is missing")
+	}
+
+	if len(strings.TrimSpace(u.fromVersion)) == 0 {
+		return errors.Errorf("Cannot execute upgrade job: from-version is missing")
+	}
+
+	if len(strings.TrimSpace(u.toVersion)) == 0 {
+		return errors.Errorf("Cannot execute upgrade job: to-version is missing")
+	}
+	return nil
+}

--- a/cmd/upgrade/executor/options.go
+++ b/cmd/upgrade/executor/options.go
@@ -24,25 +24,25 @@ import (
 
 // UpgradeOptions stores information required for upgrade
 type UpgradeOptions struct {
-	resourceName      string
-	resourceKind      string
 	fromVersion       string
 	toVersion         string
-	namespace         string
+	openebsNamespace  string
 	imageURLPrefix    string
 	toVersionImageTag string
+	resourceKind      string
+	JivaVolumeOptions
 }
 
 var (
 	options = &UpgradeOptions{
-		namespace:      "openebs",
-		imageURLPrefix: "quay.io/openebs/",
+		openebsNamespace: "openebs",
+		imageURLPrefix:   "quay.io/openebs/",
 	}
 )
 
 // RunPreFlightChecks will ensure the sanity of the common upgrade options
 func (u *UpgradeOptions) RunPreFlightChecks(cmd *cobra.Command) error {
-	if len(strings.TrimSpace(u.namespace)) != 0 {
+	if len(strings.TrimSpace(u.openebsNamespace)) != 0 {
 		return errors.Errorf("Cannot execute upgrade job: namespace is missing")
 	}
 
@@ -53,5 +53,10 @@ func (u *UpgradeOptions) RunPreFlightChecks(cmd *cobra.Command) error {
 	if len(strings.TrimSpace(u.toVersion)) == 0 {
 		return errors.Errorf("Cannot execute upgrade job: to-version is missing")
 	}
+
+	if len(strings.TrimSpace(u.resourceKind)) == 0 {
+		return errors.Errorf("Cannot execute upgrade job: resource details are missing")
+	}
+
 	return nil
 }

--- a/cmd/upgrade/executor/options.go
+++ b/cmd/upgrade/executor/options.go
@@ -31,7 +31,8 @@ type UpgradeOptions struct {
 	toVersionImageTag string
 	resourceKind      string
 	JivaVolumeOptions
-	cStorSPCOptions
+	CStorSPCOptions
+	CStorVolumeOptions
 }
 
 var (

--- a/cmd/upgrade/executor/options.go
+++ b/cmd/upgrade/executor/options.go
@@ -44,7 +44,7 @@ var (
 
 // RunPreFlightChecks will ensure the sanity of the common upgrade options
 func (u *UpgradeOptions) RunPreFlightChecks(cmd *cobra.Command) error {
-	if len(strings.TrimSpace(u.openebsNamespace)) != 0 {
+	if len(strings.TrimSpace(u.openebsNamespace)) == 0 {
 		return errors.Errorf("Cannot execute upgrade job: namespace is missing")
 	}
 

--- a/cmd/upgrade/executor/options.go
+++ b/cmd/upgrade/executor/options.go
@@ -17,9 +17,9 @@ limitations under the License.
 package executor
 
 import (
-	"strings"
-	"github.com/spf13/cobra"
 	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
+	"github.com/spf13/cobra"
+	"strings"
 )
 
 // UpgradeOptions stores information required for upgrade
@@ -41,7 +41,7 @@ var (
 )
 
 // RunPreFlightChecks will ensure the sanity of the common upgrade options
-func (u *UpgradeOptions) RunPreFlightChecks( cmd *cobra.Command ) error {
+func (u *UpgradeOptions) RunPreFlightChecks(cmd *cobra.Command) error {
 	if len(strings.TrimSpace(u.namespace)) != 0 {
 		return errors.Errorf("Cannot execute upgrade job: namespace is missing")
 	}

--- a/cmd/upgrade/executor/options.go
+++ b/cmd/upgrade/executor/options.go
@@ -31,6 +31,7 @@ type UpgradeOptions struct {
 	toVersionImageTag string
 	resourceKind      string
 	JivaVolumeOptions
+	cStorSPCOptions
 }
 
 var (
@@ -56,6 +57,16 @@ func (u *UpgradeOptions) RunPreFlightChecks(cmd *cobra.Command) error {
 
 	if len(strings.TrimSpace(u.resourceKind)) == 0 {
 		return errors.Errorf("Cannot execute upgrade job: resource details are missing")
+	}
+
+	return nil
+}
+
+// InitializeDefaults will ensure the default values for optional options are
+// set.
+func (u *UpgradeOptions) InitializeDefaults(cmd *cobra.Command) error {
+	if len(strings.TrimSpace(u.toVersionImageTag)) == 0 {
+		u.toVersionImageTag = u.toVersion
 	}
 
 	return nil

--- a/cmd/upgrade/executor/setup_job.go
+++ b/cmd/upgrade/executor/setup_job.go
@@ -80,7 +80,7 @@ func NewJob() *cobra.Command {
 // PreRun will check for environement variables to be read and intialized.
 func PreRun(cmd *cobra.Command, args []string) {
 	namespace := getOpenEBSNamespace()
-	if len(strings.TrimSpace(namespace)) == 0 {
+	if len(strings.TrimSpace(namespace)) != 0 {
 		options.openebsNamespace = namespace
 	}
 }

--- a/cmd/upgrade/executor/setup_job.go
+++ b/cmd/upgrade/executor/setup_job.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2019 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executor
+
+import (
+	"flag"
+	"fmt"
+	//"os"
+	"strings"
+
+	//"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	//errors "github.com/openebs/maya/pkg/errors/v1alpha1"
+)
+
+var (
+	cmdName = "upgrade"
+	usage   = fmt.Sprintf("%s", cmdName)
+)
+
+// NewJob will setup a new upgrade job
+func NewJob() *cobra.Command {
+	// Create a new command.
+	cmd := &cobra.Command{
+		Use:   usage,
+		Short: "OpenEBS Upgrade Utility",
+		Long: `An utility to uggrade OpenEBS Storage Pools and Volumes,
+			run as a Kubernetes Job`,
+		PersistentPreRun: PreRun,
+	}
+
+	cmd.AddCommand(
+		NewUpgradeJivaVolumeJob(),
+	)
+
+	cmd.PersistentFlags().StringVarP(&options.fromVersion,
+		"from-version", "",
+		options.fromVersion,
+		"current version of the resource (pool or volume) being upgraded.")
+
+	cmd.PersistentFlags().StringVarP(&options.toVersion,
+		"to-version", "",
+		options.toVersion,
+		"new version to which resource (pool or volume) should be upgraded.")
+
+	cmd.PersistentFlags().StringVarP(&options.namespace,
+		"openebs-namespace", "",
+		options.namespace,
+		"namespace where openebs is installed.")
+
+	cmd.PersistentFlags().StringVarP(&options.imageUrlPrefix,
+		"to-version-image-prefix", "",
+		options.imageUrlPrefix,
+		"custom image prefix, when not using the default.")
+
+	cmd.PersistentFlags().StringVarP(&options.toVersionImageTag,
+		"to-version-image-tag", "",
+		options.toVersionImageTag,
+		"custom image tag, when not using the default.")
+
+	cmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+
+	// Hack: Without the following line, the logs will be prefixed with Error
+	_ = flag.CommandLine.Parse([]string{})
+
+	return cmd
+}
+
+// PreRun will check for environement variables to be read and intialized.
+func PreRun(cmd *cobra.Command, args []string) {
+	namespace := getOpenEBSNamespace()
+	if len(strings.TrimSpace(namespace)) == 0 {
+		options.namespace = namespace
+	}
+}

--- a/cmd/upgrade/executor/setup_job.go
+++ b/cmd/upgrade/executor/setup_job.go
@@ -41,6 +41,7 @@ func NewJob() *cobra.Command {
 	cmd.AddCommand(
 		NewUpgradeJivaVolumeJob(),
 		NewUpgradeCStorSPCJob(),
+		NewUpgradeCStorVolumeJob(),
 	)
 
 	cmd.PersistentFlags().StringVarP(&options.fromVersion,

--- a/cmd/upgrade/executor/setup_job.go
+++ b/cmd/upgrade/executor/setup_job.go
@@ -33,7 +33,7 @@ func NewJob() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "upgrade",
 		Short: "OpenEBS Upgrade Utility",
-		Long: `An utility to uggrade OpenEBS Storage Pools and Volumes,
+		Long: `An utility to upgrade OpenEBS Storage Pools and Volumes,
 			run as a Kubernetes Job`,
 		PersistentPreRun: PreRun,
 	}

--- a/cmd/upgrade/executor/setup_job.go
+++ b/cmd/upgrade/executor/setup_job.go
@@ -18,7 +18,7 @@ package executor
 
 import (
 	"flag"
-	"fmt"
+	//"fmt"
 	//"os"
 	"strings"
 
@@ -27,16 +27,11 @@ import (
 	//errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 )
 
-var (
-	cmdName = "upgrade"
-	usage   = fmt.Sprintf("%s", cmdName)
-)
-
 // NewJob will setup a new upgrade job
 func NewJob() *cobra.Command {
 	// Create a new command.
 	cmd := &cobra.Command{
-		Use:   usage,
+		Use:   "upgrade",
 		Short: "OpenEBS Upgrade Utility",
 		Long: `An utility to uggrade OpenEBS Storage Pools and Volumes,
 			run as a Kubernetes Job`,
@@ -62,9 +57,9 @@ func NewJob() *cobra.Command {
 		options.namespace,
 		"namespace where openebs is installed.")
 
-	cmd.PersistentFlags().StringVarP(&options.imageUrlPrefix,
+	cmd.PersistentFlags().StringVarP(&options.imageURLPrefix,
 		"to-version-image-prefix", "",
-		options.imageUrlPrefix,
+		options.imageURLPrefix,
 		"custom image prefix, when not using the default.")
 
 	cmd.PersistentFlags().StringVarP(&options.toVersionImageTag,

--- a/cmd/upgrade/executor/setup_job.go
+++ b/cmd/upgrade/executor/setup_job.go
@@ -40,6 +40,7 @@ func NewJob() *cobra.Command {
 
 	cmd.AddCommand(
 		NewUpgradeJivaVolumeJob(),
+		NewUpgradeCStorSPCJob(),
 	)
 
 	cmd.PersistentFlags().StringVarP(&options.fromVersion,

--- a/cmd/upgrade/executor/setup_job.go
+++ b/cmd/upgrade/executor/setup_job.go
@@ -45,27 +45,27 @@ func NewJob() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&options.fromVersion,
 		"from-version", "",
 		options.fromVersion,
-		"current version of the resource (pool or volume) being upgraded.")
+		"current version of the resource.")
 
 	cmd.PersistentFlags().StringVarP(&options.toVersion,
 		"to-version", "",
 		options.toVersion,
-		"new version to which resource (pool or volume) should be upgraded.")
+		"new version to which resource should be upgraded.")
 
-	cmd.PersistentFlags().StringVarP(&options.namespace,
+	cmd.PersistentFlags().StringVarP(&options.openebsNamespace,
 		"openebs-namespace", "",
-		options.namespace,
-		"namespace where openebs is installed.")
+		options.openebsNamespace,
+		"namespace where openebs components are installed.")
 
 	cmd.PersistentFlags().StringVarP(&options.imageURLPrefix,
 		"to-version-image-prefix", "",
 		options.imageURLPrefix,
-		"custom image prefix, when not using the default.")
+		"[optional] custom image prefix.")
 
 	cmd.PersistentFlags().StringVarP(&options.toVersionImageTag,
 		"to-version-image-tag", "",
 		options.toVersionImageTag,
-		"custom image tag, when not using the default.")
+		"[optional] custom image tag. If not specified, to-version will be used")
 
 	cmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 
@@ -79,6 +79,6 @@ func NewJob() *cobra.Command {
 func PreRun(cmd *cobra.Command, args []string) {
 	namespace := getOpenEBSNamespace()
 	if len(strings.TrimSpace(namespace)) == 0 {
-		options.namespace = namespace
+		options.openebsNamespace = namespace
 	}
 }


### PR DESCRIPTION
This PR refactors the upgrade binary to make use of COBRA CLI. The upgrades can be performed on jiva volume, cstor spc and cstor volume using the new CLI. 

```
kiran_mova@kmova-dev:1.0.0-1.1.0$ upgrade
An utility to uggrade OpenEBS Storage Pools and Volumes,
                        run as a Kubernetes Job
Usage:
  upgrade [command]
Available Commands:
  cstor-spc    Upgrade cStor SPC
  cstor-volume Upgrade CStor Volume
  help         Help about any command
  jiva-volume  Upgrade Jiva Volume
```

The upgrades can also be performed using a Kubernetes Job YAML. A sample YAML for upgrading Jiva Volume is as follows:

```
---
apiVersion: batch/v1
kind: Job
metadata:
  name: jiva-upg-100111-pvc-713e3bb6-afd2-11e9-8e79-42010a800065
  namespace: openebs
spec:
  backoffLimit: 4
  template:
    spec:
      serviceAccountName: openebs-maya-operator
      containers:
      - name:  upgrade
        image: openebs/m-upgrade:dev-1000110RC2-072606
        args:
        - "jiva-volume"
        - "--from-version=1.0.0"
        - "--to-version=1.1.0-RC2"
        - "--openebs-namespace=openebs"
        - "--pv-name=pvc-713e3bb6-afd2-11e9-8e79-42010a800065"
        tty: true
      restartPolicy: Never
---
```

In the above example, the service account, namespace and volname
should be customized. `kubectl logs` on the job pod will provide error/info details. 

**Special notes for your reviewer**:
- This PR doesn't validate the actual upgrade functionality. It only refactors the CLI. 
- While testing the upgrade using the kubectl jobs, found a few inconsistencies in terms of the upgrade binary accessing the state of the control and storage pods. For example: the upgrade client was getting the count for openbs-apiserver as 2, where as `kubectl` was showing only 1.
- Future PRs will refactor the upgrade code for providing additional details for debugging the failures. 

Signed-off-by: kmova <kiran.mova@mayadata.io>


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests