### PR TITLE
[2696] fix(cvr): changing Duplicate status as Online on CVR

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -306,8 +306,8 @@ func (c *CStorVolumeReplicaController) cVRAddEventHandler(
 			string(common.AlreadyPresent),
 			string(common.MessageResourceAlreadyPresent),
 		)
-		// If the volume already present then return the cvr status as duplicate
-		return string(apis.CVRStatusErrorDuplicate), nil
+		// If the volume already present then return the cvr status as online
+		return string(apis.CVRStatusOnline), nil
 	}
 
 	// Setting quorum to true for newly creating Volumes.
@@ -465,12 +465,6 @@ func IsRecreateStatus(cVR *apis.CStorVolumeReplica) bool {
 	}
 	glog.V(4).Infof("Not Recreate status: %v", string(cVR.ObjectMeta.UID))
 	return false
-}
-
-// IsErrorDuplicate flags if cvr resource is a duplicate
-// entry
-func IsErrorDuplicate(cvrObj *apis.CStorVolumeReplica) bool {
-	return cvrObj.Status.Phase == apis.CVRStatusErrorDuplicate
 }
 
 //  getCVRStatus is a wrapper that fetches the status of cstor volume.

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/new_replica_controller.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/new_replica_controller.go
@@ -209,7 +209,7 @@ func NewCStorVolumeReplicaController(
 					return
 				}
 
-				if IsErrorDuplicate(newCVR) || IsOnlyStatusChange(oldCVR, newCVR) {
+				if IsOnlyStatusChange(oldCVR, newCVR) {
 					// do nothing
 					return
 				}

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/new_replica_controller.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/new_replica_controller.go
@@ -124,7 +124,7 @@ func NewCStorVolumeReplicaController(
 			AddFunc: func(obj interface{}) {
 				cvrObj := obj.(*apis.CStorVolumeReplica)
 
-				if !IsRightCStorVolumeReplica(cvrObj) || IsErrorDuplicate(cvrObj) {
+				if !IsRightCStorVolumeReplica(cvrObj) {
 					// do nothing
 					return
 				}

--- a/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
@@ -78,8 +78,6 @@ const (
 	CVRStatusDeletionFailed CStorVolumeReplicaPhase = "DeletionFailed"
 	// CVRStatusInvalid ensures invalid resource.
 	CVRStatusInvalid CStorVolumeReplicaPhase = "Invalid"
-	// CVRStatusErrorDuplicate ensures error due to duplicate resource.
-	CVRStatusErrorDuplicate CStorVolumeReplicaPhase = "Invalid"
 	// CVRStatusInit ensures Init task of cvr resource.
 	CVRStatusInit CStorVolumeReplicaPhase = "Init"
 	// CVRStatusRecreate ensures recreation task of cvr resource.


### PR DESCRIPTION
Fixes https://github.com/openebs/openebs/issues/2696
`Background:`
cstor-pool-mgmt maintains list of volumes available during import time. In Add handler, if the replica is not part of the list and CVR status is Empty, but, 'zfs list' shows that volume is available, it sets status as 'Duplicate' in CVR.
In Add/Update handler, any CVR with Duplicate status will not be reconciled, and the status will be left at Duplicate if it is set to duplicate once.
This status will NOT cause any problem to IOs because when the pool is imported, all the replicas gets activated. Only problem with this is the 'Status' which is NOT updated.

This situation of setting status as 'Duplicate' might be happening when the pool pods are restarted, pool-mgmt container is talking to a pool in another pod which might be going down, and CVR status is not set but volume is created in old pod.
In this case, pool-mgmt came up and found that pool is imported (in another pod), it populates list of volumes and starts replica controller. Old pod created volume but not updated the status of CVR. Replica controller in new pod finds the volume is created and sets the status to Duplicate.

This can have serious impact if the pool disks are ephemeral. In ephemeral case, replicas need to be re-created. As the status is 'Duplicate', it doesn't reconcile and the volume will NOT be created.

`Fix:`
If this 'Duplicate' status is required to find/avoid duplicate datasets at ZFS, then this status is NOT required as ZFS never allows duplicate datasets.
If the status is to avoid having duplicate CVRs on the same pool, this status will NEITHER help to find it without leaving any corner cases. Detecting duplicate CVRs will be possible by pushing some CVR related specific info into dataset.
So, fix for this issue is to remove code around this 'Duplicate' status.

`Workaround:`
Existing workaround without this fix is:
- set the status to "" if this is freshly created replica or "Recreate" if volume is already created, but want to recreate on new pool. Even if volume is already existing in the pool, set to "Recreate"
- Restart cstor-pool-mgmt container only

Signed-off-by: Vitta <vitta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests