### PR TITLE
refact(upgrade): added switch case for 1.2 upgrade and command for upgradetask

### DIFF
--- a/cmd/upgrade/executor/cstor_spc.go
+++ b/cmd/upgrade/executor/cstor_spc.go
@@ -103,6 +103,18 @@ func (u *UpgradeOptions) RunCStorSPCUpgrade(cmd *cobra.Command) error {
 			fmt.Println(err)
 			return errors.Errorf("Failed to upgrade cStor SPC %v:", u.cstorSPC.spcName)
 		}
+	case "1.1.0-1.2.0":
+		fmt.Println("Upgrading to 1.2.0")
+		err := upgrade100to110.Exec(u.fromVersion, u.toVersion,
+			u.resourceKind,
+			u.cstorSPC.spcName,
+			u.openebsNamespace,
+			u.imageURLPrefix,
+			u.toVersionImageTag)
+		if err != nil {
+			fmt.Println(err)
+			return errors.Errorf("Failed to upgrade cStor SPC %v:", u.cstorSPC.spcName)
+		}
 	default:
 		return errors.Errorf("Invalid from version %s or to version %s", u.fromVersion, u.toVersion)
 	}

--- a/cmd/upgrade/executor/cstor_spc.go
+++ b/cmd/upgrade/executor/cstor_spc.go
@@ -20,12 +20,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/openebs/maya/pkg/util"
 	"github.com/spf13/cobra"
 
 	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 	upgrade090to100 "github.com/openebs/maya/pkg/upgrade/0.9.0-1.0.0/v1alpha1"
-	upgrade100to110 "github.com/openebs/maya/pkg/upgrade/1.0.0-1.1.0/v1alpha1"
+	upgrade100to120 "github.com/openebs/maya/pkg/upgrade/1.0.0-1.1.0/v1alpha1"
 )
 
 // CStorSPCOptions stores information required for cstor SPC upgrade
@@ -91,21 +92,9 @@ func (u *UpgradeOptions) RunCStorSPCUpgrade(cmd *cobra.Command) error {
 			fmt.Println(err)
 			return errors.Errorf("Failed to upgrade cStor SPC %v:", u.cstorSPC.spcName)
 		}
