### PR TITLE
cast(hostname): fetch hostname from nodename

### DIFF
--- a/pkg/kubernetes/node/v1alpha1/functions.go
+++ b/pkg/kubernetes/node/v1alpha1/functions.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"text/template"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetHostName returns the hostname corresponding to
+// the provided node name
+func GetHostName(name string) (string, error) {
+	return KubeClientInstanceOrDie().GetHostName(name, metav1.GetOptions{})
+}
+
+// GetHostNameOrNodeName returns the hostname corresponding
+// to the provided node name or node name itself if hostname
+// is not available
+func GetHostNameOrNodeName(name string) (string, error) {
+	return KubeClientInstanceOrDie().
+		GetHostNameOrNodeName(name, metav1.GetOptions{})
+}
+
+// TemplateFunctions exposes a few functions as go template functions
+func TemplateFunctions() template.FuncMap {
+	return template.FuncMap{
+		"kubeNodeGetHostName":           GetHostName,
+		"kubeNodeGetHostNameOrNodeName": GetHostNameOrNodeName,
+	}
+}

--- a/pkg/templatefuncs/v1alpha1/templatefuncs.go
+++ b/pkg/templatefuncs/v1alpha1/templatefuncs.go
@@ -32,6 +32,7 @@ import (
 	poolselection "github.com/openebs/maya/pkg/algorithm/cstorpoolselect/v1alpha1"
 	stringer "github.com/openebs/maya/pkg/apis/stringer/v1alpha1"
 	csp "github.com/openebs/maya/pkg/cstor/pool/v1alpha2"
+	node "github.com/openebs/maya/pkg/kubernetes/node/v1alpha1"
 	v1alpha1 "github.com/openebs/maya/pkg/task/v1alpha1"
 	result "github.com/openebs/maya/pkg/upgrade/result/v1alpha1"
 	"github.com/openebs/maya/pkg/util"
@@ -847,6 +848,10 @@ func AllCustomFuncs() template.FuncMap {
 	}
 	ur := result.TemplateFunctions()
 	for k, v := range ur {
+		f[k] = v
+	}
+	nod := node.TemplateFunctions()
+	for k, v := range nod {
 		f[k] = v
 	}
 


### PR DESCRIPTION
This commit exposes a go template function to fetch the hostname of a K8s node from the given node name. It also adds a singleton instance of k8s client for node APIs to avoid roundtrips to k8s
API server.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests