### PR TITLE
chore(cspc):remove name field from raid group.

### DIFF
--- a/cmd/cstor-pool-mgmt/pool/v1alpha2/create.go
+++ b/cmd/cstor-pool-mgmt/pool/v1alpha2/create.go
@@ -68,7 +68,7 @@ func Create(csp *apis.CStorPoolInstance) error {
 	// Lets update it with extra config, if provided
 	for _, r := range raidGroups {
 		if e := addRaidGroup(csp, r); e != nil {
-			err = ErrorWrapf(err, "Failed to add raidGroup{%s}.. %s", r.Name, e.Error())
+			err = ErrorWrapf(err, "Failed to add raidGroup{%#v}.. %s", r, e.Error())
 		}
 	}
 

--- a/cmd/cstor-pool-mgmt/pool/v1alpha2/disk_operation.go
+++ b/cmd/cstor-pool-mgmt/pool/v1alpha2/disk_operation.go
@@ -82,7 +82,7 @@ func addNewVdevFromCSP(csp *apis.CStorPoolInstance) error {
 		}
 		if wholeGroup {
 			if er := addRaidGroup(csp, raidGroup); er != nil {
-				err = ErrorWrapf(err, "Failed to add raidGroup{%s}.. %s", raidGroup.Name, er.Error())
+				err = ErrorWrapf(err, "Failed to add raidGroup{%#v}.. %s", raidGroup, er.Error())
 			}
 		} else if len(devlist) != 0 {
 			if _, er := zfs.NewPoolExpansion().

--- a/pkg/apis/openebs.io/v1alpha1/cstorpool_cluster.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstorpool_cluster.go
@@ -117,9 +117,6 @@ type RaidGroup struct {
 	// radiz2 -- TODO
 	// Optional -- defaults to `defaultRaidGroupType` present in `PoolConfig`
 	Type string `json:"type"`
-	// Name is the name of the group.
-	// Required -- to be given by user.
-	Name string `json:"name"`
 	// IsWriteCache is to enable this group as a write cache.
 	IsWriteCache bool `json:"isWriteCache"`
 	// IsSpare is to declare this group as spare which will be

--- a/pkg/cstor/poolcluster/v1alpha1/raidgroups/build.go
+++ b/pkg/cstor/poolcluster/v1alpha1/raidgroups/build.go
@@ -42,16 +42,6 @@ func (b *Builder) WithType(poolType string) *Builder {
 	return b
 }
 
-// WithName sets the name field of raid group with provided value.
-func (b *Builder) WithName(name string) *Builder {
-	if len(name) == 0 {
-		b.errs = append(b.errs, errors.New("failed to build raid group object: missing group name"))
-		return b
-	}
-	b.rg.object.Name = name
-	return b
-}
-
 // WithWriteCache flags the IsWriteCache field of raid group.
 func (b *Builder) WithWriteCache(cacheFile string) *Builder {
 	b.rg.object.IsWriteCache = true


### PR DESCRIPTION
This PR removes the name field from raid groups in CSPC as it is and should not be used.
Signed-off-by: Ashutosh Kumar <ashutosh.kumar@openebs.io>
