### PR TITLE
chore(cstor-pool, bdd): enhace test with pool pod restart

### DIFF
--- a/tests/cstor/pool/reconciliation/reconciliation_test.go
+++ b/tests/cstor/pool/reconciliation/reconciliation_test.go
@@ -86,7 +86,7 @@ var _ = Describe("STRIPED SPARSE SPC", func() {
 			)
 			poolPodObj := poolPodList.Items[0]
 
-			oldGUID := ops.ExecuteZpoolCMDEventually(&poolPodObj, zpoolGUIDCmd)
+			oldGUID := ops.ExecuteCMDEventually(&poolPodObj, zpoolGUIDCmd)
 
 			By("Restarting cstor pool pod")
 			err = ops.RestartPodEventually(&poolPodObj)
@@ -105,7 +105,7 @@ var _ = Describe("STRIPED SPARSE SPC", func() {
 			)
 			poolPodObj = poolPodList.Items[0]
 
-			newGUID := ops.ExecuteZpoolCMDEventually(&poolPodObj, zpoolGUIDCmd)
+			newGUID := ops.ExecuteCMDEventually(&poolPodObj, zpoolGUIDCmd)
 
 			//Check zpool pool guid before and after restarts
 			Expect(oldGUID).To(

--- a/tests/cstor/pool/reconciliation/reconciliation_test.go
+++ b/tests/cstor/pool/reconciliation/reconciliation_test.go
@@ -20,6 +20,7 @@ import (
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	spc "github.com/openebs/maya/pkg/storagepoolclaim/v1alpha1"
 	"github.com/openebs/maya/tests/artifacts"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -299,4 +300,93 @@ var _ = Describe("RAIDZ2 SPARSE SPC", func() {
 		})
 	})
 
+})
+
+var _ = Describe("SPC POOL POD DELETION", func() {
+	When("We apply sparse-striped-auto spc yaml with maxPool count equal to 1"+
+		"on a k8s cluster having at least one capable node", func() {
+		It("pool resources count should be 1 with no error and healthy status", func() {
+			namespace := string(artifacts.OpenebsNamespace)
+			builtSpcObj := spc.NewBuilder().
+				WithGenerateName(spcName).
+				WithDiskType(string(apis.TypeSparseCPV)).
+				WithMaxPool(1).
+				WithOverProvisioning(false).
+				WithPoolType(string(apis.PoolTypeStripedCPV)).
+				Build()
+			spcObj = builtSpcObj.Object
+
+			// Create a storage pool claim
+			_, err := ops.SPCClient.Create(spcObj)
+			Expect(err).To(BeNil())
+			cspCount := ops.GetHealthyCSPCount(spcObj.Name, 1)
+			Expect(cspCount).To(Equal(1))
+
+			// get pool pod corresponding to above spc
+			poolPodList, err := ops.PodClient.WithNamespace(namespace).
+				List(metav1.ListOptions{
+					LabelSelector: "openebs.io/storage-pool-claim=" + spcObj.Name,
+				},
+				)
+			Expect(err).To(BeNil(), "failed to get list of pool pods")
+
+			// verify pod status
+			status := ops.IsPodRunningEventually(namespace, poolPodList.Items[0].Name)
+			Expect(status).To(Equal(true), "while checking status of pool pod {%s}", poolPodList.Items[0].Name)
+
+			// Exec into cstor-pool pod and get pool guid
+			oldOutput, err := ops.PodClient.WithNamespace(namespace).
+				Exec(
+					poolPodList.Items[0].Name,
+					&corev1.PodExecOptions{
+						Command: []string{
+							"/bin/bash",
+							"-c",
+							"zpool get guid -H | awk '{print $3}'",
+						},
+						Container: poolPodList.Items[0].Spec.Containers[0].Name,
+						Stdin:     false,
+						Stdout:    true,
+						Stderr:    true,
+					},
+				)
+			Expect(err).To(BeNil(), "while geting the zpool pool guid of pod {%s} before restart", poolPodList.Items[0].Name)
+
+			newPoolPodObj, err := ops.RestartPodEventually(
+				namespace,
+				metav1.ListOptions{
+					LabelSelector: "openebs.io/storage-pool-claim=" + spcObj.Name,
+				},
+			)
+			Expect(err).To(BeNil(), "failed to restart cstor pool pod")
+
+			// Exec into cstor-pool pod and get pool guid
+			newOutput, err := ops.PodClient.WithNamespace(namespace).
+				Exec(
+					newPoolPodObj.Name,
+					&corev1.PodExecOptions{
+						Command: []string{
+							"/bin/bash",
+							"-c",
+							"zpool get guid -H | awk '{print $3}'",
+						},
+						Container: newPoolPodObj.Spec.Containers[0].Name,
+						Stdin:     false,
+						Stdout:    true,
+						Stderr:    true,
+					},
+				)
+			Expect(err).To(BeNil(), "while geting the zpool pool guid of pod {%s} after restart", newPoolPodObj)
+
+			//Check zpool pool guid before and after restarts
+			Expect(oldOutput.Stdout).To(Equal(newOutput.Stdout), "pool is created after restarting the pool pod")
+		})
+	})
+
+	When("Cleaning up spc", func() {
+		It("should delete the spc", func() {
+			_, err := ops.SPCClient.Delete(spcObj.Name, &metav1.DeleteOptions{})
+			Expect(err).To(BeNil())
+		})
+	})
 })

--- a/tests/cstor/pool/reconciliation/reconciliation_test.go
+++ b/tests/cstor/pool/reconciliation/reconciliation_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+/*
 var _ = Describe("STRIPED SPARSE SPC", func() {
 
 	When("We apply sparse-striped-auto spc yaml with maxPool count equal to 3 on a k8s cluster having at least 3 capable node", func() {
@@ -300,7 +301,7 @@ var _ = Describe("RAIDZ2 SPARSE SPC", func() {
 		})
 	})
 
-})
+})*/
 
 var _ = Describe("SPC POOL POD DELETION", func() {
 	When("We apply sparse-striped-auto spc yaml with maxPool count equal to 1 "+
@@ -361,7 +362,7 @@ var _ = Describe("SPC POOL POD DELETION", func() {
 			)
 
 			By("Restarting cstor pool pod")
-			newPoolPodObj, err := ops.RestartPodsEventually(
+			newPoolPodObj, err := ops.RestartSinglePodsEventually(
 				namespace,
 				metav1.ListOptions{
 					LabelSelector: "openebs.io/storage-pool-claim=" + spcObj.Name,

--- a/tests/operations.go
+++ b/tests/operations.go
@@ -364,9 +364,9 @@ func (ops *Operations) IsPodRunningEventually(namespace, podName string) bool {
 		Should(BeTrue())
 }
 
-// ExecuteZpoolCMDEventually executes the zpool command in cstor pool container
+// ExecuteCMDEventually executes the command on pod container
 // and returns stdout
-func (ops *Operations) ExecuteZpoolCMDEventually(podObj *corev1.Pod, cmd string) string {
+func (ops *Operations) ExecuteCMDEventually(podObj *corev1.Pod, cmd string) string {
 	var err error
 	output := &pod.ExecOutput{}
 	podName := podObj.Name
@@ -395,8 +395,10 @@ func (ops *Operations) ExecuteZpoolCMDEventually(podObj *corev1.Pod, cmd string)
 			)
 		Expect(err).ShouldNot(
 			HaveOccurred(),
-			"while geting the zpool pool guid of pod {%s}",
+			"failed to execute command {%s} on pod {%s} namespace {%s}",
+			cmd,
 			podName,
+			namespace,
 		)
 		if output.Stdout != "" {
 			return output.Stdout
@@ -404,12 +406,12 @@ func (ops *Operations) ExecuteZpoolCMDEventually(podObj *corev1.Pod, cmd string)
 		time.Sleep(5 * time.Second)
 	}
 	err = errors.Errorf(
-		"failed to execute cmd %s on pool pod %s",
+		"failed to execute cmd %s on pod %s",
 		cmd,
 		podName,
 	)
 	Expect(err).To(BeNil(),
-		"failed to execute cmd {%s} on pool pod {%s} in namespace {%s} stdout {%s}",
+		"failed to execute cmd {%s} on pod {%s} in namespace {%s} stdout {%s}",
 		cmd,
 		podName,
 		namespace,

--- a/tests/operations.go
+++ b/tests/operations.go
@@ -409,10 +409,11 @@ func (ops *Operations) ExecuteZpoolCMDEventually(podObj *corev1.Pod, cmd string)
 		podName,
 	)
 	Expect(err).To(BeNil(),
-		"failed to execute cmd %s on pool pod %s in namespace %s",
+		"failed to execute cmd {%s} on pool pod {%s} in namespace {%s} stdout {%s}",
 		cmd,
 		podName,
 		namespace,
+		output.Stdout,
 	)
 	return ""
 }

--- a/tests/operations.go
+++ b/tests/operations.go
@@ -393,9 +393,9 @@ func (ops *Operations) GetPodList(
 	return podList, nil
 }
 
-// RestartPodsEventually returns pod object after
+// RestartSinglePodsEventually returns pod object after
 // restarting the single pod if error happens in between it returns error
-func (ops *Operations) RestartPodsEventually(
+func (ops *Operations) RestartSinglePodsEventually(
 	namespace string,
 	listOpts metav1.ListOptions) (*corev1.Pod, error) {
 	podList, err := ops.GetPodList(namespace, listOpts, 1)


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR enhance existing bdd to check pod creation after restarting cstor pool pod.

Sample out of BDD:
When I create pool pod using ci image i.e openebs/cstor-pool-mgmt:ci.
Upon restart of cstor-sparse-pool pod pool is imported (verifying with zpool guid).
```sh
Running Suite: Test cstor invalid config
========================================
Random Seed: 1564472691
Will run 1 of 1 specs

STEP: waiting for maya-apiserver pod to come into running state
STEP: waiting for openebs-provisioner pod to come into running state
STEP: Verifying 'admission-server' pod status as running
SPC POOL POD DELETION when We apply sparse-striped-auto spc yaml with maxPool count equal to 1on a k8s cluster having at least one capable node 
  pool resources count should be 1 with no error and healthy status
  /home/sai/gocode/src/github.com/openebs/maya/tests/cstor/pool/reconciliation/reconciliation_test.go:308

• [SLOW TEST:22.383 seconds]
SPC POOL POD DELETION
/home/sai/gocode/src/github.com/openebs/maya/tests/cstor/pool/reconciliation/reconciliation_test.go:305
  when We apply sparse-striped-auto spc yaml with maxPool count equal to 1on a k8s cluster having at least one capable node
  /home/sai/gocode/src/github.com/openebs/maya/tests/cstor/pool/reconciliation/reconciliation_test.go:306
    pool resources count should be 1 with no error and healthy status
    /home/sai/gocode/src/github.com/openebs/maya/tests/cstor/pool/reconciliation/reconciliation_test.go:308
------------------------------
```

When I create a cstor-pool with ci image openebs/cstor-pool-mgmt:ci
cstor pool is creating upon restarts of cstor sparse pool pod(verifying with zpool guid).
```sh
Running Suite: Test cstor invalid config
========================================
Random Seed: 1564474518
Will run 2 of 2 specs

STEP: waiting for maya-apiserver pod to come into running state
STEP: waiting for openebs-provisioner pod to come into running state
STEP: Verifying 'admission-server' pod status as running
SPC POOL POD DELETION when We apply sparse-striped-auto spc yaml with maxPool count equal to 1on a k8s cluster having at least one capable node 
  pool resources count should be 1 with no error and healthy status
  /home/sai/gocode/src/github.com/openebs/maya/tests/cstor/pool/reconciliation/reconciliation_test.go:308

• Failure [71.206 seconds]
SPC POOL POD DELETION
/home/sai/gocode/src/github.com/openebs/maya/tests/cstor/pool/reconciliation/reconciliation_test.go:305
  when We apply sparse-striped-auto spc yaml with maxPool count equal to 1on a k8s cluster having at least one capable node
  /home/sai/gocode/src/github.com/openebs/maya/tests/cstor/pool/reconciliation/reconciliation_test.go:306
    pool resources count should be 1 with no error and healthy status [It]
    /home/sai/gocode/src/github.com/openebs/maya/tests/cstor/pool/reconciliation/reconciliation_test.go:308

    pool is created after restarting the pool pod
    Expected
        <string>: 13045116073415178721
        
    to equal
        <string>: 2563682489522013285
        

    /home/sai/gocode/src/github.com/openebs/maya/tests/cstor/pool/reconciliation/reconciliation_test.go:382
------------------------------
Summarizing 1 Failure:

[Fail] SPC POOL POD DELETION when We apply sparse-striped-auto spc yaml with maxPool count equal to 1on a k8s cluster having at least one capable node [It] pool resources count should be 1 with no error and healthy status 
/home/sai/gocode/src/github.com/openebs/maya/tests/cstor/pool/reconciliation/reconciliation_test.go:382

Ran 2 of 2 Specs in 71.228 seconds
FAIL! -- 1 Passed | 1 Failed | 0 Pending | 0 Skipped
--- FAIL: TestSource (71.23s)
FAIL

```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests