### PR TITLE
fix(installer): skip recreation of storage class and spc resources by maya-apiserver

### DIFF
--- a/pkg/client/k8s/v1alpha1/resource.go
+++ b/pkg/client/k8s/v1alpha1/resource.go
@@ -226,7 +226,7 @@ func (r *createOrUpdate) Apply(obj *unstructured.Unstructured, subresources ...s
 	// in case if they are already present in the cluster
 	if !r.ForceOverWrite {
 		glog.Infof(
-			"skip updation of resource {%s/%s} in namespace {%s}"+
+			"skip updation of resource {%s/%s} in namespace {%s}, "+
 				"since resource already exists in cluster",
 			resource.GroupVersionKind(),
 			resource.GetName(),

--- a/pkg/client/k8s/v1alpha1/resource.go
+++ b/pkg/client/k8s/v1alpha1/resource.go
@@ -22,6 +22,7 @@ package v1alpha1
 import (
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -217,6 +218,17 @@ func (r *createOrUpdate) Apply(obj *unstructured.Unstructured, subresources ...s
 			return r.options.Creator.Create(obj, subresources...)
 		}
 		return nil, err
+	}
+	// NOTE: We are returning same unstructured object in case if spc and sc are
+	// already installed
+	if obj.GetKind() == "StoragePoolClaim" || obj.GetKind() == "StorageClass" {
+		glog.Infof(
+			"{%s/%s} already exist in cluster",
+			obj.GroupVersionKind(),
+			obj.GetName(),
+		)
+		resource, err = obj, nil
+		return
 	}
 	return r.options.Updater.Update(resource, obj, subresources...)
 }

--- a/pkg/install/v1alpha1/installer.go
+++ b/pkg/install/v1alpha1/installer.go
@@ -114,7 +114,7 @@ func (i *simpleInstaller) Install() []error {
 		cu := k8s.CreateOrUpdate(k8s.GroupVersionResourceFromGVK(unstruct), unstruct.GetNamespace())
 		cu.ForceOverWrite = CanResourceOverWrite(unstruct.GetKind())
 		u, err := cu.Apply(unstruct)
-		if err == nil && !cu.ForceOverWrite {
+		if err == nil && cu.ForceOverWrite {
 			glog.V(2).Infof(
 				"{%s/%s} installed successfully at namespace {%s}",
 				u.GroupVersionKind(),


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR skip installation of user end resources(storageclass and 
storagepoolclaim) by maya-apiserver i.e if SC or SPC are already
exist in the cluster maya-apiserver will skip installation of those resources.

*Example logs of maya-apiserver*:
```
I0825 18:11:33.121167       6 start.go:287] Starting maya api server ...
I0825 18:11:33.970135       6 resource.go:225] {storage.k8s.io/v1, Kind=StorageClass/openebs-jiva-default} already exist in cluster
I0825 18:11:34.435542       6 resource.go:225] {storage.k8s.io/v1, Kind=StorageClass/openebs-cstor-sparse} already exist in cluster
I0825 18:11:34.439773       6 resource.go:225] {openebs.io/v1alpha1, Kind=StoragePoolClaim/cstor-sparse-pool} already exist in cluster
I0825 18:11:34.445678       6 resource.go:225] {storage.k8s.io/v1, Kind=StorageClass/openebs-snapshot-promoter} already exist in cluster
I0825 18:11:34.668265       6 resource.go:225] {storage.k8s.io/v1, Kind=StorageClass/openebs-hostpath} already exist in cluster
I0825 18:11:34.675191       6 resource.go:225] {storage.k8s.io/v1, Kind=StorageClass/openebs-device} already exist in cluster
```


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes This PR fixes https://github.com/openebs/openebs/issues/2665

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests