### PR TITLE
chore(cspc,cspi) : make zpool names same for all pools of a given CSPC

### DIFF
--- a/cmd/cspc-operator/app/start.go
+++ b/cmd/cspc-operator/app/start.go
@@ -126,6 +126,7 @@ func getSyncInterval() time.Duration {
 	resyncInterval, err := strconv.Atoi(os.Getenv("RESYNC_INTERVAL"))
 	if err != nil || resyncInterval == 0 {
 		glog.Warningf("Incorrect resync interval %q obtained from env, defaulting to %q seconds", resyncInterval, ResyncInterval)
+		return ResyncInterval
 	}
 	return time.Duration(resyncInterval) * time.Second
 }

--- a/cmd/cspi-mgmt/app/utils.go
+++ b/cmd/cspi-mgmt/app/utils.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"reflect"
 
-	"github.com/openebs/maya/cmd/cstor-pool-mgmt/controller/common"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	"github.com/pkg/errors"
 )
@@ -28,11 +27,14 @@ import (
 const (
 	// PoolPrefix is prefix for pool name
 	PoolPrefix string = "cstor-"
+	// OpenEBSIOCSPIID is the environment variable specified in pod.
+	// It holds the UID of the CSPI
+	OpenEBSIOCSPIID string = "OPENEBS_IO_CSPI_ID"
 )
 
 // IsRightCStorPoolInstanceMgmt is to check if the pool request is for this pod.
 func IsRightCStorPoolInstanceMgmt(cspi *apis.CStorPoolInstance) bool {
-	return os.Getenv(string(common.OpenEBSIOCStorID)) == string(cspi.ObjectMeta.UID)
+	return os.Getenv(string(OpenEBSIOCSPIID)) == string(cspi.GetUID())
 }
 
 // IsDestroyed is to check if the call is for cStorPoolInstance destroy.

--- a/pkg/apis/openebs.io/v1alpha1/cstor_volume.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_volume.go
@@ -68,46 +68,6 @@ type CStorVolumeStatus struct {
 	Conditions []CStorVolumeCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,4,rep,name=conditions"`
 }
 
-// CStorVolumeCondition contains details about state of cstorvolume
-type CStorVolumeCondition struct {
-	Type   CStorVolumeConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=CStorVolumeConditionType"`
-	Status ConditionStatus          `json:"status" protobuf:"bytes,2,opt,name=status,casttype=ConditionStatus"`
-	// Last time we probed the condition.
-	// +optional
-	LastProbeTime metav1.Time `json:"lastProbeTime,omitempty" protobuf:"bytes,3,opt,name=lastProbeTime"`
-	// Last time the condition transitioned from one status to another.
-	// +optional
-	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty" protobuf:"bytes,4,opt,name=lastTransitionTime"`
-	// Unique, this should be a short, machine understandable string that gives the reason
-	// for condition's last transition. If it reports "ResizePending" that means the underlying
-	// cstorvolume is being resized.
-	// +optional
-	Reason string `json:"reason,omitempty" protobuf:"bytes,5,opt,name=reason"`
-	// Human-readable message indicating details about last transition.
-	// +optional
-	Message string `json:"message,omitempty" protobuf:"bytes,6,opt,name=message"`
-}
-
-// CStorVolumeConditionType is a valid value of CStorVolumeCondition.Type
-type CStorVolumeConditionType string
-
-const (
-	// CStorVolumeResizing - a user trigger resize of pvc has been started
-	CStorVolumeResizing CStorVolumeConditionType = "Resizing"
-)
-
-// ConditionStatus states in which state condition is present
-type ConditionStatus string
-
-const (
-	//ConditionInProgress means corresponding operation is inprogress.
-	ConditionInProgress ConditionStatus = "InProgress"
-	// ConditionSuccess means corresponding condition is success
-	ConditionSuccess ConditionStatus = "Success"
-	// ConditionFailure means corresponding condition is failure
-	ConditionFailure ConditionStatus = "Failure"
-)
-
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +resource:path=cstorvolume
 

--- a/pkg/kubernetes/container/v1alpha1/container.go
+++ b/pkg/kubernetes/container/v1alpha1/container.go
@@ -358,6 +358,33 @@ func (b *Builder) WithEnvsNew(envs []corev1.EnvVar) *Builder {
 	return b
 }
 
+// WithEnvs sets the envs of the container
+func (b *Builder) WithEnvs(envs []corev1.EnvVar) *Builder {
+	if envs == nil {
+		b.errors = append(
+			b.errors,
+			errors.New("failed to build container object: nil envs"),
+		)
+		return b
+	}
+
+	if len(envs) == 0 {
+		b.errors = append(
+			b.errors,
+			errors.New("failed to build container object: missing envs"),
+		)
+		return b
+	}
+
+	if b.con.Env == nil {
+		b.WithEnvsNew(envs)
+		return b
+	}
+
+	b.con.Env = append(b.con.Env, envs...)
+	return b
+}
+
 // WithLivenessProbe sets the liveness probe of the container
 func (b *Builder) WithLivenessProbe(liveness *corev1.Probe) *Builder {
 	if liveness == nil {


### PR DESCRIPTION
This PR will do following :

1. Make zpool names same for all pools of a given CSPC.

2. Apart from above, it fixes a minor bug by putting proper image name
   for CSPI deployment.

3. It introduces env vars to tune cspc-operator resync interval and images
   for cspi-mgmt.

Signed-off-by: Ashutosh Kumar <ashutosh.kumar@openebs.io>