### PR TITLE
chore(naming): change var names from CSP to CSPI

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/cstor-pool-instance/controller.go
+++ b/cmd/cstor-pool-mgmt/controller/cstor-pool-instance/controller.go
@@ -95,11 +95,11 @@ func NewCStorPoolInstanceController(
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: poolControllerName})
 
 	controller := &CStorPoolInstanceController{
-		kubeclientset:   kubeclientset,
-		clientset:       clientset,
+		kubeclientset:           kubeclientset,
+		clientset:               clientset,
 		cStorPoolInstanceSynced: cStorPoolInstanceInformer.Informer().HasSynced,
-		workqueue:       workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), poolControllerName),
-		recorder:        recorder,
+		workqueue:               workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), poolControllerName),
+		recorder:                recorder,
 	}
 
 	glog.Info("Setting up event handlers for CSP")

--- a/cmd/cstor-pool-mgmt/controller/cstor-pool-instance/runner.go
+++ b/cmd/cstor-pool-mgmt/controller/cstor-pool-instance/runner.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package poolcontroller
+package poolinstancecontroller
 
 import (
 	"fmt"
@@ -30,27 +30,27 @@ import (
 // as syncing informer caches and starting workers. It will block until stopCh
 // is closed, at which point it will shutdown the workqueue and wait for
 // workers to finish processing their current work items.
-func (c *CStorPoolController) Run(threadiness int, stopCh <-chan struct{}) error {
+func (c *CStorPoolInstanceController) Run(threadiness int, stopCh <-chan struct{}) error {
 	defer runtime.HandleCrash()
 	defer c.workqueue.ShutDown()
 
 	// Start the informer factories to begin populating the informer caches
-	glog.Info("Starting CStorPool controller")
+	glog.Info("Starting CStorPoolInstance controller")
 
 	// Wait for the k8s caches to be synced before starting workers
 	glog.Info("Waiting for informer caches to sync")
-	if ok := cache.WaitForCacheSync(stopCh, c.cStorPoolSynced); !ok {
+	if ok := cache.WaitForCacheSync(stopCh, c.cStorPoolInstanceSynced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
-	glog.Info("Starting CStorPool workers")
-	// Launch worker to process CStorPool resources
+	glog.Info("Starting CStorPoolInstance workers")
+	// Launch worker to process CStorPoolInstance resources
 	for i := 0; i < threadiness; i++ {
 		go wait.Until(c.runWorker, common.ResourceWorkerInterval, stopCh)
 	}
 
-	glog.Info("Started CStorPool workers")
+	glog.Info("Started CStorPoolInstance workers")
 	<-stopCh
-	glog.Info("Shutting down CStorPool workers")
+	glog.Info("Shutting down CStorPoolInstance workers")
 
 	return nil
 }
@@ -58,14 +58,14 @@ func (c *CStorPoolController) Run(threadiness int, stopCh <-chan struct{}) error
 // runWorker is a long-running function that will continually call the
 // processNextWorkItem function in order to read and process a message on the
 // workqueue.
-func (c *CStorPoolController) runWorker() {
+func (c *CStorPoolInstanceController) runWorker() {
 	for c.processNextWorkItem() {
 	}
 }
 
 // processNextWorkItem will read a single work item off the workqueue and
 // attempt to process it, by calling the syncHandler.
-func (c *CStorPoolController) processNextWorkItem() bool {
+func (c *CStorPoolInstanceController) processNextWorkItem() bool {
 	obj, shutdown := c.workqueue.Get()
 	if shutdown {
 		return false
@@ -97,7 +97,7 @@ func (c *CStorPoolController) processNextWorkItem() bool {
 			return nil
 		}
 		// Run the reconcile, passing it the namespace/name string of the
-		// cStorPool resource to be synced.
+		// cStorPoolInstance resource to be synced.
 		if err := c.reconcile(q.Key); err != nil {
 			return fmt.Errorf("error syncing '%s': %s", q.Key, err.Error())
 		}

--- a/cmd/cstor-pool-mgmt/controller/cstor-pool-instance/utils.go
+++ b/cmd/cstor-pool-mgmt/controller/cstor-pool-instance/utils.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package poolcontroller
+package poolinstancecontroller
 
 import (
 	"os"
@@ -30,69 +30,69 @@ const (
 	PoolPrefix string = "cstor-"
 )
 
-// IsRightCStorPoolMgmt is to check if the pool request is for this pod.
-func IsRightCStorPoolMgmt(csp *apis.CStorPoolInstance) bool {
-	return os.Getenv(string(common.OpenEBSIOCStorID)) == string(csp.ObjectMeta.UID)
+// IsRightCStorPoolInstanceMgmt is to check if the pool request is for this pod.
+func IsRightCStorPoolInstanceMgmt(cspi *apis.CStorPoolInstance) bool {
+	return os.Getenv(string(common.OpenEBSIOCStorID)) == string(cspi.ObjectMeta.UID)
 }
 
-// IsDestroyed is to check if the call is for cStorPool destroy.
-func IsDestroyed(csp *apis.CStorPoolInstance) bool {
-	return csp.ObjectMeta.DeletionTimestamp != nil
+// IsDestroyed is to check if the call is for cStorPoolInstance destroy.
+func IsDestroyed(cspi *apis.CStorPoolInstance) bool {
+	return cspi.ObjectMeta.DeletionTimestamp != nil
 }
 
-// IsOnlyStatusChange is to check only status change of cStorPool object.
-func IsOnlyStatusChange(ocsp, ncsp *apis.CStorPoolInstance) bool {
-	if reflect.DeepEqual(ocsp.Spec, ncsp.Spec) &&
-		!reflect.DeepEqual(ocsp.Status, ncsp.Status) {
+// IsOnlyStatusChange is to check only status change of cStorPoolInstance object.
+func IsOnlyStatusChange(ocspi, ncspi *apis.CStorPoolInstance) bool {
+	if reflect.DeepEqual(ocspi.Spec, ncspi.Spec) &&
+		!reflect.DeepEqual(ocspi.Status, ncspi.Status) {
 		return true
 	}
 	return false
 }
 
-// IsStatusChange is to check only status change of cStorPool object.
+// IsStatusChange is to check only status change of cStorPoolInstance object.
 func IsStatusChange(oldStatus, newStatus apis.CStorPoolStatus) bool {
 	return !reflect.DeepEqual(oldStatus, newStatus)
 }
 
-// IsSyncEvent is to check if ResourceVersion of cStorPool object is not modifed.
-func IsSyncEvent(ocsp, ncsp *apis.CStorPoolInstance) bool {
-	return ncsp.ResourceVersion == ocsp.ResourceVersion
+// IsSyncEvent is to check if ResourceVersion of cStorPoolInstance object is not modifed.
+func IsSyncEvent(ocspi, ncspi *apis.CStorPoolInstance) bool {
+	return ncspi.ResourceVersion == ocspi.ResourceVersion
 }
 
-// IsEmptyStatus is to check if the status of cStorPool object is empty.
-func IsEmptyStatus(csp *apis.CStorPoolInstance) bool {
-	return csp.Status.Phase == apis.CStorPoolStatusEmpty
+// IsEmptyStatus is to check if the status of cStorPoolInstance object is empty.
+func IsEmptyStatus(cspi *apis.CStorPoolInstance) bool {
+	return cspi.Status.Phase == apis.CStorPoolStatusEmpty
 }
 
-// IsPendingStatus is to check if the status of cStorPool object is pending.
-func IsPendingStatus(csp *apis.CStorPoolInstance) bool {
-	return csp.Status.Phase == apis.CStorPoolStatusPending
+// IsPendingStatus is to check if the status of cStorPoolInstance object is pending.
+func IsPendingStatus(cspi *apis.CStorPoolInstance) bool {
+	return cspi.Status.Phase == apis.CStorPoolStatusPending
 }
 
-// IsErrorDuplicate is to check if the status of cStorPool object is error-duplicate.
-func IsErrorDuplicate(csp *apis.CStorPoolInstance) bool {
-	return csp.Status.Phase == apis.CStorPoolStatusErrorDuplicate
+// IsErrorDuplicate is to check if the status of cStorPoolInstance object is error-duplicate.
+func IsErrorDuplicate(cspi *apis.CStorPoolInstance) bool {
+	return cspi.Status.Phase == apis.CStorPoolStatusErrorDuplicate
 }
 
 // IsDeletionFailedBefore is to make sure no other operation should happen if the
-// status of cStorPool is deletion-failed.
-func IsDeletionFailedBefore(csp *apis.CStorPoolInstance) bool {
-	return csp.Status.Phase == apis.CStorPoolStatusDeletionFailed
+// status of cStorPoolInstance is deletion-failed.
+func IsDeletionFailedBefore(cspi *apis.CStorPoolInstance) bool {
+	return cspi.Status.Phase == apis.CStorPoolStatusDeletionFailed
 }
 
 // IsUIDSet check if UID is set or not
-func IsUIDSet(csp *apis.CStorPoolInstance) bool {
-	return len(csp.ObjectMeta.UID) != 0
+func IsUIDSet(cspi *apis.CStorPoolInstance) bool {
+	return len(cspi.ObjectMeta.UID) != 0
 }
 
 // IsReconcileDisabled check if reconciliation is disabled for given object or not
-func IsReconcileDisabled(csp *apis.CStorPoolInstance) bool {
-	return csp.Annotations[string(apis.OpenEBSDisableReconcileKey)] == "true"
+func IsReconcileDisabled(cspi *apis.CStorPoolInstance) bool {
+	return cspi.Annotations[string(apis.OpenEBSDisableReconcileKey)] == "true"
 }
 
-// IsHostNameChanged check if hostname for CSP object is changed
-func IsHostNameChanged(ocsp, ncsp *apis.CStorPoolInstance) bool {
-	return ncsp.Spec.HostName != ocsp.Spec.HostName
+// IsHostNameChanged check if hostname for CSPI object is changed
+func IsHostNameChanged(ocspi, ncspi *apis.CStorPoolInstance) bool {
+	return ncspi.Spec.HostName != ocspi.Spec.HostName
 }
 
 // IsEmpty check if string is empty or not
@@ -110,7 +110,7 @@ func ErrorWrapf(err error, format string, args ...interface{}) error {
 	return errors.Wrapf(err, format, args...)
 }
 
-// PoolName return pool name for given CSP object
-func PoolName(csp *apis.CStorPoolInstance) string {
-	return PoolPrefix + string(csp.ObjectMeta.UID)
+// PoolName return pool name for given CSPI object
+func PoolName(cspi *apis.CStorPoolInstance) string {
+	return PoolPrefix + string(cspi.ObjectMeta.UID)
 }

--- a/cmd/cstor-pool-mgmt/controller/start-controller/controller.go
+++ b/cmd/cstor-pool-mgmt/controller/start-controller/controller.go
@@ -39,9 +39,9 @@ import (
 	informers "github.com/openebs/maya/pkg/client/generated/informers/externalversions"
 	"github.com/openebs/maya/pkg/signals"
 
-	poolcontroller1 "github.com/openebs/maya/cmd/cstor-pool-mgmt/controller/pool-controller"
+	poolcontroller "github.com/openebs/maya/cmd/cstor-pool-mgmt/controller/pool-controller"
 	//poolcontroller2 "github.com/openebs/maya/cmd/cstor-pool-mgmt/controller/new-pool-controller"
-	poolcontroller "github.com/openebs/maya/cmd/cstor-pool-mgmt/controller/cstor-pool-instance"
+	poolcontrollerinstance "github.com/openebs/maya/cmd/cstor-pool-mgmt/controller/cstor-pool-instance"
 	//// for v1alpha2
 	//clientset2 "github.com/openebs/maya/pkg/client/generated/openebs.io/v1alpha2/clientset/internalclientset"
 	//informers2 "github.com/openebs/maya/pkg/client/generated/openebs.io/v1alpha2/informer/externalversions"
@@ -111,13 +111,12 @@ func StartControllers(kubeconfig string) {
 	// openebsInformerFactory2 constructs a new instance of openebs sharedInformerFactory.
 	//openebsInformerFactory2 := informers.NewSharedInformerFactory(openebsClient2, getSyncInterval())
 
-	//TODO: Remove below code
 	//// Instantiate the cStor Pool and VolumeReplica controllers.
-	cStorPoolController1 := poolcontroller1.NewCStorPoolController(kubeClient, openebsClient, kubeInformerFactory,
+	cStorPoolController := poolcontroller.NewCStorPoolController(kubeClient, openebsClient, kubeInformerFactory,
 		openebsInformerFactory)
 
-	// Instantiate the cStor Pool and VolumeReplica controllers.
-	cStorPoolController := poolcontroller.NewCStorPoolController(kubeClient, openebsClient, kubeInformerFactory,
+	// Instantiate the cStor Pool Instance and VolumeReplica controllers.
+	cStorPoolInstanceController := poolcontrollerinstance.NewCStorPoolInstanceController(kubeClient, openebsClient, kubeInformerFactory,
 		openebsInformerFactory)
 
 	volumeReplicaController := replicacontroller.NewCStorVolumeReplicaController(kubeClient, openebsClient, kubeInformerFactory,
@@ -142,7 +141,7 @@ func StartControllers(kubeconfig string) {
 
 	// Run controller for cStorPool.
 	go func() {
-		if err = cStorPoolController1.Run(NumThreads, stopCh); err != nil {
+		if err = cStorPoolController.Run(NumThreads, stopCh); err != nil {
 			glog.Fatalf("Error running CStorPool controller: %s", err.Error())
 		}
 		wg.Done()
@@ -152,7 +151,7 @@ func StartControllers(kubeconfig string) {
 
 	// Run controller for cStorPool.
 	go func() {
-		if err = cStorPoolController.Run(NumThreads, stopCh); err != nil {
+		if err = cStorPoolInstanceController.Run(NumThreads, stopCh); err != nil {
 			glog.Fatalf("Error running CStorPool controller: %s", err.Error())
 		}
 		wg.Done()


### PR DESCRIPTION
A new controller for new schema `CStorPoolInstance` has been added to maya. But, the variable names that are used for same are still as 'csp' or 'cstorpool' etc.

This PR is to change the variable/structure/function names in cmd/cstor-pool-mgmt/controller/cstor-pool-instance from csp/CStorPool to cspi/CStorPoolInstance.

This doesn't change any schema related things.

Signed-off-by: Vitta <vitta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests