### PR TITLE
fix:(cspc,pool expansion): create BDC(s) for BD(s) that are used in expansion

### DIFF
--- a/cmd/maya-apiserver/cstor-operator/cspc/operations.go
+++ b/cmd/maya-apiserver/cstor-operator/cspc/operations.go
@@ -86,7 +86,8 @@ func (pc *PoolConfig) addGroupToPool(cspcPoolSpec *apis.PoolSpec, csp *apis.NewT
 			for _, bd := range cspcRaidGroup.BlockDevices {
 				err := pc.isBDUsable(bd.BlockDeviceName)
 				if err != nil {
-					glog.Errorf("could not use bd %s for expanding pool %s:%s", bd.BlockDeviceName, csp.Name, err.Error())
+					glog.Errorf("could not use bd %s for expanding pool " +
+						"%s:%s", bd.BlockDeviceName, csp.Name, err.Error())
 					validGroup = false
 					break
 				}
@@ -127,18 +128,23 @@ func (pc *PoolConfig) addBlockDeviceToGroup(group *apis.RaidGroup, csp *apis.New
 			if len(group.BlockDevices) > len(groupOnCSP.BlockDevices) {
 				newBDs, err := getAddedBlockDevicesInGroup(group, &groupOnCSP)
 				if err != nil {
-					glog.V(2).Infof("Failed to get newly added block device on group {%+v}", group)
+					glog.V(2).Infof("Failed to get newly " +
+						"added block device on group {%+v}", group)
 				}
 				if len(newBDs) == 0 {
-					glog.V(2).Infof("No new block devices added for group {%+v} on csp %s", groupOnCSP, csp.Name)
+					glog.V(2).Infof("No new block devices " +
+						"added for group {%+v} on csp %s", groupOnCSP, csp.Name)
 				}
 				for _, bdName := range newBDs {
 					err := pc.isBDUsable(bdName)
 					if err != nil {
-						glog.Errorf("could not use bd %s for expanding pool %s:%s", bdName, csp.Name, err.Error())
+						glog.Errorf("could not use bd %s for " +
+							"expanding pool %s:%s", bdName, csp.Name, err.Error())
 						break
 					}
-					csp.Spec.RaidGroups[i].BlockDevices = append(csp.Spec.RaidGroups[i].BlockDevices, apis.CStorPoolClusterBlockDevice{BlockDeviceName: bdName})
+					csp.Spec.RaidGroups[i].BlockDevices =
+						append(csp.Spec.RaidGroups[i].BlockDevices,
+							apis.CStorPoolClusterBlockDevice{BlockDeviceName: bdName})
 				}
 
 			}

--- a/cmd/maya-apiserver/cstor-operator/cspc/operations.go
+++ b/cmd/maya-apiserver/cstor-operator/cspc/operations.go
@@ -136,6 +136,7 @@ func (pc *PoolConfig) addBlockDeviceToGroup(group *apis.RaidGroup, csp *apis.New
 					err := pc.isBDUsable(bdName)
 					if err != nil {
 						glog.Errorf("could not use bd %s for expanding pool %s:%s", bdName, csp.Name, err.Error())
+						break
 					}
 					csp.Spec.RaidGroups[i].BlockDevices = append(csp.Spec.RaidGroups[i].BlockDevices, apis.CStorPoolClusterBlockDevice{BlockDeviceName: bdName})
 				}

--- a/cmd/maya-apiserver/cstor-operator/cspc/operations.go
+++ b/cmd/maya-apiserver/cstor-operator/cspc/operations.go
@@ -210,20 +210,20 @@ func (pc *PoolConfig) getCSPWithNodeName(nodeName string) (*apis.NewTestCStorPoo
 func (pc *PoolConfig) isBDUsable(bdName string) error {
 	bdObj, err := apisbd.NewKubeClient().WithNamespace(pc.AlgorithmConfig.Namespace).Get(bdName, metav1.GetOptions{})
 	if err != nil {
-		errors.Wrapf(err, "could not get bd object %s", bdName)
+		return errors.Wrapf(err, "could not get bd object %s", bdName)
 	}
 	err = pc.AlgorithmConfig.ClaimBD(bdObj)
 	if err != nil {
-		errors.Wrapf(err, "failed to claim bd %s", bdName)
+		return errors.Wrapf(err, "failed to claim bd %s", bdName)
 
 	}
 	isBDUsable, err := pc.AlgorithmConfig.IsClaimedBDUsable(bdObj)
 	if err != nil {
-		errors.Wrapf(err, "bd %s cannot be used as could not get claim status", bdName)
+		return errors.Wrapf(err, "bd %s cannot be used as could not get claim status", bdName)
 	}
 
 	if !isBDUsable {
-		errors.Errorf("BD %s cannot be used as it is already claimed but not by cspc", bdName)
+		return errors.Errorf("BD %s cannot be used as it is already claimed but not by cspc", bdName)
 	}
 	return nil
 }

--- a/cmd/maya-apiserver/cstor-operator/cspc/operations.go
+++ b/cmd/maya-apiserver/cstor-operator/cspc/operations.go
@@ -86,7 +86,7 @@ func (pc *PoolConfig) addGroupToPool(cspcPoolSpec *apis.PoolSpec, csp *apis.NewT
 			for _, bd := range cspcRaidGroup.BlockDevices {
 				err := pc.isBDUsable(bd.BlockDeviceName)
 				if err != nil {
-					glog.Errorf("could not use bd %s for expanding pool " +
+					glog.Errorf("could not use bd %s for expanding pool "+
 						"%s:%s", bd.BlockDeviceName, csp.Name, err.Error())
 					validGroup = false
 					break
@@ -128,17 +128,17 @@ func (pc *PoolConfig) addBlockDeviceToGroup(group *apis.RaidGroup, csp *apis.New
 			if len(group.BlockDevices) > len(groupOnCSP.BlockDevices) {
 				newBDs, err := getAddedBlockDevicesInGroup(group, &groupOnCSP)
 				if err != nil {
-					glog.V(2).Infof("Failed to get newly " +
+					glog.V(2).Infof("Failed to get newly "+
 						"added block device on group {%+v}", group)
 				}
 				if len(newBDs) == 0 {
-					glog.V(2).Infof("No new block devices " +
+					glog.V(2).Infof("No new block devices "+
 						"added for group {%+v} on csp %s", groupOnCSP, csp.Name)
 				}
 				for _, bdName := range newBDs {
 					err := pc.isBDUsable(bdName)
 					if err != nil {
-						glog.Errorf("could not use bd %s for " +
+						glog.Errorf("could not use bd %s for "+
 							"expanding pool %s:%s", bdName, csp.Name, err.Error())
 						break
 					}
@@ -146,7 +146,6 @@ func (pc *PoolConfig) addBlockDeviceToGroup(group *apis.RaidGroup, csp *apis.New
 						append(csp.Spec.RaidGroups[i].BlockDevices,
 							apis.CStorPoolClusterBlockDevice{BlockDeviceName: bdName})
 				}
-
 			}
 		}
 	}

--- a/cmd/maya-apiserver/cstor-operator/cspc/operations.go
+++ b/cmd/maya-apiserver/cstor-operator/cspc/operations.go
@@ -200,7 +200,9 @@ func getAddedBlockDevicesInGroup(groupOnCSPC, groupOnCSP *apis.RaidGroup) ([]str
 // getCSPWithNodeName returns a csp object with provided node name
 // TODO: Move to CSP package
 func (pc *PoolConfig) getCSPWithNodeName(nodeName string) (*apis.NewTestCStorPool, error) {
-	cspList, _ := apiscsp.NewKubeClient().WithNamespace(pc.AlgorithmConfig.Namespace).
+	cspList, _ := apiscsp.
+		NewKubeClient().
+		WithNamespace(pc.AlgorithmConfig.Namespace).
 		List(metav1.ListOptions{LabelSelector: string(apis.CStorPoolClusterCPK) + "=" + pc.AlgorithmConfig.CSPC.Name})
 
 	cspListBuilder := apiscsp.ListBuilderFromAPIList(cspList).WithFilter(apiscsp.HasNodeName(nodeName)).List()
@@ -214,7 +216,10 @@ func (pc *PoolConfig) getCSPWithNodeName(nodeName string) (*apis.NewTestCStorPoo
 // If BD has no BDC -- it is created
 // TODO: Move to algorithm package
 func (pc *PoolConfig) isBDUsable(bdName string) error {
-	bdObj, err := apisbd.NewKubeClient().WithNamespace(pc.AlgorithmConfig.Namespace).Get(bdName, metav1.GetOptions{})
+	bdObj, err := apisbd.
+		NewKubeClient().
+		WithNamespace(pc.AlgorithmConfig.Namespace).
+		Get(bdName, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrapf(err, "could not get bd object %s", bdName)
 	}

--- a/cmd/maya-apiserver/cstor-operator/cspc/operations.go
+++ b/cmd/maya-apiserver/cstor-operator/cspc/operations.go
@@ -20,6 +20,7 @@ import (
 	"github.com/golang/glog"
 	nodeselect "github.com/openebs/maya/pkg/algorithm/nodeselect/v1alpha2"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	apisbd "github.com/openebs/maya/pkg/blockdevice/v1alpha2"
 	apiscsp "github.com/openebs/maya/pkg/cstor/newpool/v1alpha3"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,11 +59,11 @@ func (pc *PoolConfig) expandPool() error {
 
 		// Pool expansion for raid group types other than striped
 		if len(pool.RaidGroups) > len(cspObj.Spec.RaidGroups) {
-			cspObj = addGroupToPool(&pool, cspObj)
+			cspObj = pc.addGroupToPool(&pool, cspObj)
 		}
 
 		// Pool expansion for striped raid group
-		expandStripedGroup(&pool, cspObj)
+		pc.expandStripedGroup(&pool, cspObj)
 
 		_, err = apiscsp.NewKubeClient().WithNamespace(pc.AlgorithmConfig.Namespace).Update(cspObj)
 		if err != nil {
@@ -74,14 +75,25 @@ func (pc *PoolConfig) expandPool() error {
 }
 
 // addGroupToPool adds a raid group to the csp
-func addGroupToPool(cspcPoolSpec *apis.PoolSpec, csp *apis.NewTestCStorPool) *apis.NewTestCStorPool {
+func (pc *PoolConfig) addGroupToPool(cspcPoolSpec *apis.PoolSpec, csp *apis.NewTestCStorPool) *apis.NewTestCStorPool {
 	for _, cspcRaidGroup := range cspcPoolSpec.RaidGroups {
+		validGroup := true
 		cspcRaidGroup := cspcRaidGroup
 		if !isRaidGroupPresentOnCSP(&cspcRaidGroup, csp) {
 			if cspcRaidGroup.Type == "" {
 				cspcRaidGroup.Type = cspcPoolSpec.PoolConfig.DefaultRaidGroupType
 			}
-			csp.Spec.RaidGroups = append(csp.Spec.RaidGroups, cspcRaidGroup)
+			for _, bd := range cspcRaidGroup.BlockDevices {
+				err := pc.isBDUsable(bd.BlockDeviceName)
+				if err != nil {
+					glog.Errorf("could not use bd %s for expanding pool %s:%s", bd.BlockDeviceName, csp.Name, err.Error())
+					validGroup = false
+					break
+				}
+			}
+			if validGroup {
+				csp.Spec.RaidGroups = append(csp.Spec.RaidGroups, cspcRaidGroup)
+			}
 		}
 	}
 	return csp
@@ -89,13 +101,13 @@ func addGroupToPool(cspcPoolSpec *apis.PoolSpec, csp *apis.NewTestCStorPool) *ap
 
 // expandStripedGroup adds newly added block devices to the striped
 // groups present on CSP
-func expandStripedGroup(cspcPoolSpec *apis.PoolSpec, csp *apis.NewTestCStorPool) {
+func (pc *PoolConfig) expandStripedGroup(cspcPoolSpec *apis.PoolSpec, csp *apis.NewTestCStorPool) {
 	for _, cspcGroup := range cspcPoolSpec.RaidGroups {
 		cspcGroup := cspcGroup
 		if getRaidGroupType(cspcGroup, cspcPoolSpec) != "stripe" || !isRaidGroupPresentOnCSP(&cspcGroup, csp) {
 			continue
 		}
-		addBlockDeviceToGroup(&cspcGroup, csp)
+		pc.addBlockDeviceToGroup(&cspcGroup, csp)
 	}
 }
 
@@ -108,7 +120,7 @@ func getRaidGroupType(group apis.RaidGroup, poolSpec *apis.PoolSpec) string {
 }
 
 // addBlockDeviceToGroup adds block devices to the provided raid group on CSP
-func addBlockDeviceToGroup(group *apis.RaidGroup, csp *apis.NewTestCStorPool) *apis.NewTestCStorPool {
+func (pc *PoolConfig) addBlockDeviceToGroup(group *apis.RaidGroup, csp *apis.NewTestCStorPool) *apis.NewTestCStorPool {
 	for i, groupOnCSP := range csp.Spec.RaidGroups {
 		groupOnCSP := groupOnCSP
 		if isRaidGroupPresentOnCSP(group, csp) {
@@ -121,6 +133,10 @@ func addBlockDeviceToGroup(group *apis.RaidGroup, csp *apis.NewTestCStorPool) *a
 					glog.V(2).Infof("No new block devices added for group {%+v} on csp %s", groupOnCSP, csp.Name)
 				}
 				for _, bdName := range newBDs {
+					err := pc.isBDUsable(bdName)
+					if err != nil {
+						glog.Errorf("could not use bd %s for expanding pool %s:%s", bdName, csp.Name, err.Error())
+					}
 					csp.Spec.RaidGroups[i].BlockDevices = append(csp.Spec.RaidGroups[i].BlockDevices, apis.CStorPoolClusterBlockDevice{BlockDeviceName: bdName})
 				}
 
@@ -186,4 +202,28 @@ func (pc *PoolConfig) getCSPWithNodeName(nodeName string) (*apis.NewTestCStorPoo
 		return &cspListBuilder.ObjectList.Items[0], nil
 	}
 	return nil, errors.New("No CSP(s) found")
+}
+
+// isBDUsable returns no error if BD can be used.
+// If BD has no BDC -- it is created
+// TODO: Move to algorithm package
+func (pc *PoolConfig) isBDUsable(bdName string) error {
+	bdObj, err := apisbd.NewKubeClient().WithNamespace(pc.AlgorithmConfig.Namespace).Get(bdName, metav1.GetOptions{})
+	if err != nil {
+		errors.Wrapf(err, "could not get bd object %s", bdName)
+	}
+	err = pc.AlgorithmConfig.ClaimBD(bdObj)
+	if err != nil {
+		errors.Wrapf(err, "failed to claim bd %s", bdName)
+
+	}
+	isBDUsable, err := pc.AlgorithmConfig.IsClaimedBDUsable(bdObj)
+	if err != nil {
+		errors.Wrapf(err, "bd %s cannot be used as could not get claim status", bdName)
+	}
+
+	if !isBDUsable {
+		errors.Errorf("BD %s cannot be used as it is already claimed but not by cspc", bdName)
+	}
+	return nil
 }


### PR DESCRIPTION
While pool expansion is carried out, the BD(s) are used to expand the pool without creating a corresponding BDC(s).
This PR fixes this issue. For every BD that will be used in pool expansion, a corresponding BDC will be created.
If a BD that is specified on CSPC for pool expansion is already claimed but not have the corresponding CSPC label, the BD will not be used for pool expansion and hence error out gracefully.
If the BD is already claimed and have a CSPC label -- the BD can be used for pool expansion.

**TODO:** Ensure that no two block devices are repeated in a CSPC manifest via validating webhook. 
Signed-off-by: Ashutosh Kumar <ashutosh.kumar@openebs.io>