### PR TITLE
fix(installer): skip re-apply of default SPC and SC resources

### DIFF
--- a/pkg/client/k8s/v1alpha1/resource_test.go
+++ b/pkg/client/k8s/v1alpha1/resource_test.go
@@ -28,4 +28,4 @@ var _ ResourceCreator = &resource{}
 var _ ResourceUpdater = &resource{}
 
 // verify if createOrUpdate struct is an implementation of ResourceApplier
-var _ ResourceApplier = &createOrUpdate{}
+var _ ResourceApplier = &ResourceCreateOrUpdater{}

--- a/tests/sanity/sanity_suite_test.go
+++ b/tests/sanity/sanity_suite_test.go
@@ -62,7 +62,10 @@ var _ = BeforeSuite(func() {
 
 	// Installing the artifacts to kubernetes cluster
 	for _, artifact := range artifacts {
-		cu := k8s.CreateOrUpdate(k8s.GroupVersionResourceFromGVK(artifact), artifact.GetNamespace())
+		cu := k8s.NewResourceCreateOrUpdater(
+			k8s.GroupVersionResourceFromGVK(artifact),
+			artifact.GetNamespace(),
+		)
 		_, err := cu.Apply(artifact)
 		Expect(err).ShouldNot(HaveOccurred())
 	}

--- a/tests/sanity/sanity_test.go
+++ b/tests/sanity/sanity_test.go
@@ -45,7 +45,10 @@ var _ = Describe("Sanity", func() {
 
 			// Installing the artifacts to kubernetes cluster
 			for _, artifact := range artifacts {
-				cu := k8s.CreateOrUpdate(k8s.GroupVersionResourceFromGVK(artifact), artifact.GetNamespace())
+				cu := k8s.NewResourceCreateOrUpdater(
+					k8s.GroupVersionResourceFromGVK(artifact),
+					artifact.GetNamespace(),
+				)
 				_, err := cu.Apply(artifact)
 				Expect(err).ShouldNot(HaveOccurred())
 				time.Sleep(waitTime * time.Second)
@@ -63,7 +66,10 @@ var _ = Describe("Sanity", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Installing the artifacts to kubernetes cluster
-			cu := k8s.CreateOrUpdate(k8s.GroupVersionResourceFromGVK(artifact), artifact.GetNamespace())
+			cu := k8s.NewResourceCreateOrUpdater(
+				k8s.GroupVersionResourceFromGVK(artifact),
+				artifact.GetNamespace(),
+			)
 			pvc, err := cu.Apply(artifact)
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -256,7 +262,10 @@ var _ = Describe("Sanity", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Installing the artifacts to kubernetes cluster
-			cu := k8s.CreateOrUpdate(k8s.GroupVersionResourceFromGVK(artifact), artifact.GetNamespace())
+			cu := k8s.NewResourceCreateOrUpdater(
+				k8s.GroupVersionResourceFromGVK(artifact),
+				artifact.GetNamespace(),
+			)
 			pvc, err := cu.Apply(artifact)
 			Expect(err).ShouldNot(HaveOccurred())
 

--- a/tests/sts/sts_suite_test.go
+++ b/tests/sts/sts_suite_test.go
@@ -78,7 +78,7 @@ var _ = BeforeSuite(func() {
 
 	// Installing the artifacts to kubernetes cluster
 	for _, artifact := range artifactsOpenEBS {
-		cu := k8s.CreateOrUpdate(
+		cu := k8s.NewResourceCreateOrUpdater(
 			k8s.GroupVersionResourceFromGVK(artifact),
 			artifact.GetNamespace(),
 		)

--- a/tests/sts/sts_test.go
+++ b/tests/sts/sts_test.go
@@ -108,7 +108,7 @@ var _ = Describe("StatefulSet", func() {
 		replicaAntiAffinityLabel := "openebs.io/replica-anti-affinity=" + STSUnstructured.GetName()
 
 		// Apply sts storageclass
-		cu := k8s.CreateOrUpdate(
+		cu := k8s.NewResourceCreateOrUpdater(
 			k8s.GroupVersionResourceFromGVK(SCUnstructured),
 			SCUnstructured.GetNamespace(),
 		)
@@ -116,7 +116,7 @@ var _ = Describe("StatefulSet", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// Apply the sts
-		cu = k8s.CreateOrUpdate(
+		cu = k8s.NewResourceCreateOrUpdater(
 			k8s.GroupVersionResourceFromGVK(STSUnstructured),
 			stsNamespace,
 		)


### PR DESCRIPTION
This commit changes maya api server installer to skip updating default SPC as well as default SC resources if they were installed previously by older version(s) of maya or prior to maya api server restart(s).

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests