### PR TITLE
refact(csi,bdd): update csi bdd to use cspc based pool

### DIFF
--- a/pkg/cstor/poolcluster/v1alpha1/build.go
+++ b/pkg/cstor/poolcluster/v1alpha1/build.go
@@ -43,6 +43,26 @@ func (b *Builder) WithName(name string) *Builder {
 	return b
 }
 
+// WithNamespace sets the Namespace field of CSPC with provided value.
+func (b *Builder) WithNamespace(namespace string) *Builder {
+	if len(namespace) == 0 {
+		b.errs = append(b.errs, errors.New("failed to build CSPC object: missing CSPC namespace"))
+		return b
+	}
+	b.cspc.object.Namespace = namespace
+	return b
+}
+
+// WithGenerateName appends a random string after the name
+func (b *Builder) WithGenerateName(name string) *Builder {
+	if len(name) == 0 {
+		b.errs = append(b.errs, errors.New("failed to build CSPC object: missing CSPC name"))
+		return b
+	}
+	b.cspc.object.GenerateName = name + "-"
+	return b
+}
+
 // WithPoolSpecBuilder adds a pool to this cspc object.
 //
 // NOTE:
@@ -67,4 +87,12 @@ func (b *Builder) Build() (*CSPC, error) {
 		return nil, errors.Errorf("%+v", b.errs)
 	}
 	return b.cspc, nil
+}
+
+// GetObj returns the CSPC  instance
+func (b *Builder) GetObj() (*apisv1alpha1.CStorPoolCluster, error) {
+	if len(b.errs) > 0 {
+		return nil, errors.Errorf("%+v", b.errs)
+	}
+	return b.cspc.object, nil
 }

--- a/pkg/cstor/poolcluster/v1alpha1/kubernetes.go
+++ b/pkg/cstor/poolcluster/v1alpha1/kubernetes.go
@@ -121,7 +121,7 @@ type KubeclientBuildOption func(*Kubeclient)
 func (k *Kubeclient) WithDefaults() {
 	if k.getClientset == nil {
 		k.getClientset = func() (clients *clientset.Clientset, err error) {
-			config, err := kclient.New().Config()
+			config, err := kclient.GetConfig(kclient.New())
 			if err != nil {
 				return nil, err
 			}
@@ -130,7 +130,7 @@ func (k *Kubeclient) WithDefaults() {
 	}
 	if k.getClientsetForPath == nil {
 		k.getClientsetForPath = func(kubeConfigPath string) (clients *clientset.Clientset, err error) {
-			config, err := kclient.New(kclient.WithKubeConfigPath(kubeConfigPath)).Config()
+			config, err := kclient.GetConfig(kclient.New(kclient.WithKubeConfigPath(kubeConfigPath)))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/cstor/poolcluster/v1alpha1/raidgroups/build.go
+++ b/pkg/cstor/poolcluster/v1alpha1/raidgroups/build.go
@@ -60,6 +60,22 @@ func (b *Builder) WithReadCache() *Builder {
 	return b
 }
 
+// WithCSPCBlockDeviceList sets the blockdevices field with provided value
+func (b *Builder) WithCSPCBlockDeviceList(cspcBDList []*apisv1alpha1.CStorPoolClusterBlockDevice) *Builder {
+	if cspcBDList == nil {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build raid group object: nil cspc blockdevice lisr"),
+		)
+		return b
+	}
+
+	for _, obj := range cspcBDList {
+		b.rg.object.BlockDevices = append(b.rg.object.BlockDevices, *obj)
+	}
+	return b
+}
+
 // Build returns the raid group
 func (b *Builder) Build() (*RG, error) {
 	if len(b.errs) > 0 {

--- a/pkg/cstor/poolcluster/v1alpha1/raidgroups/build.go
+++ b/pkg/cstor/poolcluster/v1alpha1/raidgroups/build.go
@@ -62,7 +62,7 @@ func (b *Builder) WithReadCache() *Builder {
 
 // WithCSPCBlockDeviceList sets the blockdevices field with provided value
 func (b *Builder) WithCSPCBlockDeviceList(cspcBDList []*apisv1alpha1.CStorPoolClusterBlockDevice) *Builder {
-	if cspcBDList == nil {
+	if len(cspcBDList) == 0 {
 		b.errs = append(
 			b.errs,
 			errors.New("failed to build raid group object: nil cspc blockdevice lisr"),

--- a/pkg/cstor/poolinstance/v1alpha3/buildlist.go
+++ b/pkg/cstor/poolinstance/v1alpha3/buildlist.go
@@ -85,6 +85,27 @@ func (lb *ListBuilder) WithFilter(pred ...Predicate) *ListBuilder {
 	return lb
 }
 
+// Filter will filter the csp instances
+// if all the predicates succeed against that
+// csp.
+func (l *CSPIList) Filter(p ...Predicate) *CSPIList {
+	var plist PredicateList
+	plist = append(plist, p...)
+	if len(plist) == 0 {
+		return l
+	}
+
+	filtered := NewListBuilder().List()
+	for _, cspAPI := range l.ObjectList.Items {
+		cspAPI := cspAPI // pin it
+		CSPI := BuilderForAPIObject(&cspAPI).CSPI
+		if plist.all(CSPI) {
+			filtered.ObjectList.Items = append(filtered.ObjectList.Items, *CSPI.Object)
+		}
+	}
+	return filtered
+}
+
 // GetCStorPool returns CStorPoolInstance object from existing
 // ListBuilder
 func (lb *ListBuilder) GetCStorPool(cspName string) *apis.CStorPoolInstance {

--- a/pkg/cstor/poolinstance/v1alpha3/kubernetes.go
+++ b/pkg/cstor/poolinstance/v1alpha3/kubernetes.go
@@ -98,7 +98,7 @@ type KubeclientBuildOption func(*Kubeclient)
 func (k *Kubeclient) WithDefaults() {
 	if k.getClientset == nil {
 		k.getClientset = func() (clients *clientset.Clientset, err error) {
-			config, err := kclient.New().Config()
+			config, err := kclient.GetConfig(kclient.New())
 			if err != nil {
 				return nil, err
 			}
@@ -107,7 +107,7 @@ func (k *Kubeclient) WithDefaults() {
 	}
 	if k.getClientsetForPath == nil {
 		k.getClientsetForPath = func(kubeConfigPath string) (clients *clientset.Clientset, err error) {
-			config, err := kclient.New(kclient.WithKubeConfigPath(kubeConfigPath)).Config()
+			config, err := kclient.GetConfig(kclient.New(kclient.WithKubeConfigPath(kubeConfigPath)))
 			if err != nil {
 				return nil, err
 			}

--- a/tests/csi/cstor/volume/provision_test.go
+++ b/tests/csi/cstor/volume/provision_test.go
@@ -48,7 +48,6 @@ var _ = Describe("[cstor] [sparse] TEST VOLUME PROVISIONING", func() {
 	BeforeEach(func() {
 		When(" creating a cstor based volume", func() {
 			By("building a cstorpoolcluster")
-			nodeSelector := map[string]string{}
 
 			var cspcBDList []*apis.CStorPoolClusterBlockDevice
 			for _, bd := range bdList.Items {
@@ -63,7 +62,7 @@ var _ = Describe("[cstor] [sparse] TEST VOLUME PROVISIONING", func() {
 					BlockDeviceName: bd.Name,
 				})
 			}
-			nodeSelector = map[string]string{string(apis.HostNameCPK): nodeName}
+			nodeSelector := map[string]string{string(apis.HostNameCPK): nodeName}
 			poolspec := poolspec.NewBuilder().
 				WithNodeSelector(nodeSelector).
 				WithCompression("off").

--- a/tests/csi/cstor/volume/suite_test.go
+++ b/tests/csi/cstor/volume/suite_test.go
@@ -37,7 +37,7 @@ var (
 	nsName             = "cstor-provision"
 	scName             = "cstor-volume"
 	openebsProvisioner = "openebs-csi.openebs.io"
-	cspcName           = "sparse-pool-auto"
+	cspcName           = "cspc-sparse"
 	nsObj              *corev1.Namespace
 	scObj              *storagev1.StorageClass
 	cspcObj            *apis.CStorPoolCluster

--- a/tests/csi/cstor/volume/suite_test.go
+++ b/tests/csi/cstor/volume/suite_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openebs/maya/tests"
 	"github.com/openebs/maya/tests/cstor"
 
+	ndmapis "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	ns "github.com/openebs/maya/pkg/kubernetes/namespace/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -32,20 +33,15 @@ import (
 )
 
 var (
-	openebsNamespace      = "openebs"
-	nsName                = "cstor-provision"
-	scName                = "cstor-volume"
-	openebsCASConfigValue = `
-- name: ReplicaCount
-  value: $count
-- name: StoragePoolClaim
-  value: $spcName
-`
+	openebsNamespace   = "openebs"
+	nsName             = "cstor-provision"
+	scName             = "cstor-volume"
 	openebsProvisioner = "openebs-csi.openebs.io"
-	spcName            = "sparse-pool-auto"
+	cspcName           = "sparse-pool-auto"
 	nsObj              *corev1.Namespace
 	scObj              *storagev1.StorageClass
-	spcObj             *apis.StoragePoolClaim
+	cspcObj            *apis.CStorPoolCluster
+	bdList             *ndmapis.BlockDeviceList
 	pvcObj             *corev1.PersistentVolumeClaim
 	podObj             *corev1.Pod
 	targetLabel        = "openebs.io/target=cstor-target"
@@ -80,6 +76,8 @@ var _ = BeforeSuite(func() {
 	By("creating above namespace")
 	nsObj, err = ops.NSClient.Create(nsObj)
 	Expect(err).To(BeNil(), "while creating namespace {%s}", nsObj.Name)
+	bdList, err = ops.BDClient.List(metav1.ListOptions{})
+	Expect(err).To(BeNil(), "while gettting blockdevices")
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
PR updates the CSI bdd tests for csi based provisioning to use cspc based cstor pools instance.

```sh
ginkgo -v -- -kubeconfig="$HOME/.kube/config" --cstor-replicas=1 --cstor-maxpools=1
Running Suite: Test cstor volume provisioning
=============================================
Random Seed: 1566897455
Will run 1 of 1 specs

STEP: waiting for maya-apiserver pod to come into running state
STEP: waiting for openebs-provisioner pod to come into running state
STEP: Verifying 'admission-server' pod status as running
STEP: building a namespace
STEP: creating above namespace
[cstor] [sparse] TEST VOLUME PROVISIONING when cstor pvc with replicacount 1 is created 
  should create cstor volume target pod
  /home/payes/gocode/src/github.com/openebs/maya/tests/csi/cstor/volume/provision_test.go:129
STEP: building a cstorpoolcluster
STEP: creating above cstorpoolcluster
STEP: verifying healthy cstorpool count
STEP: building SC parameters with generated SPC name
STEP: building a storageclass
STEP: creating above storageclass
STEP: building a pvc
STEP: creating above pvc
STEP: verifying pvc status as bound
STEP: building a busybox app pod deployment using above csi cstor volume
STEP: verifying target pod count as 1 once the app has been deployed
STEP: verifying cstorvolume replica count
STEP: verifying app pod is running
STEP: restarting application to remount the volume again
STEP: verifying app pod is terminated properly
STEP: verifying app pod is running again
STEP: deleting application deployment
STEP: deleting above pvc
STEP: verifying target pod count as 0
STEP: verifying deleted pvc
STEP: verifying if cstorvolume is deleted
STEP: deleting resources created for testing cstor volume provisioning
STEP: deleting cstorpoolcluster
STEP: deleting storageclass

• [SLOW TEST:200.376 seconds]
[cstor] [sparse] TEST VOLUME PROVISIONING
/home/payes/gocode/src/github.com/openebs/maya/tests/csi/cstor/volume/provision_test.go:40
  when cstor pvc with replicacount 1 is created
  /home/payes/gocode/src/github.com/openebs/maya/tests/csi/cstor/volume/provision_test.go:128
    should create cstor volume target pod
    /home/payes/gocode/src/github.com/openebs/maya/tests/csi/cstor/volume/provision_test.go:129
------------------------------
STEP: deleting namespace

Ran 1 of 1 Specs in 200.443 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 3m26.848671948s
Test Suite Passed
```

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [x] Commit has integration tests