### PR TITLE
refact(upgrade): added functionality to create and update the UpgradeTask CR

### DIFF
--- a/cmd/upgrade/executor/env.go
+++ b/cmd/upgrade/executor/env.go
@@ -29,6 +29,6 @@ func getOpenEBSNamespace() string {
 	return menv.Get(menv.OpenEBSNamespace)
 }
 
-func getUpgradeTaskCRName() string {
-	return menv.Get("UPGRADE_TASK")
+func getUpgradeTaskLabel() string {
+	return menv.Get("UPGRADE_TASK_LABEL")
 }

--- a/cmd/upgrade/executor/resource.go
+++ b/cmd/upgrade/executor/resource.go
@@ -53,15 +53,17 @@ func NewUpgradeResourceJob() *cobra.Command {
 		Long:    resourceUpgradeCmdHelpText,
 		Example: `upgrade resource`,
 		Run: func(cmd *cobra.Command, args []string) {
-			upgradeTaskCRName := getUpgradeTaskLabel()
+			upgradeTaskLabel := getUpgradeTaskLabel()
 			openebsNamespace := getOpenEBSNamespace()
 			upgradeTaskList, err := utask.NewKubeClient().
 				WithNamespace(openebsNamespace).
 				List(metav1.ListOptions{
-					LabelSelector: upgradeTaskCRName,
+					LabelSelector: upgradeTaskLabel,
 				})
 			util.CheckErr(err, util.Fatal)
-
+			if len(upgradeTaskList.Items) == 0 {
+				util.Fatal("No resource found for given label")
+			}
 			for _, cr := range upgradeTaskList.Items {
 				util.CheckErr(options.InitializeFromUpgradeTaskResource(
 					cr, cmd), util.Fatal)

--- a/cmd/upgrade/executor/resource.go
+++ b/cmd/upgrade/executor/resource.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/golang/glog"
 
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/upgrade/v1alpha1"
 	"github.com/openebs/maya/pkg/util"
 	"github.com/spf13/cobra"
 
@@ -52,27 +53,40 @@ func NewUpgradeResourceJob() *cobra.Command {
 		Long:    resourceUpgradeCmdHelpText,
 		Example: `upgrade resource`,
 		Run: func(cmd *cobra.Command, args []string) {
-			util.CheckErr(options.InitializeFromUpgradeTaskResource(cmd), util.Fatal)
-			util.CheckErr(options.RunPreFlightChecks(cmd), util.Fatal)
-			util.CheckErr(options.RunResourceUpgradeChecks(cmd), util.Fatal)
-			util.CheckErr(options.InitializeDefaults(cmd), util.Fatal)
-			util.CheckErr(options.RunResourceUpgrade(cmd), util.Fatal)
+			upgradeTaskCRName := getUpgradeTaskLabel()
+			openebsNamespace := getOpenEBSNamespace()
+			upgradeTaskList, err := utask.NewKubeClient().
+				WithNamespace(openebsNamespace).
+				List(metav1.ListOptions{
+					LabelSelector: upgradeTaskCRName,
+				})
+			util.CheckErr(err, util.Fatal)
+
+			for _, cr := range upgradeTaskList.Items {
+				util.CheckErr(options.InitializeFromUpgradeTaskResource(
+					cr, cmd), util.Fatal)
+				util.CheckErr(options.RunPreFlightChecks(cmd), util.Fatal)
+				util.CheckErr(options.RunResourceUpgradeChecks(cmd), util.Fatal)
+				util.CheckErr(options.InitializeDefaults(cmd), util.Fatal)
+				util.CheckErr(options.RunResourceUpgrade(cmd), util.Fatal)
+			}
 		},
 	}
+	// TODO
+	// cmd.Flags().StringVarP(&options.resource.label,
+	// 	"label", "",
+	// 	options.resource.label,
+	// 	"label of the upgradetasks to be upgraded. Run \"kubectl get utask \", to get label")
 
 	return cmd
 }
 
 // InitializeFromUpgradeTaskResource will populate the UpgradeOptions from given UpgradeTask
-func (u *UpgradeOptions) InitializeFromUpgradeTaskResource(cmd *cobra.Command) error {
-	upgradeTaskCRName := getUpgradeTaskCRName()
+func (u *UpgradeOptions) InitializeFromUpgradeTaskResource(
+	upgradeTaskCRObj apis.UpgradeTask, cmd *cobra.Command) error {
+
 	if len(strings.TrimSpace(u.openebsNamespace)) == 0 {
 		return errors.Errorf("Cannot execute upgrade job: namespace is missing")
-	}
-	upgradeTaskCRObj, err := utask.NewKubeClient().WithNamespace(u.openebsNamespace).
-		Get(upgradeTaskCRName, metav1.GetOptions{})
-	if err != nil {
-		return err
 	}
 	if len(strings.TrimSpace(upgradeTaskCRObj.Spec.FromVersion)) != 0 {
 		u.fromVersion = upgradeTaskCRObj.Spec.FromVersion
@@ -90,6 +104,10 @@ func (u *UpgradeOptions) InitializeFromUpgradeTaskResource(cmd *cobra.Command) e
 	case upgradeTaskCRObj.Spec.ResourceSpec.CStorPool != nil:
 		u.resourceKind = "cstorPool"
 		u.resource.name = upgradeTaskCRObj.Spec.ResourceSpec.CStorPool.PoolName
+
+	case upgradeTaskCRObj.Spec.ResourceSpec.StoragePoolClaim != nil:
+		u.resourceKind = "storagePoolClaim"
+		u.resource.name = upgradeTaskCRObj.Spec.ResourceSpec.StoragePoolClaim.SPCName
 
 	case upgradeTaskCRObj.Spec.ResourceSpec.CStorVolume != nil:
 		u.resourceKind = "cstorVolume"
@@ -124,7 +142,7 @@ func (u *UpgradeOptions) RunResourceUpgrade(cmd *cobra.Command) error {
 			u.imageURLPrefix,
 			u.toVersionImageTag)
 		if err != nil {
-			return errors.Errorf("Failed to upgrade %v %v:", u.resourceKind, u.resource.name)
+			return errors.Wrapf(err, "Failed to upgrade %v %v:", u.resourceKind, u.resource.name)
 		}
 	default:
 		return errors.Errorf("Invalid from version %s or to version %s", u.fromVersion, u.toVersion)

--- a/cmd/upgrade/executor/resource.go
+++ b/cmd/upgrade/executor/resource.go
@@ -25,9 +25,9 @@ import (
 	"github.com/openebs/maya/pkg/util"
 	"github.com/spf13/cobra"
 
-	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 	upgrade100to120 "github.com/openebs/maya/pkg/upgrade/1.0.0-1.1.0/v1alpha1"
 	utask "github.com/openebs/maya/pkg/upgrade/v1alpha2"
+	errors "github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -142,7 +142,7 @@ func (u *UpgradeOptions) RunResourceUpgrade(cmd *cobra.Command) error {
 			u.imageURLPrefix,
 			u.toVersionImageTag)
 		if err != nil {
-			return errors.Wrapf(err, "Failed to upgrade %v %v:", u.resourceKind, u.resource.name)
+			return errors.Wrapf(err, "Failed to upgrade %v %v", u.resourceKind, u.resource.name)
 		}
 	default:
 		return errors.Errorf("Invalid from version %s or to version %s", u.fromVersion, u.toVersion)

--- a/pkg/apis/openebs.io/upgrade/v1alpha1/upgradetask.go
+++ b/pkg/apis/openebs.io/upgrade/v1alpha1/upgradetask.go
@@ -163,6 +163,8 @@ const (
 	Verify UpgradeStep = "VERIFY"
 	// Rollback is the step to rollback to previous version if upgrade fails
 	Rollback UpgradeStep = "ROLLBACK"
+	// PoolInstanceUpgrade is the step to verify resource before upgrade
+	PoolInstanceUpgrade UpgradeStep = "POOL_INSTANCE_UPGRADE"
 )
 
 // StepPhase defines the phase of a UpgradeStep

--- a/pkg/kubernetes/job/kubernetes.go
+++ b/pkg/kubernetes/job/kubernetes.go
@@ -1,0 +1,352 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package job
+
+import (
+	"encoding/json"
+
+	client "github.com/openebs/maya/pkg/kubernetes/client/v1alpha1"
+	"github.com/pkg/errors"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+// getClientsetFn is a typed function that
+// abstracts fetching of internal clientset
+type getClientsetFn func() (clientset *kubernetes.Clientset, err error)
+
+// getClientsetFromPathFn is a typed function that
+// abstracts fetching of clientset from kubeConfigPath
+type getClientsetForPathFn func(
+	kubeConfigPath string,
+) (*kubernetes.Clientset, error)
+
+// getFn is a typed function that abstracts get of job instances
+type getFn func(
+	cli *kubernetes.Clientset,
+	name, namespace string,
+	opts metav1.GetOptions,
+) (*batchv1.Job, error)
+
+// listFn is a typed function that abstracts list of job instances
+type listFn func(
+	cli *kubernetes.Clientset,
+	namespace string,
+	opts metav1.ListOptions,
+) (*batchv1.JobList, error)
+
+// delFn is a typed function that abstracts delete of job instances
+type delFn func(
+	cli *kubernetes.Clientset,
+	name, namespace string,
+	opts *metav1.DeleteOptions,
+) error
+
+// createFn is a typed function that abstracts delete of job instances
+type createFn func(
+	cli *kubernetes.Clientset,
+	job *batchv1.Job,
+	namespace string,
+) (*batchv1.Job, error)
+
+// patchFn is a typed function that abstracts patch of job instances
+type patchFn func(
+	cli *kubernetes.Clientset,
+	name, namespace string,
+	pt types.PatchType,
+	data []byte,
+	subresources ...string,
+) (*batchv1.Job, error)
+
+// Kubeclient enables kubernetes API operations on job instance
+type Kubeclient struct {
+	// clientset refers to kubernetes clientset. It is responsible to
+	// make kubernetes API calls for crud op
+	clientset *kubernetes.Clientset
+	namespace string
+
+	// kubeconfig path to get kubernetes clientset
+	kubeConfigPath string
+
+	// functions useful during mocking
+	getClientset        getClientsetFn
+	getClientsetForPath getClientsetForPathFn
+	list                listFn
+	get                 getFn
+	del                 delFn
+	create              createFn
+	patch               patchFn
+}
+
+// KubeclientBuildOption defines the abstraction to build a kubeclient instance
+type KubeclientBuildOption func(*Kubeclient)
+
+// defaultGetClientset is the default implementation to
+// get kubernetes clientset instance
+func defaultGetClientset() (clients *kubernetes.Clientset, err error) {
+	config, err := client.New().Config()
+	if err != nil {
+		return nil, err
+	}
+	return kubernetes.NewForConfig(config)
+}
+
+// defaultGetClientsetForPath is the default implementation to
+// get kubernetes clientset instance based on the given
+// kubeconfig path
+func defaultGetClientsetForPath(
+	kubeConfigPath string,
+) (clients *kubernetes.Clientset, err error) {
+	return client.New(client.WithKubeConfigPath(kubeConfigPath)).
+		Clientset()
+}
+
+// defaultCreate is the default implementation to get
+// a job instance in kubernetes cluster
+func defaultGet(
+	cli *kubernetes.Clientset,
+	name, namespace string,
+	opts metav1.GetOptions,
+) (r *batchv1.Job, err error) {
+	r, err = cli.BatchV1().
+		Jobs(namespace).
+		Get(name, opts)
+	return
+}
+
+// defaultCreate is the default implementation to list
+// job instances in kubernetes cluster
+func defaultList(
+	cli *kubernetes.Clientset,
+	namespace string,
+	opts metav1.ListOptions,
+) (rl *batchv1.JobList, err error) {
+	rl, err = cli.BatchV1().
+		Jobs(namespace).
+		List(opts)
+	return
+}
+
+// defaultCreate is the default implementation to delete
+// a job instance in kubernetes cluster
+func defaultDel(
+	cli *kubernetes.Clientset,
+	name, namespace string,
+	opts *metav1.DeleteOptions,
+) (err error) {
+	deletePropagation := metav1.DeletePropagationForeground
+	opts.PropagationPolicy = &deletePropagation
+	err = cli.BatchV1().
+		Jobs(namespace).
+		Delete(name, opts)
+	return
+}
+
+// defaultCreate is the default implementation to create
+// a job instance in kubernetes cluster
+func defaultCreate(
+	cli *kubernetes.Clientset,
+	job *batchv1.Job,
+	namespace string,
+) (*batchv1.Job, error) {
+	return cli.BatchV1().
+		Jobs(namespace).
+		Create(job)
+}
+
+// defaultPatch is the default implementation to patch
+// a job instance in kubernetes cluster
+func defaultPatch(
+	cli *kubernetes.Clientset,
+	name, namespace string,
+	pt types.PatchType,
+	data []byte,
+	subresources ...string,
+) (*batchv1.Job, error) {
+	return cli.BatchV1().
+		Jobs(namespace).
+		Patch(name, pt, data, subresources...)
+}
+
+// withDefaults sets the default options of kubeclient instance
+func (k *Kubeclient) withDefaults() {
+	if k.getClientset == nil {
+		k.getClientset = defaultGetClientset
+	}
+	if k.getClientsetForPath == nil {
+		k.getClientsetForPath = defaultGetClientsetForPath
+	}
+	if k.get == nil {
+		k.get = defaultGet
+	}
+	if k.list == nil {
+		k.list = defaultList
+	}
+	if k.del == nil {
+		k.del = defaultDel
+	}
+	if k.create == nil {
+		k.create = defaultCreate
+	}
+	if k.patch == nil {
+		k.patch = defaultPatch
+	}
+}
+
+// WithClientset sets the kubernetes client against the kubeclient instance
+func WithClientset(c *kubernetes.Clientset) KubeclientBuildOption {
+	return func(k *Kubeclient) {
+		k.clientset = c
+	}
+}
+
+// WithNamespace set namespace in kubeclient object
+func WithNamespace(namespace string) KubeclientBuildOption {
+	return func(k *Kubeclient) {
+		k.namespace = namespace
+	}
+}
+
+// WithNamespace set namespace in kubeclient object
+func (k *Kubeclient) WithNamespace(namespace string) *Kubeclient {
+	k.namespace = namespace
+	return k
+}
+
+// WithKubeConfigPath sets the kubeConfig path
+// against client instance
+func WithKubeConfigPath(path string) KubeclientBuildOption {
+	return func(k *Kubeclient) {
+		k.kubeConfigPath = path
+	}
+}
+
+// NewKubeClient returns a new instance of kubeclient meant for job,
+// caller can configure it with different kubeclientBuildOption
+func NewKubeClient(opts ...KubeclientBuildOption) *Kubeclient {
+	k := &Kubeclient{}
+	for _, o := range opts {
+		o(k)
+	}
+	k.withDefaults()
+	return k
+}
+
+func (k *Kubeclient) getClientsetForPathOrDirect() (
+	*kubernetes.Clientset, error) {
+	if k.kubeConfigPath != "" {
+		return k.getClientsetForPath(k.kubeConfigPath)
+	}
+	return k.getClientset()
+}
+
+// getClientOrCached returns either a new
+// instance of kubernetes client or its cached copy
+func (k *Kubeclient) getClientOrCached() (*kubernetes.Clientset, error) {
+	if k.clientset != nil {
+		return k.clientset, nil
+	}
+
+	cs, err := k.getClientsetForPathOrDirect()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get clientset")
+	}
+	k.clientset = cs
+	return k.clientset, nil
+}
+
+// Get returns job object for given name
+func (k *Kubeclient) Get(name string, opts metav1.GetOptions) (
+	*batchv1.Job, error) {
+	cli, err := k.getClientOrCached()
+	if err != nil {
+		return nil, err
+	}
+	return k.get(cli, name, k.namespace, opts)
+}
+
+// GetRaw returns job object for given name in byte format
+func (k *Kubeclient) GetRaw(name string, opts metav1.GetOptions) (
+	[]byte, error) {
+	svc, err := k.Get(name, opts)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(svc)
+}
+
+// List returns list of jobs
+func (k *Kubeclient) List(opts metav1.ListOptions) (
+	*batchv1.JobList, error) {
+	cli, err := k.getClientOrCached()
+	if err != nil {
+		return nil, err
+	}
+	return k.list(cli, k.namespace, opts)
+}
+
+// ListRaw returns list of jobs in byte format
+func (k *Kubeclient) ListRaw(opts metav1.ListOptions) ([]byte, error) {
+	svcList, err := k.List(opts)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(svcList)
+}
+
+// Delete returns job object for given name
+func (k *Kubeclient) Delete(name string, options *metav1.DeleteOptions) error {
+	cli, err := k.getClientOrCached()
+	if err != nil {
+		return err
+	}
+	return k.del(cli, name, k.namespace, options)
+}
+
+// Create creates a job in specified namespace in kubernetes cluster
+func (k *Kubeclient) Create(job *batchv1.Job) (*batchv1.Job, error) {
+	if job == nil {
+		return nil, errors.New("failed to create job: nil job object")
+	}
+	cli, err := k.getClientOrCached()
+	if err != nil {
+		return nil, errors.Wrapf(
+			err,
+			"failed to create job {%s} in namespace {%s}",
+			job.Name,
+			job.Namespace,
+		)
+	}
+	return k.create(cli, job, k.namespace)
+}
+
+// Patch patches job object for given name
+func (k *Kubeclient) Patch(
+	name string,
+	pt types.PatchType,
+	data []byte,
+	subresources ...string,
+) (*batchv1.Job, error) {
+	cli, err := k.getClientOrCached()
+	if err != nil {
+		return nil, err
+	}
+
+	return k.patch(cli, name, k.namespace, pt, data, subresources...)
+}

--- a/pkg/kubernetes/pod/v1alpha1/kubernetes.go
+++ b/pkg/kubernetes/pod/v1alpha1/kubernetes.go
@@ -89,11 +89,7 @@ func defaultExec(
 	// for transporting shell-style streams
 	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
 	if err != nil {
-		return nil, errors.Wrapf(
-			err,
-			"failed to exec into pod {%s}: failed to connect to the provided server",
-			name,
-		)
+		return nil, err
 	}
 
 	// Stream initiates transport of standard shell streams
@@ -106,11 +102,7 @@ func defaultExec(
 		Tty:    opts.TTY,
 	})
 	if err != nil {
-		return nil, errors.Wrapf(
-			err,
-			"failed to exec into pod {%s}: failed to stream",
-			name,
-		)
+		return nil, err
 	}
 
 	execOutput := &ExecOutput{

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/csp_upgrade.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/csp_upgrade.go
@@ -207,7 +207,7 @@ func cspUpgrade(cspName, openebsNamespace string) (*utask.UpgradeTask, error) {
 				Status: utask.Status{
 					Phase:   utask.StepErrored,
 					Message: "failed to verify cstor pool",
-					Reason:  strings.ReplaceAll(err.Error(), ":", ""),
+					Reason:  strings.Replace(err.Error(), ":", "", -1),
 				},
 			},
 			openebsNamespace,
@@ -227,7 +227,7 @@ func cspUpgrade(cspName, openebsNamespace string) (*utask.UpgradeTask, error) {
 				Status: utask.Status{
 					Phase:   utask.StepErrored,
 					Message: "failed to verify cstor pool deployment",
-					Reason:  strings.ReplaceAll(err.Error(), ":", ""),
+					Reason:  strings.Replace(err.Error(), ":", "", -1),
 				},
 			},
 			openebsNamespace,
@@ -276,7 +276,7 @@ func cspUpgrade(cspName, openebsNamespace string) (*utask.UpgradeTask, error) {
 				Status: utask.Status{
 					Phase:   utask.StepErrored,
 					Message: "failed to patch cstor pool deployment",
-					Reason:  strings.ReplaceAll(err.Error(), ":", ""),
+					Reason:  strings.Replace(err.Error(), ":", "", -1),
 				},
 			},
 			openebsNamespace,
@@ -296,7 +296,7 @@ func cspUpgrade(cspName, openebsNamespace string) (*utask.UpgradeTask, error) {
 				Status: utask.Status{
 					Phase:   utask.StepErrored,
 					Message: "failed to patch cstor pool",
-					Reason:  strings.ReplaceAll(err.Error(), ":", ""),
+					Reason:  strings.Replace(err.Error(), ":", "", -1),
 				},
 			},
 			openebsNamespace,

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/csp_upgrade.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/csp_upgrade.go
@@ -190,34 +190,20 @@ func (c *cstorCSPOptions) preUpgrade(cspName, openebsNamespace string) error {
 		return uerr
 	}
 
-	c.utaskObj, uerr = updateUpgradeDetailedStatus(
-		c.utaskObj,
-		utask.UpgradeDetailedStatuses{
-			Step: utask.PreUpgrade,
-			Status: utask.Status{
-				Phase: utask.StepWaiting,
-			},
-		},
-		openebsNamespace,
-	)
+	statusObj := utask.UpgradeDetailedStatuses{Step: utask.PreUpgrade}
+
+	statusObj.Phase = utask.StepWaiting
+	c.utaskObj, uerr = updateUpgradeDetailedStatus(c.utaskObj, statusObj, openebsNamespace)
 	if uerr != nil && isENVPresent {
 		return uerr
 	}
 
 	c.cspObj, err = getCSPObject(cspName)
 	if err != nil {
-		c.utaskObj, uerr = updateUpgradeDetailedStatus(
-			c.utaskObj,
-			utask.UpgradeDetailedStatuses{
-				Step: utask.PreUpgrade,
-				Status: utask.Status{
-					Phase:   utask.StepErrored,
-					Message: "failed to verify cstor pool",
-					Reason:  strings.Replace(err.Error(), ":", "", -1),
-				},
-			},
-			openebsNamespace,
-		)
+		statusObj.Phase = utask.StepErrored
+		statusObj.Message = "failed to verify cstor pool"
+		statusObj.Reason = strings.Replace(err.Error(), ":", "", -1)
+		c.utaskObj, uerr = updateUpgradeDetailedStatus(c.utaskObj, statusObj, openebsNamespace)
 		if uerr != nil && isENVPresent {
 			return uerr
 		}
@@ -226,35 +212,19 @@ func (c *cstorCSPOptions) preUpgrade(cspName, openebsNamespace string) error {
 
 	c.cspDeployObj, err = getCSPDeployment(cspName, openebsNamespace)
 	if err != nil {
-		c.utaskObj, uerr = updateUpgradeDetailedStatus(
-			c.utaskObj,
-			utask.UpgradeDetailedStatuses{
-				Step: utask.PreUpgrade,
-				Status: utask.Status{
-					Phase:   utask.StepErrored,
-					Message: "failed to verify cstor pool deployment",
-					Reason:  strings.Replace(err.Error(), ":", "", -1),
-				},
-			},
-			openebsNamespace,
-		)
+		statusObj.Message = "failed to verify cstor pool deployment"
+		statusObj.Reason = strings.Replace(err.Error(), ":", "", -1)
+		c.utaskObj, uerr = updateUpgradeDetailedStatus(c.utaskObj, statusObj, openebsNamespace)
 		if uerr != nil && isENVPresent {
 			return uerr
 		}
 		return err
 	}
 
-	c.utaskObj, uerr = updateUpgradeDetailedStatus(
-		c.utaskObj,
-		utask.UpgradeDetailedStatuses{
-			Step: utask.PreUpgrade,
-			Status: utask.Status{
-				Phase:   utask.StepCompleted,
-				Message: "Pre-upgrade steps were successful",
-			},
-		},
-		openebsNamespace,
-	)
+	statusObj.Phase = utask.StepCompleted
+	statusObj.Message = "Pre-upgrade steps were successful"
+	statusObj.Reason = ""
+	c.utaskObj, uerr = updateUpgradeDetailedStatus(c.utaskObj, statusObj, openebsNamespace)
 	if uerr != nil && isENVPresent {
 		return uerr
 	}
@@ -263,34 +233,19 @@ func (c *cstorCSPOptions) preUpgrade(cspName, openebsNamespace string) error {
 
 func (c *cstorCSPOptions) targetUpgarde(openebsNamespace string) error {
 	var err, uerr error
-	c.utaskObj, uerr = updateUpgradeDetailedStatus(
-		c.utaskObj,
-		utask.UpgradeDetailedStatuses{
-			Step: utask.TargetUpgrade,
-			Status: utask.Status{
-				Phase: utask.StepWaiting,
-			},
-		},
-		openebsNamespace,
-	)
+	statusObj := utask.UpgradeDetailedStatuses{Step: utask.TargetUpgrade}
+	statusObj.Phase = utask.StepWaiting
+	c.utaskObj, uerr = updateUpgradeDetailedStatus(c.utaskObj, statusObj, openebsNamespace)
 	if uerr != nil && isENVPresent {
 		return uerr
 	}
 
 	err = patchCSPDeploy(c.cspDeployObj, openebsNamespace)
 	if err != nil {
-		c.utaskObj, uerr = updateUpgradeDetailedStatus(
-			c.utaskObj,
-			utask.UpgradeDetailedStatuses{
-				Step: utask.TargetUpgrade,
-				Status: utask.Status{
-					Phase:   utask.StepErrored,
-					Message: "failed to patch cstor pool deployment",
-					Reason:  strings.Replace(err.Error(), ":", "", -1),
-				},
-			},
-			openebsNamespace,
-		)
+		statusObj.Phase = utask.StepErrored
+		statusObj.Message = "failed to patch cstor pool deployment"
+		statusObj.Reason = strings.Replace(err.Error(), ":", "", -1)
+		c.utaskObj, uerr = updateUpgradeDetailedStatus(c.utaskObj, statusObj, openebsNamespace)
 		if uerr != nil && isENVPresent {
 			return uerr
 		}
@@ -299,35 +254,19 @@ func (c *cstorCSPOptions) targetUpgarde(openebsNamespace string) error {
 
 	err = patchCSP(c.cspObj)
 	if err != nil {
-		c.utaskObj, uerr = updateUpgradeDetailedStatus(
-			c.utaskObj,
-			utask.UpgradeDetailedStatuses{
-				Step: utask.TargetUpgrade,
-				Status: utask.Status{
-					Phase:   utask.StepErrored,
-					Message: "failed to patch cstor pool",
-					Reason:  strings.Replace(err.Error(), ":", "", -1),
-				},
-			},
-			openebsNamespace,
-		)
+		statusObj.Message = "failed to patch cstor pool"
+		statusObj.Reason = strings.Replace(err.Error(), ":", "", -1)
+		c.utaskObj, uerr = updateUpgradeDetailedStatus(c.utaskObj, statusObj, openebsNamespace)
 		if uerr != nil && isENVPresent {
 			return uerr
 		}
 		return err
 	}
 
-	c.utaskObj, uerr = updateUpgradeDetailedStatus(
-		c.utaskObj,
-		utask.UpgradeDetailedStatuses{
-			Step: utask.TargetUpgrade,
-			Status: utask.Status{
-				Phase:   utask.StepCompleted,
-				Message: "Target upgrade was successful",
-			},
-		},
-		openebsNamespace,
-	)
+	statusObj.Phase = utask.StepCompleted
+	statusObj.Message = "Target upgrade was successful"
+	statusObj.Reason = ""
+	c.utaskObj, uerr = updateUpgradeDetailedStatus(c.utaskObj, statusObj, openebsNamespace)
 	if uerr != nil && isENVPresent {
 		return uerr
 	}

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/csp_upgrade.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/csp_upgrade.go
@@ -17,9 +17,13 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"fmt"
+	"strings"
 	"text/template"
 
+	"github.com/golang/glog"
+
+	utask "github.com/openebs/maya/pkg/apis/openebs.io/upgrade/v1alpha1"
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 	templates "github.com/openebs/maya/pkg/upgrade/templates/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -58,47 +62,55 @@ func getCSPDeployPatchDetails(
 	return patchDetails, nil
 }
 
-func cspUpgrade(cspName, openebsNamespace string) error {
+func getCSPObject(cspName string) (*apis.CStorPool, error) {
 	if cspName == "" {
-		return errors.Errorf("missing csp name")
+		return nil, errors.Errorf("missing csp name")
 	}
-	if openebsNamespace == "" {
-		return errors.Errorf("missing openebs namespace")
-	}
-
 	cspObj, err := cspClient.Get(cspName, metav1.GetOptions{})
 	if err != nil {
-		return errors.Wrapf(err, "failed to get csp %s", cspName)
+		return nil, errors.Wrapf(err, "failed to get csp %s", cspName)
 	}
 	cspVersion := cspObj.Labels["openebs.io/version"]
 	if (cspVersion != currentVersion) && (cspVersion != upgradeVersion) {
-		return errors.Errorf(
-			"cstor pool version %s is neither %s nor %s\n",
+		return nil, errors.Errorf(
+			"cstor pool version %s is neither %s nor %s",
 			cspVersion,
 			currentVersion,
 			upgradeVersion,
 		)
+	}
+	return cspObj, nil
+}
+
+func getCSPDeployment(cspName, openebsNamespace string) (*appsv1.Deployment, error) {
+	if openebsNamespace == "" {
+		return nil, errors.Errorf("missing openebs namespace")
 	}
 	cspLabel := "openebs.io/cstor-pool=" + cspName
 	cspDeployObj, err := getDeployment(cspLabel, openebsNamespace)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get deployment for csp %s", cspName)
+		return nil, errors.Wrapf(err, "failed to get deployment for csp %s", cspName)
 	}
 	if cspDeployObj.Name == "" {
-		return errors.Errorf("missing deployment name for csp %s", cspName)
+		return nil, errors.Errorf("missing deployment name for csp %s", cspName)
 	}
 	cspDeployVersion, err := getOpenEBSVersion(cspDeployObj)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if (cspDeployVersion != currentVersion) && (cspDeployVersion != upgradeVersion) {
-		return errors.Errorf(
-			"cstor pool version %s is neither %s nor %s\n",
-			cspVersion,
+		return nil, errors.Errorf(
+			"cstor pool version %s is neither %s nor %s",
+			cspDeployVersion,
 			currentVersion,
 			upgradeVersion,
 		)
 	}
+	return cspDeployObj, nil
+}
+
+func patchCSP(cspObj *apis.CStorPool) error {
+	cspVersion := cspObj.Labels["openebs.io/version"]
 	if cspVersion == currentVersion {
 		tmpl, err := template.New("cspPatch").
 			Parse(templates.OpenebsVersionPatch)
@@ -112,18 +124,22 @@ func cspUpgrade(cspName, openebsNamespace string) error {
 		cspPatch := buffer.String()
 		buffer.Reset()
 		_, err = cspClient.Patch(
-			cspName,
+			cspObj.Name,
 			types.MergePatchType,
 			[]byte(cspPatch),
 		)
 		if err != nil {
-			return errors.Wrapf(err, "failed to patch csp %s", cspName)
+			return errors.Wrapf(err, "failed to patch csp %s", cspObj.Name)
 		}
-		fmt.Printf("patched csp %s\n", cspName)
+		glog.Infof("patched csp %s", cspObj.Name)
 	} else {
-		fmt.Printf("csp %s already in %s version\n", cspName, upgradeVersion)
+		glog.Infof("csp %s already in %s version", cspObj.Name, upgradeVersion)
 	}
+	return nil
+}
 
+func patchCSPDeploy(cspDeployObj *appsv1.Deployment, openebsNamespace string) error {
+	cspDeployVersion := cspDeployObj.Labels["openebs.io/version"]
 	if cspDeployVersion == currentVersion {
 		patchDetails, err := getCSPDeployPatchDetails(cspDeployObj)
 		if err != nil {
@@ -150,13 +166,169 @@ func cspUpgrade(cspName, openebsNamespace string) error {
 		if err != nil {
 			return errors.Wrapf(err, "failed to patch deployment %s", cspDeployObj.Name)
 		}
-		fmt.Printf("patched csp deployment %s\n", cspName)
+		glog.Infof("patched csp deployment %s", cspDeployObj.Name)
 	} else {
-		fmt.Printf("csp deployment %s already in %s version\n",
+		glog.Infof("csp deployment %s already in %s version",
 			cspDeployObj.Name,
 			upgradeVersion,
 		)
 	}
-	fmt.Println("Upgrade Successful for csp", cspName)
 	return nil
+}
+
+func cspUpgrade(cspName, openebsNamespace string) (*utask.UpgradeTask, error) {
+	var err, uerr error
+	var utaskObj *utask.UpgradeTask
+	utaskObj, uerr = getOrCreateUpgradeTask("cstorPool", cspName, openebsNamespace)
+	if uerr != nil && isENVPresent {
+		return nil, uerr
+	}
+
+	utaskObj, uerr = updateUpgradeDetailedStatus(
+		utaskObj,
+		utask.UpgradeDetailedStatuses{
+			Step: utask.PreUpgrade,
+			Status: utask.Status{
+				Phase: utask.StepWaiting,
+			},
+		},
+		openebsNamespace,
+	)
+	if uerr != nil && isENVPresent {
+		return nil, uerr
+	}
+
+	cspObj, err := getCSPObject(cspName)
+	if err != nil {
+		utaskObj, uerr = updateUpgradeDetailedStatus(
+			utaskObj,
+			utask.UpgradeDetailedStatuses{
+				Step: utask.PreUpgrade,
+				Status: utask.Status{
+					Phase:   utask.StepErrored,
+					Message: "failed to verify cstor pool",
+					Reason:  strings.ReplaceAll(err.Error(), ":", ""),
+				},
+			},
+			openebsNamespace,
+		)
+		if uerr != nil && isENVPresent {
+			return nil, uerr
+		}
+		return utaskObj, err
+	}
+
+	cspDeployObj, err := getCSPDeployment(cspName, openebsNamespace)
+	if err != nil {
+		utaskObj, uerr = updateUpgradeDetailedStatus(
+			utaskObj,
+			utask.UpgradeDetailedStatuses{
+				Step: utask.PreUpgrade,
+				Status: utask.Status{
+					Phase:   utask.StepErrored,
+					Message: "failed to verify cstor pool deployment",
+					Reason:  strings.ReplaceAll(err.Error(), ":", ""),
+				},
+			},
+			openebsNamespace,
+		)
+		if uerr != nil && isENVPresent {
+			return nil, uerr
+		}
+		return utaskObj, err
+	}
+
+	utaskObj, uerr = updateUpgradeDetailedStatus(
+		utaskObj,
+		utask.UpgradeDetailedStatuses{
+			Step: utask.PreUpgrade,
+			Status: utask.Status{
+				Phase:   utask.StepCompleted,
+				Message: "Pre-upgrade steps were successful",
+			},
+		},
+		openebsNamespace,
+	)
+	if uerr != nil && isENVPresent {
+		return nil, uerr
+	}
+
+	utaskObj, uerr = updateUpgradeDetailedStatus(
+		utaskObj,
+		utask.UpgradeDetailedStatuses{
+			Step: utask.TargetUpgrade,
+			Status: utask.Status{
+				Phase: utask.StepWaiting,
+			},
+		},
+		openebsNamespace,
+	)
+	if uerr != nil && isENVPresent {
+		return nil, uerr
+	}
+
+	err = patchCSPDeploy(cspDeployObj, openebsNamespace)
+	if err != nil {
+		utaskObj, uerr = updateUpgradeDetailedStatus(
+			utaskObj,
+			utask.UpgradeDetailedStatuses{
+				Step: utask.TargetUpgrade,
+				Status: utask.Status{
+					Phase:   utask.StepErrored,
+					Message: "failed to patch cstor pool deployment",
+					Reason:  strings.ReplaceAll(err.Error(), ":", ""),
+				},
+			},
+			openebsNamespace,
+		)
+		if uerr != nil && isENVPresent {
+			return nil, uerr
+		}
+		return utaskObj, err
+	}
+
+	err = patchCSP(cspObj)
+	if err != nil {
+		utaskObj, uerr = updateUpgradeDetailedStatus(
+			utaskObj,
+			utask.UpgradeDetailedStatuses{
+				Step: utask.TargetUpgrade,
+				Status: utask.Status{
+					Phase:   utask.StepErrored,
+					Message: "failed to patch cstor pool",
+					Reason:  strings.ReplaceAll(err.Error(), ":", ""),
+				},
+			},
+			openebsNamespace,
+		)
+		if uerr != nil && isENVPresent {
+			return nil, uerr
+		}
+		return utaskObj, err
+	}
+
+	utaskObj, uerr = updateUpgradeDetailedStatus(
+		utaskObj,
+		utask.UpgradeDetailedStatuses{
+			Step: utask.TargetUpgrade,
+			Status: utask.Status{
+				Phase:   utask.StepCompleted,
+				Message: "Target upgrade was successful",
+			},
+		},
+		openebsNamespace,
+	)
+	if uerr != nil && isENVPresent {
+		return nil, uerr
+	}
+
+	utaskObj.Status.Phase = utask.UpgradeSuccess
+	utaskObj.Status.CompletedTime = metav1.Now()
+	utaskObj, uerr = utaskClient.WithNamespace(openebsNamespace).
+		Update(utaskObj)
+	if uerr != nil && isENVPresent {
+		return nil, uerr
+	}
+	glog.Infof("Upgrade Successful for csp %s", cspName)
+	return utaskObj, nil
 }

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/csp_upgrade.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/csp_upgrade.go
@@ -198,9 +198,9 @@ func (c *cstorCSPOptions) preUpgrade(cspName, openebsNamespace string) error {
 		return uerr
 	}
 
+	statusObj.Phase = utask.StepErrored
 	c.cspObj, err = getCSPObject(cspName)
 	if err != nil {
-		statusObj.Phase = utask.StepErrored
 		statusObj.Message = "failed to verify cstor pool"
 		statusObj.Reason = strings.Replace(err.Error(), ":", "", -1)
 		c.utaskObj, uerr = updateUpgradeDetailedStatus(c.utaskObj, statusObj, openebsNamespace)
@@ -240,9 +240,9 @@ func (c *cstorCSPOptions) poolInstanceUpgarde(openebsNamespace string) error {
 		return uerr
 	}
 
+	statusObj.Phase = utask.StepErrored
 	err = patchCSPDeploy(c.cspDeployObj, openebsNamespace)
 	if err != nil {
-		statusObj.Phase = utask.StepErrored
 		statusObj.Message = "failed to patch cstor pool deployment"
 		statusObj.Reason = strings.Replace(err.Error(), ":", "", -1)
 		c.utaskObj, uerr = updateUpgradeDetailedStatus(c.utaskObj, statusObj, openebsNamespace)

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/csp_upgrade.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/csp_upgrade.go
@@ -231,9 +231,9 @@ func (c *cstorCSPOptions) preUpgrade(cspName, openebsNamespace string) error {
 	return nil
 }
 
-func (c *cstorCSPOptions) targetUpgarde(openebsNamespace string) error {
+func (c *cstorCSPOptions) poolInstanceUpgarde(openebsNamespace string) error {
 	var err, uerr error
-	statusObj := utask.UpgradeDetailedStatuses{Step: utask.TargetUpgrade}
+	statusObj := utask.UpgradeDetailedStatuses{Step: utask.PoolInstanceUpgrade}
 	statusObj.Phase = utask.StepWaiting
 	c.utaskObj, uerr = updateUpgradeDetailedStatus(c.utaskObj, statusObj, openebsNamespace)
 	if uerr != nil && isENVPresent {
@@ -264,7 +264,7 @@ func (c *cstorCSPOptions) targetUpgarde(openebsNamespace string) error {
 	}
 
 	statusObj.Phase = utask.StepCompleted
-	statusObj.Message = "Target upgrade was successful"
+	statusObj.Message = "Pool instance upgrade was successful"
 	statusObj.Reason = ""
 	c.utaskObj, uerr = updateUpgradeDetailedStatus(c.utaskObj, statusObj, openebsNamespace)
 	if uerr != nil && isENVPresent {
@@ -283,7 +283,7 @@ func cspUpgrade(cspName, openebsNamespace string) (*utask.UpgradeTask, error) {
 		return options.utaskObj, err
 	}
 
-	err = options.targetUpgarde(openebsNamespace)
+	err = options.poolInstanceUpgarde(openebsNamespace)
 	if err != nil {
 		return options.utaskObj, err
 	}

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/cstor_volume_upgrade.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/cstor_volume_upgrade.go
@@ -275,6 +275,7 @@ func (c *cstorVolumeOptions) preUpgrade(pvName, openebsNamespace string) error {
 		return uerr
 	}
 
+	statusObj.Phase = utask.StepErrored
 	c.ns, err = getPVCDeploymentsNamespace(pvName, pvLabel, openebsNamespace)
 	if err != nil {
 		statusObj.Message = "failed to get namespace for pvc deployments"
@@ -330,9 +331,9 @@ func (c *cstorVolumeOptions) targetUpgrade(pvName, openebsNamespace string) erro
 		return uerr
 	}
 
+	statusObj.Phase = utask.StepErrored
 	err = patchTargetDeploy(c.targetDeployObj, c.ns)
 	if err != nil {
-		statusObj.Phase = utask.StepErrored
 		statusObj.Message = "failed to patch target deployment"
 		statusObj.Reason = strings.Replace(err.Error(), ":", "", -1)
 		c.utaskObj, uerr = updateUpgradeDetailedStatus(c.utaskObj, statusObj, openebsNamespace)
@@ -383,10 +384,10 @@ func (c *cstorVolumeOptions) replicaUpgrade(openebsNamespace string) error {
 		return uerr
 	}
 
+	statusObj.Phase = utask.StepErrored
 	for _, cvrObj := range c.cvrList.Items {
 		err = patchCVR(cvrObj.Name, openebsNamespace)
 		if err != nil {
-			statusObj.Phase = utask.StepErrored
 			statusObj.Message = "failed to patch cstor volume replica"
 			statusObj.Reason = strings.Replace(err.Error(), ":", "", -1)
 			c.utaskObj, uerr = updateUpgradeDetailedStatus(c.utaskObj, statusObj, openebsNamespace)

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/cstor_volume_upgrade.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/cstor_volume_upgrade.go
@@ -292,7 +292,7 @@ func cstorVolumeUpgrade(pvName, openebsNamespace string) (*utask.UpgradeTask, er
 				Status: utask.Status{
 					Phase:   utask.StepErrored,
 					Message: "failed to verify csp for cstor volume",
-					Reason:  strings.ReplaceAll(err.Error(), ":", ""),
+					Reason:  strings.Replace(err.Error(), ":", "", -1),
 				},
 			},
 			openebsNamespace,
@@ -312,7 +312,7 @@ func cstorVolumeUpgrade(pvName, openebsNamespace string) (*utask.UpgradeTask, er
 				Status: utask.Status{
 					Phase:   utask.StepErrored,
 					Message: "failed to get namespace for pvc deployments",
-					Reason:  strings.ReplaceAll(err.Error(), ":", ""),
+					Reason:  strings.Replace(err.Error(), ":", "", -1),
 				},
 			},
 			openebsNamespace,
@@ -332,7 +332,7 @@ func cstorVolumeUpgrade(pvName, openebsNamespace string) (*utask.UpgradeTask, er
 				Status: utask.Status{
 					Phase:   utask.StepErrored,
 					Message: "failed to get target details",
-					Reason:  strings.ReplaceAll(err.Error(), ":", ""),
+					Reason:  strings.Replace(err.Error(), ":", "", -1),
 				},
 			},
 			openebsNamespace,
@@ -352,7 +352,7 @@ func cstorVolumeUpgrade(pvName, openebsNamespace string) (*utask.UpgradeTask, er
 				Status: utask.Status{
 					Phase:   utask.StepErrored,
 					Message: "failed to get replica details",
-					Reason:  strings.ReplaceAll(err.Error(), ":", ""),
+					Reason:  strings.Replace(err.Error(), ":", "", -1),
 				},
 			},
 			openebsNamespace,
@@ -400,7 +400,7 @@ func cstorVolumeUpgrade(pvName, openebsNamespace string) (*utask.UpgradeTask, er
 				Status: utask.Status{
 					Phase:   utask.StepErrored,
 					Message: "failed to patch target deployment",
-					Reason:  strings.ReplaceAll(err.Error(), ":", ""),
+					Reason:  strings.Replace(err.Error(), ":", "", -1),
 				},
 			},
 			openebsNamespace,
@@ -420,7 +420,7 @@ func cstorVolumeUpgrade(pvName, openebsNamespace string) (*utask.UpgradeTask, er
 				Status: utask.Status{
 					Phase:   utask.StepErrored,
 					Message: "failed to patch target service",
-					Reason:  strings.ReplaceAll(err.Error(), ":", ""),
+					Reason:  strings.Replace(err.Error(), ":", "", -1),
 				},
 			},
 			openebsNamespace,
@@ -440,7 +440,7 @@ func cstorVolumeUpgrade(pvName, openebsNamespace string) (*utask.UpgradeTask, er
 				Status: utask.Status{
 					Phase:   utask.StepErrored,
 					Message: "failed to patch cstor volume",
-					Reason:  strings.ReplaceAll(err.Error(), ":", ""),
+					Reason:  strings.Replace(err.Error(), ":", "", -1),
 				},
 			},
 			openebsNamespace,
@@ -490,7 +490,7 @@ func cstorVolumeUpgrade(pvName, openebsNamespace string) (*utask.UpgradeTask, er
 					Status: utask.Status{
 						Phase:   utask.StepErrored,
 						Message: "failed to patch cstor volume replica",
-						Reason:  strings.ReplaceAll(err.Error(), ":", ""),
+						Reason:  strings.Replace(err.Error(), ":", "", -1),
 					},
 				},
 				openebsNamespace,

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/exec.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/exec.go
@@ -18,7 +18,6 @@ package v1alpha1
 
 import (
 	"bytes"
-	"fmt"
 
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/upgrade/v1alpha1"
 	csp "github.com/openebs/maya/pkg/cstor/pool/v1alpha3"
@@ -111,15 +110,10 @@ func Exec(fromVersion, toVersion, kind, name,
 		err = errors.Errorf("Invalid kind for upgrade")
 	}
 
-	fmt.Println(err)
-
 	if err != nil {
-		fmt.Println("enter the if block")
 		if utaskObj != nil {
 			backoffLimit, uerr := getBackoffLimit(openebsNamespace)
 			if uerr != nil {
-				fmt.Println("error is returned")
-				fmt.Println(uerr)
 				return uerr
 			}
 			if utaskObj.Status.Retries == backoffLimit {
@@ -130,13 +124,9 @@ func Exec(fromVersion, toVersion, kind, name,
 			_, uerr = utaskClient.WithNamespace(openebsNamespace).
 				Update(utaskObj)
 			if uerr != nil && isENVPresent {
-				fmt.Println("error is returned")
-				fmt.Println(uerr)
 				return uerr
 			}
 		}
-		fmt.Println("error is returned")
-		fmt.Println(err)
 		return err
 	}
 	if utaskObj != nil {

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/exec.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/exec.go
@@ -18,15 +18,20 @@ package v1alpha1
 
 import (
 	"bytes"
+	"fmt"
 
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/upgrade/v1alpha1"
 	csp "github.com/openebs/maya/pkg/cstor/pool/v1alpha3"
 	cv "github.com/openebs/maya/pkg/cstor/volume/v1alpha1"
 	cvr "github.com/openebs/maya/pkg/cstor/volumereplica/v1alpha1"
+	menv "github.com/openebs/maya/pkg/env/v1alpha1"
 	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 	deploy "github.com/openebs/maya/pkg/kubernetes/deployment/appsv1/v1alpha1"
+	job "github.com/openebs/maya/pkg/kubernetes/job"
 	pv "github.com/openebs/maya/pkg/kubernetes/persistentvolume/v1alpha1"
 	pod "github.com/openebs/maya/pkg/kubernetes/pod/v1alpha1"
 	svc "github.com/openebs/maya/pkg/kubernetes/service/v1alpha1"
+	utask "github.com/openebs/maya/pkg/upgrade/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -36,7 +41,10 @@ var (
 	urlPrefix      = ""
 	imageTag       = ""
 
-	buffer bytes.Buffer
+	buffer   bytes.Buffer
+	utaskObj *apis.UpgradeTask
+
+	isENVPresent bool
 
 	cvClient      = cv.NewKubeclient()
 	cvrClient     = cvr.NewKubeclient()
@@ -44,7 +52,9 @@ var (
 	serviceClient = svc.NewKubeClient()
 	pvClient      = pv.NewKubeClient()
 	podClient     = pod.NewKubeClient()
+	jobClient     = job.NewKubeClient()
 	cspClient     = csp.KubeClient()
+	utaskClient   = utask.NewKubeClient()
 )
 
 // Exec ...
@@ -86,27 +96,77 @@ func Exec(fromVersion, toVersion, kind, name,
 
 	switch kind {
 	case "jivaVolume":
-		err = jivaUpgrade(name, openebsNamespace)
-		if err != nil {
-			return err
-		}
+		utaskObj, err = jivaUpgrade(name, openebsNamespace)
+
 	case "storagePoolClaim":
-		err = spcUpgrade(name, openebsNamespace)
-		if err != nil {
-			return err
-		}
+		utaskObj, err = spcUpgrade(name, openebsNamespace)
+
 	case "cstorPool":
-		err = cspUpgrade(name, openebsNamespace)
-		if err != nil {
-			return err
-		}
+		utaskObj, err = cspUpgrade(name, openebsNamespace)
+
 	case "cstorVolume":
-		err = cstorVolumeUpgrade(name, openebsNamespace)
-		if err != nil {
-			return err
-		}
+		utaskObj, err = cstorVolumeUpgrade(name, openebsNamespace)
+
 	default:
-		return errors.Errorf("Invalid kind for upgrade")
+		err = errors.Errorf("Invalid kind for upgrade")
+	}
+
+	fmt.Println(err)
+
+	if err != nil {
+		fmt.Println("enter the if block")
+		if utaskObj != nil {
+			backoffLimit, uerr := getBackoffLimit(openebsNamespace)
+			if uerr != nil {
+				fmt.Println("error is returned")
+				fmt.Println(uerr)
+				return uerr
+			}
+			if utaskObj.Status.Retries == backoffLimit {
+				utaskObj.Status.Phase = apis.UpgradeError
+				utaskObj.Status.CompletedTime = metav1.Now()
+			}
+			utaskObj.Status.Retries = utaskObj.Status.Retries + 1
+			_, uerr = utaskClient.WithNamespace(openebsNamespace).
+				Update(utaskObj)
+			if uerr != nil && isENVPresent {
+				fmt.Println("error is returned")
+				fmt.Println(uerr)
+				return uerr
+			}
+		}
+		fmt.Println("error is returned")
+		fmt.Println(err)
+		return err
+	}
+	if utaskObj != nil {
+		utaskObj.Status.Phase = apis.UpgradeSuccess
+		utaskObj.Status.CompletedTime = metav1.Now()
+		_, uerr := utaskClient.WithNamespace(openebsNamespace).
+			Update(utaskObj)
+		if uerr != nil && isENVPresent {
+			return uerr
+		}
 	}
 	return nil
+}
+
+func getBackoffLimit(openebsNamespace string) (int, error) {
+	podName := menv.Get("POD_NAME")
+	podObj, err := podClient.WithNamespace(openebsNamespace).
+		Get(podName, metav1.GetOptions{})
+	if err != nil {
+		return 0, err
+	}
+	jobObj, err := jobClient.WithNamespace(openebsNamespace).
+		Get(podObj.OwnerReferences[0].Name, metav1.GetOptions{})
+	if err != nil {
+		return 0, err
+	}
+	// if backoffLimit not present it returns the default as 6
+	if jobObj.Spec.BackoffLimit == nil {
+		return 6, nil
+	}
+	backoffLimit := int(*jobObj.Spec.BackoffLimit)
+	return backoffLimit, nil
 }

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/exec.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/exec.go
@@ -60,6 +60,10 @@ var (
 func Exec(fromVersion, toVersion, kind, name,
 	openebsNamespace, urlprefix, imagetag string) error {
 
+	if menv.Get("UPGRADE_TASK_LABEL") != "" {
+		isENVPresent = true
+	}
+
 	// verify openebs namespace and check maya-apiserver version
 	upgradeVersion = toVersion
 	currentVersion = fromVersion

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/helper.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/helper.go
@@ -275,6 +275,8 @@ func getOrCreateUpgradeTask(kind, name, openebsNamespace string) (*apis.UpgradeT
 				},
 			}
 		}
+		// the below logic first tries to fetch the CR if not found
+		// then creates a new CR
 		utaskObj1, err1 := utaskClient.WithNamespace(openebsNamespace).
 			Get(utaskObj.Name, metav1.GetOptions{})
 		if err1 != nil {

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/jiva_upgrade.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/jiva_upgrade.go
@@ -503,14 +503,14 @@ func (j *jivaVolumeOptions) verify(controllerLabel, openebsNamespace string) err
 	// Verify synced replicas
 	err = validateSync(controllerLabel, j.ns)
 	if err != nil {
-		statusObj.Message = "failed to verify synced replicas"
+		statusObj.Message = "failed to verify synced replicas. Please check it manually using the steps mentioned in https://docs.openebs.io/docs/next/mayactl.html"
 		statusObj.Reason = strings.Replace(err.Error(), ":", "", -1)
 		j.utaskObj, uerr = updateUpgradeDetailedStatus(j.utaskObj, statusObj, openebsNamespace)
 		if uerr != nil && isENVPresent {
 			return uerr
 		}
 		if k8serror.IsForbidden(err) {
-			glog.Warningf("failed to verify replica sync : %v", err)
+			glog.Warningf("failed to verify replica sync : %v\n Please check it manually using the steps mentioned in https://docs.openebs.io/docs/next/mayactl.html", err)
 			return nil
 		}
 		return err

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/jiva_upgrade.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/jiva_upgrade.go
@@ -357,34 +357,20 @@ func (j *jivaVolumeOptions) preupgrade(pvName, openebsNamespace string) error {
 		return uerr
 	}
 
-	j.utaskObj, uerr = updateUpgradeDetailedStatus(
-		j.utaskObj,
-		utask.UpgradeDetailedStatuses{
-			Step: utask.PreUpgrade,
-			Status: utask.Status{
-				Phase: utask.StepWaiting,
-			},
-		},
-		openebsNamespace,
-	)
+	statusObj := utask.UpgradeDetailedStatuses{Step: utask.PreUpgrade}
+
+	statusObj.Phase = utask.StepWaiting
+	j.utaskObj, uerr = updateUpgradeDetailedStatus(j.utaskObj, statusObj, openebsNamespace)
 	if uerr != nil && isENVPresent {
 		return uerr
 	}
 
 	j.ns, err = getPVCDeploymentsNamespace(pvName, pvLabel, openebsNamespace)
 	if err != nil {
-		j.utaskObj, uerr = updateUpgradeDetailedStatus(
-			j.utaskObj,
-			utask.UpgradeDetailedStatuses{
-				Step: utask.PreUpgrade,
-				Status: utask.Status{
-					Phase:   utask.StepErrored,
-					Message: "failed to get namespace for pvc deployments",
-					Reason:  strings.Replace(err.Error(), ":", "", -1),
-				},
-			},
-			openebsNamespace,
-		)
+		statusObj.Phase = utask.StepErrored
+		statusObj.Message = "failed to get namespace for pvc deployments"
+		statusObj.Reason = strings.Replace(err.Error(), ":", "", -1)
+		j.utaskObj, uerr = updateUpgradeDetailedStatus(j.utaskObj, statusObj, openebsNamespace)
 		if uerr != nil && isENVPresent {
 			return uerr
 		}
@@ -394,18 +380,9 @@ func (j *jivaVolumeOptions) preupgrade(pvName, openebsNamespace string) error {
 	// fetching replica deployment details
 	j.replicaObj, err = getReplica(replicaLabel, j.ns)
 	if err != nil {
-		j.utaskObj, uerr = updateUpgradeDetailedStatus(
-			j.utaskObj,
-			utask.UpgradeDetailedStatuses{
-				Step: utask.PreUpgrade,
-				Status: utask.Status{
-					Phase:   utask.StepErrored,
-					Message: "failed to get replica details",
-					Reason:  strings.Replace(err.Error(), ":", "", -1),
-				},
-			},
-			openebsNamespace,
-		)
+		statusObj.Message = "failed to get replica details"
+		statusObj.Reason = strings.Replace(err.Error(), ":", "", -1)
+		j.utaskObj, uerr = updateUpgradeDetailedStatus(j.utaskObj, statusObj, openebsNamespace)
 		if uerr != nil && isENVPresent {
 			return uerr
 		}
@@ -416,35 +393,19 @@ func (j *jivaVolumeOptions) preupgrade(pvName, openebsNamespace string) error {
 	// fetching controller deployment details
 	j.controllerObj, err = getController(controllerLabel, j.ns)
 	if err != nil {
-		j.utaskObj, uerr = updateUpgradeDetailedStatus(
-			j.utaskObj,
-			utask.UpgradeDetailedStatuses{
-				Step: utask.PreUpgrade,
-				Status: utask.Status{
-					Phase:   utask.StepErrored,
-					Message: "failed to get target details",
-					Reason:  strings.Replace(err.Error(), ":", "", -1),
-				},
-			},
-			openebsNamespace,
-		)
+		statusObj.Message = "failed to get target details"
+		statusObj.Reason = strings.Replace(err.Error(), ":", "", -1)
+		j.utaskObj, uerr = updateUpgradeDetailedStatus(j.utaskObj, statusObj, openebsNamespace)
 		if uerr != nil && isENVPresent {
 			return uerr
 		}
 		return err
 	}
 
-	j.utaskObj, uerr = updateUpgradeDetailedStatus(
-		j.utaskObj,
-		utask.UpgradeDetailedStatuses{
-			Step: utask.PreUpgrade,
-			Status: utask.Status{
-				Phase:   utask.StepCompleted,
-				Message: "Pre-upgrade steps were successful",
-			},
-		},
-		openebsNamespace,
-	)
+	statusObj.Phase = utask.StepCompleted
+	statusObj.Message = "Pre-upgrade steps were successful"
+	statusObj.Reason = ""
+	j.utaskObj, uerr = updateUpgradeDetailedStatus(j.utaskObj, statusObj, openebsNamespace)
 	if uerr != nil && isENVPresent {
 		return uerr
 	}
@@ -453,16 +414,9 @@ func (j *jivaVolumeOptions) preupgrade(pvName, openebsNamespace string) error {
 
 func (j *jivaVolumeOptions) replicaUpgrade(openebsNamespace string) error {
 	var err, uerr error
-	j.utaskObj, uerr = updateUpgradeDetailedStatus(
-		j.utaskObj,
-		utask.UpgradeDetailedStatuses{
-			Step: utask.ReplicaUpgrade,
-			Status: utask.Status{
-				Phase: utask.StepWaiting,
-			},
-		},
-		openebsNamespace,
-	)
+	statusObj := utask.UpgradeDetailedStatuses{Step: utask.ReplicaUpgrade}
+	statusObj.Phase = utask.StepWaiting
+	j.utaskObj, uerr = updateUpgradeDetailedStatus(j.utaskObj, statusObj, openebsNamespace)
 	if uerr != nil && isENVPresent {
 		return uerr
 	}
@@ -470,35 +424,20 @@ func (j *jivaVolumeOptions) replicaUpgrade(openebsNamespace string) error {
 	// replica patch
 	err = patchReplica(j.replicaObj, j.ns)
 	if err != nil {
-		j.utaskObj, uerr = updateUpgradeDetailedStatus(
-			j.utaskObj,
-			utask.UpgradeDetailedStatuses{
-				Step: utask.ReplicaUpgrade,
-				Status: utask.Status{
-					Phase:   utask.StepErrored,
-					Message: "failed to patch replica depoyment",
-					Reason:  strings.Replace(err.Error(), ":", "", -1),
-				},
-			},
-			openebsNamespace,
-		)
+		statusObj.Phase = utask.StepErrored
+		statusObj.Message = "failed to patch replica depoyment"
+		statusObj.Reason = strings.Replace(err.Error(), ":", "", -1)
+		j.utaskObj, uerr = updateUpgradeDetailedStatus(j.utaskObj, statusObj, openebsNamespace)
 		if uerr != nil && isENVPresent {
 			return uerr
 		}
 		return err
 	}
 
-	j.utaskObj, uerr = updateUpgradeDetailedStatus(
-		j.utaskObj,
-		utask.UpgradeDetailedStatuses{
-			Step: utask.ReplicaUpgrade,
-			Status: utask.Status{
-				Phase:   utask.StepCompleted,
-				Message: "Replica upgrade was successful",
-			},
-		},
-		openebsNamespace,
-	)
+	statusObj.Phase = utask.StepCompleted
+	statusObj.Message = "Replica upgrade was successful"
+	statusObj.Reason = ""
+	j.utaskObj, uerr = updateUpgradeDetailedStatus(j.utaskObj, statusObj, openebsNamespace)
 	if uerr != nil && isENVPresent {
 		return uerr
 	}
@@ -507,16 +446,9 @@ func (j *jivaVolumeOptions) replicaUpgrade(openebsNamespace string) error {
 
 func (j *jivaVolumeOptions) targetUpgrade(pvName, openebsNamespace string) error {
 	var err, uerr error
-	j.utaskObj, uerr = updateUpgradeDetailedStatus(
-		j.utaskObj,
-		utask.UpgradeDetailedStatuses{
-			Step: utask.TargetUpgrade,
-			Status: utask.Status{
-				Phase: utask.StepWaiting,
-			},
-		},
-		openebsNamespace,
-	)
+	statusObj := utask.UpgradeDetailedStatuses{Step: utask.TargetUpgrade}
+	statusObj.Phase = utask.StepWaiting
+	j.utaskObj, uerr = updateUpgradeDetailedStatus(j.utaskObj, statusObj, openebsNamespace)
 	if uerr != nil && isENVPresent {
 		return uerr
 	}
@@ -524,18 +456,10 @@ func (j *jivaVolumeOptions) targetUpgrade(pvName, openebsNamespace string) error
 	// controller patch
 	err = patchController(j.controllerObj, j.ns)
 	if err != nil {
-		j.utaskObj, uerr = updateUpgradeDetailedStatus(
-			j.utaskObj,
-			utask.UpgradeDetailedStatuses{
-				Step: utask.TargetUpgrade,
-				Status: utask.Status{
-					Phase:   utask.StepErrored,
-					Message: "failed to patch target depoyment",
-					Reason:  strings.Replace(err.Error(), ":", "", -1),
-				},
-			},
-			openebsNamespace,
-		)
+		statusObj.Phase = utask.StepErrored
+		statusObj.Message = "failed to patch target depoyment"
+		statusObj.Reason = strings.Replace(err.Error(), ":", "", -1)
+		j.utaskObj, uerr = updateUpgradeDetailedStatus(j.utaskObj, statusObj, openebsNamespace)
 		if uerr != nil && isENVPresent {
 			return uerr
 		}
@@ -546,35 +470,19 @@ func (j *jivaVolumeOptions) targetUpgrade(pvName, openebsNamespace string) error
 
 	err = patchService(serviceLabel, j.ns)
 	if err != nil {
-		j.utaskObj, uerr = updateUpgradeDetailedStatus(
-			j.utaskObj,
-			utask.UpgradeDetailedStatuses{
-				Step: utask.TargetUpgrade,
-				Status: utask.Status{
-					Phase:   utask.StepErrored,
-					Message: "failed to patch target service",
-					Reason:  strings.Replace(err.Error(), ":", "", -1),
-				},
-			},
-			openebsNamespace,
-		)
+		statusObj.Message = "failed to patch target service"
+		statusObj.Reason = strings.Replace(err.Error(), ":", "", -1)
+		j.utaskObj, uerr = updateUpgradeDetailedStatus(j.utaskObj, statusObj, openebsNamespace)
 		if uerr != nil && isENVPresent {
 			return uerr
 		}
 		return err
 	}
 
-	j.utaskObj, uerr = updateUpgradeDetailedStatus(
-		j.utaskObj,
-		utask.UpgradeDetailedStatuses{
-			Step: utask.TargetUpgrade,
-			Status: utask.Status{
-				Phase:   utask.StepCompleted,
-				Message: "Target upgrade was successful",
-			},
-		},
-		openebsNamespace,
-	)
+	statusObj.Phase = utask.StepCompleted
+	statusObj.Message = "Target upgrade was successful"
+	statusObj.Reason = ""
+	j.utaskObj, uerr = updateUpgradeDetailedStatus(j.utaskObj, statusObj, openebsNamespace)
 	if uerr != nil && isENVPresent {
 		return uerr
 	}
@@ -583,53 +491,30 @@ func (j *jivaVolumeOptions) targetUpgrade(pvName, openebsNamespace string) error
 
 func (j *jivaVolumeOptions) verify(controllerLabel, openebsNamespace string) error {
 	var err, uerr error
-	j.utaskObj, uerr = updateUpgradeDetailedStatus(
-		j.utaskObj,
-		utask.UpgradeDetailedStatuses{
-			Step: utask.Verify,
-			Status: utask.Status{
-				Phase: utask.StepWaiting,
-			},
-		},
-		openebsNamespace,
-	)
+	statusObj := utask.UpgradeDetailedStatuses{Step: utask.Verify}
+	statusObj.Phase = utask.StepWaiting
+	j.utaskObj, uerr = updateUpgradeDetailedStatus(j.utaskObj, statusObj, openebsNamespace)
 	if uerr != nil && isENVPresent {
 		return uerr
 	}
 
 	// Verify synced replicas
 	err = validateSync(controllerLabel, j.ns)
-
 	if err != nil {
-		j.utaskObj, uerr = updateUpgradeDetailedStatus(
-			j.utaskObj,
-			utask.UpgradeDetailedStatuses{
-				Step: utask.Verify,
-				Status: utask.Status{
-					Phase:   utask.StepErrored,
-					Message: "failed to verify synced replicas",
-					Reason:  strings.Replace(err.Error(), ":", "", -1),
-				},
-			},
-			openebsNamespace,
-		)
+		statusObj.Phase = utask.StepErrored
+		statusObj.Message = "failed to verify synced replicas"
+		statusObj.Reason = strings.Replace(err.Error(), ":", "", -1)
+		j.utaskObj, uerr = updateUpgradeDetailedStatus(j.utaskObj, statusObj, openebsNamespace)
 		if uerr != nil && isENVPresent {
 			return uerr
 		}
 		return err
 	}
 
-	j.utaskObj, uerr = updateUpgradeDetailedStatus(
-		j.utaskObj,
-		utask.UpgradeDetailedStatuses{
-			Step: utask.Verify,
-			Status: utask.Status{
-				Phase:   utask.StepCompleted,
-				Message: "Replica sync was successful",
-			},
-		},
-		openebsNamespace,
-	)
+	statusObj.Phase = utask.StepCompleted
+	statusObj.Message = "Replica sync was successful"
+	statusObj.Reason = ""
+	j.utaskObj, uerr = updateUpgradeDetailedStatus(j.utaskObj, statusObj, openebsNamespace)
 	if uerr != nil && isENVPresent {
 		return uerr
 	}

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/jiva_upgrade.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/jiva_upgrade.go
@@ -365,9 +365,9 @@ func (j *jivaVolumeOptions) preupgrade(pvName, openebsNamespace string) error {
 		return uerr
 	}
 
+	statusObj.Phase = utask.StepErrored
 	j.ns, err = getPVCDeploymentsNamespace(pvName, pvLabel, openebsNamespace)
 	if err != nil {
-		statusObj.Phase = utask.StepErrored
 		statusObj.Message = "failed to get namespace for pvc deployments"
 		statusObj.Reason = strings.Replace(err.Error(), ":", "", -1)
 		j.utaskObj, uerr = updateUpgradeDetailedStatus(j.utaskObj, statusObj, openebsNamespace)
@@ -421,10 +421,10 @@ func (j *jivaVolumeOptions) replicaUpgrade(openebsNamespace string) error {
 		return uerr
 	}
 
+	statusObj.Phase = utask.StepErrored
 	// replica patch
 	err = patchReplica(j.replicaObj, j.ns)
 	if err != nil {
-		statusObj.Phase = utask.StepErrored
 		statusObj.Message = "failed to patch replica depoyment"
 		statusObj.Reason = strings.Replace(err.Error(), ":", "", -1)
 		j.utaskObj, uerr = updateUpgradeDetailedStatus(j.utaskObj, statusObj, openebsNamespace)
@@ -453,10 +453,10 @@ func (j *jivaVolumeOptions) targetUpgrade(pvName, openebsNamespace string) error
 		return uerr
 	}
 
+	statusObj.Phase = utask.StepErrored
 	// controller patch
 	err = patchController(j.controllerObj, j.ns)
 	if err != nil {
-		statusObj.Phase = utask.StepErrored
 		statusObj.Message = "failed to patch target depoyment"
 		statusObj.Reason = strings.Replace(err.Error(), ":", "", -1)
 		j.utaskObj, uerr = updateUpgradeDetailedStatus(j.utaskObj, statusObj, openebsNamespace)
@@ -498,10 +498,10 @@ func (j *jivaVolumeOptions) verify(controllerLabel, openebsNamespace string) err
 		return uerr
 	}
 
+	statusObj.Phase = utask.StepErrored
 	// Verify synced replicas
 	err = validateSync(controllerLabel, j.ns)
 	if err != nil {
-		statusObj.Phase = utask.StepErrored
 		statusObj.Message = "failed to verify synced replicas"
 		statusObj.Reason = strings.Replace(err.Error(), ":", "", -1)
 		j.utaskObj, uerr = updateUpgradeDetailedStatus(j.utaskObj, statusObj, openebsNamespace)

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/jiva_upgrade.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/jiva_upgrade.go
@@ -29,6 +29,7 @@ import (
 	templates "github.com/openebs/maya/pkg/upgrade/templates/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 
@@ -507,6 +508,10 @@ func (j *jivaVolumeOptions) verify(controllerLabel, openebsNamespace string) err
 		j.utaskObj, uerr = updateUpgradeDetailedStatus(j.utaskObj, statusObj, openebsNamespace)
 		if uerr != nil && isENVPresent {
 			return uerr
+		}
+		if k8serror.IsForbidden(err) {
+			glog.Warningf("failed to verify replica sync : %v", err)
+			return nil
 		}
 		return err
 	}

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/jiva_upgrade.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/jiva_upgrade.go
@@ -317,7 +317,7 @@ func jivaUpgrade(pvName, openebsNamespace string) (*utask.UpgradeTask, error) {
 				Status: utask.Status{
 					Phase:   utask.StepErrored,
 					Message: "failed to get namespace for pvc deployments",
-					Reason:  strings.ReplaceAll(err.Error(), ":", ""),
+					Reason:  strings.Replace(err.Error(), ":", "", -1),
 				},
 			},
 			openebsNamespace,
@@ -338,7 +338,7 @@ func jivaUpgrade(pvName, openebsNamespace string) (*utask.UpgradeTask, error) {
 				Status: utask.Status{
 					Phase:   utask.StepErrored,
 					Message: "failed to get replica details",
-					Reason:  strings.ReplaceAll(err.Error(), ":", ""),
+					Reason:  strings.Replace(err.Error(), ":", "", -1),
 				},
 			},
 			openebsNamespace,
@@ -360,7 +360,7 @@ func jivaUpgrade(pvName, openebsNamespace string) (*utask.UpgradeTask, error) {
 				Status: utask.Status{
 					Phase:   utask.StepErrored,
 					Message: "failed to get target details",
-					Reason:  strings.ReplaceAll(err.Error(), ":", ""),
+					Reason:  strings.Replace(err.Error(), ":", "", -1),
 				},
 			},
 			openebsNamespace,
@@ -410,7 +410,7 @@ func jivaUpgrade(pvName, openebsNamespace string) (*utask.UpgradeTask, error) {
 				Status: utask.Status{
 					Phase:   utask.StepErrored,
 					Message: "failed to patch replica depoyment",
-					Reason:  strings.ReplaceAll(err.Error(), ":", ""),
+					Reason:  strings.Replace(err.Error(), ":", "", -1),
 				},
 			},
 			openebsNamespace,
@@ -460,7 +460,7 @@ func jivaUpgrade(pvName, openebsNamespace string) (*utask.UpgradeTask, error) {
 				Status: utask.Status{
 					Phase:   utask.StepErrored,
 					Message: "failed to patch target depoyment",
-					Reason:  strings.ReplaceAll(err.Error(), ":", ""),
+					Reason:  strings.Replace(err.Error(), ":", "", -1),
 				},
 			},
 			openebsNamespace,
@@ -480,7 +480,7 @@ func jivaUpgrade(pvName, openebsNamespace string) (*utask.UpgradeTask, error) {
 				Status: utask.Status{
 					Phase:   utask.StepErrored,
 					Message: "failed to patch target service",
-					Reason:  strings.ReplaceAll(err.Error(), ":", ""),
+					Reason:  strings.Replace(err.Error(), ":", "", -1),
 				},
 			},
 			openebsNamespace,

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/spc_upgrade.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/spc_upgrade.go
@@ -62,6 +62,15 @@ func spcUpgrade(spcName, openebsNamespace string) (*utask.UpgradeTask, error) {
 		if err != nil {
 			return utaskObj, err
 		}
+		if utaskObj != nil {
+			utaskObj.Status.Phase = utask.UpgradeSuccess
+			utaskObj.Status.CompletedTime = metav1.Now()
+			_, uerr := utaskClient.WithNamespace(openebsNamespace).
+				Update(utaskObj)
+			if uerr != nil && isENVPresent {
+				return nil, uerr
+			}
+		}
 	}
 	glog.Infof("Upgrade Successful for spc %s", spcName)
 	return nil, nil

--- a/pkg/upgrade/1.0.0-1.1.0/v1alpha1/spc_upgrade.go
+++ b/pkg/upgrade/1.0.0-1.1.0/v1alpha1/spc_upgrade.go
@@ -17,8 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"fmt"
-
+	"github.com/golang/glog"
+	utask "github.com/openebs/maya/pkg/apis/openebs.io/upgrade/v1alpha1"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,31 +38,31 @@ func verifyCSPNodeName(cspList *apis.CStorPoolList) error {
 	return nil
 }
 
-func spcUpgrade(spcName, openebsNamespace string) error {
+func spcUpgrade(spcName, openebsNamespace string) (*utask.UpgradeTask, error) {
 
 	spcLabel := "openebs.io/storage-pool-claim=" + spcName
 	cspList, err := cspClient.List(metav1.ListOptions{
 		LabelSelector: spcLabel,
 	})
 	if err != nil {
-		return errors.Wrapf(err, "failed to list csp for spc %s", spcName)
+		return nil, errors.Wrapf(err, "failed to list csp for spc %s", spcName)
 	}
 	if len(cspList.Items) == 0 {
-		return errors.Errorf("no csp found for spc %s: no csp found", spcName)
+		return nil, errors.Errorf("no csp found for spc %s: no csp found", spcName)
 	}
 	err = verifyCSPNodeName(cspList)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	for _, cspObj := range cspList.Items {
 		if cspObj.Name == "" {
-			return errors.Errorf("missing csp name")
+			return nil, errors.Errorf("missing csp name")
 		}
-		err = cspUpgrade(cspObj.Name, openebsNamespace)
+		utaskObj, err := cspUpgrade(cspObj.Name, openebsNamespace)
 		if err != nil {
-			return err
+			return utaskObj, err
 		}
 	}
-	fmt.Println("Upgrade Successful for spc", spcName)
-	return nil
+	glog.Infof("Upgrade Successful for spc %s", spcName)
+	return nil, nil
 }


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds the code create or read from the UpgradeTask CR.
If the CR is not present job will create one for the resource. 
It also updates the CR with the current status of the upgrade.
This PR also includes the ability to upgrade multiple resources in one single job.

Sample job yaml will be
```
apiVersion: batch/v1
kind: Job
metadata:
  # VERIFY that you have provided a unique name for this upgrade job.
  # The name can be any valid K8s string for name. This example uses
  # the following convention: jiva-vol-<flattened-from-to-versions>-<pv-name>
  name: jiva-vol-100110-pvc-7904a228-ca69-11e9-9c4f-54e1ad5e8320
  
  # VERIFY the value of namespace is same as the namespace where openebs components
  # are installed. You can verify using the command:
  # `kubectl get pods -n <openebs-namespace> -l openebs.io/component-name=maya-apiserver`
  # The above command should return status of the openebs-apiserver.
  namespace: openebs

spec:
  backoffLimit: 4
  template:
    spec:
      
      # VERIFY the value of serviceAccountName is pointing to service account
      # created within openebs namespace. Use the non-default account.
      # by running `kubectl get sa -n <openebs-namespace>`
      serviceAccountName: openebs-maya-operator
      
      containers:
      - name:  upgrade
        args: 
        - "jiva-volume"
        - "--from-version=1.0.0"
        - "--to-version=1.1.0"
        
        # VERIFY that you have provided the correct cStor PV Name
        - "--pv-name=pvc-7904a228-ca69-11e9-9c4f-54e1ad5e8320"
        
        # Following are optional parameters
        # Log Level
        - "--v=4"
        
        # DO NOT CHANGE BELOW PARAMETERS
        env:
        - name: OPENEBS_NAMESPACE
          valueFrom:
            fieldRef:
              fieldPath: metadata.namespace
        - name: POD_NAME
          valueFrom:
            fieldRef:
              fieldPath: metadata.name
        tty: true 
        image: openebs/m-upgrade:ci
        imagePullPolicy: IfNotPresent
      restartPolicy: OnFailure
```

Sample Success UpgradeTask CR
```
apiVersion: openebs.io/v1alpha1
kind: UpgradeTask
metadata:
  creationTimestamp: "2019-08-29T15:17:33Z"
  generation: 9
  name: upgrade-jiva-volume-pvc-7904a228-ca69-11e9-9c4f-54e1ad5e8320
  namespace: openebs
  labels:
    app: app-name
  resourceVersion: "9464"
  selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/upgradetasks/upgrade-jiva-volume-pvc-7904a228-ca69-11e9-9c4f-54e1ad5e8320
  uid: 1ff2551d-ca70-11e9-9c4f-54e1ad5e8320
spec:
  fromVersion: 1.0.0
  imagePrefix: quay.io/openebs/
  imageTag: 1.1.0
  jivaVolume:
    pvName: pvc-7904a228-ca69-11e9-9c4f-54e1ad5e8320
  toVersion: 1.1.0
status:
  completedTime: "2019-08-29T15:18:27Z"
  phase: Success
  retries: 0
  startTime: "2019-08-29T15:17:33Z"
  upgradeDetailedStatuses:
  - lastUpdatedAt: "2019-08-29T15:17:33Z"
    message: Pre-upgrade steps were successful
    phase: Completed
    startTime: "2019-08-29T15:17:33Z"
    step: PRE_UPGRADE
  - lastUpdatedAt: "2019-08-29T15:17:59Z"
    message: Replica upgrade was successful
    phase: Completed
    startTime: "2019-08-29T15:17:33Z"
    step: REPLICA_UPGRADE
  - lastUpdatedAt: "2019-08-29T15:18:26Z"
    message: Target upgrade was successful
    phase: Completed
    startTime: "2019-08-29T15:17:59Z"
    step: TARGET_UPGRADE
```
Sample Error UpgradeTask CR
```
apiVersion: openebs.io/v1alpha1
kind: UpgradeTask
metadata:
  creationTimestamp: "2019-08-29T15:24:13Z"
  generation: 20
  name: upgrade-jiva-volume-pvc-792c8504-ca69-11e9-9c4f-54e1ad5e8320
  namespace: openebs
  labels:
    app: app-name
  resourceVersion: "10682"
  selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/upgradetasks/upgrade-jiva-volume-pvc-792c8504-ca69-11e9-9c4f-54e1ad5e8320
  uid: 0e7233c3-ca71-11e9-9c4f-54e1ad5e8320
spec:
  fromVersion: 1.0.0
  imagePrefix: quay.io/openebs/
  imageTag: 1.1.0
  jivaVolume:
    pvName: pvc-792c8504-ca69-11e9-9c4f-54e1ad5e8320
  toVersion: 1.1.0
status:
  completedTime: "2019-08-29T15:25:55Z"
  phase: Error
  retries: 5
  startTime: "2019-08-29T15:24:13Z"
  upgradeDetailedStatuses:
  - lastUpdatedAt: "2019-08-29T15:25:55Z"
    message: failed to get target details
    phase: Errored
    reason: failed to get controller deployment
    startTime: "2019-08-29T15:25:55Z"
    step: PRE_UPGRADE
```
If the CRs is already created then the CR label can be passed instead of args in the job to upgrade multiple resources of similar kind in one job.

Sample UpgradeTask job
```
apiVersion: batch/v1
kind: Job
metadata:
  # VERIFY that you have provided a unique name for this upgrade job.
  # The name can be any valid K8s string for name. This example uses
  # the following convention: jiva-vol-<flattened-from-to-versions>-<pv-name>
  name: jiva-volume-100110-pvc-794c53a7-ca69-11e9-9c4f-54e1ad5e8320
  
  # VERIFY the value of namespace is same as the namespace where openebs components
  # are installed. You can verify using the command:
  # `kubectl get pods -n <openebs-namespace> -l openebs.io/component-name=maya-apiserver`
  # The above command should return status of the openebs-apiserver.
  namespace: openebs

spec:
  template:
    spec:
      
      # VERIFY the value of serviceAccountName is pointing to service account
      # created within openebs namespace. Use the non-default account.
      # by running `kubectl get sa -n <openebs-namespace>`
      serviceAccountName: openebs-maya-operator 
      containers:
      - name:  upgrade
        args:
        - "resource"
        
        # Following are optional parameters
        # Log Level
        - "--v=4"
        
        env:
        - name: OPENEBS_NAMESPACE
          value: "openebs"
        - name: UPGRADE_TASK_LABEL
          value: "app=app-name"
        - name: POD_NAME
          valueFrom:
            fieldRef:
              fieldPath: metadata.name
        tty: true 
        image: openebs/m-upgrade:ci 
        imagePullPolicy: IfNotPresent
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests