### PR TITLE
refact(localpv): change all references from nodeName to nodeHostname

### DIFF
--- a/cmd/provisioner-localpv/app/helper_hostpath.go
+++ b/cmd/provisioner-localpv/app/helper_hostpath.go
@@ -93,7 +93,7 @@ func (p *Provisioner) createInitPod(pOpts *HelperPodOptions) error {
 	initPod, _ := pod.NewBuilder().
 		WithName("init-" + pOpts.name).
 		WithRestartPolicy(corev1.RestartPolicyNever).
-		WithNodeSelectorHostname(pOpts.nodeHostname).
+		WithNodeSelectorHostnameNew(pOpts.nodeHostname).
 		WithContainerBuilder(
 			container.NewBuilder().
 				WithName("local-path-init").
@@ -170,7 +170,7 @@ func (p *Provisioner) createCleanupPod(pOpts *HelperPodOptions) error {
 	cleanerPod, _ := pod.NewBuilder().
 		WithName("cleanup-" + pOpts.name).
 		WithRestartPolicy(corev1.RestartPolicyNever).
-		WithNodeSelectorHostname(pOpts.nodeHostname).
+		WithNodeSelectorHostnameNew(pOpts.nodeHostname).
 		WithContainerBuilder(
 			container.NewBuilder().
 				WithName("local-path-cleanup").

--- a/cmd/provisioner-localpv/app/helper_hostpath.go
+++ b/cmd/provisioner-localpv/app/helper_hostpath.go
@@ -42,28 +42,31 @@ var (
 )
 
 // HelperPodOptions contains the options that
-// will launch a Pod on a specific node (nodeName)
+// will launch a Pod on a specific node (nodeHostname)
 // to execute a command (cmdsForPath) on a given
 // volume path (path)
 type HelperPodOptions struct {
-	//nodeName represents the host where pod should be launched.
-	nodeName string
+	//nodeHostname represents the hostname of the node where pod should be launched.
+	nodeHostname string
+
 	//name is the name of the PV for which the pod is being launched
 	name string
+
 	//cmdsForPath represent either create (mkdir) or delete(rm)
 	//commands that need to be executed on the volume path.
 	cmdsForPath []string
+
 	//path is the volume hostpath directory
 	path string
 }
 
 // validate checks that the required fields to launch
 // helper pods are valid. helper pods are used to either
-// create or delete a directory (path) on a given node (nodeName).
+// create or delete a directory (path) on a given node hostname (nodeHostname).
 // name refers to the volume being created or deleted.
 func (pOpts *HelperPodOptions) validate() error {
-	if pOpts.name == "" || pOpts.path == "" || pOpts.nodeName == "" {
-		return errors.Errorf("invalid empty name or path or node")
+	if pOpts.name == "" || pOpts.path == "" || pOpts.nodeHostname == "" {
+		return errors.Errorf("invalid empty name or hostpath or hostname")
 	}
 	return nil
 }
@@ -90,7 +93,7 @@ func (p *Provisioner) createInitPod(pOpts *HelperPodOptions) error {
 	initPod, _ := pod.NewBuilder().
 		WithName("init-" + pOpts.name).
 		WithRestartPolicy(corev1.RestartPolicyNever).
-		WithNodeName(pOpts.nodeName).
+		WithNodeSelectorHostname(pOpts.nodeHostname).
 		WithContainerBuilder(
 			container.NewBuilder().
 				WithName("local-path-init").
@@ -167,7 +170,7 @@ func (p *Provisioner) createCleanupPod(pOpts *HelperPodOptions) error {
 	cleanerPod, _ := pod.NewBuilder().
 		WithName("cleanup-" + pOpts.name).
 		WithRestartPolicy(corev1.RestartPolicyNever).
-		WithNodeName(pOpts.nodeName).
+		WithNodeSelectorHostname(pOpts.nodeHostname).
 		WithContainerBuilder(
 			container.NewBuilder().
 				WithName("local-path-cleanup").

--- a/cmd/provisioner-localpv/app/provisioner.go
+++ b/cmd/provisioner-localpv/app/provisioner.go
@@ -49,12 +49,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 )
 
-const (
-	//KeyNodeHostname represents the key values used for specifying the Node Affinity
-	// based on the hostname
-	KeyNodeHostname = "kubernetes.io/hostname"
-)
-
 // NewProvisioner will create a new Provisioner object and initialize
 //  it with global information used across PV create and delete operations.
 func NewProvisioner(stopCh chan struct{}, kubeClient *clientset.Clientset) (*Provisioner, error) {
@@ -100,9 +94,13 @@ func (p *Provisioner) Provision(opts pvController.VolumeOptions) (*v1.Persistent
 			return nil, fmt.Errorf("Only support ReadWriteOnce access mode")
 		}
 	}
-	//node := opts.SelectedNode
+
 	if opts.SelectedNode == nil {
 		return nil, fmt.Errorf("configuration error, no node was specified")
+	}
+
+	if GetNodeHostname(opts.SelectedNode) == "" {
+		return nil, fmt.Errorf("configuration error, node{%v} hostname is empty", opts.SelectedNode.Name)
 	}
 
 	name := opts.PVName

--- a/cmd/provisioner-localpv/app/provisioner_blockdevice.go
+++ b/cmd/provisioner-localpv/app/provisioner_blockdevice.go
@@ -39,9 +39,9 @@ func (p *Provisioner) ProvisionBlockDevice(opts pvController.VolumeOptions, volu
 
 	//Extract the details to create a Block Device Claim
 	blkDevOpts := &HelperBlockDeviceOptions{
-		nodeName: nodeHostname,
-		name:     name,
-		capacity: capacity.String(),
+		nodeHostname: nodeHostname,
+		name:         name,
+		capacity:     capacity.String(),
 	}
 
 	path, blkPath, err := p.getBlockDevicePath(blkDevOpts)

--- a/cmd/provisioner-localpv/app/provisioner_hostpath.go
+++ b/cmd/provisioner-localpv/app/provisioner_hostpath.go
@@ -44,10 +44,10 @@ func (p *Provisioner) ProvisionHostPath(opts pvController.VolumeOptions, volumeC
 	//Before using the path for local PV, make sure it is created.
 	initCmdsForPath := []string{"mkdir", "-m", "0777", "-p"}
 	podOpts := &HelperPodOptions{
-		cmdsForPath: initCmdsForPath,
-		name:        name,
-		path:        path,
-		nodeName:    nodeHostname,
+		cmdsForPath:  initCmdsForPath,
+		name:         name,
+		path:         path,
+		nodeHostname: nodeHostname,
 	}
 
 	iErr := p.createInitPod(podOpts)
@@ -119,10 +119,10 @@ func (p *Provisioner) DeleteHostPath(pv *v1.PersistentVolume) (err error) {
 	glog.Infof("Deleting volume %v at %v:%v", pv.Name, node, path)
 	cleanupCmdsForPath := []string{"rm", "-rf"}
 	podOpts := &HelperPodOptions{
-		cmdsForPath: cleanupCmdsForPath,
-		name:        pv.Name,
-		path:        path,
-		nodeName:    node,
+		cmdsForPath:  cleanupCmdsForPath,
+		name:         pv.Name,
+		path:         path,
+		nodeHostname: node,
 	}
 
 	if err := p.createCleanupPod(podOpts); err != nil {

--- a/cmd/provisioner-localpv/app/provisioner_hostpath.go
+++ b/cmd/provisioner-localpv/app/provisioner_hostpath.go
@@ -110,19 +110,19 @@ func (p *Provisioner) DeleteHostPath(pv *v1.PersistentVolume) (err error) {
 		return errors.Errorf("no HostPath set")
 	}
 
-	node := pvObj.GetAffinitedNode()
-	if node == "" {
-		return errors.Errorf("cannot find affinited node")
+	hostname := pvObj.GetAffinitedNodeHostname()
+	if hostname == "" {
+		return errors.Errorf("cannot find affinited node hostname")
 	}
 
 	//Initiate clean up only when reclaim policy is not retain.
-	glog.Infof("Deleting volume %v at %v:%v", pv.Name, node, path)
+	glog.Infof("Deleting volume %v at %v:%v", pv.Name, hostname, path)
 	cleanupCmdsForPath := []string{"rm", "-rf"}
 	podOpts := &HelperPodOptions{
 		cmdsForPath:  cleanupCmdsForPath,
 		name:         pv.Name,
 		path:         path,
-		nodeHostname: node,
+		nodeHostname: hostname,
 	}
 
 	if err := p.createCleanupPod(podOpts); err != nil {

--- a/pkg/kubernetes/persistentvolume/v1alpha1/persistentvolume.go
+++ b/pkg/kubernetes/persistentvolume/v1alpha1/persistentvolume.go
@@ -87,9 +87,20 @@ func (p *PV) GetPath() string {
 	return ""
 }
 
-// GetAffinitedNode returns nodeName configured using the NodeAffinity
-// This method expects only a single node to be set.
-func (p *PV) GetAffinitedNode() string {
+// GetAffinitedNodeHostname returns hostname configured using the NodeAffinity
+// This method expects only a single hostname to be set.
+//
+// The PV object will have the node's hostname specified as follows:
+//   nodeAffinity:
+//     required:
+//       nodeSelectorTerms:
+//       - matchExpressions:
+//         - key: kubernetes.io/hostname
+//           operator: In
+//           values:
+//           - hostname
+//
+func (p *PV) GetAffinitedNodeHostname() string {
 	nodeAffinity := p.object.Spec.NodeAffinity
 	if nodeAffinity == nil {
 		return ""
@@ -99,7 +110,7 @@ func (p *PV) GetAffinitedNode() string {
 		return ""
 	}
 
-	node := ""
+	hostname := ""
 	for _, selectorTerm := range required.NodeSelectorTerms {
 		for _, expression := range selectorTerm.MatchExpressions {
 			if expression.Key == KeyNode &&
@@ -107,15 +118,15 @@ func (p *PV) GetAffinitedNode() string {
 				if len(expression.Values) != 1 {
 					return ""
 				}
-				node = expression.Values[0]
+				hostname = expression.Values[0]
 				break
 			}
 		}
-		if node != "" {
+		if hostname != "" {
 			break
 		}
 	}
-	return node
+	return hostname
 }
 
 // IsNil is predicate to filter out nil PV

--- a/pkg/kubernetes/pod/v1alpha1/build.go
+++ b/pkg/kubernetes/pod/v1alpha1/build.go
@@ -121,8 +121,9 @@ func (b *Builder) WithNodeName(nodeName string) *Builder {
 	return b
 }
 
-// WithNodeSelectorHostname sets the Pod NodeSelector to the provided hostname value
-func (b *Builder) WithNodeSelectorHostname(hostname string) *Builder {
+// WithNodeSelectorHostnameNew sets the Pod NodeSelector to the provided hostname value
+// This function replaces (resets) the NodeSelector to use only hostname selector
+func (b *Builder) WithNodeSelectorHostnameNew(hostname string) *Builder {
 	if len(hostname) == 0 {
 		b.errs = append(
 			b.errs,

--- a/pkg/kubernetes/pod/v1alpha1/build.go
+++ b/pkg/kubernetes/pod/v1alpha1/build.go
@@ -23,6 +23,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	// k8sNodeLabelKeyHostname is the label key used by Kubernetes
+	// to store the hostname on the node resource.
+	k8sNodeLabelKeyHostname = "kubernetes.io/hostname"
+)
+
 // Builder is the builder object for Pod
 type Builder struct {
 	pod  *Pod
@@ -112,6 +118,23 @@ func (b *Builder) WithNodeName(nodeName string) *Builder {
 		return b
 	}
 	b.pod.object.Spec.NodeName = nodeName
+	return b
+}
+
+// WithNodeSelectorHostname sets the Pod NodeSelector to the provided hostname value
+func (b *Builder) WithNodeSelectorHostname(hostname string) *Builder {
+	if len(hostname) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build Pod object: missing Pod hostname"),
+		)
+		return b
+	}
+
+	b.pod.object.Spec.NodeSelector = map[string]string{
+		k8sNodeLabelKeyHostname: hostname,
+	}
+
 	return b
 }
 


### PR DESCRIPTION
For provisioning Local PV, there are several components that work together like:
- provisioner that gets the node resource from Kubernetes
- helper pods that create/delete hostpath on selected node
- PV node affinity.

The provisioner was extracting the host name from the node resource
and passing it as:
- node name to init helper pod and
- hostname to PV node affinity.

Later during deprovision, the hostname was extracted from the PV
and passed as node name to cleanup helper pod.

One fix could have been to extract both node name and hostname and pass them as per the requirement.
To make this happen, during deprovision - the node resource will have to be obtained and node name extracted.
Also, using hostname and nodename for different interactions increases the cost of maintaining the code.

Hence, changed the code to use hostname in all the localpv components.

Refactored the code to make use of node hostname across all components.
- To make this explicit, the nodeName is changed to nodeHostname.
- Changed the helper pods to use hostname instead of node names as node selector.
- Also added a check in the provisioner to fail, in case the hostname is missing on the node resource.

In addition, debug message log level is change from info to debug.

Note: The constant `kubernetes.io/hostname` is defined multiple times
in different packages to maintain package level isolation. It is possible
that in a future refactoring state, a common types can be setup to contain
all the commonly used constants.

Signed-off-by: kmova <kiran.mova@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests