### PR TITLE
chore(cspi): add custom columns for cspi resource

### DIFF
--- a/pkg/install/v1alpha1/openebs_crds.go
+++ b/pkg/install/v1alpha1/openebs_crds.go
@@ -136,6 +136,22 @@ spec:
     shortNames:
     - cspi
   additionalPrinterColumns:
+  - JSONPath: .spec.hostName
+    name: HostName
+    description: Host name where cstorpool instances scheduled
+    type: string
+  - JSONPath: .status.capacity.used
+    name: Allocated
+    description: The amount of storage space within the pool that has been physically allocated
+    type: string
+  - JSONPath: .status.capacity.free
+    name: Free
+    description: The amount of free space available in the pool
+    type: string
+  - JSONPath: .status.capacity.total
+    name: Capacity
+    description: Total size of the storage pool
+    type: string
   - JSONPath: .status.phase
     name: Status
     description: Identifies the current health of the pool


### PR DESCRIPTION
```sh
kubectl get cspi -n openebs

NAME               HOSTNAME    ALLOCATED   FREE    CAPACITY   STATUS   AGE
cspc-sparse-2kht   127.0.0.1   281K        9.94G   9.94G      ONLINE   13m
```

Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>
