### PR TITLE
fix(cstor-operater): read host Name from new path of blockdeviceclaim

### DIFF
--- a/pkg/apis/openebs.io/ndm/v1alpha1/blockdeviceclaim_types.go
+++ b/pkg/apis/openebs.io/ndm/v1alpha1/blockdeviceclaim_types.go
@@ -43,7 +43,7 @@ type DeviceClaimSpec struct {
 	// DeviceType represents the type of drive like SSD, HDD etc.,
 	DeviceType string `json:"deviceType"`
 
-	// Node name from where blockdevice has to be claimed.
+	// HostName from where blockdevice has to be claimed.
 	HostName string `json:"hostName"`
 
 	// Details of the device to be claimed

--- a/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim.go
+++ b/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim.go
@@ -177,7 +177,7 @@ func (bdc *BlockDeviceClaim) GetNodeAtributesHostName() string {
 	return bdc.Object.Spec.BlockDeviceNodeAttributes.HostName
 }
 
-// GetHostName return hostName from blcokdeviceclaim
+// GetHostName return hostName from blockdeviceclaim
 func (bdc *BlockDeviceClaim) GetHostName() string {
 	hostName := bdc.GetNodeAtributesHostName()
 	if hostName == "" {
@@ -191,8 +191,8 @@ func (bdcl *BlockDeviceClaimList) Len() int {
 	return len(bdcl.ObjectList.Items)
 }
 
-// GetBlockDeviceNamesByNode returns map of node name and corresponding block devices to that
-// node from block device claim list
+// GetBlockDeviceNamesByNode returns map of node name and corresponding blockdevices to that
+// node from blockdeviceclaim list
 func (bdcl *BlockDeviceClaimList) GetBlockDeviceNamesByNode() map[string][]string {
 	newNodeBDList := make(map[string][]string)
 	if bdcl == nil {

--- a/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim.go
+++ b/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim.go
@@ -199,6 +199,7 @@ func (bdcl *BlockDeviceClaimList) GetBlockDeviceNamesByNode() map[string][]strin
 		return newNodeBDList
 	}
 	for _, bdc := range bdcl.ObjectList.Items {
+		bdc := bdc
 		bdcObj := BlockDeviceClaim{Object: &bdc}
 		hostName := bdcObj.GetHostName()
 		newNodeBDList[hostName] = append(

--- a/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim.go
+++ b/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim.go
@@ -167,6 +167,25 @@ func (bdc *BlockDeviceClaim) IsStatus(status string) bool {
 	return string(bdc.Object.Status.Phase) == status
 }
 
+// GetSpecHostName return hostName from spec of blockdeviceclaim
+func (bdc *BlockDeviceClaim) GetSpecHostName() string {
+	return bdc.Object.Spec.HostName
+}
+
+// GetNodeAtributesHostName return hostName from blockdeviceclaim attribute hostName
+func (bdc *BlockDeviceClaim) GetNodeAtributesHostName() string {
+	return bdc.Object.Spec.BlockDeviceNodeAttributes.HostName
+}
+
+// GetHostName return hostName from blcokdeviceclaim
+func (bdc *BlockDeviceClaim) GetHostName() string {
+	hostName := bdc.GetNodeAtributesHostName()
+	if hostName == "" {
+		return bdc.GetSpecHostName()
+	}
+	return hostName
+}
+
 // Len returns the length og BlockDeviceClaimList.
 func (bdcl *BlockDeviceClaimList) Len() int {
 	return len(bdcl.ObjectList.Items)
@@ -180,7 +199,12 @@ func (bdcl *BlockDeviceClaimList) GetBlockDeviceNamesByNode() map[string][]strin
 		return newNodeBDList
 	}
 	for _, bdc := range bdcl.ObjectList.Items {
-		newNodeBDList[bdc.Spec.HostName] = append(newNodeBDList[bdc.Spec.HostName], bdc.Spec.BlockDeviceName)
+		bdcObj := BlockDeviceClaim{Object: &bdc}
+		hostName := bdcObj.GetHostName()
+		newNodeBDList[hostName] = append(
+			newNodeBDList[hostName],
+			bdcObj.Object.Spec.BlockDeviceName,
+		)
 	}
 	return newNodeBDList
 }

--- a/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim_test.go
+++ b/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim_test.go
@@ -51,7 +51,9 @@ func TestGetBDList(t *testing.T) {
 							TypeMeta:   metav1.TypeMeta{},
 							ObjectMeta: metav1.ObjectMeta{},
 							Spec: ndm.DeviceClaimSpec{
-								HostName:        "openebs-1234",
+								BlockDeviceNodeAttributes: ndm.BlockDeviceNodeAttributes{
+									HostName: "openebs-1234",
+								},
 								BlockDeviceName: "blockdevice1",
 							},
 						},
@@ -59,7 +61,9 @@ func TestGetBDList(t *testing.T) {
 							TypeMeta:   metav1.TypeMeta{},
 							ObjectMeta: metav1.ObjectMeta{},
 							Spec: ndm.DeviceClaimSpec{
-								HostName:        "openebs-1234",
+								BlockDeviceNodeAttributes: ndm.BlockDeviceNodeAttributes{
+									HostName: "openebs-1234",
+								},
 								BlockDeviceName: "blockdevice2",
 							},
 						},
@@ -67,7 +71,9 @@ func TestGetBDList(t *testing.T) {
 							TypeMeta:   metav1.TypeMeta{},
 							ObjectMeta: metav1.ObjectMeta{},
 							Spec: ndm.DeviceClaimSpec{
-								HostName:        "openebs-1234",
+								BlockDeviceNodeAttributes: ndm.BlockDeviceNodeAttributes{
+									HostName: "openebs-1234",
+								},
 								BlockDeviceName: "blockdevice3",
 							},
 						},
@@ -84,6 +90,51 @@ func TestGetBDList(t *testing.T) {
 			nodeBDList := test.bdcList.GetBlockDeviceNamesByNode()
 			if len(nodeBDList) != test.nodeCount {
 				t.Errorf("Test %q failed: expected block device object count %d but got %d", name, test.nodeCount, len(nodeBDList))
+			}
+		})
+	}
+}
+
+func TestGetHostName(t *testing.T) {
+	tests := map[string]struct {
+		bdc            *BlockDeviceClaim
+		expectedOutput string
+	}{
+		"Test with blockdevice attribute hostname": {
+			bdc: &BlockDeviceClaim{
+				Object: &ndm.BlockDeviceClaim{
+					Spec: ndm.DeviceClaimSpec{
+						BlockDeviceNodeAttributes: ndm.BlockDeviceNodeAttributes{
+							HostName: "fakeNode1",
+						},
+					},
+				},
+			},
+			expectedOutput: "fakeNode1",
+		},
+		"Test with spec hostName": {
+			bdc: &BlockDeviceClaim{
+				Object: &ndm.BlockDeviceClaim{
+					Spec: ndm.DeviceClaimSpec{
+						HostName: "fakeNode2",
+					},
+				},
+			},
+			expectedOutput: "fakeNode2",
+		},
+		"Test with empty": {
+			bdc: &BlockDeviceClaim{
+				Object: &ndm.BlockDeviceClaim{},
+			},
+			expectedOutput: "",
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			hostName := test.bdc.GetHostName()
+			if hostName != test.expectedOutput {
+				t.Errorf("Test %q failed: expected hostName %s but got hostName %s", name, test.expectedOutput, hostName)
 			}
 		})
 	}

--- a/tests/cstor/pool/negative/provision_without_disk_test.go
+++ b/tests/cstor/pool/negative/provision_without_disk_test.go
@@ -80,7 +80,7 @@ var _ = Describe("[cstor] [-ve] TEST PROVISION WITHOUT DISK", func() {
 			Expect(err).To(BeNil(), "while creating storagepoolclaim {%s}", spcObj.Name)
 
 			By("verifying cstorpool count as 0")
-			cspCount := ops.GetHealthyCSPCountEventually(spcObj.Name, cstor.PoolCount)
+			cspCount := ops.GetHealthyCSPCount(spcObj.Name, cstor.PoolCount)
 			Expect(cspCount).To(Equal(0), "while checking cstorpool count")
 
 		})

--- a/tests/cstor/pool/negative/provision_without_disk_test.go
+++ b/tests/cstor/pool/negative/provision_without_disk_test.go
@@ -80,7 +80,7 @@ var _ = Describe("[cstor] [-ve] TEST PROVISION WITHOUT DISK", func() {
 			Expect(err).To(BeNil(), "while creating storagepoolclaim {%s}", spcObj.Name)
 
 			By("verifying cstorpool count as 0")
-			cspCount := ops.GetHealthyCSPCount(spcObj.Name, cstor.PoolCount)
+			cspCount := ops.GetHealthyCSPCountEventually(spcObj.Name, cstor.PoolCount)
 			Expect(cspCount).To(Equal(0), "while checking cstorpool count")
 
 		})


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR read hostname from the new path in blockdeviceclaim.
i.e (cstor-operator read hostname from blockdeviceclaim.spec.BlockDeviceNodeAttributes.HostName instead of blockdeviceclaim.Spec.HostName).


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests