### PR TITLE
refactor(localpv bdd): allow to test when only local pv is installed

### DIFF
--- a/tests/artifacts/openebs-ci.go
+++ b/tests/artifacts/openebs-ci.go
@@ -60,10 +60,11 @@ type LabelSelector string
 const (
 	MayaAPIServerLabelSelector             LabelSelector = "name=maya-apiserver"
 	OpenEBSProvisionerLabelSelector        LabelSelector = "name=openebs-provisioner"
-	OpenEBSLocalPVProvisionerLabelSelector LabelSelector = "name=openebs-localpv-provisioner"
+	OpenEBSLocalPVProvisionerLabelSelector LabelSelector = "openebs.io/component-name=openebs-localpv-provisioner"
 	OpenEBSSnapshotOperatorLabelSelector   LabelSelector = "name=openebs-snapshot-operator"
 	OpenEBSAdmissionServerLabelSelector    LabelSelector = "app=admission-webhook"
-	OpenEBSNDMLabelSelector                LabelSelector = "name=openebs-ndm"
+	OpenEBSNDMLabelSelector                LabelSelector = "openebs.io/component-name=openebs-ndm"
+	OpenEBSNDMOperatorLabelSelector        LabelSelector = "openebs.io/component-name=ndm-operator"
 	OpenEBSCStorPoolLabelSelector          LabelSelector = "app=cstor-pool"
 )
 

--- a/tests/localpv/hostpath_test.go
+++ b/tests/localpv/hostpath_test.go
@@ -85,6 +85,7 @@ var _ = Describe("TEST HOSTPATH LOCAL PV", func() {
 				WithSelectorMatchLabelsNew(labelselector).
 				WithPodTemplateSpecBuilder(
 					pts.NewBuilder().
+						WithLabelsNew(labelselector).
 						WithContainerBuildersNew(
 							container.NewBuilder().
 								WithName("busybox").

--- a/tests/localpv/suite_test.go
+++ b/tests/localpv/suite_test.go
@@ -54,21 +54,21 @@ var _ = BeforeSuite(func() {
 
 	ops = tests.NewOperations(tests.WithKubeConfigPath(kubeConfigPath))
 
-	By("waiting for maya-apiserver pod to come into running state")
-	podCount := ops.GetPodRunningCountEventually(
-		string(artifacts.OpenebsNamespace),
-		string(artifacts.MayaAPIServerLabelSelector),
-		1,
-	)
-	Expect(podCount).To(Equal(1))
-
 	By("waiting for openebs-localpv-provisioner pod to come into running state")
-	podCount = ops.GetPodRunningCountEventually(
+	provPodCount := ops.GetPodRunningCountEventually(
 		string(artifacts.OpenebsNamespace),
 		string(artifacts.OpenEBSLocalPVProvisionerLabelSelector),
 		1,
 	)
-	Expect(podCount).To(Equal(1))
+	Expect(provPodCount).To(Equal(1))
+
+	By("waiting for openebs-ndm-operator pod to come into running state")
+	ndmPodCount := ops.GetPodRunningCountEventually(
+		string(artifacts.OpenebsNamespace),
+		string(artifacts.OpenEBSNDMOperatorLabelSelector),
+		1,
+	)
+	Expect(ndmPodCount).To(Equal(1))
 
 	By("building a namespace")
 	namespaceObj, err = ns.NewBuilder().


### PR DESCRIPTION
There have been some requests to allow only installing
the Local PV related components. Refer: https://github.com/openebs/openebs/issues/2706

This PR refactors the Local PV BDDs to check on
local pv and ndm components instead of m-apiserver.

Also, fixed an issue with a test failing to create the
hostpath deployment. labels were missed on the pod spec.

Signed-off-by: kmova <kiran.mova@mayadata.io>


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests