### PR TITLE
feat(leader-election): add lease API with leader election for cvc-controller

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1122,6 +1122,8 @@
     "k8s.io/client-go/third_party/forked/golang/template",
     "k8s.io/client-go/tools/cache",
     "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/client-go/tools/leaderelection",
+    "k8s.io/client-go/tools/leaderelection/resourcelock",
     "k8s.io/client-go/tools/record",
     "k8s.io/client-go/tools/reference",
     "k8s.io/client-go/tools/remotecommand",

--- a/cmd/cstorvolumeclaim/controller_base.go
+++ b/cmd/cstorvolumeclaim/controller_base.go
@@ -242,7 +242,7 @@ func (c *CVCController) deleteCVC(obj interface{}) {
 // as syncing informer caches and starting workers. It will block until stopCh
 // is closed, at which point it will shutdown the workqueue and wait for
 // workers to finish processing their current work items.
-func (c *CVCController) Run(threadiness int, stopCh <-chan struct{}) error {
+func (c *CVCController) Run(threadiness int, stopCh <-chan struct{}) {
 	defer runtime.HandleCrash()
 	defer c.workqueue.ShutDown()
 
@@ -252,7 +252,8 @@ func (c *CVCController) Run(threadiness int, stopCh <-chan struct{}) error {
 	// Wait for the k8s caches to be synced before starting workers
 	klog.Info("Waiting for informer caches to sync")
 	if ok := cache.WaitForCacheSync(stopCh, c.cvcSynced); !ok {
-		return fmt.Errorf("failed to wait for caches to sync")
+		klog.Errorf("failed to sync cvc caches")
+		return
 	}
 	klog.Info("Starting CVC workers")
 	// Launch worker to process CVC resources
@@ -264,8 +265,6 @@ func (c *CVCController) Run(threadiness int, stopCh <-chan struct{}) error {
 	klog.Info("Started CVC workers")
 	<-stopCh
 	klog.Info("Shutting down CVC workers")
-
-	return nil
 }
 
 // runWorker is a long-running function that will continually call the

--- a/cmd/cstorvolumeclaim/start.go
+++ b/cmd/cstorvolumeclaim/start.go
@@ -39,8 +39,9 @@ import (
 )
 
 var (
-	masterURL              string
-	kubeconfig             string
+	masterURL  string
+	kubeconfig string
+	// lease lock resource name for lease API resource
 	leaderElectionLockName = "cvc-controller-leader"
 )
 
@@ -50,7 +51,7 @@ var (
 	leaderElectionNamespace = flag.String("leader-election-namespace", "", "The namespace where the leader election resource exists. Defaults to the pod namespace if not set.")
 )
 
-// Start starts the cstor-operator.
+// Start starts the cstorvolumeclaim controller.
 func Start(controllerMtx *sync.RWMutex) error {
 	// Get in cluster config
 	cfg, err := getClusterConfig(kubeconfig)

--- a/cmd/cstorvolumeclaim/start.go
+++ b/cmd/cstorvolumeclaim/start.go
@@ -17,6 +17,10 @@ limitations under the License.
 package cstorvolumeclaim
 
 import (
+	"context"
+	"flag"
+	"os"
+	"os/signal"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -27,7 +31,7 @@ import (
 	clientset "github.com/openebs/maya/pkg/client/generated/clientset/versioned"
 	informers "github.com/openebs/maya/pkg/client/generated/informers/externalversions"
 	ndmclientset "github.com/openebs/maya/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset"
-	"github.com/openebs/maya/pkg/signals"
+	leader "github.com/openebs/maya/pkg/kubernetes/leaderelection"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -35,15 +39,19 @@ import (
 )
 
 var (
-	masterURL  string
-	kubeconfig string
+	masterURL              string
+	kubeconfig             string
+	leaderElectionLockName = "cvc-controller-leader"
+)
+
+// Command line flags
+var (
+	leaderElection          = flag.Bool("leader-election", true, "Enables leader election.")
+	leaderElectionNamespace = flag.String("leader-election-namespace", "", "The namespace where the leader election resource exists. Defaults to the pod namespace if not set.")
 )
 
 // Start starts the cstor-operator.
 func Start(controllerMtx *sync.RWMutex) error {
-	// set up signals so we handle the first shutdown signal gracefully
-	stopCh := signals.SetupSignalHandler()
-
 	// Get in cluster config
 	cfg, err := getClusterConfig(kubeconfig)
 	if err != nil {
@@ -70,13 +78,13 @@ func Start(controllerMtx *sync.RWMutex) error {
 
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, time.Second*30)
 	cvcInformerFactory := informers.NewSharedInformerFactory(openebsClient, time.Second*30)
+
 	// Build() fn of all controllers calls AddToScheme to adds all types of this
 	// clientset into the given scheme.
 	// If multiple controllers happen to call this AddToScheme same time,
 	// it causes panic with error saying concurrent map access.
 	// This lock is used to serialize the AddToScheme call of all controllers.
 	controllerMtx.Lock()
-
 	controller, err := NewCVCControllerBuilder().
 		withKubeClient(kubeClient).
 		withOpenEBSClient(openebsClient).
@@ -93,16 +101,37 @@ func Start(controllerMtx *sync.RWMutex) error {
 
 	// blocking call, can't use defer to release the lock
 	controllerMtx.Unlock()
-
 	if err != nil {
 		return errors.Wrapf(err, "error building controller instance")
 	}
 
-	go kubeInformerFactory.Start(stopCh)
-	go cvcInformerFactory.Start(stopCh)
-
 	// Threadiness defines the number of workers to be launched in Run function
-	return controller.Run(2, stopCh)
+	run := func(context.Context) {
+		// run...
+		stopCh := make(chan struct{})
+		kubeInformerFactory.Start(stopCh)
+		cvcInformerFactory.Start(stopCh)
+		go controller.Run(2, stopCh)
+
+		// ...until SIGINT
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt)
+		<-c
+		close(stopCh)
+	}
+
+	if !*leaderElection {
+		run(context.TODO())
+	} else {
+		le := leader.NewLeaderElection(kubeClient, leaderElectionLockName, run)
+		if *leaderElectionNamespace != "" {
+			le.WithNamespace(*leaderElectionNamespace)
+		}
+		if err := le.Run(); err != nil {
+			klog.Fatalf("failed to initialize leader election: %v", err)
+		}
+	}
+	return nil
 }
 
 // GetClusterConfig return the config for k8s.

--- a/pkg/kubernetes/leaderelection/leader_election.go
+++ b/pkg/kubernetes/leaderelection/leader_election.go
@@ -42,8 +42,8 @@ const (
 	defaultRetryPeriod   = 5 * time.Second
 )
 
-// leaderElection is a convenience wrapper around client-go's leader election library.
-type leaderElection struct {
+// LeaderElection is a convenience wrapper around client-go's leader election library.
+type LeaderElection struct {
 	runFunc func(ctx context.Context)
 
 	// the lockName identifies the leader election config and should be shared across all members
@@ -65,13 +65,13 @@ type leaderElection struct {
 }
 
 // NewLeaderElection returns the default & preferred leader election type
-func NewLeaderElection(clientset kubernetes.Interface, lockName string, runFunc func(ctx context.Context)) *leaderElection {
+func NewLeaderElection(clientset kubernetes.Interface, lockName string, runFunc func(ctx context.Context)) *LeaderElection {
 	return NewLeaderElectionWithLeases(clientset, lockName, runFunc)
 }
 
 // NewLeaderElectionWithLeases returns an implementation of leader election using Leases
-func NewLeaderElectionWithLeases(clientset kubernetes.Interface, lockName string, runFunc func(ctx context.Context)) *leaderElection {
-	return &leaderElection{
+func NewLeaderElectionWithLeases(clientset kubernetes.Interface, lockName string, runFunc func(ctx context.Context)) *LeaderElection {
+	return &LeaderElection{
 		runFunc:       runFunc,
 		lockName:      lockName,
 		resourceLock:  resourcelock.LeasesResourceLock,
@@ -83,8 +83,8 @@ func NewLeaderElectionWithLeases(clientset kubernetes.Interface, lockName string
 }
 
 // NewLeaderElectionWithEndpoints returns an implementation of leader election using Endpoints
-func NewLeaderElectionWithEndpoints(clientset kubernetes.Interface, lockName string, runFunc func(ctx context.Context)) *leaderElection {
-	return &leaderElection{
+func NewLeaderElectionWithEndpoints(clientset kubernetes.Interface, lockName string, runFunc func(ctx context.Context)) *LeaderElection {
+	return &LeaderElection{
 		runFunc:       runFunc,
 		lockName:      lockName,
 		resourceLock:  resourcelock.EndpointsResourceLock,
@@ -96,8 +96,8 @@ func NewLeaderElectionWithEndpoints(clientset kubernetes.Interface, lockName str
 }
 
 // NewLeaderElectionWithConfigMaps returns an implementation of leader election using ConfigMaps
-func NewLeaderElectionWithConfigMaps(clientset kubernetes.Interface, lockName string, runFunc func(ctx context.Context)) *leaderElection {
-	return &leaderElection{
+func NewLeaderElectionWithConfigMaps(clientset kubernetes.Interface, lockName string, runFunc func(ctx context.Context)) *LeaderElection {
+	return &LeaderElection{
 		runFunc:       runFunc,
 		lockName:      lockName,
 		resourceLock:  resourcelock.ConfigMapsResourceLock,
@@ -108,27 +108,33 @@ func NewLeaderElectionWithConfigMaps(clientset kubernetes.Interface, lockName st
 	}
 }
 
-func (l *leaderElection) WithIdentity(identity string) {
+// WithIdentity ...
+func (l *LeaderElection) WithIdentity(identity string) {
 	l.identity = identity
 }
 
-func (l *leaderElection) WithNamespace(namespace string) {
+// WithNamespace ...
+func (l *LeaderElection) WithNamespace(namespace string) {
 	l.namespace = namespace
 }
 
-func (l *leaderElection) WithLeaseDuration(leaseDuration time.Duration) {
+// WithLeaseDuration ...
+func (l *LeaderElection) WithLeaseDuration(leaseDuration time.Duration) {
 	l.leaseDuration = leaseDuration
 }
 
-func (l *leaderElection) WithRenewDeadline(renewDeadline time.Duration) {
+// WithRenewDeadline ...
+func (l *LeaderElection) WithRenewDeadline(renewDeadline time.Duration) {
 	l.renewDeadline = renewDeadline
 }
 
-func (l *leaderElection) WithRetryPeriod(retryPeriod time.Duration) {
+// WithRetryPeriod ...
+func (l *LeaderElection) WithRetryPeriod(retryPeriod time.Duration) {
 	l.retryPeriod = retryPeriod
 }
 
-func (l *leaderElection) Run() error {
+// Run ...
+func (l *LeaderElection) Run() error {
 	if l.identity == "" {
 		id, err := defaultLeaderElectionIdentity()
 		if err != nil {

--- a/pkg/kubernetes/leaderelection/leader_election.go
+++ b/pkg/kubernetes/leaderelection/leader_election.go
@@ -133,7 +133,7 @@ func (l *LeaderElection) WithRetryPeriod(retryPeriod time.Duration) {
 	l.retryPeriod = retryPeriod
 }
 
-// Run ...
+// Run starts the leader loop
 func (l *LeaderElection) Run() error {
 	if l.identity == "" {
 		id, err := defaultLeaderElectionIdentity()
@@ -180,7 +180,8 @@ func (l *LeaderElection) Run() error {
 			},
 		},
 	}
-
+	// RunOrDie starts a client with the provided config or panics if the
+	// leaderconfig fails to validate.
 	leaderelection.RunOrDie(context.TODO(), leaderConfig)
 	return nil // should never reach here
 }

--- a/pkg/kubernetes/leaderelection/leader_election.go
+++ b/pkg/kubernetes/leaderelection/leader_election.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2019 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderelection
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog"
+)
+
+const (
+	openEBS              = "openebs"
+	defaultLeaseDuration = 15 * time.Second
+	defaultRenewDeadline = 10 * time.Second
+	defaultRetryPeriod   = 5 * time.Second
+)
+
+// leaderElection is a convenience wrapper around client-go's leader election library.
+type leaderElection struct {
+	runFunc func(ctx context.Context)
+
+	// the lockName identifies the leader election config and should be shared across all members
+	lockName string
+	// the identity is the unique identity of the currently running member
+	identity string
+	// the namespace to store the lock resource
+	namespace string
+	// resourceLock defines the type of leaderelection that should be used
+	// valid options are resourcelock.LeasesResourceLock, resourcelock.EndpointsResourceLock,
+	// and resourcelock.ConfigMapsResourceLock
+	resourceLock string
+
+	leaseDuration time.Duration
+	renewDeadline time.Duration
+	retryPeriod   time.Duration
+
+	clientset kubernetes.Interface
+}
+
+// NewLeaderElection returns the default & preferred leader election type
+func NewLeaderElection(clientset kubernetes.Interface, lockName string, runFunc func(ctx context.Context)) *leaderElection {
+	return NewLeaderElectionWithLeases(clientset, lockName, runFunc)
+}
+
+// NewLeaderElectionWithLeases returns an implementation of leader election using Leases
+func NewLeaderElectionWithLeases(clientset kubernetes.Interface, lockName string, runFunc func(ctx context.Context)) *leaderElection {
+	return &leaderElection{
+		runFunc:       runFunc,
+		lockName:      lockName,
+		resourceLock:  resourcelock.LeasesResourceLock,
+		leaseDuration: defaultLeaseDuration,
+		renewDeadline: defaultRenewDeadline,
+		retryPeriod:   defaultRetryPeriod,
+		clientset:     clientset,
+	}
+}
+
+// NewLeaderElectionWithEndpoints returns an implementation of leader election using Endpoints
+func NewLeaderElectionWithEndpoints(clientset kubernetes.Interface, lockName string, runFunc func(ctx context.Context)) *leaderElection {
+	return &leaderElection{
+		runFunc:       runFunc,
+		lockName:      lockName,
+		resourceLock:  resourcelock.EndpointsResourceLock,
+		leaseDuration: defaultLeaseDuration,
+		renewDeadline: defaultRenewDeadline,
+		retryPeriod:   defaultRetryPeriod,
+		clientset:     clientset,
+	}
+}
+
+// NewLeaderElectionWithConfigMaps returns an implementation of leader election using ConfigMaps
+func NewLeaderElectionWithConfigMaps(clientset kubernetes.Interface, lockName string, runFunc func(ctx context.Context)) *leaderElection {
+	return &leaderElection{
+		runFunc:       runFunc,
+		lockName:      lockName,
+		resourceLock:  resourcelock.ConfigMapsResourceLock,
+		leaseDuration: defaultLeaseDuration,
+		renewDeadline: defaultRenewDeadline,
+		retryPeriod:   defaultRetryPeriod,
+		clientset:     clientset,
+	}
+}
+
+func (l *leaderElection) WithIdentity(identity string) {
+	l.identity = identity
+}
+
+func (l *leaderElection) WithNamespace(namespace string) {
+	l.namespace = namespace
+}
+
+func (l *leaderElection) WithLeaseDuration(leaseDuration time.Duration) {
+	l.leaseDuration = leaseDuration
+}
+
+func (l *leaderElection) WithRenewDeadline(renewDeadline time.Duration) {
+	l.renewDeadline = renewDeadline
+}
+
+func (l *leaderElection) WithRetryPeriod(retryPeriod time.Duration) {
+	l.retryPeriod = retryPeriod
+}
+
+func (l *leaderElection) Run() error {
+	if l.identity == "" {
+		id, err := defaultLeaderElectionIdentity()
+		if err != nil {
+			return fmt.Errorf("error getting the default leader identity: %v", err)
+		}
+
+		l.identity = id
+	}
+
+	if l.namespace == "" {
+		l.namespace = inClusterNamespace()
+	}
+
+	broadcaster := record.NewBroadcaster()
+	broadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: l.clientset.CoreV1().Events(l.namespace)})
+	eventRecorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: fmt.Sprintf("%s/%s", l.lockName, string(l.identity))})
+
+	rlConfig := resourcelock.ResourceLockConfig{
+		Identity:      sanitizeName(l.identity),
+		EventRecorder: eventRecorder,
+	}
+
+	lock, err := resourcelock.New(l.resourceLock, l.namespace, sanitizeName(l.lockName), l.clientset.CoreV1(), l.clientset.CoordinationV1(), rlConfig)
+	if err != nil {
+		return err
+	}
+
+	leaderConfig := leaderelection.LeaderElectionConfig{
+		Lock:          lock,
+		LeaseDuration: l.leaseDuration,
+		RenewDeadline: l.renewDeadline,
+		RetryPeriod:   l.retryPeriod,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(ctx context.Context) {
+				klog.V(2).Info("became leader, starting")
+				l.runFunc(ctx)
+			},
+			OnStoppedLeading: func() {
+				klog.Fatal("stopped leading")
+			},
+			OnNewLeader: func(identity string) {
+				klog.V(3).Infof("new leader detected, current leader: %s", identity)
+			},
+		},
+	}
+
+	leaderelection.RunOrDie(context.TODO(), leaderConfig)
+	return nil // should never reach here
+}
+
+func defaultLeaderElectionIdentity() (string, error) {
+	return os.Hostname()
+}
+
+// sanitizeName sanitizes the provided string so it can be consumed by leader election library
+func sanitizeName(name string) string {
+	re := regexp.MustCompile("[^a-zA-Z0-9-]")
+	name = re.ReplaceAllString(name, "-")
+	if name[len(name)-1] == '-' {
+		// name must not end with '-'
+		name = name + "X"
+	}
+	return name
+}
+
+// inClusterNamespace returns the namespace in which the pod is running in by checking
+// the env var POD_NAMESPACE, then the file /var/run/secrets/kubernetes.io/serviceaccount/namespace.
+// if neither returns a valid namespace, the "openebs" namespace is returned
+func inClusterNamespace() string {
+	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
+		return ns
+	}
+
+	if data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
+			return ns
+		}
+	}
+	return openEBS
+}

--- a/pkg/kubernetes/leaderelection/leader_election_test.go
+++ b/pkg/kubernetes/leaderelection/leader_election_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderelection
+
+import (
+	"testing"
+)
+
+func Test_sanitizeName(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		output string
+	}{
+		{
+			"requires no change",
+			"test-driver",
+			"test-driver",
+		},
+		{
+			"has characters that should be replaced",
+			"test!driver/foo",
+			"test-driver-foo",
+		},
+		{
+			"has trailing space",
+			"driver\\",
+			"driver-X",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			output := sanitizeName(test.input)
+			if output != test.output {
+				t.Logf("expected name: %q", test.output)
+				t.Logf("actual name: %q", output)
+				t.Errorf("unexpected santized name")
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This commits adds the leader-election API with lease for cvc-controller using built-in Kubernetes leader election APIs.

Leader election, in simple words, is the mechanism that guarantees that only one instance of the cvc-controller — or one instance of the maya-apiserver — is actively making decisions, while all the other
instances are inactive, but ready to take leadership if something happens to the active one.

Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->


**Special notes for your reviewer**:
Note: Tested the changes with 2 replicas of maya-apiserver pod and at the time only 1 pod took the lease and processed the event.

```sh
prateek:maya$ kubectl get pods -n openebs
NAME                                           READY   STATUS    RESTARTS   AGE
maya-apiserver-5c866997b4-mmwf8                1/1     Running   0          97s
maya-apiserver-5c866997b4-zn864                1/1     Running   4          9m10s
openebs-admission-server-bbc846f44-88zdz       1/1     Running   0          9m10s
openebs-localpv-provisioner-64f78dc779-k58bs   1/1     Running   0          9m10s
openebs-ndm-k4zlm                              1/1     Running   0          9m10s
openebs-ndm-operator-778465c4f4-ztc9k          1/1     Running   1          9m10s

$ kubectl get lease -n openebs
NAME                             HOLDER                            AGE
cvc-controller-leader   maya-apiserver-5c866997b4-zn864   7m48s

$ kubectl describe lease cvc-controller-leader -n openebs
Name:         cvc-controller-leader
Namespace:    openebs
Labels:       <none>
Annotations:  <none>
API Version:  coordination.k8s.io/v1
Kind:         Lease
Metadata:
  Creation Timestamp:  2019-09-20T07:47:04Z
  Resource Version:    1371
  Self Link:           /apis/coordination.k8s.io/v1/namespaces/openebs/leases/cvc-controller-leader
  UID:                 a7a6eed9-281e-4e35-b5ac-c2e00f181fda
Spec:
  Acquire Time:            2019-09-20T07:47:04.871504Z
  Holder Identity:         maya-apiserver-5c866997b4-zn864
  Lease Duration Seconds:  15
  Lease Transitions:       0
  Renew Time:              2019-09-20T07:58:56.427688Z
Events:
  Type    Reason          Age   From                                                            Message
  ----    ------          ----  ----                                                            -------
  Normal  LeaderElection  11m   cvc-controller-leader-election/maya-apiserver-5c866997b4-zn864  maya-apiserver-5c866997b4-zn864 became leader

$ kubect get lease cvc-controller-leader -n openebs -oyaml
apiVersion: coordination.k8s.io/v1
kind: Lease
metadata:
  creationTimestamp: "2019-09-20T07:47:04Z"
  name: cvc-controller-leader
  namespace: openebs
  resourceVersion: "1150"
  selfLink: /apis/coordination.k8s.io/v1/namespaces/openebs/leases/cvc-controller-leader
  uid: a7a6eed9-281e-4e35-b5ac-c2e00f181fda
spec:
  acquireTime: "2019-09-20T07:47:04.871504Z"
  holderIdentity: maya-apiserver-5c866997b4-zn864
  leaseDurationSeconds: 15
  leaseTransitions: 0
  renewTime: "2019-09-20T07:54:55.949018Z"
```

Step 2: If delete the leader maya-apisever pod, then other inactive maya-apiserver will take the lease and become the leader 
```sh
$ kubectl get pods -n openebs
NAME                                           READY   STATUS        RESTARTS   AGE
maya-apiserver-5c866997b4-kxvvz                1/1     Running       0          9s
maya-apiserver-5c866997b4-mmwf8                1/1     Running       0          8m55s
maya-apiserver-5c866997b4-zn864                1/1     Terminating   4          16m


$ kubectl describe lease -n openebs
Name:         cvc-controller-leader
Namespace:    openebs
Labels:       <none>
Annotations:  <none>
API Version:  coordination.k8s.io/v1
Kind:         Lease
Metadata:
  Creation Timestamp:  2019-09-20T07:47:04Z
  Resource Version:    1606
  Self Link:           /apis/coordination.k8s.io/v1/namespaces/openebs/leases/cvc-controller-leader
  UID:                 a7a6eed9-281e-4e35-b5ac-c2e00f181fda
Spec:
  Acquire Time:            2019-09-20T08:02:38.999205Z
  Holder Identity:         maya-apiserver-5c866997b4-kxvvz
  Lease Duration Seconds:  15
  Lease Transitions:       1
  Renew Time:              2019-09-20T08:02:49.044758Z
Events:
  Type    Reason          Age   From                                                            Message
  ----    ------          ----  ----                                                            -------
  Normal  LeaderElection  15m   cvc-controller-leader-election/maya-apiserver-5c866997b4-zn864  maya-apiserver-5c866997b4-zn864 became leader
  Normal  LeaderElection  13s   cvc-controller-leader-election/maya-apiserver-5c866997b4-kxvvz  maya-apiserver-5c866997b4-kxvvz became leader
```