### PR TITLE
chore(cstor-pool, bdd): enhace cstor pool creation test by adding required validations

### DIFF
--- a/cmd/maya-apiserver/cstor-operator/spc/storagepool_create.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/storagepool_create.go
@@ -21,8 +21,8 @@ import (
 	nodeselect "github.com/openebs/maya/pkg/algorithm/nodeselect/v1alpha1"
 	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
-	blockdevice "github.com/openebs/maya/pkg/blockdevice/v1alpha1"
 	"github.com/openebs/maya/pkg/storagepool"
+	spcv1alpha1 "github.com/openebs/maya/pkg/storagepoolclaim/v1alpha1"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -196,7 +196,7 @@ func (pc *PoolCreateConfig) withDisks(casPool *apis.CasPool, spc *apis.StoragePo
 		}
 		return casPool, nil
 	}
-	count := blockdevice.DefaultDiskCount[spc.Spec.PoolSpec.PoolType]
+	count := spcv1alpha1.DefaultDiskCount[spc.Spec.PoolSpec.PoolType]
 	for i := 0; i < len(claimedNodeBDs.BlockDeviceList); i = i + count {
 		var bdList []apis.CspBlockDevice
 		var group apis.BlockDeviceGroup

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node.go
@@ -185,7 +185,7 @@ func (ac *Config) selectNode(nodeBlockDeviceMap map[string]*blockDeviceList) *no
 	var bdCount int
 	// minRequiredDiskCount will hold the required number of disk that should be selected from a qualified
 	// node for specific pool type
-	minRequiredDiskCount := blockdevice.DefaultDiskCount[ac.poolType()]
+	minRequiredDiskCount := spcv1alpha1.DefaultDiskCount[ac.poolType()]
 	for node, val := range nodeBlockDeviceMap {
 		// If the current block device count on the node is less than the required disks
 		// then this is a dirty node and it will not qualify.

--- a/pkg/blockdevice/v1alpha1/blockdevice.go
+++ b/pkg/blockdevice/v1alpha1/blockdevice.go
@@ -41,14 +41,6 @@ const (
 	FilterNonRelesedDevices = "filterNonRelesedDevices"
 )
 
-// DefaultDiskCount is a map containing the default block device count of various raid types.
-var DefaultDiskCount = map[string]int{
-	string(apis.PoolTypeMirroredCPV): int(apis.MirroredBlockDeviceCountCPV),
-	string(apis.PoolTypeStripedCPV):  int(apis.StripedBlockDeviceCountCPV),
-	string(apis.PoolTypeRaidzCPV):    int(apis.RaidzBlockDeviceCountCPV),
-	string(apis.PoolTypeRaidz2CPV):   int(apis.Raidz2BlockDeviceCountCPV),
-}
-
 // KubernetesClient is the kubernetes client which will implement block device actions/behaviours
 type KubernetesClient struct {
 	// Kubeclientset is a standard kubernetes clientset

--- a/pkg/storagepoolclaim/v1alpha1/storagepoolclaim.go
+++ b/pkg/storagepoolclaim/v1alpha1/storagepoolclaim.go
@@ -18,10 +18,11 @@ package v1alpha1
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/golang/glog"
 	"github.com/openebs/maya/pkg/util"
 	"github.com/pkg/errors"
-	"time"
 
 	bdc "github.com/openebs/maya/pkg/blockdeviceclaim/v1alpha1"
 	env "github.com/openebs/maya/pkg/env/v1alpha1"
@@ -40,6 +41,14 @@ const (
 var SupportedDiskTypes = map[apis.CasPoolValString]bool{
 	apis.TypeSparseCPV: true,
 	apis.TypeDiskCPV:   true,
+}
+
+// DefaultDiskCount is a map containing the default block device count of various raid types.
+var DefaultDiskCount = map[string]int{
+	string(apis.PoolTypeMirroredCPV): int(apis.MirroredBlockDeviceCountCPV),
+	string(apis.PoolTypeStripedCPV):  int(apis.StripedBlockDeviceCountCPV),
+	string(apis.PoolTypeRaidzCPV):    int(apis.RaidzBlockDeviceCountCPV),
+	string(apis.PoolTypeRaidz2CPV):   int(apis.Raidz2BlockDeviceCountCPV),
 }
 
 // SPC encapsulates StoragePoolClaim api object.

--- a/tests/cstor/pool/negative/invalid_config_test.go
+++ b/tests/cstor/pool/negative/invalid_config_test.go
@@ -59,7 +59,7 @@ var _ = Describe("[cstor] [-ve] TEST INVALID STORAGEPOOLCLAIM", func() {
 			Expect(err).To(BeNil(), "while creating storagepoolclaim {%s}", spcObj.Name)
 
 			By("verifying cstorpool count as 0")
-			cspCount := ops.GetCSPCount(spcObj.Name, cstor.PoolCount)
+			cspCount := ops.GetHealthyCSPCount(spcObj.Name, cstor.PoolCount)
 			Expect(cspCount).To(Equal(0), "while checking cstorpool count")
 
 		})
@@ -82,7 +82,7 @@ var _ = Describe("[cstor] [-ve] TEST INVALID STORAGEPOOLCLAIM", func() {
 			Expect(err).To(BeNil(), "while creating storagepoolclaim {%s}", spcObj.Name)
 
 			By("verifying cstorpool count as 0")
-			cspCount := ops.GetCSPCount(spcObj.Name, cstor.PoolCount)
+			cspCount := ops.GetHealthyCSPCount(spcObj.Name, cstor.PoolCount)
 			Expect(cspCount).To(Equal(0), "while checking cstorpool count")
 
 		})
@@ -105,7 +105,7 @@ var _ = Describe("[cstor] [-ve] TEST INVALID STORAGEPOOLCLAIM", func() {
 			Expect(err).To(BeNil(), "while creating storagepoolclaim {%s}", spcObj.Name)
 
 			By("verifying cstorpool count as 0")
-			cspCount := ops.GetCSPCount(spcObj.Name, cstor.PoolCount)
+			cspCount := ops.GetHealthyCSPCount(spcObj.Name, cstor.PoolCount)
 			Expect(cspCount).To(Equal(0), "while checking cstorpool count")
 
 		})

--- a/tests/cstor/pool/negative/provision_without_disk_test.go
+++ b/tests/cstor/pool/negative/provision_without_disk_test.go
@@ -80,7 +80,7 @@ var _ = Describe("[cstor] [-ve] TEST PROVISION WITHOUT DISK", func() {
 			Expect(err).To(BeNil(), "while creating storagepoolclaim {%s}", spcObj.Name)
 
 			By("verifying cstorpool count as 0")
-			cspCount := ops.GetCSPCount(spcObj.Name, cstor.PoolCount)
+			cspCount := ops.GetHealthyCSPCountEventually(spcObj.Name, cstor.PoolCount)
 			Expect(cspCount).To(Equal(0), "while checking cstorpool count")
 
 		})

--- a/tests/cstor/pool/reconciliation/reconciliation_test.go
+++ b/tests/cstor/pool/reconciliation/reconciliation_test.go
@@ -18,7 +18,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
-	spc "github.com/openebs/maya/pkg/storagepoolclaim/v1alpha1"
+	spc_v1alpha1 "github.com/openebs/maya/pkg/storagepoolclaim/v1alpha1"
 	"github.com/openebs/maya/tests/artifacts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -27,11 +27,16 @@ var (
 	zpoolGUIDCmd = "zpool get guid -H | awk '{print $3}'"
 )
 
+// This function is local to this package
+func getLabelSelector(spc *apis.StoragePoolClaim) string {
+	return string(apis.StoragePoolClaimCPK) + "=" + spc.Name
+}
+
 var _ = Describe("STRIPED SPARSE SPC", func() {
 
 	When("We apply sparse-striped-auto spc yaml with maxPool count equal to 3 on a k8s cluster having at least 3 capable node", func() {
 		It("pool resources count should be 3 with no error and healthy status", func() {
-			Spc = spc.NewBuilder().
+			Spc = spc_v1alpha1.NewBuilder().
 				WithGenerateName(spcName).
 				WithDiskType(string(apis.TypeSparseCPV)).
 				WithMaxPool(3).
@@ -45,20 +50,26 @@ var _ = Describe("STRIPED SPARSE SPC", func() {
 			Expect(err).To(BeNil())
 			cspCount := ops.GetHealthyCSPCount(spcObj.Name, 3)
 			Expect(cspCount).To(Equal(3))
+			// Check blockdeviceclaim count after creating the cstor pool
+			bdcCount := ops.GetBDCCount(getLabelSelector(spcObj), string(artifacts.OpenebsNamespace))
+			Expect(bdcCount).To(Equal(spc_v1alpha1.DefaultDiskCount[string(apis.PoolTypeStripedCPV)]))
+			// Check is there any extra csp's are created
+			cspCount = ops.GetCSPCount(spcObj.Name)
+			Expect(cspCount).To(Equal(3), "mismatch of csp count")
 
-			Expect(ops.IsSPCFinalizerExistsOnSPC(spcObj.Name, spc.SPCFinalizer)).To(BeTrue())
+			Expect(ops.IsSPCFinalizerExistsOnSPC(spcObj.Name, spc_v1alpha1.SPCFinalizer)).To(BeTrue())
 
 			Expect(ops.IsSPCFinalizerExistsOnBDCs(metav1.ListOptions{
-				LabelSelector: string(apis.StoragePoolClaimCPK) + "=" + spcObj.Name,
-			}, spc.SPCFinalizer)).To(BeTrue())
+				LabelSelector: getLabelSelector(spcObj),
+			}, spc_v1alpha1.SPCFinalizer)).To(BeTrue())
 		})
 	})
 
 	When("Remove finalizer", func() {
 		It("make sure finalizer comes back as part of reconcilation", func() {
-			err := Spc.RemoveFinalizer(spc.SPCFinalizer)
+			err := Spc.RemoveFinalizer(spc_v1alpha1.SPCFinalizer)
 			Expect(err).To(BeNil())
-			Expect(ops.IsSPCFinalizerExistsOnSPC(spcObj.Name, spc.SPCFinalizer)).To(BeTrue())
+			Expect(ops.IsSPCFinalizerExistsOnSPC(spcObj.Name, spc_v1alpha1.SPCFinalizer)).To(BeTrue())
 		})
 	})
 
@@ -153,7 +164,7 @@ var _ = Describe("STRIPED SPARSE SPC", func() {
 			Expect(err).To(BeNil())
 
 			// update the spc to set maxPool field to 1
-			obj := spc.BuilderForAPIObject(newSPC).WithMaxPool(1)
+			obj := spc_v1alpha1.BuilderForAPIObject(newSPC).WithMaxPool(1)
 			_, err = ops.SPCClient.Update(obj.Spc.Object)
 			Expect(err).To(BeNil())
 
@@ -167,7 +178,7 @@ var _ = Describe("STRIPED SPARSE SPC", func() {
 		It("should delete the spc", func() {
 			_, err := ops.SPCClient.Delete(spcObj.Name, &metav1.DeleteOptions{})
 			Expect(err).To(BeNil())
-			bdcCount := ops.GetBDCCount(
+			bdcCount := ops.GetBDCCountEventually(
 				metav1.ListOptions{
 					LabelSelector: string(apis.StoragePoolClaimCPK) + "=" + spcObj.Name},
 				0, string(artifacts.OpenebsNamespace))
@@ -182,7 +193,7 @@ var _ = Describe("MIRRORED SPARSE SPC", func() {
 	// Test Case #1 (sparse-striped-auto-spc). | TestType : Pool Creation
 	When("We apply sparse-mirrored-auto spc yaml with maxPool count equal to 3 on a k8s cluster having at least 3 capable node", func() {
 		It("pool resources count should be 3 with no error and healthy status", func() {
-			spcObj = spc.NewBuilder().
+			spcObj = spc_v1alpha1.NewBuilder().
 				WithGenerateName(spcName).
 				WithDiskType(string(apis.TypeSparseCPV)).
 				WithMaxPool(3).
@@ -195,6 +206,11 @@ var _ = Describe("MIRRORED SPARSE SPC", func() {
 			Expect(err).To(BeNil())
 			cspCount := ops.GetHealthyCSPCount(spcObj.Name, 3)
 			Expect(cspCount).To(Equal(3))
+			bdcCount := ops.GetBDCCount(getLabelSelector(spcObj), string(artifacts.OpenebsNamespace))
+			Expect(bdcCount).To(Equal(spc_v1alpha1.DefaultDiskCount[string(apis.PoolTypeMirroredCPV)]))
+			// Check is there any extra csp's are created
+			cspCount = ops.GetCSPCount(spcObj.Name)
+			Expect(cspCount).To(Equal(3), "mismatch of csp count")
 		})
 	})
 
@@ -243,7 +259,7 @@ var _ = Describe("RAIDZ SPARSE SPC", func() {
 	When("We apply sparse-raidz-auto spc yaml with maxPool count equal to 3 on a k8s cluster having at least 3 capable node", func() {
 		It("pool resources count should be 3 with no error and healthy status", func() {
 
-			spcObj = spc.NewBuilder().
+			spcObj = spc_v1alpha1.NewBuilder().
 				WithGenerateName(spcName).
 				WithDiskType(string(apis.TypeSparseCPV)).
 				WithMaxPool(3).
@@ -256,6 +272,11 @@ var _ = Describe("RAIDZ SPARSE SPC", func() {
 			Expect(err).To(BeNil())
 			cspCount := ops.GetHealthyCSPCount(spcObj.Name, 3)
 			Expect(cspCount).To(Equal(3))
+			bdcCount := ops.GetBDCCount(getLabelSelector(spcObj), string(artifacts.OpenebsNamespace))
+			Expect(bdcCount).To(Equal(spc_v1alpha1.DefaultDiskCount[string(apis.PoolTypeRaidzCPV)]))
+			// Check is there any extra csp's are created
+			cspCount = ops.GetCSPCount(spcObj.Name)
+			Expect(cspCount).To(Equal(3), "mismatch of csp count")
 		})
 	})
 
@@ -303,7 +324,14 @@ var _ = Describe("RAIDZ2 SPARSE SPC", func() {
 	// Test Case #1 (sparse-striped-auto-spc). | TestType : Pool Creation
 	When("We apply sparse-raidz2-auto spc yaml with maxPool count equal to 3 on a k8s cluster having at least 3 capable node", func() {
 		It("pool resources count should be 3 with no error and healthy status", func() {
-			spcObj = spc.NewBuilder().
+			mayaPodList, err := ops.PodClient.
+				WithNamespace(string(artifacts.OpenebsNamespace)).
+				List(metav1.ListOptions{LabelSelector: string(artifacts.MayaAPIServerLabelSelector)})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(len(mayaPodList.Items)).To(Equal(1))
+			mayaPod := mayaPodList.Items[0]
+
+			spcObj = spc_v1alpha1.NewBuilder().
 				WithGenerateName(spcName).
 				WithDiskType(string(apis.TypeSparseCPV)).
 				WithMaxPool(3).
@@ -312,10 +340,21 @@ var _ = Describe("RAIDZ2 SPARSE SPC", func() {
 				Build().Object
 
 			// Create a storage pool claim
-			_, err := ops.SPCClient.Create(spcObj)
+			_, err = ops.SPCClient.Create(spcObj)
 			Expect(err).To(BeNil())
-			cspCount := ops.GetHealthyCSPCount(spcObj.Name, 3)
-			Expect(cspCount).To(Equal(3))
+			By("Restarting maya-apiserver pod")
+			// TODO: Need to make sure after partial BDC creation need to delete
+			// maya-apiserver pod
+			err = ops.RestartPodEventually(&mayaPod)
+			Expect(err).To(BeNil(), "failed to restart maya-apiserver pod")
+
+			cspCount := ops.GetHealthyCSPCount(spcObj.Name, 1)
+			Expect(cspCount).To(Equal(1))
+			bdcCount := ops.GetBDCCount(getLabelSelector(spcObj), string(artifacts.OpenebsNamespace))
+			Expect(bdcCount).To(Equal(spc_v1alpha1.DefaultDiskCount[string(apis.PoolTypeRaidz2CPV)]))
+			// Check is there any extra csp's are created
+			cspCount = ops.GetCSPCount(spcObj.Name)
+			Expect(cspCount).To(Equal(3), "mismatch of csp count")
 		})
 	})
 

--- a/tests/cstor/pool/reconciliation/reconciliation_test.go
+++ b/tests/cstor/pool/reconciliation/reconciliation_test.go
@@ -52,9 +52,12 @@ var _ = Describe("STRIPED SPARSE SPC", func() {
 			Expect(cspCount).To(Equal(3))
 			// Check blockdeviceclaim count after creating the cstor pool
 			bdcCount := ops.GetBDCCount(getLabelSelector(spcObj), string(artifacts.OpenebsNamespace))
-			Expect(bdcCount).To(Equal(spc_v1alpha1.DefaultDiskCount[string(apis.PoolTypeStripedCPV)]))
+			Expect(bdcCount).To(
+				Equal(spc_v1alpha1.DefaultDiskCount[string(apis.PoolTypeStripedCPV)]*3),
+				"mismatch of blockdeviceclaim count",
+			)
 			// Check is there any extra csp's are created
-			cspCount = ops.GetCSPCount(spcObj.Name)
+			cspCount = ops.GetCSPCount(getLabelSelector(spcObj))
 			Expect(cspCount).To(Equal(3), "mismatch of csp count")
 
 			Expect(ops.IsSPCFinalizerExistsOnSPC(spcObj.Name, spc_v1alpha1.SPCFinalizer)).To(BeTrue())
@@ -207,9 +210,12 @@ var _ = Describe("MIRRORED SPARSE SPC", func() {
 			cspCount := ops.GetHealthyCSPCount(spcObj.Name, 3)
 			Expect(cspCount).To(Equal(3))
 			bdcCount := ops.GetBDCCount(getLabelSelector(spcObj), string(artifacts.OpenebsNamespace))
-			Expect(bdcCount).To(Equal(spc_v1alpha1.DefaultDiskCount[string(apis.PoolTypeMirroredCPV)]))
+			Expect(bdcCount).To(
+				Equal(spc_v1alpha1.DefaultDiskCount[string(apis.PoolTypeMirroredCPV)]*3),
+				"mismatch of blockdeviceclaim count",
+			)
 			// Check is there any extra csp's are created
-			cspCount = ops.GetCSPCount(spcObj.Name)
+			cspCount = ops.GetCSPCount(getLabelSelector(spcObj))
 			Expect(cspCount).To(Equal(3), "mismatch of csp count")
 		})
 	})
@@ -273,9 +279,12 @@ var _ = Describe("RAIDZ SPARSE SPC", func() {
 			cspCount := ops.GetHealthyCSPCount(spcObj.Name, 3)
 			Expect(cspCount).To(Equal(3))
 			bdcCount := ops.GetBDCCount(getLabelSelector(spcObj), string(artifacts.OpenebsNamespace))
-			Expect(bdcCount).To(Equal(spc_v1alpha1.DefaultDiskCount[string(apis.PoolTypeRaidzCPV)]))
+			Expect(bdcCount).To(
+				Equal(spc_v1alpha1.DefaultDiskCount[string(apis.PoolTypeRaidzCPV)]*3),
+				"mismatch of blockdeviceclaim count",
+			)
 			// Check is there any extra csp's are created
-			cspCount = ops.GetCSPCount(spcObj.Name)
+			cspCount = ops.GetCSPCount(getLabelSelector(spcObj))
 			Expect(cspCount).To(Equal(3), "mismatch of csp count")
 		})
 	})
@@ -348,12 +357,15 @@ var _ = Describe("RAIDZ2 SPARSE SPC", func() {
 			err = ops.RestartPodEventually(&mayaPod)
 			Expect(err).To(BeNil(), "failed to restart maya-apiserver pod")
 
-			cspCount := ops.GetHealthyCSPCount(spcObj.Name, 1)
-			Expect(cspCount).To(Equal(1))
+			cspCount := ops.GetHealthyCSPCount(spcObj.Name, 3)
+			Expect(cspCount).To(Equal(3))
 			bdcCount := ops.GetBDCCount(getLabelSelector(spcObj), string(artifacts.OpenebsNamespace))
-			Expect(bdcCount).To(Equal(spc_v1alpha1.DefaultDiskCount[string(apis.PoolTypeRaidz2CPV)]))
+			Expect(bdcCount).To(
+				Equal(spc_v1alpha1.DefaultDiskCount[string(apis.PoolTypeRaidz2CPV)]*3),
+				"mismatch of blockdeviceclaim count",
+			)
 			// Check is there any extra csp's are created
-			cspCount = ops.GetCSPCount(spcObj.Name)
+			cspCount = ops.GetCSPCount(getLabelSelector(spcObj))
 			Expect(cspCount).To(Equal(3), "mismatch of csp count")
 		})
 	})


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR does the following changes
1. Enhances the cstor pool creation test with required validations.
2. Moves DefaultDiskCount count from blockdevice package to storagepoolclaim package.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests