### PR TITLE
fix(cspc-operator): get cspc name from cspi labels instead of annotaions

### DIFF
--- a/cmd/cspc-operator/app/storagepool_create.go
+++ b/cmd/cspc-operator/app/storagepool_create.go
@@ -205,7 +205,7 @@ func getDeployOwnerReference(csp *apis.CStorPoolInstance) []metav1.OwnerReferenc
 // TODO: Use builder for labels and annotations
 func getDeployLabels(csp *apis.CStorPoolInstance) map[string]string {
 	return map[string]string{
-		string(apis.CStorPoolClusterCPK): csp.Annotations[string(apis.CStorPoolClusterCPK)],
+		string(apis.CStorPoolClusterCPK): csp.Labels[string(apis.CStorPoolClusterCPK)],
 		"app":                            "cstor-pool",
 		"openebs.io/cstor-pool-instance": csp.Name,
 		"openebs.io/version":             version.GetVersion(),


### PR DESCRIPTION

Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
```sh
k get deploy cspc-sparse-5f2z -oyaml
apiVersion: apps/v1
kind: Deployment
metadata:
  annotations:
    deployment.kubernetes.io/revision: "1"
    openebs.io/monitoring: pool_exporter_prometheus
  creationTimestamp: "2019-08-30T07:58:18Z"
  generation: 1
  labels:
    app: cstor-pool
    openebs.io/cstor-pool-cluster: cspc-sparse
    openebs.io/cstor-pool-instance: cspc-sparse-5f2z
    openebs.io/version: 1.2.0
  name: cspc-sparse-5f2z
  namespace: openebs
  ownerReferences:
  - apiVersion: openebs.io/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: CStorPoolInstance
    name: cspc-sparse-5f2z
    uid: 799d0566-3a61-4312-a221-654ac01be1af
  resourceVersion: "5819"
  selfLink: /apis/apps/v1/namespaces/openebs/deployments/cspc-sparse-5f2z
  uid: 6acaa521-9d00-4f9a-bccc-83e2641cb426
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: cstor-pool
  strategy:
    type: Recreate
  template:
    metadata:
      annotations:
        openebs.io/monitoring: pool_exporter_prometheus
        prometheus.io/path: /metrics
        prometheus.io/port: "9500"
        prometheus.io/scrape: "true"
      creationTimestamp: null
      labels:
        app: cstor-pool
        openebs.io/cstor-pool-cluster: cspc-sparse
        openebs.io/cstor-pool-instance: cspc-sparse-5f2z
        openebs.io/version: 1.2.0
    spec:
```