### PR TITLE
Fix shell quoting in livenessprobe command in csp yaml

### DIFF
--- a/cmd/cspc-operator/app/storagepool_create.go
+++ b/cmd/cspc-operator/app/storagepool_create.go
@@ -344,7 +344,7 @@ func getPoolLivenessProbe() *corev1.Probe {
 	probe := &corev1.Probe{
 		Handler: corev1.Handler{
 			Exec: &corev1.ExecAction{
-				Command: []string{"/bin/sh", "-c", "zfs set io.openebs:livenesstimestap='$(date)' cstor-$OPENEBS_IO_POOL_NAME"},
+				Command: []string{"/bin/sh", "-c", "zfs set io.openebs:livenesstimestamp=\"$(date)\" cstor-$OPENEBS_IO_POOL_NAME"},
 			},
 		},
 		FailureThreshold:    3,

--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -259,7 +259,7 @@ spec:
                 command:
                 - /bin/sh
                 - -c
-                - zfs set io.openebs:livenesstimestap='$(date)' cstor-$OPENEBS_IO_CSTOR_ID
+                - zfs set io.openebs:livenesstimestamp="$(date)" cstor-$OPENEBS_IO_CSTOR_ID
               failureThreshold: 3
               initialDelaySeconds: 300
               periodSeconds: 10


### PR DESCRIPTION
Signed-off-by: Meghna Singh <meghna.singh@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
With this PR the command in livenessProbe in cstorpool yaml will set the value of  `io.openebs:livenesstimestamp` property to current timestamp, whose value earlier was set to $date due to some quoting issue in the command. This PR fixes it. 


