### PR TITLE
bdd(csi): Add tests for pvc deletion without app

### DIFF
--- a/pkg/cstorvolumeclaim/v1alpha1/build.go
+++ b/pkg/cstorvolumeclaim/v1alpha1/build.go
@@ -1,0 +1,355 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"strconv"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/api/core/v1"
+	resource "k8s.io/apimachinery/pkg/api/resource"
+)
+
+// Builder is the builder object for CStorVolumeClaim
+type Builder struct {
+	cvc  *CStorVolumeClaim
+	errs []error
+}
+
+// NewBuilder returns new instance of Builder
+func NewBuilder() *Builder {
+	return &Builder{
+		cvc: &CStorVolumeClaim{
+			object: &apis.CStorVolumeClaim{},
+		},
+	}
+}
+
+// BuildFrom returns new instance of Builder
+// from the provided api instance
+func BuildFrom(cvc *apis.CStorVolumeClaim) *Builder {
+	if cvc == nil {
+		b := NewBuilder()
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build cstorvolumeclaim object: nil cvc"),
+		)
+		return b
+	}
+	return &Builder{
+		cvc: &CStorVolumeClaim{
+			object: cvc,
+		},
+	}
+}
+
+// WithName sets the Name of CStorVolumeClaim
+func (b *Builder) WithName(name string) *Builder {
+	if name == "" {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build cstorvolumeclaim object: missing name"),
+		)
+		return b
+	}
+	b.cvc.object.Name = name
+	return b
+}
+
+// WithGenerateName sets the GenerateName of CStorVolumeClaim
+func (b *Builder) WithGenerateName(name string) *Builder {
+	if name == "" {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build cstorvolumeclaim object: missing generateName",
+			),
+		)
+		return b
+	}
+
+	b.cvc.object.GenerateName = name
+	return b
+}
+
+// WithNamespace resets the Namespace of CStorVolumeClaim with provided arguments
+func (b *Builder) WithNamespace(namespace string) *Builder {
+	if namespace == "" {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build cstorvolumeclaim object: missing namespace",
+			),
+		)
+		return b
+	}
+	b.cvc.object.Namespace = namespace
+	return b
+}
+
+// WithStatusPhase updates the phase of CStorVolumeClaim
+func (b *Builder) WithStatusPhase(
+	phase apis.CStorVolumeClaimPhase) *Builder {
+	if phase == "" {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build cstorvolumeclaim object: missing phase",
+			),
+		)
+		return b
+	}
+	b.cvc.object.Status.Phase = phase
+	return b
+}
+
+// WithStatusConditions updates the status of CStorVolumeClaim
+func (b *Builder) WithStatusConditions(
+	conditions []apis.CStorVolumeClaimCondition) *Builder {
+	if len(conditions) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build cstorvolumeclaim object: missing conditions",
+			),
+		)
+		return b
+	}
+	b.cvc.object.Status.Conditions = append(b.cvc.object.Status.Conditions,
+		conditions...)
+	return b
+}
+
+// WithStatusConditionsNew resets the status of CStorVolumeClaim
+func (b *Builder) WithStatusConditionsNew(
+	conditions []apis.CStorVolumeClaimCondition) *Builder {
+	if len(conditions) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build cstorvolumeclaim object: missing conditions",
+			),
+		)
+		return b
+	}
+	b.cvc.object.Status.Conditions = conditions
+	return b
+}
+
+// WithAnnotations merges existing annotations of CStorVolumeClaim if any
+// with the ones that are provided here
+func (b *Builder) WithAnnotations(annotations map[string]string) *Builder {
+	if len(annotations) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build cstorvolumeclaim object: missing annotations",
+			),
+		)
+		return b
+	}
+
+	if b.cvc.object.Annotations == nil {
+		return b.WithAnnotationsNew(annotations)
+	}
+
+	for key, value := range annotations {
+		b.cvc.object.Annotations[key] = value
+	}
+	return b
+}
+
+// WithAnnotationsNew resets existing annotations of CStorVolumeiClaim
+// if any with ones that are provided here
+func (b *Builder) WithAnnotationsNew(annotations map[string]string) *Builder {
+	if len(annotations) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build cstorvolumeclaim object: no new annotations",
+			),
+		)
+		return b
+	}
+
+	// copy of original map
+	newannotations := map[string]string{}
+	for key, value := range annotations {
+		newannotations[key] = value
+	}
+
+	// override
+	b.cvc.object.Annotations = newannotations
+	return b
+}
+
+// WithLabels merges existing labels of CStorVolumeClaim if any
+// with the ones that are provided here
+func (b *Builder) WithLabels(labels map[string]string) *Builder {
+	if len(labels) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build cstorvolumeclaim object: missing labels",
+			),
+		)
+		return b
+	}
+
+	if b.cvc.object.Labels == nil {
+		return b.WithLabelsNew(labels)
+	}
+
+	for key, value := range labels {
+		b.cvc.object.Labels[key] = value
+	}
+	return b
+}
+
+// WithLabelsNew resets existing labels of CStorVolumeClaim if any with
+// ones that are provided here
+func (b *Builder) WithLabelsNew(labels map[string]string) *Builder {
+	if len(labels) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build cstorvolumeclaim object: no new labels",
+			),
+		)
+		return b
+	}
+
+	// copy of original map
+	newlbls := map[string]string{}
+	for key, value := range labels {
+		newlbls[key] = value
+	}
+
+	// override
+	b.cvc.object.Labels = newlbls
+	return b
+}
+
+// WithFinalizers merges existing finalizers of CStorVolumeClaim if any
+// with the ones that are provided here
+func (b *Builder) WithFinalizers(finalizers []string) *Builder {
+	if len(finalizers) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build cstorvolumeclaim object: missing finalizers",
+			),
+		)
+		return b
+	}
+
+	if b.cvc.object.Finalizers == nil {
+		return b.WithFinalizersNew(finalizers)
+	}
+
+	b.cvc.object.Finalizers = append(b.cvc.object.Finalizers, finalizers...)
+	return b
+}
+
+// WithFinalizersNew resets existing finalizers of CStorVolumeClaim if any with
+// ones that are provided here
+func (b *Builder) WithFinalizersNew(finalizers []string) *Builder {
+	if len(finalizers) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build cstorvolumeclaim object: no new finalizers",
+			),
+		)
+		return b
+	}
+
+	// override
+	b.cvc.object.Finalizers = nil
+	b.cvc.object.Finalizers = append(b.cvc.object.Finalizers, finalizers...)
+	return b
+}
+
+// WithCapacity sets the Capacity of CstorVOlumeClaim by converting string
+// capacity into Quantity
+func (b *Builder) WithCapacity(capacity string) *Builder {
+	resCapacity, err := resource.ParseQuantity(capacity)
+	if err != nil {
+		b.errs = append(
+			b.errs,
+			errors.Wrapf(
+				err,
+				"failed to build CStorVolumeClaim object: failed to parse capacity {%s}",
+				capacity,
+			),
+		)
+		return b
+	}
+	return b.WithCapacityQty(resCapacity)
+}
+
+// WithCapacityQty sets Capacity of CStorVOlumeClaim
+func (b *Builder) WithCapacityQty(resCapacity resource.Quantity) *Builder {
+	resourceList := metav1.ResourceList{
+		metav1.ResourceName(metav1.ResourceStorage): resCapacity,
+	}
+	b.cvc.object.Spec.Capacity = resourceList
+	return b
+}
+
+// WithReplicaCount sets replica count of CStorVolumeClaim
+func (b *Builder) WithReplicaCount(count string) *Builder {
+
+	replicaCount, err := strconv.Atoi(count)
+	if err != nil {
+		b.errs = append(
+			b.errs,
+			errors.Wrapf(
+				err,
+				"failed to build cstorvolumeclaim object {%s}",
+				count,
+			),
+		)
+		return b
+	}
+	b.cvc.object.Spec.ReplicaCount = replicaCount
+	return b
+}
+
+// WithNodeID sets NodeID details of CStorVolumeClaim
+func (b *Builder) WithNodeID(nodeID string) *Builder {
+	if nodeID == "" {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build cstorvolumeclaim object: missing nodeID",
+			),
+		)
+		return b
+	}
+	b.cvc.object.Publish.NodeID = nodeID
+	return b
+}
+
+// Build returns the CStorVolumeClaim API instance
+func (b *Builder) Build() (*apis.CStorVolumeClaim, error) {
+	if len(b.errs) > 0 {
+		return nil, errors.Errorf("%+v", b.errs)
+	}
+	return b.cvc.object, nil
+}

