### PR TITLE
feat(localpv): allow provisioning in clusters where nodename != hostname

### DIFF
--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -213,3 +213,12 @@ func GetLocalPVType(pv *v1.PersistentVolume) string {
 	}
 	return ""
 }
+
+// GetNodeHostname extracts the Hostname from the labels on the Node
+func GetNodeHostname(n *v1.Node) string {
+	hostname, found := n.Labels[KeyNodeHostname]
+	if found {
+		return hostname
+	}
+	return n.Name
+}

--- a/cmd/provisioner-localpv/app/provisioner.go
+++ b/cmd/provisioner-localpv/app/provisioner.go
@@ -50,9 +50,9 @@ import (
 )
 
 const (
-	//KeyNode represents the key values used for specifying the Node Affinity
+	//KeyNodeHostname represents the key values used for specifying the Node Affinity
 	// based on the hostname
-	KeyNode = "kubernetes.io/hostname"
+	KeyNodeHostname = "kubernetes.io/hostname"
 )
 
 // NewProvisioner will create a new Provisioner object and initialize

--- a/cmd/provisioner-localpv/app/provisioner_blockdevice.go
+++ b/cmd/provisioner-localpv/app/provisioner_blockdevice.go
@@ -31,7 +31,7 @@ import (
 //  with a Block Device
 func (p *Provisioner) ProvisionBlockDevice(opts pvController.VolumeOptions, volumeConfig *VolumeConfig) (*v1.PersistentVolume, error) {
 	pvc := opts.PVC
-	node := opts.SelectedNode
+	nodeHostname := GetNodeHostname(opts.SelectedNode)
 	name := opts.PVName
 	capacity := opts.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
 	stgType := volumeConfig.GetStorageType()
@@ -39,7 +39,7 @@ func (p *Provisioner) ProvisionBlockDevice(opts pvController.VolumeOptions, volu
 
 	//Extract the details to create a Block Device Claim
 	blkDevOpts := &HelperBlockDeviceOptions{
-		nodeName: node.Name,
+		nodeName: nodeHostname,
 		name:     name,
 		capacity: capacity.String(),
 	}
@@ -49,7 +49,7 @@ func (p *Provisioner) ProvisionBlockDevice(opts pvController.VolumeOptions, volu
 		glog.Infof("Initialize volume %v failed: %v", name, err)
 		return nil, err
 	}
-	glog.Infof("Creating volume %v on %v at %v(%v)", name, node.Name, path, blkPath)
+	glog.Infof("Creating volume %v on %v at %v(%v)", name, nodeHostname, path, blkPath)
 	if path == "" {
 		path = blkPath
 		glog.Infof("Using block device{%v} with fs{%v}", blkPath, fsType)
@@ -84,7 +84,7 @@ func (p *Provisioner) ProvisionBlockDevice(opts pvController.VolumeOptions, volu
 		WithVolumeMode(fs).
 		WithCapacityQty(pvc.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]).
 		WithLocalHostPathFormat(path, fsType).
-		WithNodeAffinity(node.Name).
+		WithNodeAffinity(nodeHostname).
 		Build()
 
 	if err != nil {

--- a/cmd/provisioner-localpv/app/provisioner_hostpath.go
+++ b/cmd/provisioner-localpv/app/provisioner_hostpath.go
@@ -30,7 +30,7 @@ import (
 //  to be provisioned and a valid PV spec returned.
 func (p *Provisioner) ProvisionHostPath(opts pvController.VolumeOptions, volumeConfig *VolumeConfig) (*v1.PersistentVolume, error) {
 	pvc := opts.PVC
-	node := opts.SelectedNode
+	nodeHostname := GetNodeHostname(opts.SelectedNode)
 	name := opts.PVName
 	stgType := volumeConfig.GetStorageType()
 
@@ -39,7 +39,7 @@ func (p *Provisioner) ProvisionHostPath(opts pvController.VolumeOptions, volumeC
 		return nil, err
 	}
 
-	glog.Infof("Creating volume %v at %v:%v", name, node.Name, path)
+	glog.Infof("Creating volume %v at %v:%v", name, nodeHostname, path)
 
 	//Before using the path for local PV, make sure it is created.
 	initCmdsForPath := []string{"mkdir", "-m", "0777", "-p"}
@@ -47,7 +47,7 @@ func (p *Provisioner) ProvisionHostPath(opts pvController.VolumeOptions, volumeC
 		cmdsForPath: initCmdsForPath,
 		name:        name,
 		path:        path,
-		nodeName:    node.Name,
+		nodeName:    nodeHostname,
 	}
 
 	iErr := p.createInitPod(podOpts)
@@ -83,7 +83,7 @@ func (p *Provisioner) ProvisionHostPath(opts pvController.VolumeOptions, volumeC
 		WithVolumeMode(fs).
 		WithCapacityQty(pvc.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]).
 		WithLocalHostDirectory(path).
-		WithNodeAffinity(node.Name).
+		WithNodeAffinity(nodeHostname).
 		Build()
 
 	if err != nil {


### PR DESCRIPTION
Refer: https://github.com/openebs/openebs/issues/2695

In some clusters, the node name is not same as the hostname as
described in the above issue. This PR modifies the Local Provisioner
to pick up the hostname from the selected node for provisioning
host path or picking the block devices.


Signed-off-by: kmova <kiran.mova@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests