### PR TITLE
fix(make): Fixing cstor-base tag

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -87,7 +87,7 @@ ifeq (${IMAGE_TAG}, )
 endif
 
 ifeq (${TRAVIS_TAG}, )
-  BASE_TAG = develop-ci
+  BASE_TAG = ci
   export BASE_TAG
 else
   BASE_TAG = ${TRAVIS_TAG}


### PR DESCRIPTION
Changes:
- The current version of makefile uses the default tag `develop-ci` for `cstor-base` image, but cStor images are pushed with default `ci` tag.

Signed-off-by: mayank <mayank.patel@mayadata.io>