-	case "1.0.0-1.1.0":
-		fmt.Println("Upgrading to 1.1.0")
-		err := upgrade100to110.Exec(u.fromVersion, u.toVersion,
-			u.resourceKind,
-			u.cstorSPC.spcName,
-			u.openebsNamespace,
-			u.imageURLPrefix,
-			u.toVersionImageTag)
-		if err != nil {
-			fmt.Println(err)
-			return errors.Errorf("Failed to upgrade cStor SPC %v:", u.cstorSPC.spcName)
-		}
-	case "1.1.0-1.2.0":
-		fmt.Println("Upgrading to 1.2.0")
-		err := upgrade100to110.Exec(u.fromVersion, u.toVersion,
+	case "1.0.0-1.1.0", "1.0.0-1.2.0", "1.1.0-1.2.0":
+		glog.Infof("Upgrading to %s", u.toVersion)
+		err := upgrade100to120.Exec(u.fromVersion, u.toVersion,
 			u.resourceKind,
 			u.cstorSPC.spcName,
 			u.openebsNamespace,

--- a/cmd/upgrade/executor/cstor_spc.go
+++ b/cmd/upgrade/executor/cstor_spc.go
@@ -17,7 +17,6 @@ limitations under the License.
 package executor
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/golang/glog"
@@ -84,12 +83,12 @@ func (u *UpgradeOptions) RunCStorSPCUpgrade(cmd *cobra.Command) error {
 
 	switch from + "-" + to {
 	case "0.9.0-1.0.0":
-		fmt.Println("Upgrading to 1.0.0")
+		glog.Infof("Upgrading to 1.0.0")
 		err := upgrade090to100.Exec(u.resourceKind,
 			u.cstorSPC.spcName,
 			u.openebsNamespace)
 		if err != nil {
-			fmt.Println(err)
+			glog.Error(err)
 			return errors.Errorf("Failed to upgrade cStor SPC %v:", u.cstorSPC.spcName)
 		}
 	case "1.0.0-1.1.0", "1.0.0-1.2.0", "1.1.0-1.2.0":
@@ -101,7 +100,7 @@ func (u *UpgradeOptions) RunCStorSPCUpgrade(cmd *cobra.Command) error {
 			u.imageURLPrefix,
 			u.toVersionImageTag)
 		if err != nil {
-			fmt.Println(err)
+			glog.Error(err)
 			return errors.Errorf("Failed to upgrade cStor SPC %v:", u.cstorSPC.spcName)
 		}
 	default:

--- a/cmd/upgrade/executor/cstor_volume.go
+++ b/cmd/upgrade/executor/cstor_volume.go
@@ -20,12 +20,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/openebs/maya/pkg/util"
 	"github.com/spf13/cobra"
 
 	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 	upgrade090to100 "github.com/openebs/maya/pkg/upgrade/0.9.0-1.0.0/v1alpha1"
-	upgrade100to110 "github.com/openebs/maya/pkg/upgrade/1.0.0-1.1.0/v1alpha1"
+	upgrade100to120 "github.com/openebs/maya/pkg/upgrade/1.0.0-1.1.0/v1alpha1"
 )
 
 // CStorVolumeOptions stores information required for cstor volume upgrade
@@ -90,21 +91,9 @@ func (u *UpgradeOptions) RunCStorVolumeUpgrade(cmd *cobra.Command) error {
 			fmt.Println(err)
 			return errors.Errorf("Failed to upgrade CStor Volume %v:", u.cstorVolume.pvName)
 		}
-	case "1.0.0-1.1.0":
-		fmt.Println("Upgrading to 1.1.0")
-		err := upgrade100to110.Exec(u.fromVersion, u.toVersion,
-			u.resourceKind,
-			u.cstorVolume.pvName,
-			u.openebsNamespace,
-			u.imageURLPrefix,
-			u.toVersionImageTag)
-		if err != nil {
-			fmt.Println(err)
-			return errors.Errorf("Failed to upgrade CStor Volume %v:", u.cstorVolume.pvName)
-		}
-	case "1.1.0-1.2.0":
-		fmt.Println("Upgrading to 1.2.0")
-		err := upgrade100to110.Exec(u.fromVersion, u.toVersion,
+	case "1.0.0-1.1.0", "1.0.0-1.2.0", "1.1.0-1.2.0":
+		glog.Infof("Upgrading to %s", u.toVersion)
+		err := upgrade100to120.Exec(u.fromVersion, u.toVersion,
 			u.resourceKind,
 			u.cstorVolume.pvName,
 			u.openebsNamespace,

--- a/cmd/upgrade/executor/cstor_volume.go
+++ b/cmd/upgrade/executor/cstor_volume.go
@@ -102,6 +102,18 @@ func (u *UpgradeOptions) RunCStorVolumeUpgrade(cmd *cobra.Command) error {
 			fmt.Println(err)
 			return errors.Errorf("Failed to upgrade CStor Volume %v:", u.cstorVolume.pvName)
 		}
+	case "1.1.0-1.2.0":
+		fmt.Println("Upgrading to 1.2.0")
+		err := upgrade100to110.Exec(u.fromVersion, u.toVersion,
+			u.resourceKind,
+			u.cstorVolume.pvName,
+			u.openebsNamespace,
+			u.imageURLPrefix,
+			u.toVersionImageTag)
+		if err != nil {
+			fmt.Println(err)
+			return errors.Errorf("Failed to upgrade CStor Volume %v:", u.cstorVolume.pvName)
+		}
 	default:
 		return errors.Errorf("Invalid from version %s or to version %s", u.fromVersion, u.toVersion)
 	}

--- a/cmd/upgrade/executor/cstor_volume.go
+++ b/cmd/upgrade/executor/cstor_volume.go
@@ -17,7 +17,6 @@ limitations under the License.
 package executor
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/golang/glog"
@@ -83,12 +82,12 @@ func (u *UpgradeOptions) RunCStorVolumeUpgrade(cmd *cobra.Command) error {
 
 	switch from + "-" + to {
 	case "0.9.0-1.0.0":
-		fmt.Println("Upgrading to 1.0.0")
+		glog.Infof("Upgrading to 1.0.0")
 		err := upgrade090to100.Exec(u.resourceKind,
 			u.cstorVolume.pvName,
 			u.openebsNamespace)
 		if err != nil {
-			fmt.Println(err)
+			glog.Error(err)
 			return errors.Errorf("Failed to upgrade CStor Volume %v:", u.cstorVolume.pvName)
 		}
 	case "1.0.0-1.1.0", "1.0.0-1.2.0", "1.1.0-1.2.0":
@@ -100,7 +99,7 @@ func (u *UpgradeOptions) RunCStorVolumeUpgrade(cmd *cobra.Command) error {
 			u.imageURLPrefix,
 			u.toVersionImageTag)
 		if err != nil {
-			fmt.Println(err)
+			glog.Error(err)
 			return errors.Errorf("Failed to upgrade CStor Volume %v:", u.cstorVolume.pvName)
 		}
 	default:

--- a/cmd/upgrade/executor/env.go
+++ b/cmd/upgrade/executor/env.go
@@ -29,6 +29,6 @@ func getOpenEBSNamespace() string {
 	return menv.Get(menv.OpenEBSNamespace)
 }
 
-func getUpgradeTask() string {
+func getUpgradeTaskCRName() string {
 	return menv.Get("UPGRADE_TASK")
 }

--- a/cmd/upgrade/executor/env.go
+++ b/cmd/upgrade/executor/env.go
@@ -28,3 +28,7 @@ import (
 func getOpenEBSNamespace() string {
 	return menv.Get(menv.OpenEBSNamespace)
 }
+
+func getUpgradeTask() string {
+	return menv.Get("UPGRADE_TASK")
+}

--- a/cmd/upgrade/executor/jiva_volume.go
+++ b/cmd/upgrade/executor/jiva_volume.go
@@ -17,7 +17,6 @@ limitations under the License.
 package executor
 
 import (
-	//"fmt"
 	"strings"
 
 	"github.com/golang/glog"

--- a/cmd/upgrade/executor/jiva_volume.go
+++ b/cmd/upgrade/executor/jiva_volume.go
@@ -26,7 +26,7 @@ import (
 
 	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 	upgrade090to100 "github.com/openebs/maya/pkg/upgrade/0.9.0-1.0.0/v1alpha1"
-	upgrade100to110 "github.com/openebs/maya/pkg/upgrade/1.0.0-1.1.0/v1alpha1"
+	upgrade100to120 "github.com/openebs/maya/pkg/upgrade/1.0.0-1.1.0/v1alpha1"
 )
 
 // JivaVolumeOptions stores information required for jiva volume upgrade
@@ -99,9 +99,9 @@ func (u *UpgradeOptions) RunJivaVolumeUpgrade(cmd *cobra.Command) error {
 				u.resourceKind,
 				u.jivaVolume.pvName)
 		}
-	case "1.0.0-1.1.0":
-		glog.Infof("Upgrading to 1.1.0")
-		err := upgrade100to110.Exec(u.fromVersion, u.toVersion,
+	case "1.0.0-1.1.0", "1.0.0-1.2.0", "1.1.0-1.2.0":
+		glog.Infof("Upgrading to %s", u.toVersion)
+		err := upgrade100to120.Exec(u.fromVersion, u.toVersion,
 			u.resourceKind,
 			u.jivaVolume.pvName,
 			u.openebsNamespace,
@@ -113,20 +113,7 @@ func (u *UpgradeOptions) RunJivaVolumeUpgrade(cmd *cobra.Command) error {
 				u.resourceKind,
 				u.jivaVolume.pvName)
 		}
-	case "1.1.0-1.2.0":
-		glog.Infof("Upgrading to 1.2.0")
-		err := upgrade100to110.Exec(u.fromVersion, u.toVersion,
-			u.resourceKind,
-			u.jivaVolume.pvName,
-			u.openebsNamespace,
-			u.imageURLPrefix,
-			u.toVersionImageTag)
-		if err != nil {
-			glog.Error(err)
-			return errors.Wrapf(err, "Failed to upgrade %s{%s}",
-				u.resourceKind,
-				u.jivaVolume.pvName)
-		}
+
 	default:
 		return errors.Errorf("Invalid from version %s or to version %s", u.fromVersion, u.toVersion)
 	}

--- a/cmd/upgrade/executor/jiva_volume.go
+++ b/cmd/upgrade/executor/jiva_volume.go
@@ -113,6 +113,20 @@ func (u *UpgradeOptions) RunJivaVolumeUpgrade(cmd *cobra.Command) error {
 				u.resourceKind,
 				u.jivaVolume.pvName)
 		}
+	case "1.1.0-1.2.0":
+		glog.Infof("Upgrading to 1.2.0")
+		err := upgrade100to110.Exec(u.fromVersion, u.toVersion,
+			u.resourceKind,
+			u.jivaVolume.pvName,
+			u.openebsNamespace,
+			u.imageURLPrefix,
+			u.toVersionImageTag)
+		if err != nil {
+			glog.Error(err)
+			return errors.Wrapf(err, "Failed to upgrade %s{%s}",
+				u.resourceKind,
+				u.jivaVolume.pvName)
+		}
 	default:
 		return errors.Errorf("Invalid from version %s or to version %s", u.fromVersion, u.toVersion)
 	}

--- a/cmd/upgrade/executor/options.go
+++ b/cmd/upgrade/executor/options.go
@@ -17,9 +17,11 @@ limitations under the License.
 package executor
 
 import (
-	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
-	"github.com/spf13/cobra"
 	"strings"
+
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
+
+	"github.com/spf13/cobra"
 )
 
 // UpgradeOptions stores information required for upgrade
@@ -33,6 +35,7 @@ type UpgradeOptions struct {
 	jivaVolume        JivaVolumeOptions
 	cstorSPC          CStorSPCOptions
 	cstorVolume       CStorVolumeOptions
+	upgradeTask       UpgradeTaskOptions
 }
 
 var (

--- a/cmd/upgrade/executor/options.go
+++ b/cmd/upgrade/executor/options.go
@@ -35,7 +35,7 @@ type UpgradeOptions struct {
 	jivaVolume        JivaVolumeOptions
 	cstorSPC          CStorSPCOptions
 	cstorVolume       CStorVolumeOptions
-	upgradeTask       UpgradeTaskOptions
+	resource          ResourceOptions
 }
 
 var (

--- a/cmd/upgrade/executor/resource.go
+++ b/cmd/upgrade/executor/resource.go
@@ -54,7 +54,7 @@ func NewUpgradeResourceJob() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			util.CheckErr(options.InitializeFromUpgradeTaskResource(cmd), util.Fatal)
 			util.CheckErr(options.RunPreFlightChecks(cmd), util.Fatal)
-			util.CheckErr(options.RunResourcekUpgradeChecks(cmd), util.Fatal)
+			util.CheckErr(options.RunResourceUpgradeChecks(cmd), util.Fatal)
 			util.CheckErr(options.InitializeDefaults(cmd), util.Fatal)
 			util.CheckErr(options.RunResourceUpgrade(cmd), util.Fatal)
 		},
@@ -99,8 +99,8 @@ func (u *UpgradeOptions) InitializeFromUpgradeTaskResource(cmd *cobra.Command) e
 	return nil
 }
 
-// RunResourcekUpgradeChecks will ensure the sanity of the upgradeTask upgrade options
-func (u *UpgradeOptions) RunResourcekUpgradeChecks(cmd *cobra.Command) error {
+// RunResourceUpgradeChecks will ensure the sanity of the upgradeTask upgrade options
+func (u *UpgradeOptions) RunResourceUpgradeChecks(cmd *cobra.Command) error {
 	if len(strings.TrimSpace(u.resource.name)) == 0 {
 		return errors.Errorf("Cannot execute upgrade job: resource name is missing")
 	}

--- a/cmd/upgrade/executor/setup_job.go
+++ b/cmd/upgrade/executor/setup_job.go
@@ -42,7 +42,7 @@ func NewJob() *cobra.Command {
 		NewUpgradeJivaVolumeJob(),
 		NewUpgradeCStorSPCJob(),
 		NewUpgradeCStorVolumeJob(),
-		NewUpgradeTaskJob(),
+		NewUpgradeResourceJob(),
 	)
 
 	cmd.PersistentFlags().StringVarP(&options.fromVersion,

--- a/cmd/upgrade/executor/setup_job.go
+++ b/cmd/upgrade/executor/setup_job.go
@@ -42,6 +42,7 @@ func NewJob() *cobra.Command {
 		NewUpgradeJivaVolumeJob(),
 		NewUpgradeCStorSPCJob(),
 		NewUpgradeCStorVolumeJob(),
+		NewUpgradeTaskJob(),
 	)
 
 	cmd.PersistentFlags().StringVarP(&options.fromVersion,

--- a/cmd/upgrade/executor/upgradetask.go
+++ b/cmd/upgrade/executor/upgradetask.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2019 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executor
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openebs/maya/pkg/util"
+	"github.com/spf13/cobra"
+
+	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
+	upgrade100to110 "github.com/openebs/maya/pkg/upgrade/1.0.0-1.1.0/v1alpha1"
+	utask "github.com/openebs/maya/pkg/upgrade/v1alpha2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	upgradeTaskJobUpgradeCmdHelpText = `
+This command upgrades the resource mentioned in upgradeTask env
+
+Usage: upgrade upgrade-task
+`
+)
+
+// UpgradeTaskOptions stores information required for upgradeTask upgrade
+type UpgradeTaskOptions struct {
+	resourceName string
+}
+
+// NewUpgradeTaskJob upgrade a resource from upgradeTask
+func NewUpgradeTaskJob() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "upgrade-task",
+		Short:   "Upgrade UpgradeTask Resource",
+		Long:    upgradeTaskJobUpgradeCmdHelpText,
+		Example: `upgrade upgrade-task`,
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(options.InitializeFromUpgradeTask(cmd), util.Fatal)
+			util.CheckErr(options.RunPreFlightChecks(cmd), util.Fatal)
+			util.CheckErr(options.RunUpgradeTaskUpgradeChecks(cmd), util.Fatal)
+			util.CheckErr(options.InitializeDefaults(cmd), util.Fatal)
+			util.CheckErr(options.RunUpgradeTaskUpgrade(cmd), util.Fatal)
+		},
+	}
+
+	return cmd
+}
+
+// InitializeFromUpgradeTask will populate the UpgradeOptions from given UpgradeTask
+func (u *UpgradeOptions) InitializeFromUpgradeTask(cmd *cobra.Command) error {
+	utaskName := getUpgradeTask()
+	if len(strings.TrimSpace(u.openebsNamespace)) == 0 {
+		return errors.Errorf("Cannot execute upgrade job: namespace is missing")
+	}
+	utaskObj, _ := utask.NewKubeClient().WithNamespace(u.openebsNamespace).
+		Get(utaskName, metav1.GetOptions{})
+
+	if len(strings.TrimSpace(utaskObj.Spec.FromVersion)) != 0 {
+		u.fromVersion = utaskObj.Spec.FromVersion
+	}
+
+	if len(strings.TrimSpace(utaskObj.Spec.ToVersion)) != 0 {
+		u.toVersion = utaskObj.Spec.ToVersion
+	}
+
+	switch {
+	case utaskObj.Spec.ResourceSpec.JivaVolume != nil:
+		u.resourceKind = "jivaVolume"
+		u.upgradeTask.resourceName = utaskObj.Spec.ResourceSpec.JivaVolume.PVName
+
+	case utaskObj.Spec.ResourceSpec.CStorPool != nil:
+		u.resourceKind = "cstorPool"
+		u.upgradeTask.resourceName = utaskObj.Spec.ResourceSpec.CStorPool.PoolName
+
+	case utaskObj.Spec.ResourceSpec.CStorVolume != nil:
+		u.resourceKind = "cstorVolume"
+		u.upgradeTask.resourceName = utaskObj.Spec.ResourceSpec.CStorVolume.PVName
+	}
+
+	return nil
+}
+
+// RunUpgradeTaskUpgradeChecks will ensure the sanity of the upgradeTask upgrade options
+func (u *UpgradeOptions) RunUpgradeTaskUpgradeChecks(cmd *cobra.Command) error {
+	if len(strings.TrimSpace(u.upgradeTask.resourceName)) == 0 {
+		return errors.Errorf("Cannot execute upgrade job: resource name is missing")
+	}
+
+	return nil
+}
+
+// RunUpgradeTaskUpgrade upgrades the given upgradeTask
+func (u *UpgradeOptions) RunUpgradeTaskUpgrade(cmd *cobra.Command) error {
+
+	from := strings.Split(u.fromVersion, "-")[0]
+	to := strings.Split(u.toVersion, "-")[0]
+
+	switch from + "-" + to {
+	case "1.0.0-1.1.0":
+		fmt.Println("Upgrading to 1.1.0")
+		err := upgrade100to110.Exec(u.fromVersion, u.toVersion,
+			u.resourceKind,
+			u.upgradeTask.resourceName,
+			u.openebsNamespace,
+			u.imageURLPrefix,
+			u.toVersionImageTag)
+		if err != nil {
+			fmt.Println(err)
+			return errors.Errorf("Failed to upgrade %v %v:", u.resourceKind, u.upgradeTask.resourceName)
+		}
+	case "1.1.0-1.2.0":
+		fmt.Println("Upgrading to 1.2.0")
+		err := upgrade100to110.Exec(u.fromVersion, u.toVersion,
+			u.resourceKind,
+			u.upgradeTask.resourceName,
+			u.openebsNamespace,
+			u.imageURLPrefix,
+			u.toVersionImageTag)
+		if err != nil {
+			fmt.Println(err)
+			return errors.Errorf("Failed to upgrade %v %v:", u.resourceKind, u.upgradeTask.resourceName)
+		}
+	default:
+		return errors.Errorf("Invalid from version %s or to version %s", u.fromVersion, u.toVersion)
+	}
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds the switch case required to upgrade from OpenEBS 1.1 to 1.2. 
It also adds a new command to read inputs from `UpgradeTask` CR instead of flags.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests