### PR TITLE
fix(csp): create pool if status is Init or PoolCreationFailed

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
@@ -157,7 +157,7 @@ func (c *CStorPoolController) cStorPoolEventHandler(operation common.QueueOperat
 		if IsCStorPoolCreateStatuses(cStorPoolGot) {
 			return c.cStorPoolCreate(cStorPoolGot)
 		}
-		if isPendingStatus(cStorPoolGot) {
+		if IsPendingStatus(cStorPoolGot) {
 			status, err := c.cStorPoolAddEventHandler(cStorPoolGot)
 			return status, err
 		}
@@ -206,7 +206,7 @@ func (c *CStorPoolController) cStorPoolCreate(cStorPoolGot *apis.CStorPool) (str
 	return string(apis.CStorPoolStatusOnline), nil
 }
 
-// cStorPoolAddEvent does import of pool, and, if it fails, attemps to create pool based on CSP CR state
+// cStorPoolAddEvent does import of pool
 func (c *CStorPoolController) cStorPoolAddEvent(cStorPoolGot *apis.CStorPool) (string, error) {
 	if pool.ImportedCStorPools == nil {
 		pool.ImportedCStorPools = map[string]*apis.CStorPool{}
@@ -254,7 +254,7 @@ func (c *CStorPoolController) cStorPoolAddEvent(cStorPoolGot *apis.CStorPool) (s
 		if common.CheckIfPresent(existingPool, string(pool.PoolPrefix)+string(cStorPoolGot.GetUID())) {
 			// In the last attempt, ignore and update the status.
 			if i == cnt-1 {
-				if isPendingStatus(cStorPoolGot) || isEmptyStatus(cStorPoolGot) {
+				if IsPendingStatus(cStorPoolGot) || IsEmptyStatus(cStorPoolGot) {
 					// Pool CR status is init. This means pool deployment was done
 					// successfully, but before updating the CR to Online status,
 					// the watcher container got restarted.
@@ -472,7 +472,7 @@ func IsCStorPoolCreateStatuses(cstorPool *apis.CStorPool) bool {
 }
 
 // IsEmptyStatus is to check if the status of cStorPool object is empty.
-func isEmptyStatus(cStorPool *apis.CStorPool) bool {
+func IsEmptyStatus(cStorPool *apis.CStorPool) bool {
 	if string(cStorPool.Status.Phase) == string(apis.CStorPoolStatusEmpty) {
 		glog.Infof("cStorPool empty status: %v", string(cStorPool.ObjectMeta.UID))
 		return true
@@ -481,8 +481,8 @@ func isEmptyStatus(cStorPool *apis.CStorPool) bool {
 	return false
 }
 
-// isPendingStatus is to check if the status of cStorPool object is pending.
-func isPendingStatus(cStorPool *apis.CStorPool) bool {
+// IsPendingStatus is to check if the status of cStorPool object is pending.
+func IsPendingStatus(cStorPool *apis.CStorPool) bool {
 	if string(cStorPool.Status.Phase) == string(apis.CStorPoolStatusPending) {
 		glog.Infof("cStorPool pending: %v", string(cStorPool.ObjectMeta.UID))
 		return true

--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
@@ -188,7 +188,6 @@ func (c *CStorPoolController) cStorPoolCreate(cStorPoolGot *apis.CStorPool) (str
 		return string(apis.CStorPoolStatusCreateFailed), err
 	}
 
-	// IsInitStatus is to check if initial status of cstorpool object is `init`.
 	if len(common.InitialImportedPoolVol) != 0 {
 		glog.Errorf("failed to handle add event: invalid status %v for pool %v with existing volumes", string(cStorPoolGot.Status.Phase), string(cStorPoolGot.GetUID()))
 		c.recorder.Event(cStorPoolGot, corev1.EventTypeWarning, string(common.FailureValidate), string(common.MessageImproperPoolStatus))

--- a/cmd/cstor-pool-mgmt/controller/pool-controller/new_pool_controller.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/new_pool_controller.go
@@ -123,7 +123,11 @@ func NewCStorPoolController(
 			q.Operation = common.QOpAdd
 			glog.Infof("cStorPool Added event : %v, %v", cStorPool.ObjectMeta.Name, string(cStorPool.ObjectMeta.UID))
 			controller.recorder.Event(cStorPool, corev1.EventTypeNormal, string(common.SuccessSynced), string(common.MessageCreateSynced))
-			cStorPool.Status.Phase = apis.CStorPoolStatusPending
+
+			if !IsCStorPoolCreateStatuses(cStorPool) {
+				cStorPool.Status.Phase = apis.CStorPoolStatusPending
+			}
+
 			cStorPool, _ = controller.clientset.OpenebsV1alpha1().CStorPools().Update(cStorPool)
 			controller.enqueueCStorPool(cStorPool, q)
 		},

--- a/pkg/apis/openebs.io/v1alpha1/cstor_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_pool.go
@@ -76,11 +76,10 @@ type CStorPoolAttr struct {
 type CStorPoolPhase string
 
 // Status written onto CStorPool and CStorVolumeReplica objects.
-// Resetting state to either Empty or Pending need to be done with care,
+// Resetting state to either Init or CreateFailed need to be done with care,
 // as, label clear and pool creation depends on this state.
 const (
 	// CStorPoolStatusEmpty ensures the create operation is to be done, if import fails.
-	// Check comment
 	CStorPoolStatusEmpty CStorPoolPhase = ""
 	// CStorPoolStatusOnline signifies that the pool is online.
 	CStorPoolStatusOnline CStorPoolPhase = "Healthy"
@@ -103,8 +102,11 @@ const (
 	// CStorPoolStatusErrorDuplicate ensures error due to duplicate resource.
 	CStorPoolStatusErrorDuplicate CStorPoolPhase = "ErrorDuplicate"
 	// CStorPoolStatusPending ensures pending task for cstorpool.
-	// Check comment
 	CStorPoolStatusPending CStorPoolPhase = "Pending"
+	// CStorPoolStatusInit is initial state of CSP, before pool creation.
+	CStorPoolStatusInit CStorPoolPhase = "Init"
+	// CStorPoolStatusCreateFailed is state when pool creation failed
+	CStorPoolStatusCreateFailed CStorPoolPhase = "PoolCreationFailed"
 )
 
 // CStorPoolStatus is for handling status of pool.


### PR DESCRIPTION
CSP mgmt creates pool if pool import fails. This can cause data loss if disk is not accessible momentarily just at the time of import.
However, pool creation need to be declarative rather than 'if-else' logic which can be design buggy and prone to errors.

This PR looks for Status.Phase as 'Init' or 'PoolCreationFailed' to create the pool. If Status.Phase is any other string, csp mgmt will try to import the pool.

This can cause impact to the current workflow of Ephemeral disks, which works as of now, as NDM can't detect it as different disk and recognizes as previous disk.

Signed-off-by: Vitta <vitta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests