### PR TITLE
fix(cspi): update status parsing and get devicePath ignoring "/dev"

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
@@ -295,7 +295,7 @@ func (c *CStorPoolController) cStorPoolAddEvent(cStorPoolGot *apis.CStorPool) (s
 		return string(apis.CStorPoolStatusOffline), errors.Wrapf(err, "failed to get device id of disks for csp %s", cStorPoolGot.Name)
 	}
 
-	devPath := pool.GetDevPath(devIDList[0])
+	devPath := pool.GetDevPathIfNotSlashDev(devIDList[0])
 	// Trigger import with dev path
 	importOptions.CachefileFlag = false
 	importOptions.DevPath = devPath

--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler_test.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler_test.go
@@ -397,14 +397,14 @@ func TestGetDevPath(t *testing.T) {
 	testGetDevPath := map[string]string{
 		"abcd":             "abcd",
 		"/dev":             "",
-		"/dev/":            "/dev",
-		"/dev/disk":        "/dev",
-		"/dev/disk/":       "/dev/disk",
-		"/dev/by-id/disk":  "/dev/by-id",
-		"/dev/by-id/disk/": "/dev/by-id/disk",
+		"/dev/":            "",
+		"/dev/disk":        "",
+		"/dev/disk/":       "",
+		"/dev/by-id/disk":  "",
+		"/dev/by-id/disk/": "",
 	}
 	for ip, op := range testGetDevPath {
-		obtainedOutput := pool.GetDevPath(ip)
+		obtainedOutput := pool.GetDevPathIfNotSlashDev(ip)
 		if obtainedOutput != op {
 			t.Fatalf("IP:%v, OP:%v, Got:%v", ip, op, obtainedOutput)
 		}

--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler_test.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler_test.go
@@ -393,9 +393,9 @@ func TestIsOnlyStatusChange(t *testing.T) {
 	}
 }
 
-func TestGetDevPath(t *testing.T) {
+func TestGetDevPathIfNotSlashDev(t *testing.T) {
 	testGetDevPath := map[string]string{
-		"abcd":             "abcd",
+		"abcd":             "",
 		"/dev":             "",
 		"/dev/":            "",
 		"/dev/disk":        "",

--- a/cmd/cstor-pool-mgmt/pool/pool.go
+++ b/cmd/cstor-pool-mgmt/pool/pool.go
@@ -172,7 +172,7 @@ func GetDevPathIfNotSlashDev(devID string) string {
 	}
 	lastindex := strings.LastIndexByte(devID, '/')
 	if lastindex == -1 {
-		lastindex = len(devID)
+		return ""
 	}
 	devidbytes := []rune(devID)
 	return string(devidbytes[0:lastindex])

--- a/cmd/cstor-pool-mgmt/pool/pool.go
+++ b/cmd/cstor-pool-mgmt/pool/pool.go
@@ -160,23 +160,31 @@ func importPoolBuilder(cStorPool *apis.CStorPool, importOptions *ImportOptions) 
 	return importAttr
 }
 
-// GetDevPath gets the path from given deviceID
-func GetDevPath(devid string) string {
-	lastindex := strings.LastIndexByte(devid, '/')
-	if lastindex == -1 {
-		lastindex = len(devid)
+// GetDevPathIfNotSlashDev gets the path from given deviceID if its not prefix
+// to "/dev"
+func GetDevPathIfNotSlashDev(devID string) string {
+	if len(devID) == 0 {
+		return ""
 	}
-	devid_bytes := []rune(devid)
-	return string(devid_bytes[0:lastindex])
+
+	if strings.HasPrefix(devID, "/dev") {
+		return ""
+	}
+	lastindex := strings.LastIndexByte(devID, '/')
+	if lastindex == -1 {
+		lastindex = len(devID)
+	}
+	devidbytes := []rune(devID)
+	return string(devidbytes[0:lastindex])
 }
 
-// CreatePool creates a new cStor pool.
+// checkForPoolExistence checks cStor pool existence.
 func checkForPoolExistence(cStorPool *apis.CStorPool, blockDeviceList []string) bool {
 	var importOptions ImportOptions
 
 	// First device in the list is picked under assumption that all pool devices resides
 	// in same place.
-	importOptions.DevPath = GetDevPath(blockDeviceList[0])
+	importOptions.DevPath = GetDevPathIfNotSlashDev(blockDeviceList[0])
 	importOptions.dontImport = true
 	stdoutStderr, _ := ImportPool(cStorPool, &importOptions)
 	glog.Infof("checkForPoolExistence output: %v", stdoutStderr)
@@ -186,7 +194,7 @@ func checkForPoolExistence(cStorPool *apis.CStorPool, blockDeviceList []string) 
 // CreatePool creates a new cStor pool.
 func CreatePool(cStorPool *apis.CStorPool, blockDeviceList []string) error {
 	exists := checkForPoolExistence(cStorPool, blockDeviceList)
-	if exists == true {
+	if exists {
 		glog.Errorf("pool %v exists, but failed to import", string(cStorPool.ObjectMeta.UID))
 		return errors.Errorf("pool %v exists, but failed to import", string(cStorPool.ObjectMeta.UID))
 	}

--- a/cmd/cstor-pool-mgmt/pool/v1alpha2/status.go
+++ b/cmd/cstor-pool-mgmt/pool/v1alpha2/status.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha2
 
 import (
+	"strings"
+
 	zfs "github.com/openebs/maya/pkg/zfs/cmd/v1alpha1"
 )
 
@@ -28,5 +30,9 @@ func GetPropertyValue(poolName, property string) (string, error) {
 		WithProperty(property).
 		WithPool(poolName).
 		Execute()
-	return string(ret), err
+	if err != nil {
+		return "", err
+	}
+	outStr := strings.Split(string(ret), "\n")
+	return outStr[0], nil
 }


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
fix the status parsing for cstorpoolinstance resource.
```sh
kubectl get cspi -n openebs
NAME               HOSTNAME    ALLOCATED   FREE    CAPACITY   STATUS   AGE
cspc-sparse-2kht   127.0.0.1   281K        9.94G   9.94G      ONLINE   13m

```