### PR TITLE
feat(jiva,localpv): allow user to customize default hostpaths

### DIFF
--- a/pkg/install/v1alpha1/jiva_pool.go
+++ b/pkg/install/v1alpha1/jiva_pool.go
@@ -26,7 +26,7 @@ metadata:
   name: default
   type: hostdir
 spec:
-  path: "/var/openebs"
+  path: {{env "OPENEBS_IO_JIVA_POOL_DIR" | default "/var/openebs"}}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass

--- a/pkg/install/v1alpha1/localpv_sc.go
+++ b/pkg/install/v1alpha1/localpv_sc.go
@@ -33,7 +33,7 @@ metadata:
       - name: StorageType
         value: "hostpath"
       - name: BasePath
-        value: "/var/openebs/local"
+        value: {{env "OPENEBS_IO_LOCALPV_HOSTPATH_DIR" | default "/var/openebs/local"}} 
 provisioner: openebs.io/local
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete


### PR DESCRIPTION
API Server creates a default jiva storage pool and local pv
hostpath storage class - using /var/openebs and /var/openebs/local
as the default hostpath directories to store the jiva replica
and local pv data.

This PR allows users to customize the default path by passing in
a ENV variable to the API Server. In addition, this also allows
user to specify different locations for local pv and jiva or even
provide the flexibility to only custommize what is required or
fallback to the default values.

The following ENV variables need to be documented.
**`OPENEBS_IO_JIVA_POOL_DIR`**
**`OPENEBS_IO_LOCALPV_HOSTPATH_DIR`**

Note: Above ENV should be added to the openebs-operator and
helm charts.

Related Issue: 
- https://github.com/openebs/openebs/issues/2665
- https://github.com/openebs/openebs/issues/2730

Signed-off-by: kmova <kiran.mova@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests