### PR TITLE
fix(cvr,cvc): use CSPI UID for volume replica creation

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/common/common.go
+++ b/cmd/cstor-pool-mgmt/controller/common/common.go
@@ -139,6 +139,10 @@ type Environment string
 const (
 	// OpenEBSIOCStorID is the environment variable specified in pod.
 	OpenEBSIOCStorID Environment = "OPENEBS_IO_CSTOR_ID"
+
+	// OpenEBSIOCSPIID is the environment variable specified in pod.
+	// It holds the UID of the CSPI
+	OpenEBSIOCSPIID string = "OPENEBS_IO_CSPI_ID"
 )
 
 // QueueOperation determines the type of operation
@@ -181,13 +185,13 @@ func PoolNameHandler(cVR *apis.CStorVolumeReplica, cnt int) bool {
 	for i := 0; ; i++ {
 		poolname, _ := pool.GetPoolName()
 		if reflect.DeepEqual(poolname, []string{}) ||
-			!CheckIfPresent(poolname, string(pool.PoolPrefix)+cVR.Labels["cstorpool.openebs.io/uid"]) {
+			!CheckIfPresent(poolname, string(pool.PoolPrefix)+cVR.Labels["cstorpoolinstance.openebs.io/uid"]) {
 			glog.Warningf("Attempt %v: No pool found", i+1)
 			time.Sleep(PoolNameHandlerInterval)
 			if i > cnt {
 				return false
 			}
-		} else if CheckIfPresent(poolname, string(pool.PoolPrefix)+cVR.Labels["cstorpool.openebs.io/uid"]) {
+		} else if CheckIfPresent(poolname, string(pool.PoolPrefix)+cVR.Labels["cstorpoolinstance.openebs.io/uid"]) {
 			return true
 		}
 	}

--- a/cmd/cstor-pool-mgmt/controller/common/common_test.go
+++ b/cmd/cstor-pool-mgmt/controller/common/common_test.go
@@ -158,8 +158,8 @@ func TestPoolNameHandler(t *testing.T) {
 					Name: "VolumeReplicaResource1",
 					UID:  "abcd123",
 					Labels: map[string]string{
-						"cstorpool.openebs.io/uid":  "123abc",
-						"cstorpool.openebs.io/name": "cstor-123abc",
+						"cstorpoolinstance.openebs.io/uid":  "123abc",
+						"cstorpoolinstance.openebs.io/name": "cstor-123abc",
 					},
 				},
 				Spec: apis.CStorVolumeReplicaSpec{

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -160,7 +160,7 @@ func (c *CStorVolumeReplicaController) cVREventHandler(
 	// cvr is created at zfs in the form poolname/volname
 	fullVolName :=
 		string(pool.PoolPrefix) +
-			cvrObj.Labels["cstorpool.openebs.io/uid"] + "/" +
+			cvrObj.Labels["cstorpoolinstance.openebs.io/uid"] + "/" +
 			cvrObj.Labels["cstorvolume.openebs.io/name"]
 
 	switch operation {
@@ -382,10 +382,10 @@ func (c *CStorVolumeReplicaController) getVolumeReplicaResource(
 // IsRightCStorVolumeReplica is to check if the cvr
 // request is for particular pod/application.
 func IsRightCStorVolumeReplica(cVR *apis.CStorVolumeReplica) bool {
-	if os.Getenv(string(common.OpenEBSIOCStorID)) == string(cVR.ObjectMeta.Labels["cstorpool.openebs.io/uid"]) {
+	if os.Getenv(string(common.OpenEBSIOCSPIID)) == string(cVR.ObjectMeta.Labels["cstorpoolinstance.openebs.io/uid"]) {
 		return true
 	}
-	return false
+	return os.Getenv(string(common.OpenEBSIOCStorID)) == string(cVR.ObjectMeta.Labels["cstorpool.openebs.io/uid"])
 }
 
 // IsDestroyEvent is to check if the call is for CStorVolumeReplica destroy.

--- a/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
+++ b/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
@@ -63,7 +63,7 @@ const (
 
 const (
 	// CStorPoolUIDKey is the key for csp object uid which is present in cvr labels.
-	CStorPoolUIDKey = "cstorpool.openebs.io/uid"
+	CStorPoolUIDKey = "cstorpoolinstance.openebs.io/uid"
 	// PvNameKey is the key for pv object uid which is present in cvr labels.
 	PvNameKey = "cstorvolume.openebs.io/name"
 	// PoolPrefix is the prefix of zpool name.
@@ -114,7 +114,7 @@ func CheckValidVolumeReplica(cVR *apis.CStorVolumeReplica) error {
 		err = fmt.Errorf("Capacity cannot be empty")
 		return err
 	}
-	if len(cVR.Labels["cstorpool.openebs.io/uid"]) == 0 {
+	if len(cVR.Labels["cstorpoolinstance.openebs.io/uid"]) == 0 {
 		err = fmt.Errorf("Pool cannot be empty")
 		return err
 	}

--- a/cmd/cstorvolumeclaim/cstorvolumeclaim.go
+++ b/cmd/cstorvolumeclaim/cstorvolumeclaim.go
@@ -117,18 +117,18 @@ func getTargetServiceOwnerReference(claim *apis.CStorVolumeClaim) []metav1.Owner
 // getCVRLabels get the labels for cstorvolumereplica
 func getCVRLabels(pool *apis.CStorPoolInstance, volumeName string) map[string]string {
 	return map[string]string{
-		"cstorpool.openebs.io/name":    pool.Name,
-		"cstorpool.openebs.io/uid":     string(pool.UID),
-		"cstorvolume.openebs.io/name":  volumeName,
-		"openebs.io/persistent-volume": volumeName,
-		"openebs.io/version":           version.GetVersion(),
+		"cstorpoolinstance.openebs.io/name": pool.Name,
+		"cstorpoolinstance.openebs.io/uid":  string(pool.UID),
+		"cstorvolume.openebs.io/name":       volumeName,
+		"openebs.io/persistent-volume":      volumeName,
+		"openebs.io/version":                version.GetVersion(),
 	}
 }
 
 // getCVRAnnotations get the annotations for cstorvolumereplica
 func getCVRAnnotations(pool *apis.CStorPoolInstance) map[string]string {
 	return map[string]string{
-		"cstorpool.openebs.io/hostname": pool.Labels["kubernetes.io/hostname"],
+		"cstorpoolinstance.openebs.io/hostname": pool.Labels["kubernetes.io/hostname"],
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- to get the pool UID update CVR annotations/labels to
  "cstorpoolinstance.openebs.io" instead of "cstorpool.openebs.io"
  as cstorPoolInstance resource.


**Special notes for your reviewer**:


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [x] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests
Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>