### PR TITLE
fix(bdc, cstor-operator): bdc creations in case of auto pool provisioning

### DIFF
--- a/cmd/maya-apiserver/cstor-operator/spc/handler.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/handler.go
@@ -259,9 +259,10 @@ func (c *Controller) create(pendingPoolCount int, spc *apis.StoragePoolClaim) er
 	}
 	glog.V(4).Infof("Lease acquired successfully on storagepoolclaim %s ", spc.Name)
 	defer newSpcLease.Release()
+	poolConfig := c.NewPoolCreateConfig(spc)
 	for poolCount := 1; poolCount <= pendingPoolCount; poolCount++ {
 		glog.Infof("Provisioning pool %d/%d for storagepoolclaim %s", poolCount, pendingPoolCount, spc.Name)
-		err = c.CreateStoragePool(spc)
+		err = poolConfig.CreateStoragePool(spc)
 		if err != nil {
 			runtime.HandleError(errors.Wrapf(err, "Pool provisioning failed for %d/%d for storagepoolclaim %s", poolCount, pendingPoolCount, spc.Name))
 		}

--- a/cmd/maya-apiserver/cstor-operator/spc/storagepool_create.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/storagepool_create.go
@@ -47,10 +47,8 @@ type CasPoolBuilder struct {
 // 1. It receives storagepoolclaim object from the spc watcher event handler.
 // 2. After successful validation, it will call a worker function for actual storage creation
 //    via the cas template specified in storagepoolclaim.
-func (c *Controller) CreateStoragePool(spcGot *apis.StoragePoolClaim) error {
-	poolconfig := c.NewPoolCreateConfig(spcGot)
-	newCasPool, err := poolconfig.getCasPool(spcGot)
-
+func (pc *PoolCreateConfig) CreateStoragePool(spcGot *apis.StoragePoolClaim) error {
+	newCasPool, err := pc.getCasPool(spcGot)
 	if err != nil {
 		return errors.Wrapf(err, "failed to build cas pool for spc %s", spcGot.Name)
 	}

--- a/pkg/algorithm/nodeselect/v1alpha1/config.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/config.go
@@ -56,6 +56,9 @@ type Config struct {
 	CspClient cstorpool.CstorpoolInterface
 	// ProvisioningType tells the type of provisioning i.e. manual or auto.
 	ProvisioningType string
+	// VisitedNodes is a map which contains the node names which has already been
+	// processed for pool provisioning
+	VisitedNodes map[string]bool
 }
 
 // getDiskK8sClient returns an instance of kubernetes client for Disk.
@@ -124,6 +127,7 @@ func NewConfig(spc *apis.StoragePoolClaim) *Config {
 		CspClient:         cspK8sClient,
 		SpClient:          spK8sClient,
 		ProvisioningType:  pT,
+		VisitedNodes:      map[string]bool{},
 	}
 	return ac
 }

--- a/pkg/algorithm/nodeselect/v1alpha1/config.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/config.go
@@ -59,6 +59,8 @@ type Config struct {
 	// VisitedNodes is a map which contains the node names which has already been
 	// processed for pool provisioning
 	VisitedNodes map[string]bool
+	// Namespace where OpenEBS is deployed
+	Namespace string
 }
 
 // getDiskK8sClient returns an instance of kubernetes client for Disk.

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node.go
@@ -58,14 +58,6 @@ func (ac *Config) NodeBlockDeviceSelector() (*nodeBlockDevice, error) {
 		return nil, err
 	}
 
-	//filteredNodeBDs = nodeBlockDeviceMap
-	//if ProvisioningType(ac.Spc) == ProvisioningTypeAuto {
-	//	filteredNodeBDs, err = ac.getFilteredNodeBlockDevices(nodeBlockDeviceMap)
-	//	if err != nil {
-	//		return nil, err
-	//	}
-	//}
-
 	selectedBD, err := ac.selectNode(nodeBlockDeviceMap)
 	if err != nil {
 		return nil, err
@@ -73,83 +65,6 @@ func (ac *Config) NodeBlockDeviceSelector() (*nodeBlockDevice, error) {
 
 	return selectedBD, nil
 }
-
-//// getFilteredNodeBlockDevices returns the map of node name and block device
-//// list if no claims are present on list of block devices. If claims are present
-//// then it retunrns those block devices on which claims are created
-//func (ac *Config) getFilteredNodeBlockDevices(
-//	nodeBDs map[string]*blockDeviceList) (map[string]*blockDeviceList, error) {
-//	namespace := env.Get(env.OpenEBSNamespace)
-//	bdcKubeclient := bdc.NewKubeClient().
-//		WithNamespace(namespace)
-//	bdcList, err := bdcKubeclient.List(metav1.ListOptions{LabelSelector: string(apis.StoragePoolClaimCPK) + "=" + ac.Spc.Name})
-//	if err != nil {
-//		return nil, err
-//	}
-//	// get used node names from csp related to spc
-//	usedNodeMap, err := ac.getUsedNodeMap()
-//	if err != nil {
-//		return nil, err
-//	}
-//	//TODO: Make smaller function before removing WIP
-//
-//	// minRequiredDiskCount will hold the required number of disk that should be selected from a qualified
-//	// node for specific pool type
-//	minRequiredBDCount := blockdevice.DefaultDiskCount[ac.poolType()]
-//
-//	newNodeBDMap := make(map[string]*blockDeviceList)
-//	// form the map of node name and blockdevice list from
-//	// blockdeviceclaims created by spc
-//	for _, bdcObj := range bdcList.Items {
-//		bdcObj := bdcObj
-//		if ac.VisitedNodes[bdcObj.Spec.HostName] ||
-//			usedNodeMap[bdcObj.Spec.HostName] == 1 {
-//			continue
-//		}
-//		if newNodeBDMap[bdcObj.Spec.HostName] == nil {
-//			newNodeBDMap[bdcObj.Spec.HostName] = &blockDeviceList{
-//				Items: []string{bdcObj.Spec.BlockDeviceName},
-//			}
-//		} else {
-//			bdList := newNodeBDMap[bdcObj.Spec.HostName]
-//			bdList.Items = append(bdList.Items, bdcObj.Spec.BlockDeviceName)
-//		}
-//	}
-//	// If selectedNodeCount is zero then we can consider it is first
-//	// reconciliation and need to send
-//	selectedNodeCount := len(newNodeBDMap)
-//
-//	// Form the map of node name and blockdevice list from existing blockdevices
-//	for nodeName, bdList := range nodeBDs {
-//		// pin it
-//		nodeName := nodeName
-//		bdList := bdList
-//		if selectedNodeCount != 0 {
-//			if newNodeBDMap[nodeName] != nil {
-//				if len(newNodeBDMap[nodeName].Items) < minRequiredBDCount {
-//					// If BDC creation failed in before reconciliation we are
-//					// inserting required no blockdevices
-//					for _, bdName := range bdList.Items {
-//						if !util.ContainsString(newNodeBDMap[nodeName].Items, bdName) {
-//							bdList := newNodeBDMap[nodeName]
-//							bdList.Items = append(bdList.Items, bdName)
-//						}
-//					}
-//				}
-//			}
-//		} else {
-//			if newNodeBDMap[nodeName] == nil {
-//				newNodeBDMap[nodeName] = &blockDeviceList{
-//					Items: bdList.Items,
-//				}
-//			}
-//		}
-//	}
-//	for node, bdList := range newNodeBDMap {
-//		glog.Infof("Node-- %s BD list %#v", node, bdList)
-//	}
-//	return newNodeBDMap, nil
-//}
 
 // getUsedBlockDeviceMap gives list of disks that has already been used for pool provisioning.
 func (ac *Config) getUsedBlockDeviceMap() (map[string]int, error) {
@@ -212,7 +127,6 @@ func (ac *Config) getCandidateNode(listBlockDevice *ndmapis.BlockDeviceList) (ma
 		//If node is already visited in this reconciliation then continue with
 		//other nodes
 		if ac.VisitedNodes[nodeName] {
-			glog.Infof("-------Ignoring node: %s", nodeName)
 			continue
 		}
 		if nodeBlockDeviceMap[nodeName] == nil {
@@ -247,26 +161,34 @@ func (ac *Config) selectNode(nodeBlockDeviceMap map[string]*blockDeviceList) (*n
 	minRequiredDiskCount := blockdevice.DefaultDiskCount[ac.poolType()]
 
 	if ProvisioningType(ac.Spc) == ProvisioningTypeAuto {
-		// List all blockdevices related to spc
+		// List all blockdeviceclaims related to spc
+		// NOTE: This list contains blockdevices on which csps' are already
+		// created filter and use it
 		bdcList, err := bdc.NewKubeClient().
 			WithNamespace(ac.Namespace).
 			List(metav1.ListOptions{LabelSelector: string(apis.StoragePoolClaimCPK) + "=" + ac.Spc.Name})
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "failed to select node and blockdevices")
 		}
 		customBDCList := bdc.BlockDeviceClaimList{
 			ObjectList: bdcList,
 		}
+		// Form node and blockdevice topology for blockdevices which has bdc
 		claimedNodes := customBDCList.GetBlockDeviceNamesByNode()
 		for claimedNodeName, bdNameList := range claimedNodes {
-			//Check is this node is usable or not
 			qualifiedBDList := []string{}
-			//TODO: Nil check againest nodeBlockDeviceMap
-			if util.ContainsString(nodeBlockDeviceMap[claimedNodeName].Items, bdNameList[0]) {
+			filteredBlockDevices := nodeBlockDeviceMap[claimedNodeName]
+
+			//Check is this node is usable or not
+			if filteredBlockDevices != nil &&
+				util.ContainsString(filteredBlockDevices.Items, bdNameList[0]) {
 				qualifiedBDList = append(qualifiedBDList, bdNameList...)
 				if len(qualifiedBDList) < minRequiredDiskCount {
 					count := minRequiredDiskCount - len(qualifiedBDList)
-					availableBDOnNode := util.ListAMinusListB(nodeBlockDeviceMap[claimedNodeName].Items, qualifiedBDList)
+					availableBDOnNode := util.ListAMinusListB(filteredBlockDevices.Items, qualifiedBDList)
+					if len(availableBDOnNode) < count {
+						continue
+					}
 					qualifiedBDList = append(qualifiedBDList, availableBDOnNode[:count]...)
 				}
 				selectedBlockDevice.BlockDevices.Items = append(selectedBlockDevice.BlockDevices.Items, qualifiedBDList...)
@@ -353,7 +275,7 @@ func (ac *Config) getBlockDevice() (*ndmapis.BlockDeviceList, error) {
 	if len(bdl.Items) == 0 {
 		return nil, errors.Errorf("type {%s} devices are not available to provision pools in %s mode", diskType, ProvisioningType(ac.Spc))
 	}
-	newBDL, err := bdl.GetFreeBlockDevices(ac.Spc.Name, ac.Namespace)
+	newBDL, err := bdl.GetUsableBlockDevices(ac.Spc.Name, ac.Namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node.go
@@ -188,12 +188,11 @@ func (ac *Config) selectNode(nodeBlockDeviceMap map[string]*blockDeviceList) (*n
 		// Form node and blockdevice topology for blockdevices which has bdc
 		claimedDevicesOnNode := customBDCList.GetBlockDeviceNamesByNode()
 		for claimedNodeName, bdNameList := range claimedDevicesOnNode {
-			qualifiedBDList := []string{}
 			filteredBlockDevices := nodeBlockDeviceMap[claimedNodeName]
 
 			//Check is this node is usable or not
 			if filteredBlockDevices != nil {
-				qualifiedBDList = util.ListIntersection(filteredBlockDevices.Items, bdNameList)
+				qualifiedBDList := util.ListIntersection(filteredBlockDevices.Items, bdNameList)
 				// check whether bdNameList contains partially created claimed BDs
 				// i.e BD count is less than required BDs
 				if len(qualifiedBDList) < minRequiredDiskCount {

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node.go
@@ -192,12 +192,12 @@ func (ac *Config) selectNode(nodeBlockDeviceMap map[string]*blockDeviceList) (*n
 
 			//Check is this node is usable or not
 			if filteredBlockDevices != nil {
-				qualifiedBDList := util.ListIntersection(filteredBlockDevices.Items, bdNameList)
+				qualifiedBDList := util.ListOperation(filteredBlockDevices.Items, bdNameList, util.IsInterSection)
 				// check whether bdNameList contains partially created claimed BDs
 				// i.e BD count is less than required BDs
 				if len(qualifiedBDList) < minRequiredDiskCount {
 					count := minRequiredDiskCount - len(qualifiedBDList)
-					availableBDOnNode := util.ListDiff(filteredBlockDevices.Items, qualifiedBDList)
+					availableBDOnNode := util.ListOperation(filteredBlockDevices.Items, qualifiedBDList, util.IsDifference)
 					if len(availableBDOnNode) < count {
 						continue
 					}

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node.go
@@ -275,11 +275,14 @@ func (ac *Config) getBlockDevice() (*ndmapis.BlockDeviceList, error) {
 	if len(bdl.Items) == 0 {
 		return nil, errors.Errorf("type {%s} devices are not available to provision pools in %s mode", diskType, ProvisioningType(ac.Spc))
 	}
-	newBDL, err := bdl.GetUsableBlockDevices(ac.Spc.Name, ac.Namespace)
-	if err != nil {
-		return nil, err
+	if ProvisioningType(ac.Spc) == ProvisioningTypeAuto {
+		newBDL, err := bdl.GetUsableBlockDevices(ac.Spc.Name, ac.Namespace)
+		if err != nil {
+			return nil, err
+		}
+		bdl = newBDL
 	}
-	return newBDL.BlockDeviceList, nil
+	return bdl.BlockDeviceList, nil
 }
 
 //TODO: Make changes in below code in refactor PR

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node_test.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node_test.go
@@ -116,11 +116,11 @@ func fakeAlgorithmConfig(spc *v1alpha1.StoragePoolClaim) *Config {
 		Clientset:     openebsFakeClientset.NewSimpleClientset(),
 	}
 	ac := &Config{
-		Spc: spc,
-
+		Spc:               spc,
 		BlockDeviceClient: bdClient,
 		CspClient:         cspK8sClient,
 		SpClient:          spK8sClient,
+		VisitedNodes:      map[string]bool{},
 	}
 
 	return ac

--- a/pkg/blockdevice/v1alpha1/blockdevice.go
+++ b/pkg/blockdevice/v1alpha1/blockdevice.go
@@ -21,6 +21,7 @@ import (
 
 	ndm "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	bdc_v1alpha1 "github.com/openebs/maya/pkg/blockdeviceclaim/v1alpha1"
 	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -201,6 +202,35 @@ func (bdl *BlockDeviceList) Filter(predicateKeys ...string) *BlockDeviceList {
 		filteredBlockDeviceList = filterOptionFuncMap[key](filteredBlockDeviceList)
 	}
 	return filteredBlockDeviceList
+}
+
+func (bdl *BlockDeviceList) GetFreeBlockDevices(spcName, namespace string) (*BlockDeviceList, error) {
+	// Initialize filtered block device list
+	filteredBlockDeviceList := &BlockDeviceList{
+		BlockDeviceList: &ndm.BlockDeviceList{},
+		errs:            nil,
+	}
+	bdcClient := bdc_v1alpha1.NewKubeClient().WithNamespace(namespace)
+	errMsg, ok := bdl.Hasitems()
+	if !ok {
+		filteredBlockDeviceList.errs = append(filteredBlockDeviceList.errs, errors.New(errMsg))
+		return filteredBlockDeviceList, nil
+	}
+	for _, bdObj := range bdl.Items {
+		if bdObj.Status.ClaimState == ndm.BlockDeviceClaimed {
+			bdcName := bdObj.Spec.ClaimRef.Name
+			bdcObj, err := bdcClient.Get(bdcName, metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			if bdcObj.Labels[string(apis.StoragePoolClaimCPK)] == spcName {
+				filteredBlockDeviceList.Items = append(filteredBlockDeviceList.Items, bdObj)
+			}
+		} else {
+			filteredBlockDeviceList.Items = append(filteredBlockDeviceList.Items, bdObj)
+		}
+	}
+	return filteredBlockDeviceList, nil
 }
 
 //filterInactive filter and give out all the inactive block device

--- a/pkg/install/v1alpha1/flags.go
+++ b/pkg/install/v1alpha1/flags.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	menv "github.com/openebs/maya/pkg/env/v1alpha1"
 	"strconv"
+
+	menv "github.com/openebs/maya/pkg/env/v1alpha1"
 )
 
 // IsDefaultStorageConfigEnabled reads from env variable to check

--- a/pkg/storagepoolclaim/v1alpha1/storagepoolclaim.go
+++ b/pkg/storagepoolclaim/v1alpha1/storagepoolclaim.go
@@ -113,6 +113,11 @@ func (spc *SPC) HasFinalizer(finalizer string) bool {
 	return util.ContainsString(finalizersList, finalizer)
 }
 
+// IsAutoProvisioning returns true if the spc is auto provisioning type
+func (spc *SPC) IsAutoProvisioning() bool {
+	return spc.Object.Spec.BlockDevices.BlockDeviceList == nil
+}
+
 // RemoveFinalizer removes the given finalizer from the object.
 func (spc *SPC) RemoveFinalizer(finalizer string) error {
 	if len(spc.Object.Finalizers) == 0 {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -147,6 +147,21 @@ func ListDiff(listA []string, listB []string) []string {
 	return outputList
 }
 
+// ListIntersection returns list of string which are in listA and listB
+func ListIntersection(listA []string, listB []string) []string {
+	outputList := []string{}
+	mapListB := map[string]bool{}
+	for _, str := range listB {
+		mapListB[str] = true
+	}
+	for _, str := range listA {
+		if mapListB[str] {
+			outputList = append(outputList, str)
+		}
+	}
+	return outputList
+}
+
 // ContainsKey returns true if the provided key is present in the provided map
 func ContainsKey(mapOfObjs map[string]interface{}, key string) bool {
 	for k := range mapOfObjs {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -134,31 +134,31 @@ func ContainsString(stringarr []string, element string) bool {
 
 //TODO: Merge ListDiff and ListIntersection into single function using
 // some functions
+// SetOperation will decides operation performed on the lists
+type SetOperation func() bool
 
-// ListDiff returns list of string which are in listA but not in listB
-func ListDiff(listA []string, listB []string) []string {
-	outputList := []string{}
-	mapListB := map[string]bool{}
-	for _, str := range listB {
-		mapListB[str] = true
-	}
-	for _, str := range listA {
-		if !mapListB[str] {
-			outputList = append(outputList, str)
-		}
-	}
-	return outputList
+// IsInterSection returns true
+func IsInterSection() bool {
+	return true
 }
 
-// ListIntersection returns list of string which are in listA and listB
-func ListIntersection(listA []string, listB []string) []string {
+// IsDifference returns false
+func IsDifference() bool {
+	return false
+}
+
+// ListOperation returns list of string which are in listA but not in listB
+// 3rd argument is IsDifferentce. If 3rd argument is IsInterSection then below
+// function return list of string which are in listA and listB
+func ListOperation(listA []string, listB []string, operation SetOperation) []string {
 	outputList := []string{}
 	mapListB := map[string]bool{}
+	opValue := operation()
 	for _, str := range listB {
 		mapListB[str] = true
 	}
 	for _, str := range listA {
-		if mapListB[str] {
+		if mapListB[str] == opValue {
 			outputList = append(outputList, str)
 		}
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -132,6 +132,21 @@ func ContainsString(stringarr []string, element string) bool {
 	return false
 }
 
+// ListAMinusListB returns list of string which are in listA but not in listB
+func ListAMinusListB(listA []string, listB []string) []string {
+	outputList := []string{}
+	mapListB := map[string]bool{}
+	for _, str := range listB {
+		mapListB[str] = true
+	}
+	for _, str := range listA {
+		if !mapListB[str] {
+			outputList = append(outputList, str)
+		}
+	}
+	return outputList
+}
+
 // ContainsKey returns true if the provided key is present in the provided map
 func ContainsKey(mapOfObjs map[string]interface{}, key string) bool {
 	for k := range mapOfObjs {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -132,8 +132,8 @@ func ContainsString(stringarr []string, element string) bool {
 	return false
 }
 
-// ListAMinusListB returns list of string which are in listA but not in listB
-func ListAMinusListB(listA []string, listB []string) []string {
+// ListDiff returns list of string which are in listA but not in listB
+func ListDiff(listA []string, listB []string) []string {
 	outputList := []string{}
 	mapListB := map[string]bool{}
 	for _, str := range listB {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -132,33 +132,32 @@ func ContainsString(stringarr []string, element string) bool {
 	return false
 }
 
-//TODO: Merge ListDiff and ListIntersection into single function using
-// some functions
-// SetOperation will decides operation performed on the lists
-type SetOperation func() bool
+//TODO: Make better enhancement
 
-// IsInterSection returns true
-func IsInterSection() bool {
-	return true
-}
-
-// IsDifference returns false
-func IsDifference() bool {
-	return false
-}
-
-// ListOperation returns list of string which are in listA but not in listB
-// 3rd argument is IsDifferentce. If 3rd argument is IsInterSection then below
-// function return list of string which are in listA and listB
-func ListOperation(listA []string, listB []string, operation SetOperation) []string {
+// ListDiff returns list of string which are in listA but not in listB
+func ListDiff(listA []string, listB []string) []string {
 	outputList := []string{}
 	mapListB := map[string]bool{}
-	opValue := operation()
 	for _, str := range listB {
 		mapListB[str] = true
 	}
 	for _, str := range listA {
-		if mapListB[str] == opValue {
+		if !mapListB[str] {
+			outputList = append(outputList, str)
+		}
+	}
+	return outputList
+}
+
+// ListIntersection returns list of string which are in listA and listB
+func ListIntersection(listA []string, listB []string) []string {
+	outputList := []string{}
+	mapListB := map[string]bool{}
+	for _, str := range listB {
+		mapListB[str] = true
+	}
+	for _, str := range listA {
+		if mapListB[str] {
 			outputList = append(outputList, str)
 		}
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -132,6 +132,9 @@ func ContainsString(stringarr []string, element string) bool {
 	return false
 }
 
+//TODO: Merge ListDiff and ListIntersection into single function using
+// some functions
+
 // ListDiff returns list of string which are in listA but not in listB
 func ListDiff(listA []string, listB []string) []string {
 	outputList := []string{}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -55,6 +55,39 @@ func TestContainsString(t *testing.T) {
 	}
 }
 
+func TestListAMinusListB(t *testing.T) {
+	tests := map[string]struct {
+		listA       []string
+		listB       []string
+		expectedLen int
+	}{
+		"contains string - positive test case - element is present": {
+			listA:       []string{"hi", "hello", "crazzy"},
+			listB:       []string{"hello"},
+			expectedLen: 2,
+		},
+		"contains string - positive test case - element is not present": {
+			listA:       []string{},
+			listB:       []string{"there", "you", "go"},
+			expectedLen: 0,
+		},
+		"contains string - boundary test case - similar elements but not same": {
+			listA:       []string{"hi there", "ok now"},
+			listB:       []string{},
+			expectedLen: 2,
+		},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			resultArr := ListAMinusListB(mock.listA, mock.listB)
+			if mock.expectedLen != len(resultArr) {
+				t.Fatalf("failed to test %q: expected element count '%d': actual element count '%d'", name, mock.expectedLen, len(resultArr))
+			}
+		})
+	}
+}
+
 func TestContainsKey(t *testing.T) {
 	tests := map[string]struct {
 		mapOfObjs map[string]interface{}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -90,6 +90,46 @@ func TestListDiff(t *testing.T) {
 	}
 }
 
+func TestListIntersection(t *testing.T) {
+	tests := map[string]struct {
+		listA       []string
+		listB       []string
+		expectedLen int
+	}{
+		"positive test case - element is present": {
+			listA:       []string{"hi", "hello", "crazzy"},
+			listB:       []string{"hello"},
+			expectedLen: 1,
+		},
+		"positive test case - ListA is empty": {
+			listA:       []string{},
+			listB:       []string{"there", "you", "go"},
+			expectedLen: 0,
+		},
+		"ListB is empty": {
+			listA:       []string{"hi there", "ok now"},
+			listB:       []string{},
+			expectedLen: 0,
+		},
+		"contains string - boundary test case - similar elements but not same": {
+			listA:       []string{"hi there", "ok now"},
+			listB:       []string{"h ithere"},
+			expectedLen: 0,
+		},
+	}
+
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			resultArr := ListIntersection(mock.listA, mock.listB)
+			if mock.expectedLen != len(resultArr) {
+				t.Fatalf("failed to test %q: expected element count '%d': actual element count '%d'", name, mock.expectedLen, len(resultArr))
+			}
+		})
+	}
+}
+
 func TestContainsKey(t *testing.T) {
 	tests := map[string]struct {
 		mapOfObjs map[string]interface{}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -55,7 +55,7 @@ func TestContainsString(t *testing.T) {
 	}
 }
 
-func TestListAMinusListB(t *testing.T) {
+func TestListDiff(t *testing.T) {
 	tests := map[string]struct {
 		listA       []string
 		listB       []string
@@ -82,7 +82,7 @@ func TestListAMinusListB(t *testing.T) {
 		name := name
 		mock := mock
 		t.Run(name, func(t *testing.T) {
-			resultArr := ListAMinusListB(mock.listA, mock.listB)
+			resultArr := ListDiff(mock.listA, mock.listB)
 			if mock.expectedLen != len(resultArr) {
 				t.Fatalf("failed to test %q: expected element count '%d': actual element count '%d'", name, mock.expectedLen, len(resultArr))
 			}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -57,24 +57,28 @@ func TestContainsString(t *testing.T) {
 
 func TestListDiff(t *testing.T) {
 	tests := map[string]struct {
-		listA       []string
-		listB       []string
-		expectedLen int
+		listA        []string
+		listB        []string
+		expectedLen  int
+		expectedList []string
 	}{
-		"contains string - positive test case - element is present": {
-			listA:       []string{"hi", "hello", "crazzy"},
-			listB:       []string{"hello"},
-			expectedLen: 2,
+		"list diff operation - positive test case - element is present": {
+			listA:        []string{"hi", "hello", "crazzy"},
+			listB:        []string{"hello"},
+			expectedLen:  2,
+			expectedList: []string{"hi", "crazzy"},
 		},
-		"contains string - positive test case - element is not present": {
-			listA:       []string{},
-			listB:       []string{"there", "you", "go"},
-			expectedLen: 0,
+		"list diff operation - positive test case - element is not present": {
+			listA:        []string{},
+			listB:        []string{"there", "you", "go"},
+			expectedLen:  0,
+			expectedList: []string{},
 		},
 		"contains string - boundary test case - similar elements but not same": {
-			listA:       []string{"hi there", "ok now"},
-			listB:       []string{},
-			expectedLen: 2,
+			listA:        []string{"hi there", "ok now"},
+			listB:        []string{},
+			expectedLen:  2,
+			expectedList: []string{"hi there", "ok now"},
 		},
 	}
 
@@ -82,9 +86,12 @@ func TestListDiff(t *testing.T) {
 		name := name
 		mock := mock
 		t.Run(name, func(t *testing.T) {
-			resultArr := ListDiff(mock.listA, mock.listB)
+			resultArr := ListOperation(mock.listA, mock.listB, IsDifference)
 			if mock.expectedLen != len(resultArr) {
 				t.Fatalf("failed to test %q: expected element count '%d': actual element count '%d'", name, mock.expectedLen, len(resultArr))
+			}
+			if !reflect.DeepEqual(resultArr, mock.expectedList) {
+				t.Fatalf("failed to test %q: expected elements '%v': actual elements  '%v'", name, mock.expectedList, resultArr)
 			}
 		})
 	}
@@ -92,29 +99,40 @@ func TestListDiff(t *testing.T) {
 
 func TestListIntersection(t *testing.T) {
 	tests := map[string]struct {
-		listA       []string
-		listB       []string
-		expectedLen int
+		listA        []string
+		listB        []string
+		expectedLen  int
+		expectedList []string
 	}{
 		"positive test case - element is present": {
-			listA:       []string{"hi", "hello", "crazzy"},
-			listB:       []string{"hello"},
-			expectedLen: 1,
+			listA:        []string{"hi", "hello", "crazzy"},
+			listB:        []string{"hello"},
+			expectedLen:  1,
+			expectedList: []string{"hello"},
 		},
 		"positive test case - ListA is empty": {
-			listA:       []string{},
-			listB:       []string{"there", "you", "go"},
-			expectedLen: 0,
+			listA:        []string{},
+			listB:        []string{"there", "you", "go"},
+			expectedLen:  0,
+			expectedList: []string{},
 		},
 		"ListB is empty": {
-			listA:       []string{"hi there", "ok now"},
-			listB:       []string{},
-			expectedLen: 0,
+			listA:        []string{"hi there", "ok now"},
+			listB:        []string{},
+			expectedLen:  0,
+			expectedList: []string{},
 		},
-		"contains string - boundary test case - similar elements but not same": {
-			listA:       []string{"hi there", "ok now"},
-			listB:       []string{"h ithere"},
-			expectedLen: 0,
+		"List is missmatch - boundary test case - similar elements but not same": {
+			listA:        []string{"hi there", "ok now"},
+			listB:        []string{"h ithere"},
+			expectedLen:  0,
+			expectedList: []string{},
+		},
+		"List is match in different order": {
+			listA:        []string{"hi there", "ok now"},
+			listB:        []string{"ok now", "hi there"},
+			expectedLen:  2,
+			expectedList: []string{"hi there", "ok now"},
 		},
 	}
 
@@ -122,9 +140,12 @@ func TestListIntersection(t *testing.T) {
 		name := name
 		mock := mock
 		t.Run(name, func(t *testing.T) {
-			resultArr := ListIntersection(mock.listA, mock.listB)
+			resultArr := ListOperation(mock.listA, mock.listB, IsInterSection)
 			if mock.expectedLen != len(resultArr) {
 				t.Fatalf("failed to test %q: expected element count '%d': actual element count '%d'", name, mock.expectedLen, len(resultArr))
+			}
+			if !reflect.DeepEqual(resultArr, mock.expectedList) {
+				t.Fatalf("failed to test %q: expected elements '%v': actual elements  '%v'", name, mock.expectedList, resultArr)
 			}
 		})
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -86,7 +86,7 @@ func TestListDiff(t *testing.T) {
 		name := name
 		mock := mock
 		t.Run(name, func(t *testing.T) {
-			resultArr := ListOperation(mock.listA, mock.listB, IsDifference)
+			resultArr := ListDiff(mock.listA, mock.listB)
 			if mock.expectedLen != len(resultArr) {
 				t.Fatalf("failed to test %q: expected element count '%d': actual element count '%d'", name, mock.expectedLen, len(resultArr))
 			}
@@ -140,7 +140,7 @@ func TestListIntersection(t *testing.T) {
 		name := name
 		mock := mock
 		t.Run(name, func(t *testing.T) {
-			resultArr := ListOperation(mock.listA, mock.listB, IsInterSection)
+			resultArr := ListIntersection(mock.listA, mock.listB)
 			if mock.expectedLen != len(resultArr) {
 				t.Fatalf("failed to test %q: expected element count '%d': actual element count '%d'", name, mock.expectedLen, len(resultArr))
 			}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -79,6 +79,8 @@ func TestListAMinusListB(t *testing.T) {
 	}
 
 	for name, mock := range tests {
+		name := name
+		mock := mock
 		t.Run(name, func(t *testing.T) {
 			resultArr := ListAMinusListB(mock.listA, mock.listB)
 			if mock.expectedLen != len(resultArr) {


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR creates required blockdeviceclaims based on spc configurations in auto mode(after the fix).

**Before the fix:**
Before the fix we are selecting blockdevices which are in claimed and unclaimed state and later we are getting the list of blockdevice claims belongs to current spc and giving preference to blockdevices which doesn't have claims this leads to create more bdc than required count.

**After the fix:**
This fix will filter the blockdevices based which are claimed by that spc and bd's which are in unclaimed state and after getting the list of blockdeviceclaims related to spc it honors this bdc list with filtered list and give preference to node which has claims on the node. 

1. BDD for this fix is present in different PR(https://github.com/openebs/maya/pull/1394).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #https://github.com/openebs/openebs/issues/2693

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests