### PR TITLE
fix(jiva): patch replica deployment with correct hostname

### DIFF
--- a/pkg/install/v1alpha1/jiva_volume.go
+++ b/pkg/install/v1alpha1/jiva_volume.go
@@ -604,7 +604,7 @@ spec:
                         {{- if ne $nodeNames "" }}
                         {{- $nodeNamesMap := $nodeNames | split " " }}
                         {{- range $k, $v := $nodeNamesMap }}
-                        - {{ $v }}
+                        - {{ kubeNodeGetHostNameOrNodeName $v }}
                         {{- end }}
                         {{- end }}
 ---
@@ -1380,9 +1380,9 @@ spec:
       {{- end }}
       template:
         spec:
-          restartPolicy: Never
+          restartPolicy: OnFailure
           nodeSelector:
-            kubernetes.io/hostname: {{ .ListItems.currentRepeatResource }}
+            kubernetes.io/hostname: {{ kubeNodeGetHostNameOrNodeName .ListItems.currentRepeatResource }}
           volumes:
           - name: replica-path
             hostPath:


### PR DESCRIPTION
Related issue: https://github.com/openebs/openebs/issues/2695

Jiva Replica Deployment uses `nodeAffinity` to ensure that
replica pods are pinned to the nodes where they are initially created.
This is achieved by the following steps during provisioning:
- Launch the ReplicaDeployment without `nodeAffinity` with
  required number of replicas.
- Read the `spec.nodeName` from each of the scheduled replica
  pods.
- Patch the repplica deployment with `nodeAffinity` by
  setting `kubernetes.io/hostname` to be `In` the list
  of selected node names.

It has been observed that in some deployments hostname != nodename.
This results in jiva replicas not getting scheduled.

This PR converts the nodename into hostname before patching
with nodeAffinity. The CAS template function to support
this conversion was added in the PR: https://github.com/openebs/maya/pull/1389

The same coversion is also done in the cleanup job for setting
the nodeSelector.

Note: We explored the alternate mechanism of patching the
nodeAffinity with `matchFields` set directly to `metadata.name`.
However `matchFields` only supports matching against a single value
and can't be used for Replica Deployment that requires matching with
more than 1 value (node names) depending on the replica count.

Signed-off-by: kmova <kiran.mova@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests