### PR TITLE
refact(cvc): use cstorPoolCluster API's instead of storagePoolClaim

### DIFF
--- a/cmd/cstorvolumeclaim/cstorvolumeclaim.go
+++ b/cmd/cstorvolumeclaim/cstorvolumeclaim.go
@@ -24,7 +24,7 @@ import (
 	menv "github.com/openebs/maya/pkg/env/v1alpha1"
 	"github.com/openebs/maya/pkg/version"
 
-	csp "github.com/openebs/maya/pkg/cstor/pool/v1alpha3"
+	ncsp "github.com/openebs/maya/pkg/cstor/newpool/v1alpha3"
 	cv "github.com/openebs/maya/pkg/cstor/volume/v1alpha1"
 	cvr "github.com/openebs/maya/pkg/cstor/volumereplica/v1alpha1"
 	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
@@ -40,9 +40,6 @@ const (
 	cvKind  = "CStorVolume"
 
 	cstorpoolNameLabel = "cstorpool.openebs.io/name"
-	// spcAnnotation annotation for spc for listing cstor pools created for
-	// a StoragePool Claim
-	spcAnnotation = "openebs.io/storage-pool-claim="
 	// ReplicaCount represents replica count value
 	ReplicaCount = "replicaCount"
 	// CStorVolumeReplicaFinalizer is the name of finalizer on CStorVolumeClaim
@@ -118,7 +115,7 @@ func getTargetServiceOwnerReference(claim *apis.CStorVolumeClaim) []metav1.Owner
 }
 
 // getCVRLabels get the labels for cstorvolumereplica
-func getCVRLabels(pool *apis.CStorPool, volumeName string) map[string]string {
+func getCVRLabels(pool *apis.NewTestCStorPool, volumeName string) map[string]string {
 	return map[string]string{
 		"cstorpool.openebs.io/name":    pool.Name,
 		"cstorpool.openebs.io/uid":     string(pool.UID),
@@ -129,7 +126,7 @@ func getCVRLabels(pool *apis.CStorPool, volumeName string) map[string]string {
 }
 
 // getCVRAnnotations get the annotations for cstorvolumereplica
-func getCVRAnnotations(pool *apis.CStorPool) map[string]string {
+func getCVRAnnotations(pool *apis.NewTestCStorPool) map[string]string {
 	return map[string]string{
 		"cstorpool.openebs.io/hostname": pool.Labels["kubernetes.io/hostname"],
 	}
@@ -172,36 +169,35 @@ func getNamespace() string {
 	return menv.Get(menv.OpenEBSNamespace)
 }
 
-// getSPC gets storagePoolClaim from cstorvolumeclaim resource
-func getSPC(
+// getCSPC gets CStorPoolCluster name from cstorvolumeclaim resource
+func getCSPC(
 	claim *apis.CStorVolumeClaim,
 ) string {
 
-	spcName := claim.Labels[string(apis.StoragePoolClaimCPK)]
-	return spcName
+	cspcName := claim.Labels[string(apis.CStorPoolClusterCPK)]
+	return cspcName
 }
 
 // listCStorPools get the list of available pool using the storagePoolClaim
 // as labelSelector.
 func listCStorPools(
-	spcName string,
+	cspcName string,
 	replicaCount int,
-) (*apis.CStorPoolList, error) {
+) (*apis.NewTestCStorPoolList, error) {
 
-	if spcName == "" {
-		return nil, errors.New("failed to list cstorpool: spc name missing")
+	if cspcName == "" {
+		return nil, errors.New("failed to list cstorpool: cspc name missing")
 	}
 
-	labelSelector := spcAnnotation + spcName
-
-	cstorPoolList, err := csp.KubeClient().List(metav1.ListOptions{
-		LabelSelector: labelSelector,
+	cstorPoolList, err := ncsp.NewKubeClient().List(metav1.ListOptions{
+		LabelSelector: string(apis.CStorPoolClusterCPK) + "=" + cspcName,
 	})
+
 	if err != nil {
 		return nil, errors.Wrapf(
 			err,
-			"failed to list cstorpool for spc {%s}",
-			spcName,
+			"failed to list cstorpool for cspc {%s}",
+			cspcName,
 		)
 	}
 	if len(cstorPoolList.Items) < replicaCount {
@@ -308,12 +304,12 @@ func distributeCVRs(
 	volume *apis.CStorVolume,
 ) error {
 
-	spcName := getSPC(claim)
-	if len(spcName) == 0 {
-		return errors.New("failed to get spc name from cstorvolumeclaim")
+	cspcName := getCSPC(claim)
+	if len(cspcName) == 0 {
+		return errors.New("failed to get cspc name from cstorvolumeclaim")
 	}
 
-	poolList, err := listCStorPools(spcName, claim.Spec.ReplicaCount)
+	poolList, err := listCStorPools(cspcName, claim.Spec.ReplicaCount)
 	if err != nil {
 		return err
 	}
@@ -342,7 +338,7 @@ func distributeCVRs(
 func createCVR(
 	service *corev1.Service,
 	volume *apis.CStorVolume,
-	pool *apis.CStorPool,
+	pool *apis.NewTestCStorPool,
 ) (*apis.CStorVolumeReplica, error) {
 
 	cvrObj, err := cvr.NewKubeclient(cvr.WithNamespace(getNamespace())).
@@ -402,8 +398,8 @@ func getUsedPoolNames(cvrList *apis.CStorVolumeReplicaList) map[string]bool {
 // GetUsablePoolList returns a list of usable cstorpools
 // which hasn't been used to create cstor volume replica
 // instances
-func getUsablePoolList(pvName string, poolList *apis.CStorPoolList) *apis.CStorPoolList {
-	usablePoolList := &apis.CStorPoolList{}
+func getUsablePoolList(pvName string, poolList *apis.NewTestCStorPoolList) *apis.NewTestCStorPoolList {
+	usablePoolList := &apis.NewTestCStorPoolList{}
 
 	pvLabel := pvSelector + "=" + pvName
 	cvrList, err := cvr.NewKubeclient(cvr.WithNamespace(getNamespace())).List(metav1.ListOptions{
@@ -423,8 +419,8 @@ func getUsablePoolList(pvName string, poolList *apis.CStorPoolList) *apis.CStorP
 }
 
 // randomizePoolList returns randomized pool list
-func randomizePoolList(list *apis.CStorPoolList) *apis.CStorPoolList {
-	res := &apis.CStorPoolList{}
+func randomizePoolList(list *apis.NewTestCStorPoolList) *apis.NewTestCStorPoolList {
+	res := &apis.NewTestCStorPoolList{}
 
 	r := rand.New(rand.NewSource(time.Now().Unix()))
 	perm := r.Perm(len(list.Items))


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit uses `CStorPoolCluster` and `NewTestCStorPool` API's for
distributing cstorvolume replicas in cstorpools instances.

```yaml
 apiVersion: openebs.io/v1alpha1
  kind: CStorVolumeClaim
  metadata:
    annotations:
      openebs.io/volumeID: pvc-8090ff6d-fb47-4464-b564-d2803dbc8cdc
    creationTimestamp: "2019-07-29T12:08:01Z"
    finalizers:
    - cvc.openebs.io/finalizer
    generation: 147
    labels:
      openebs.io/cstor-pool-cluster: cspc-sparse
    name: pvc-8090ff6d-fb47-4464-b564-d2803dbc8cdc
    namespace: openebs
    resourceVersion: "4989"
    selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/cstorvolumeclaims/pvc-8090ff6d-fb47-4464-b564-d2803dbc8cdc
    uid: 6216eb91-e0d5-4f2a-b7fb-3907e0d71fac
  publish:
    nodeId: 127.0.0.1
  spec:
    capacity:
      storage: "5368709120"
    cstorVolumeRef:
      apiVersion: openebs.io/v1alpha1
      kind: CStorVolume
      name: pvc-8090ff6d-fb47-4464-b564-d2803dbc8cdc
      namespace: openebs
      resourceVersion: "3336"
      uid: fb31906d-9d4b-468f-94b9-f76a7ab5e204
    replicaCount: 1
  status:
    capacity:
      storage: "5368709120"
    phase: Bound
```

2. **NSPC:**
```yaml
apiVersion: openebs.io/v1alpha1
kind: NewTestCStorPool
metadata:
  creationTimestamp: "2019-07-29T11:47:49Z"
  finalizers:
  - cstorpoolcluster.openebs.io/finalizer
  generation: 136
  labels:
    kubernetes.io/hostname: 127.0.0.1
    openebs.io/cas-type: cstor
    openebs.io/cstor-pool-cluster: cspc-sparse
    openebs.io/version: 1.1.0
  name: cspc-sparse-56h6
  namespace: openebs
  ownerReferences:
  - apiVersion: openebs.io/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: CStorPoolCluster
    name: cspc-sparse
    uid: 2fd01de6-6ddb-4838-a03c-582276079f55
  resourceVersion: "5003"
  selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/newtestcstorpools/cspc-sparse-56h6
  uid: 2285fef6-98d4-44c4-9fab-664bc8d89fc3
spec:
  hostName: 127.0.0.1
  nodeSelector:
    kubernetes.io/hostname: 127.0.0.1
  poolConfig:
    cacheFile: ""
    compression: "off"
    defaultRaidGroupType: stripe
    overProvisioning: false
  raidGroup:
  - blockDevices:
    - blockDeviceName: sparse-37a7de580322f43a13338bf2467343f5
      capacity: ""
      devLink: /var/openebs/sparse/3-ndm-sparse.img
    isReadCache: false
    isSpare: false
    isWriteCache: false
    name: ""
    type: stripe
status:
  capacity:
    free: |
      9.88G
    total: |
      9.94G
    used: |
      54.6M
  lastTransitionTime: null
  lastUpdateTime: null
  phase: |
    ONLINE

```


Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->