### PR TITLE
Update cspc status filter in csi BDD tests

### DIFF
--- a/tests/operations.go
+++ b/tests/operations.go
@@ -597,7 +597,7 @@ func (ops *Operations) GetHealthyCSPICount(cspcName string, expectedCSPICount in
 		cspiCount = cspi.
 			ListBuilderFromAPIList(cspiAPIList).
 			List().
-			Filter(cspi.HasLabel(string(apis.CStorPoolClusterCPK), cspcName), cspi.IsStatus("ONLINE\n")).
+			Filter(cspi.HasLabel(string(apis.CStorPoolClusterCPK), cspcName), cspi.IsStatus("ONLINE")).
 			Len()
 
 		if cspiCount == expectedCSPICount {


### PR DESCRIPTION
This change is made adhering to the recent commits updating cspi status column.
```
ginkgo -v -- -kubeconfig="$HOME/.kube/config" --cstor-replicas=1 --cstor-maxpools=1
Running Suite: Test cstor volume provisioning
=============================================
Random Seed: 1567547530
Will run 1 of 1 specs

STEP: waiting for maya-apiserver pod to come into running state
STEP: waiting for openebs-provisioner pod to come into running state
STEP: Verifying 'admission-server' pod status as running
STEP: building a namespace
STEP: creating above namespace
[cstor] [sparse] TEST VOLUME PROVISIONING when cstor pvc with replicacount 1 is created 
  should create cstor volume target pod
  /home/payes/gocode/src/github.com/openebs/maya/tests/csi/cstor/volume/provision_test.go:128
STEP: building a cstorpoolcluster
STEP: creating above cstorpoolcluster
STEP: verifying healthy cstorpool count
STEP: building SC parameters with generated SPC name
STEP: building a storageclass
STEP: creating above storageclass
STEP: building a pvc
STEP: creating above pvc
STEP: verifying pvc status as bound
STEP: building a busybox app pod deployment using above csi cstor volume
STEP: verifying target pod count as 1 once the app has been deployed
STEP: verifying cstorvolume replica count
STEP: verifying app pod is running
STEP: restarting application to remount the volume again
STEP: verifying app pod is terminated properly
STEP: verifying app pod is running again
STEP: deleting application deployment
STEP: deleting above pvc
STEP: verifying target pod count as 0
STEP: verifying deleted pvc
STEP: verifying if cstorvolume is deleted
STEP: deleting resources created for testing cstor volume provisioning
STEP: deleting cstorpoolcluster
STEP: deleting storageclass

• [SLOW TEST:200.352 seconds]
[cstor] [sparse] TEST VOLUME PROVISIONING
/home/payes/gocode/src/github.com/openebs/maya/tests/csi/cstor/volume/provision_test.go:40
  when cstor pvc with replicacount 1 is created
  /home/payes/gocode/src/github.com/openebs/maya/tests/csi/cstor/volume/provision_test.go:127
    should create cstor volume target pod
    /home/payes/gocode/src/github.com/openebs/maya/tests/csi/cstor/volume/provision_test.go:128
------------------------------
STEP: deleting namespace

Ran 1 of 1 Specs in 200.447 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 3m27.518596534s
Test Suite Passed
```