### PR TITLE
chrore(cspc): enable cspc-operator to take lease for the lifetime on cspc

### DIFF
--- a/cmd/cspc-operator/app/cspc_lease.go
+++ b/cmd/cspc-operator/app/cspc_lease.go
@@ -82,6 +82,10 @@ func (sl *Lease) Hold() error {
 			return err
 		}
 	}
+	// If the pod which has already acquired lease and want again to acquire,grant it.
+	if leaseValueObj.Holder == sl.getPodName() {
+		return nil
+	}
 	// If leaseValue is empty acquire lease.
 	// If leaseValue is empty check whether it is expired.
 	// If leaseValue is not empty and not expired check whether the holder is live.

--- a/cmd/cspc-operator/app/handler.go
+++ b/cmd/cspc-operator/app/handler.go
@@ -206,7 +206,6 @@ func (pc *PoolConfig) create(pendingPoolCount int, cspc *apis.CStorPoolCluster) 
 		return errors.Wrapf(err, "Could not acquire lease on cspc object")
 	}
 	klog.V(4).Infof("Lease acquired successfully on cstorpoolcluster %s ", cspc.Name)
-	defer newSpcLease.Release()
 	for poolCount := 1; poolCount <= pendingPoolCount; poolCount++ {
 		err = pc.CreateStoragePool()
 		if err != nil {


### PR DESCRIPTION
This PR will enable highly available lease for cspc-operator pod.
Once a cspc-operator pod acquires a lease on CSPC object, only that pod will be able to process and no other pod will be able to process the CSPC with lease.
If in case, the leader ( leader is the pod who has acquired the lease on the CSPC ) has died another pod can acquire CSPC with lease for processing it.

Signed-off-by: Ashutosh Kumar <ashutosh.kumar@openebs.io>