--- a/pkg/cstorvolumeclaim/v1alpha1/cstor_volume_claim.go
+++ b/pkg/cstorvolumeclaim/v1alpha1/cstor_volume_claim.go
@@ -26,7 +26,7 @@ type CStorVolumeClaim struct {
 	object *apis.CStorVolumeClaim
 }
 
-// List is a list of cstorvolumeclaim objects
+// CStorVolumeClaimList is a list of cstorvolumeclaim objects
 type CStorVolumeClaimList struct {
 	// list of cstor volume claims
 	items []*CStorVolumeClaim

--- a/pkg/cstorvolumeclaim/v1alpha1/cstor_volume_claim.go
+++ b/pkg/cstorvolumeclaim/v1alpha1/cstor_volume_claim.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+)
+
+// CStorVolumeClaim a wrapper for ume object
+type CStorVolumeClaim struct {
+	// actual cstorvolumeclaim object
+	object *apis.CStorVolumeClaim
+}
+
+// List is a list of cstorvolumeclaim objects
+type CStorVolumeClaimList struct {
+	// list of cstor volume claims
+	items []*CStorVolumeClaim
+}
+
+// ListBuilder enables building
+// an instance of umeCStorVolumeClaimList
+type ListBuilder struct {
+	list    *CStorVolumeClaimList
+	filters PredicateList
+}
+
+// NewListBuilder returns a new instance
+// of listBuilder
+func NewListBuilder() *ListBuilder {
+	return &ListBuilder{list: &CStorVolumeClaimList{}}
+}
+
+// WithAPIList builds the list of cstorvolume claim
+// instances based on the provided
+// CStorVolumeClaim api instances
+func (b *ListBuilder) WithAPIList(
+	list *apis.CStorVolumeClaimList) *ListBuilder {
+	if list == nil {
+		return b
+	}
+	for _, c := range list.Items {
+		c := c
+		b.list.items = append(b.list.items, &CStorVolumeClaim{object: &c})
+	}
+	return b
+}
+
+// List returns the list of CStorVolumeClaims (cvcs)
+// instances that was built by this
+// builder
+func (b *ListBuilder) List() *CStorVolumeClaimList {
+	if b.filters == nil || len(b.filters) == 0 {
+		return b.list
+	}
+	filtered := &CStorVolumeClaimList{}
+	for _, cv := range b.list.items {
+		if b.filters.all(cv) {
+			filtered.items = append(filtered.items, cv)
+		}
+	}
+	return filtered
+}
+
+// Len returns the number of items present
+// in the CStorVolumeClaimList
+func (l *CStorVolumeClaimList) Len() int {
+	return len(l.items)
+}
+
+// Predicate defines an abstraction
+// to determine conditional checks
+// against the provided cstorvolume claim instance
+type Predicate func(*CStorVolumeClaim) bool
+
+// PredicateList holds a list of cstor volume claims
+// based predicates
+type PredicateList []Predicate
+
+// all returns true if all the predicates
+// succeed against the provided cstorvolumeclaim
+// instance
+func (l PredicateList) all(c *CStorVolumeClaim) bool {
+	for _, check := range l {
+		if !check(c) {
+			return false
+		}
+	}
+	return true
+}
+
+// WithFilter adds filters on which the cstorvolumeclaim has to be filtered
+func (b *ListBuilder) WithFilter(pred ...Predicate) *ListBuilder {
+	b.filters = append(b.filters, pred...)
+	return b
+}
+
+// NewForAPIObject returns a new instance of cstorvolume
+func NewForAPIObject(obj *apis.CStorVolumeClaim) *CStorVolumeClaim {
+	return &CStorVolumeClaim{
+		object: obj,
+	}
+}

--- a/pkg/cstorvolumeclaim/v1alpha1/kubernetes.go
+++ b/pkg/cstorvolumeclaim/v1alpha1/kubernetes.go
@@ -1,0 +1,497 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"fmt"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+
+	clientset "github.com/openebs/maya/pkg/client/generated/clientset/versioned"
+	client "github.com/openebs/maya/pkg/kubernetes/client/v1alpha1"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
+)
+
+// getClientsetFn is a typed function that
+// abstracts fetching of internal clientset
+type getClientsetFn func() (clientset *clientset.Clientset, err error)
+
+// getClientsetFromPathFn is a typed function that
+// abstracts fetching of clientset from kubeConfigPath
+type getClientsetForPathFn func(
+	kubeConfigPath string) (clientset *clientset.Clientset, err error)
+
+// createFn is a typed function that abstracts
+// creating csi volume instance
+type createFn func(
+	cli *clientset.Clientset,
+	upgradeResultObj *apis.CStorVolumeClaim,
+	namespace string) (*apis.CStorVolumeClaim, error)
+
+// getFn is a typed function that abstracts
+// fetching a csi volume instance
+type getFn func(cli *clientset.Clientset, name, namespace string,
+	opts metav1.GetOptions) (*apis.CStorVolumeClaim, error)
+
+// listFn is a typed function that abstracts
+// listing of csi volume instances
+type listFn func(
+	cli *clientset.Clientset,
+	namespace string,
+	opts metav1.ListOptions) (*apis.CStorVolumeClaimList, error)
+
+// delFn is a typed function that abstracts
+// deleting a csi volume instance
+type delFn func(
+	cli *clientset.Clientset,
+	name,
+	namespace string,
+	opts *metav1.DeleteOptions) error
+
+// updateFn is a typed function that abstracts
+// updating csi volume instance
+type updateFn func(
+	cli *clientset.Clientset,
+	cvc *apis.CStorVolumeClaim,
+	namespace string) (*apis.CStorVolumeClaim, error)
+
+// patchFn is a typed function that abstracts
+// patching csi volume instance
+type patchFn func(
+	cli *clientset.Clientset,
+	oldCVC *apis.CStorVolumeClaim,
+	newCVC *apis.CStorVolumeClaim,
+	subresources ...string,
+) (*apis.CStorVolumeClaim, error)
+
+// Kubeclient enables kubernetes API operations
+// on csi volume instance
+type Kubeclient struct {
+	// clientset refers to csi volume's
+	// clientset that will be responsible to
+	// make kubernetes API calls
+	clientset *clientset.Clientset
+
+	kubeConfigPath string
+
+	// namespace holds the namespace on which
+	// kubeclient has to operate
+	namespace string
+
+	// functions useful during mocking
+	getClientset        getClientsetFn
+	getClientsetForPath getClientsetForPathFn
+	get                 getFn
+	list                listFn
+	del                 delFn
+	create              createFn
+	update              updateFn
+	patch               patchFn
+}
+
+// KubeclientBuildOption defines the abstraction
+// to build a kubeclient instance
+type KubeclientBuildOption func(*Kubeclient)
+
+// defaultGetClientset is the default implementation to
+// get kubernetes clientset instance
+func defaultGetClientset() (clients *clientset.Clientset, err error) {
+
+	config, err := client.GetConfig(client.New())
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset.NewForConfig(config)
+
+}
+
+// defaultGetClientsetForPath is the default implementation to
+// get kubernetes clientset instance based on the given
+// kubeconfig path
+func defaultGetClientsetForPath(
+	kubeConfigPath string,
+) (clients *clientset.Clientset, err error) {
+	config, err := client.GetConfig(
+		client.New(client.WithKubeConfigPath(kubeConfigPath)))
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset.NewForConfig(config)
+}
+
+// defaultGet is the default implementation to get
+// a cstorvolumeclaim instance in kubernetes cluster
+func defaultGet(
+	cli *clientset.Clientset,
+	name, namespace string,
+	opts metav1.GetOptions,
+) (*apis.CStorVolumeClaim, error) {
+	return cli.OpenebsV1alpha1().
+		CStorVolumeClaims(namespace).
+		Get(name, opts)
+}
+
+// defaultList is the default implementation to list
+// CstorVolumeClaim instances in kubernetes cluster
+func defaultList(
+	cli *clientset.Clientset,
+	namespace string,
+	opts metav1.ListOptions,
+) (*apis.CStorVolumeClaimList, error) {
+	return cli.OpenebsV1alpha1().
+		CStorVolumeClaims(namespace).
+		List(opts)
+}
+
+// defaultCreate is the default implementation to delete
+// a cstorvolumeclaim instance in kubernetes cluster
+func defaultDel(
+	cli *clientset.Clientset,
+	name, namespace string,
+	opts *metav1.DeleteOptions,
+) error {
+	deletePropagation := metav1.DeletePropagationForeground
+	opts.PropagationPolicy = &deletePropagation
+	err := cli.OpenebsV1alpha1().
+		CStorVolumeClaims(namespace).
+		Delete(name, opts)
+	return err
+}
+
+// defaultCreate is the default implementation to create
+// a cstorvolumeclaim instance in kubernetes cluster
+func defaultCreate(
+	cli *clientset.Clientset,
+	cvc *apis.CStorVolumeClaim,
+	namespace string,
+) (*apis.CStorVolumeClaim, error) {
+	return cli.OpenebsV1alpha1().
+		CStorVolumeClaims(namespace).
+		Create(cvc)
+}
+
+// defaultPatch is the default implementation to patch
+// a cstorvolumeclaim instance in kubernetes cluster
+func defaultPatch(
+	cli *clientset.Clientset,
+	oldCVC *apis.CStorVolumeClaim,
+	newCVC *apis.CStorVolumeClaim,
+	subresources ...string,
+) (*apis.CStorVolumeClaim, error) {
+	patchBytes, err := getPatchData(oldCVC, newCVC)
+	if err != nil {
+		return nil,
+			fmt.Errorf(
+				"can't patch CVC %s as generate path data failed: %v",
+				CVCKey(oldCVC), err,
+			)
+	}
+
+	updatedCVC, updateErr := cli.OpenebsV1alpha1().
+		CStorVolumeClaims(oldCVC.Namespace).
+		Patch(
+			oldCVC.Name, types.MergePatchType,
+			patchBytes, subresources...,
+		)
+	if updateErr != nil {
+		return nil,
+			fmt.Errorf("can't patch status of  CVC %s with %v",
+				CVCKey(oldCVC), updateErr,
+			)
+	}
+	return updatedCVC, nil
+}
+
+// defaultUpdate is the default implementation to update
+// a cstorvolumeclaim instance in kubernetes cluster
+func defaultUpdate(
+	cli *clientset.Clientset,
+	cvc *apis.CStorVolumeClaim,
+	namespace string,
+) (*apis.CStorVolumeClaim, error) {
+	return cli.OpenebsV1alpha1().
+		CStorVolumeClaims(namespace).
+		Update(cvc)
+}
+
+// withDefaults sets the default options
+// of kubeclient instance
+func (k *Kubeclient) withDefaults() {
+	if k.getClientset == nil {
+		k.getClientset = defaultGetClientset
+	}
+	if k.getClientsetForPath == nil {
+		k.getClientsetForPath = defaultGetClientsetForPath
+	}
+	if k.get == nil {
+		k.get = defaultGet
+	}
+	if k.list == nil {
+		k.list = defaultList
+	}
+	if k.del == nil {
+		k.del = defaultDel
+	}
+	if k.create == nil {
+		k.create = defaultCreate
+	}
+	if k.update == nil {
+		k.update = defaultUpdate
+	}
+	if k.patch == nil {
+		k.patch = defaultPatch
+	}
+}
+
+// WithClientSet sets the kubernetes client against
+// the kubeclient instance
+func WithClientSet(c *clientset.Clientset) KubeclientBuildOption {
+	return func(k *Kubeclient) {
+		k.clientset = c
+	}
+}
+
+// WithNamespace sets the kubernetes client against
+// the provided namespace
+func WithNamespace(namespace string) KubeclientBuildOption {
+	return func(k *Kubeclient) {
+		k.namespace = namespace
+	}
+}
+
+// WithNamespace sets the provided namespace
+// against this Kubeclient instance
+func (k *Kubeclient) WithNamespace(namespace string) *Kubeclient {
+	k.namespace = namespace
+	return k
+}
+
+// WithKubeConfigPath sets the kubernetes client
+// against the provided path
+func WithKubeConfigPath(path string) KubeclientBuildOption {
+	return func(k *Kubeclient) {
+		k.kubeConfigPath = path
+	}
+}
+
+// NewKubeclient returns a new instance of
+// kubeclient meant for csi volume operations
+func NewKubeclient(opts ...KubeclientBuildOption) *Kubeclient {
+	k := &Kubeclient{}
+	for _, o := range opts {
+		o(k)
+	}
+
+	k.withDefaults()
+	return k
+}
+
+func (k *Kubeclient) getClientsetForPathOrDirect() (
+	*clientset.Clientset, error) {
+	if k.kubeConfigPath != "" {
+		return k.getClientsetForPath(k.kubeConfigPath)
+	}
+
+	return k.getClientset()
+}
+
+// getClientOrCached returns either a new instance
+// of kubernetes client or its cached copy
+func (k *Kubeclient) getClientOrCached() (*clientset.Clientset, error) {
+	if k.clientset != nil {
+		return k.clientset, nil
+	}
+
+	c, err := k.getClientsetForPathOrDirect()
+	if err != nil {
+		return nil,
+			errors.Wrapf(
+				err,
+				"failed to get clientset",
+			)
+	}
+
+	k.clientset = c
+	return k.clientset, nil
+}
+
+// Create creates a cstorvolumeclaim instance
+// in kubernetes cluster
+func (k *Kubeclient) Create(
+	cvc *apis.CStorVolumeClaim) (*apis.CStorVolumeClaim, error) {
+	if cvc == nil {
+		return nil,
+			errors.New(
+				"failed to create cstovolumeclaim: nil cvc object",
+			)
+	}
+	cli, err := k.getClientOrCached()
+	if err != nil {
+		return nil, errors.Wrapf(
+			err,
+			"failed to create cvc {%s} in namespace {%s}",
+			cvc.Name,
+			k.namespace,
+		)
+	}
+
+	return k.create(cli, cvc, k.namespace)
+}
+
+// Get returns cstorvolumeclaim object for given name
+func (k *Kubeclient) Get(
+	name string,
+	opts metav1.GetOptions,
+) (*apis.CStorVolumeClaim, error) {
+	if name == "" {
+		return nil,
+			errors.New(
+				"failed to get cstorvolumeclaim: missing cvc name",
+			)
+	}
+
+	cli, err := k.getClientOrCached()
+	if err != nil {
+		return nil, errors.Wrapf(
+			err,
+			"failed to get cstorvolumeclaim {%s} in namespace {%s}",
+			name,
+			k.namespace,
+		)
+	}
+	return k.get(cli, name, k.namespace, opts)
+}
+
+// GetRaw returns cstorvolumeclaim instance
+// in bytes
+func (k *Kubeclient) GetRaw(
+	name string,
+	opts metav1.GetOptions,
+) ([]byte, error) {
+	if name == "" {
+		return nil, errors.New(
+			"failed to get raw cstorvolumeclaim: missing cvc name",
+		)
+	}
+	cvc, err := k.Get(name, opts)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err,
+			"failed to get cstorvolumeclaim {%s} in namespace {%s}",
+			name,
+			k.namespace,
+		)
+	}
+
+	return json.Marshal(cvc)
+}
+
+// List returns a list of cstorvolumeclaim
+// instances present in kubernetes cluster
+func (k *Kubeclient) List(
+	opts metav1.ListOptions,
+) (*apis.CStorVolumeClaimList, error) {
+	cli, err := k.getClientOrCached()
+	if err != nil {
+		return nil, errors.Wrapf(
+			err,
+			"failed to list cstorvolumeclaims in namespace {%s}",
+			k.namespace,
+		)
+	}
+
+	return k.list(cli, k.namespace, opts)
+}
+
+// Delete deletes the cstorvolumeclaim from
+// kubernetes
+func (k *Kubeclient) Delete(name string) error {
+	if name == "" {
+		return errors.New(
+			"failed to delete cstorvolumeclaim: missing cvc name",
+		)
+	}
+	cli, err := k.getClientOrCached()
+	if err != nil {
+		return errors.Wrapf(
+			err,
+			"failed to delete cstorvolumeclaim {%s} in namespace {%s}",
+			name,
+			k.namespace,
+		)
+	}
+
+	return k.del(cli, name, k.namespace, &metav1.DeleteOptions{})
+}
+
+// Update updates this cstorvolumeclaim instance
+// against kubernetes cluster
+func (k *Kubeclient) Update(
+	cvc *apis.CStorVolumeClaim,
+) (*apis.CStorVolumeClaim, error) {
+	if cvc == nil {
+		return nil,
+			errors.New(
+				"failed to update cstorvolumeclaim: nil cvc object",
+			)
+	}
+
+	cli, err := k.getClientOrCached()
+	if err != nil {
+		return nil, errors.Wrapf(
+			err,
+			"failed to update cstorvolumeclaim {%s} in namespace {%s}",
+			cvc.Name,
+			cvc.Namespace,
+		)
+	}
+
+	return k.update(cli, cvc, k.namespace)
+}
+
+// Patch patches this cstorvolumeclaim instance
+// against kubernetes cluster
+func (k *Kubeclient) Patch(
+	oldCVC *apis.CStorVolumeClaim,
+	newCVC *apis.CStorVolumeClaim,
+	subresources ...string,
+) (*apis.CStorVolumeClaim, error) {
+	if oldCVC == nil || newCVC == nil {
+		return nil,
+			errors.New(
+				"failed to update cstorvolumeclaim: nil cvc object",
+			)
+	}
+
+	cli, err := k.getClientOrCached()
+	if err != nil {
+		return nil, errors.Wrapf(
+			err,
+			"failed to update cstorvolumeclaim {%s} in namespace {%s}",
+			newCVC.Name,
+			newCVC.Namespace,
+		)
+	}
+
+	return k.patch(cli, oldCVC, newCVC, subresources...)
+}

--- a/pkg/cstorvolumeclaim/v1alpha1/kubernetes.go
+++ b/pkg/cstorvolumeclaim/v1alpha1/kubernetes.go
@@ -77,8 +77,7 @@ type updateFn func(
 // patching csi volume instance
 type patchFn func(
 	cli *clientset.Clientset,
-	oldCVC *apis.CStorVolumeClaim,
-	newCVC *apis.CStorVolumeClaim,
+	oldCVC, newCVC *apis.CStorVolumeClaim,
 	subresources ...string,
 ) (*apis.CStorVolumeClaim, error)
 
@@ -194,8 +193,7 @@ func defaultCreate(
 // a cstorvolumeclaim instance in kubernetes cluster
 func defaultPatch(
 	cli *clientset.Clientset,
-	oldCVC *apis.CStorVolumeClaim,
-	newCVC *apis.CStorVolumeClaim,
+	oldCVC, newCVC *apis.CStorVolumeClaim,
 	subresources ...string,
 ) (*apis.CStorVolumeClaim, error) {
 	patchBytes, err := getPatchData(oldCVC, newCVC)
@@ -472,8 +470,7 @@ func (k *Kubeclient) Update(
 // Patch patches this cstorvolumeclaim instance
 // against kubernetes cluster
 func (k *Kubeclient) Patch(
-	oldCVC *apis.CStorVolumeClaim,
-	newCVC *apis.CStorVolumeClaim,
+	oldCVC, newCVC *apis.CStorVolumeClaim,
 	subresources ...string,
 ) (*apis.CStorVolumeClaim, error) {
 	if oldCVC == nil || newCVC == nil {

--- a/pkg/cstorvolumeclaim/v1alpha1/utils.go
+++ b/pkg/cstorvolumeclaim/v1alpha1/utils.go
@@ -1,0 +1,30 @@
+package v1alpha1
+
+import (
+	"encoding/json"
+	"fmt"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+)
+
+// CVCKey returns an unique key of a CVC object,
+func CVCKey(cvc *apis.CStorVolumeClaim) string {
+	return fmt.Sprintf("%s/%s", cvc.Namespace, cvc.Name)
+}
+
+func getPatchData(oldObj, newObj interface{}) ([]byte, error) {
+	oldData, err := json.Marshal(oldObj)
+	if err != nil {
+		return nil, fmt.Errorf("marshal old object failed: %v", err)
+	}
+	newData, err := json.Marshal(newObj)
+	if err != nil {
+		return nil, fmt.Errorf("mashal new object failed: %v", err)
+	}
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, oldObj)
+	if err != nil {
+		return nil, fmt.Errorf("CreateTwoWayMergePatch failed: %v", err)
+	}
+	return patchBytes, nil
+}

--- a/pkg/cstorvolumeclaim/v1alpha1/utils.go
+++ b/pkg/cstorvolumeclaim/v1alpha1/utils.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v1alpha1
 
 import (

--- a/tests/csi/cstor/volume/pvc_without_app_test.go
+++ b/tests/csi/cstor/volume/pvc_without_app_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("[csi] [cstor] TEST PVC CREATION DELETION WITHOUT APP", func() {
+	BeforeEach(preparePVCCreationDeletionWithoutAppTest)
+	AfterEach(cleanupAfterPVCCreationDeletionWithoutAppTest)
+
+	Context("PVC is created and deleted", func() {
+		It("Should run PVC creation and deletion test", pvcCreationDeletionWithoutAppTest)
+	})
+})
+
+func pvcCreationDeletionWithoutAppTest() {
+	By("creating and verifying PVC bound status", createAndVerifyPVC)
+	By("should verify cvc count as 1", func() { verifyCstorVolumeClaimCount(1) })
+	By("Deleting pvc", deletePVC)
+	By("should verify cvc count as 0", func() { verifyCstorVolumeClaimCount(0) })
+	By("Verifying deletion of components related to volume", verifyVolumeComponentsDeletion)
+}
+
+func preparePVCCreationDeletionWithoutAppTest() {
+	By("Creating storage class", createStorageClass)
+}
+
+func cleanupAfterPVCCreationDeletionWithoutAppTest() {
+	By("Deleting storage class", deleteStorageClass)
+}

--- a/tests/csi/cstor/volume/utils.go
+++ b/tests/csi/cstor/volume/utils.go
@@ -163,7 +163,7 @@ func createAndVerifyPVC() {
 	)
 
 	By("creating above pvc")
-	_, err = ops.PVCClient.WithNamespace(nsObj.Name).Create(pvcObj)
+	pvcObj, err = ops.PVCClient.WithNamespace(nsObj.Name).Create(pvcObj)
 	Expect(err).To(
 		BeNil(),
 		"while creating pvc {%s} in namespace {%s}",
@@ -175,6 +175,14 @@ func createAndVerifyPVC() {
 	status := ops.IsPVCBoundEventually(pvcName)
 	Expect(status).To(Equal(true),
 		"while checking status equal to bound")
+
+	pvcObj, err = ops.PVCClient.WithNamespace(nsObj.Name).Get(pvcObj.Name, metav1.GetOptions{})
+	Expect(err).To(
+		BeNil(),
+		"while retrieving pvc {%s} in namespace {%s}",
+		pvcName,
+		nsObj.Name,
+	)
 }
 
 func createDeployVerifyApp() {
@@ -284,8 +292,13 @@ func verifyTargetPodCount(count int) {
 
 func verifyCstorVolumeReplicaCount(count int) {
 	targetVolumeLabel := pvLabel + pvcObj.Spec.VolumeName
-	cvrCount := ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, targetVolumeLabel, count)
-	Expect(cvrCount).To(Equal(true), "while checking cstorvolume replica count")
+	isReqCVRCount := ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, targetVolumeLabel, count)
+	Expect(isReqCVRCount).To(Equal(true), "while checking cstorvolume replica count")
+}
+
+func verifyCstorVolumeClaimCount(count int) {
+	isReqCVCCount := ops.GetCstorVolumeClaimCountEventually(openebsNamespace, pvcObj.Spec.VolumeName, count)
+	Expect(isReqCVCCount).To(Equal(true), "while checking cstorvolume claim count")
 }
 
 func restartAppPodAndVerifyRunningStatus() {


### PR DESCRIPTION
```
ginkgo -v -- -kubeconfig="$HOME/.kube/config" --cstor-replicas=1 --cstor-maxpools=1
Running Suite: Test cstor volume provisioning
=============================================
Random Seed: 1569306542
Will run 1 of 1 specs

STEP: waiting for maya-apiserver pod to come into running state
STEP: waiting for openebs-provisioner pod to come into running state
STEP: Verifying 'admission-server' pod status as running
STEP: building a namespace
STEP: creating above namespace
[csi] [cstor] TEST PVC CREATION DELETION WITHOUT APP PVC is created and deleted 
  Should run PVC creation and deletion test
  /home/payes/gocode/src/github.com/openebs/maya/tests/csi/cstor/volume/pvc_without_app_test.go:28
STEP: Creating storage class
STEP: building a storageclass
STEP: creating above storageclass
STEP: creating and verifying PVC bound status
STEP: building a pvc
STEP: creating above pvc
STEP: verifying pvc status as bound
STEP: should verify cvc count as 1
STEP: Deleting pvc
STEP: verifying deleted pvc
STEP: should verify cvc count as 0
STEP: Verifying deletion of components related to volume
STEP: verifying target pod count as 0
STEP: verifying if cstorvolume is deleted
STEP: Verifying cstorvolume replica count
STEP: Deleting storage class
STEP: deleting storageclass

• [SLOW TEST:20.405 seconds]
[csi] [cstor] TEST PVC CREATION DELETION WITHOUT APP
/home/payes/gocode/src/github.com/openebs/maya/tests/csi/cstor/volume/pvc_without_app_test.go:23
  PVC is created and deleted
  /home/payes/gocode/src/github.com/openebs/maya/tests/csi/cstor/volume/pvc_without_app_test.go:27
    Should run PVC creation and deletion test
    /home/payes/gocode/src/github.com/openebs/maya/tests/csi/cstor/volume/pvc_without_app_test.go:28
------------------------------
STEP: deleting namespace

Ran 1 of 1 Specs in 20.606 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 33.331543064s
Test Suite Passed
```