### PR TITLE
fix(cvr,cspc,cspi): use Pool env to get the pool instance uid

### DIFF
--- a/cmd/cspc-operator/app/storagepool_create.go
+++ b/cmd/cspc-operator/app/storagepool_create.go
@@ -127,7 +127,7 @@ func (pc *PoolConfig) GetPoolDeploySpec(csp *apis.CStorPoolInstance) (*appsv1.De
 						WithImagePullPolicy(corev1.PullIfNotPresent).
 						WithPrivilegedSecurityContext(&privileged).
 						WithEnvsNew(getPoolMgmtEnv(csp)).
-						WithEnvs(getCSPIUIDAsEnv(pc.AlgorithmConfig.CSPC)).
+						WithEnvs(getPoolUIDAsEnv(pc.AlgorithmConfig.CSPC)).
 						// TODO : Resource and Limit
 						WithVolumeMountsNew(getPoolMgmtMounts()),
 					// For CStor-Pool container
@@ -140,7 +140,7 @@ func (pc *PoolConfig) GetPoolDeploySpec(csp *apis.CStorPoolInstance) (*appsv1.De
 						WithPortsNew(getContainerPort(12000, 3232, 3233)).
 						WithLivenessProbe(getPoolLivenessProbe()).
 						WithEnvsNew(getPoolEnv(csp)).
-						WithEnvs(getCSPIUIDAsEnv(pc.AlgorithmConfig.CSPC)).
+						WithEnvs(getPoolUIDAsEnv(pc.AlgorithmConfig.CSPC)).
 						WithLifeCycle(getPoolLifeCycle()).
 						WithVolumeMountsNew(getPoolMounts()),
 					// For maya exporter
@@ -296,7 +296,7 @@ func getSparseDirPath() string {
 	return dir
 }
 
-func getCSPIUIDAsEnv(cspc *apis.CStorPoolCluster) []corev1.EnvVar {
+func getPoolUIDAsEnv(cspc *apis.CStorPoolCluster) []corev1.EnvVar {
 	var env []corev1.EnvVar
 	return append(
 		env,

--- a/cmd/cstor-pool-mgmt/controller/common/common.go
+++ b/cmd/cstor-pool-mgmt/controller/common/common.go
@@ -139,9 +139,11 @@ type Environment string
 const (
 	// OpenEBSIOCStorID is the environment variable specified in pod.
 	OpenEBSIOCStorID Environment = "OPENEBS_IO_CSTOR_ID"
-	// OpenEBSIOCSPIID is the environment variable specified in pod.
+	// OpenEBSIOCSPIID is cstorpoolinstance name as environment variable
+	// specified in pool instance pods.
 	OpenEBSIOCSPIID Environment = "OPENEBS_IO_CSPI_ID"
-	// OpenEBSIOPoolName is the environment variable specified in pod.
+	// OpenEBSIOPoolName is cstorpoolcluster name as environment variable
+	// specified in pod instance pods.
 	OpenEBSIOPoolName Environment = "OPENEBS_IO_POOL_NAME"
 )
 

--- a/cmd/cstor-pool-mgmt/controller/common/common.go
+++ b/cmd/cstor-pool-mgmt/controller/common/common.go
@@ -139,6 +139,10 @@ type Environment string
 const (
 	// OpenEBSIOCStorID is the environment variable specified in pod.
 	OpenEBSIOCStorID Environment = "OPENEBS_IO_CSTOR_ID"
+	// OpenEBSIOCSPIID is the environment variable specified in pod.
+	OpenEBSIOCSPIID Environment = "OPENEBS_IO_CSPI_ID"
+	// OpenEBSIOPoolName is the environment variable specified in pod.
+	OpenEBSIOPoolName Environment = "OPENEBS_IO_POOL_NAME"
 )
 
 // QueueOperation determines the type of operation
@@ -181,13 +185,13 @@ func PoolNameHandler(cVR *apis.CStorVolumeReplica, cnt int) bool {
 	for i := 0; ; i++ {
 		poolname, _ := pool.GetPoolName()
 		if reflect.DeepEqual(poolname, []string{}) ||
-			!CheckIfPresent(poolname, string(pool.PoolPrefix)+cVR.Labels["cstorpool.openebs.io/uid"]) {
+			!CheckIfPresent(poolname, volumereplica.PoolNameFromCVR(cVR)) {
 			glog.Warningf("Attempt %v: No pool found", i+1)
 			time.Sleep(PoolNameHandlerInterval)
 			if i > cnt {
 				return false
 			}
-		} else if CheckIfPresent(poolname, string(pool.PoolPrefix)+cVR.Labels["cstorpool.openebs.io/uid"]) {
+		} else if CheckIfPresent(poolname, volumereplica.PoolNameFromCVR(cVR)) {
 			return true
 		}
 	}
@@ -259,7 +263,7 @@ func CheckForCStorPool() {
 			time.Sleep(PoolNameHandlerInterval)
 			continue
 		}
-		glog.Info("CStorPool found")
+		glog.Infof("CStorPool found %v", poolname)
 		break
 	}
 }

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -160,7 +160,6 @@ func (c *CStorVolumeReplicaController) cVREventHandler(
 	// cvr is created at zfs in the form poolname/volname
 	fullVolName :=
 		volumereplica.PoolNameFromCVR(cvrObj) + "/" +
-			//cvrObj.Labels["cstorpool.openebs.io/uid"] + "/" +
 			cvrObj.Labels["cstorvolume.openebs.io/name"]
 
 	switch operation {
@@ -379,32 +378,16 @@ func (c *CStorVolumeReplicaController) getVolumeReplicaResource(
 	return cStorVolumeReplicaUpdated, nil
 }
 
-/*
-func PoolName(cvr *apis.CStorVolumeReplica) string {
-	if string(cvr.ObjectMeta.Labels["cstorpool.openebs.io/uid"]) != "" {
-		return cvr.Labels["cstorpool.openebs.io/uid"]
-	}
-	if string(cvr.ObjectMeta.Labels["cstorpoolinstance.openebs.io/uid"]) != "" {
-		return os.Getenv(string(common.OpenEBSIOPoolName))
-	}
-	return ""
-}
-*/
-
 // IsRightCStorVolumeReplica is to check if the cvr
 // request is for particular pod/application.
 func IsRightCStorVolumeReplica(cVR *apis.CStorVolumeReplica) bool {
 	if strings.TrimSpace(string(cVR.ObjectMeta.Labels["cstorpool.openebs.io/uid"])) != "" {
-		if os.Getenv(string(common.OpenEBSIOCStorID)) == string(cVR.ObjectMeta.Labels["cstorpool.openebs.io/uid"]) {
-			return true
-		}
-		return false
+		return os.Getenv(string(common.OpenEBSIOCStorID)) ==
+			string(cVR.ObjectMeta.Labels["cstorpool.openebs.io/uid"])
 	}
 	if strings.TrimSpace(string(cVR.ObjectMeta.Labels["cstorpoolinstance.openebs.io/uid"])) != "" {
-		if os.Getenv(string(common.OpenEBSIOCSPIID)) == string(cVR.ObjectMeta.Labels["cstorpoolinstance.openebs.io/uid"]) {
-			return true
-		}
-		return false
+		return os.Getenv(string(common.OpenEBSIOCSPIID)) ==
+			string(cVR.ObjectMeta.Labels["cstorpoolinstance.openebs.io/uid"])
 	}
 	return false
 }

--- a/cmd/cstor-pool-mgmt/pool/v1alpha2/utils.go
+++ b/cmd/cstor-pool-mgmt/pool/v1alpha2/utils.go
@@ -17,6 +17,9 @@ limitations under the License.
 package v1alpha2
 
 import (
+	"os"
+
+	"github.com/openebs/maya/cmd/cstor-pool-mgmt/controller/common"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	"github.com/pkg/errors"
 )
@@ -38,7 +41,7 @@ func ErrorWrapf(err error, format string, args ...interface{}) error {
 
 // PoolName return pool name for given CSP object
 func PoolName(csp *apis.CStorPoolInstance) string {
-	return PoolPrefix + string(csp.ObjectMeta.UID)
+	return PoolPrefix + os.Getenv(string(common.OpenEBSIOPoolName))
 }
 
 // IsEmpty check if string is empty or not

--- a/cmd/cstorvolumeclaim/cstorvolumeclaim.go
+++ b/cmd/cstorvolumeclaim/cstorvolumeclaim.go
@@ -117,18 +117,18 @@ func getTargetServiceOwnerReference(claim *apis.CStorVolumeClaim) []metav1.Owner
 // getCVRLabels get the labels for cstorvolumereplica
 func getCVRLabels(pool *apis.CStorPoolInstance, volumeName string) map[string]string {
 	return map[string]string{
-		"cstorpool.openebs.io/name":    pool.Name,
-		"cstorpool.openebs.io/uid":     string(pool.UID),
-		"cstorvolume.openebs.io/name":  volumeName,
-		"openebs.io/persistent-volume": volumeName,
-		"openebs.io/version":           version.GetVersion(),
+		"cstorpoolinstance.openebs.io/name": pool.Name,
+		"cstorpoolinstance.openebs.io/uid":  string(pool.UID),
+		"cstorvolume.openebs.io/name":       volumeName,
+		"openebs.io/persistent-volume":      volumeName,
+		"openebs.io/version":                version.GetVersion(),
 	}
 }
 
 // getCVRAnnotations get the annotations for cstorvolumereplica
 func getCVRAnnotations(pool *apis.CStorPoolInstance) map[string]string {
 	return map[string]string{
-		"cstorpool.openebs.io/hostname": pool.Labels["kubernetes.io/hostname"],
+		"cstorpoolinstance.openebs.io/hostname": pool.Labels["kubernetes.io/hostname"],
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Changes will add the env `OPENSBS_IO_POOL_NAME`  to get the `cstorPoolInstance` uid in case of cspc and csi based volumes provisioning.

**Special notes for your reviewer**:
- Above changes are done taking care with backward compatibilities for
  older way of provisioning.
- `OPENSBS_IO_POOL_NAME` env has to be added in case of backup and restore controllers.

## CstorVolumeReplica resource:
```
k get cvr -oyaml
apiVersion: v1
items:
- apiVersion: openebs.io/v1alpha1
  kind: CStorVolumeReplica
  metadata:
    annotations:
      cstorpoolinstance.openebs.io/hostname: 127.0.0.1
       finalizers:
    - cstorvolumereplica.openebs.io/finalizer
    generation: 12
    labels:
      cstorpoolinstance.openebs.io/name: cspc-sparse-xgk5
      cstorpoolinstance.openebs.io/uid: bf9024b9-4831-4dd2-b265-80f259c9890f
      cstorvolume.openebs.io/name: pvc-63d8583c-1f06-4457-a1a0-db5707478b90
      openebs.io/persistent-volume: pvc-63d8583c-1f06-4457-a1a0-db5707478b90
      openebs.io/version: 1.1.0

```
**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests
Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>