### PR TITLE
refact(cv,cvr,cspc,cspi): populate version details for csi based provisioning

### DIFF
--- a/cmd/cspc-operator/app/handler.go
+++ b/cmd/cspc-operator/app/handler.go
@@ -18,12 +18,15 @@ package app
 
 import (
 	"fmt"
+
 	bdc "github.com/openebs/maya/pkg/blockdeviceclaim/v1alpha1"
 	apiscspc "github.com/openebs/maya/pkg/cstor/poolcluster/v1alpha1"
+	"github.com/openebs/maya/pkg/version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	apiscsp "github.com/openebs/maya/pkg/cstor/poolinstance/v1alpha3"
 	"time"
+
+	apiscsp "github.com/openebs/maya/pkg/cstor/poolinstance/v1alpha3"
 
 	nodeselect "github.com/openebs/maya/pkg/algorithm/nodeselect/v1alpha2"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
@@ -117,6 +120,12 @@ func (c *Controller) syncCSPC(cspcGot *apis.CStorPoolCluster) error {
 		c.recorder.Event(cspcGot, corev1.EventTypeWarning, "Getting Namespace", message)
 		klog.Errorf("Could not sync CSPC {%s}: got empty namespace for openebs from env variable", cspcGot.Name)
 		return nil
+	}
+
+	_, err := c.populateVersion(cspcGot)
+	if err != nil {
+		klog.Errorf("failed to add versionDetails to CSPC %s:%s", cspcGot.Name, err.Error())
+		return err
 	}
 
 	pc, err := c.NewPoolConfig(cspcGot, openebsNameSpace)
@@ -354,4 +363,59 @@ func (pc *PoolConfig) removeSPCFinalizerOnAssociatedBDC() error {
 	}
 
 	return nil
+}
+
+// populateVersion assigns VersionDetails for old cspc object and newly created
+// cspc
+func (c *Controller) populateVersion(cspc *apis.CStorPoolCluster) (*apis.CStorPoolCluster, error) {
+	if cspc.VersionDetails.Current == "" {
+		var err error
+		var v string
+		var obj *apis.CStorPoolCluster
+		v, err = c.EstimateCSPCVersion(cspc)
+		if err != nil {
+			return nil, err
+		}
+		cspc.VersionDetails.Current = v
+		// For newly created spc Desired field will also be empty.
+		cspc.VersionDetails.Desired = v
+		cspc.VersionDetails.DependentsUpgraded = true
+		obj, err = c.clientset.OpenebsV1alpha1().
+			CStorPoolClusters(env.Get(env.OpenEBSNamespace)).
+			Update(cspc)
+
+		if err != nil {
+			return nil, errors.Wrapf(
+				err,
+				"failed to update spc %s while adding versiondetails",
+				cspc.Name,
+			)
+		}
+		klog.Infof("Version %s added on spc %s", v, cspc.Name)
+		return obj, nil
+	}
+	return cspc, nil
+}
+
+// EstimateCSPCVersion returns the cspi version if any cspi is present for the cspc or
+// returns the maya version as the new cspi created will be of maya version
+func (c *Controller) EstimateCSPCVersion(cspc *apis.CStorPoolCluster) (string, error) {
+
+	cspiList, err := c.clientset.OpenebsV1alpha1().
+		CStorPoolInstances(env.Get(env.OpenEBSNamespace)).
+		List(
+			metav1.ListOptions{
+				LabelSelector: string(apis.CStorPoolClusterCPK) + "=" + cspc.Name,
+			})
+	if err != nil {
+		return "", errors.Wrapf(
+			err,
+			"failed to get the cstorpool instance list related to cspc : %s",
+			cspc.Name,
+		)
+	}
+	if len(cspiList.Items) == 0 {
+		return version.Current(), nil
+	}
+	return cspiList.Items[0].Labels[string(apis.OpenEBSVersionKey)], nil
 }

--- a/cmd/cspc-operator/app/handler.go
+++ b/cmd/cspc-operator/app/handler.go
@@ -125,7 +125,7 @@ func (c *Controller) syncCSPC(cspcGot *apis.CStorPoolCluster) error {
 	cspcGot, err := c.populateVersion(cspcGot)
 	if err != nil {
 		klog.Errorf("failed to add versionDetails to CSPC %s:%s", cspcGot.Name, err.Error())
-		return err
+		return nil
 	}
 
 	pc, err := c.NewPoolConfig(cspcGot, openebsNameSpace)

--- a/cmd/cspc-operator/app/handler.go
+++ b/cmd/cspc-operator/app/handler.go
@@ -122,7 +122,7 @@ func (c *Controller) syncCSPC(cspcGot *apis.CStorPoolCluster) error {
 		return nil
 	}
 
-	_, err := c.populateVersion(cspcGot)
+	cspcGot, err := c.populateVersion(cspcGot)
 	if err != nil {
 		klog.Errorf("failed to add versionDetails to CSPC %s:%s", cspcGot.Name, err.Error())
 		return err

--- a/cmd/cstorvolumeclaim/controller.go
+++ b/cmd/cstorvolumeclaim/controller.go
@@ -263,12 +263,11 @@ func (c *CVCController) createVolumeOperation(cvc *apis.CStorVolumeClaim) (*apis
 		return nil, err
 	}
 
-	// update the cstorvolume reference, phase as "Bound", desired
-	// capacity and version details
-	cvc, err = CVCWithVersionAndRefernceDetails(cvc, volumeRef)
-	if err != nil {
-		return nil, err
-	}
+	// update the cstorvolume reference, phase as "Bound" and desired
+	// capacity
+	cvc.Spec.CStorVolumeRef = volumeRef
+	cvc.Status.Phase = apis.CStorVolumeClaimPhaseBound
+	cvc.Status.Capacity = cvc.Spec.Capacity
 
 	err = c.updateCVCObj(cvc, cvObj)
 	if err != nil {

--- a/cmd/cstorvolumeclaim/controller.go
+++ b/cmd/cstorvolumeclaim/controller.go
@@ -263,11 +263,12 @@ func (c *CVCController) createVolumeOperation(cvc *apis.CStorVolumeClaim) (*apis
 		return nil, err
 	}
 
-	// update the cstorvolume reference, phase as "Bound" and desired
-	// capacity
-	cvc.Spec.CStorVolumeRef = volumeRef
-	cvc.Status.Phase = apis.CStorVolumeClaimPhaseBound
-	cvc.Status.Capacity = cvc.Spec.Capacity
+	// update the cstorvolume reference, phase as "Bound", desired
+	// capacity and version details
+	cvc, err = CVCWithVersionDetails(cvc, volumeRef)
+	if err != nil {
+		return nil, err
+	}
 
 	err = c.updateCVCObj(cvc, cvObj)
 	if err != nil {

--- a/cmd/cstorvolumeclaim/controller.go
+++ b/cmd/cstorvolumeclaim/controller.go
@@ -265,7 +265,7 @@ func (c *CVCController) createVolumeOperation(cvc *apis.CStorVolumeClaim) (*apis
 
 	// update the cstorvolume reference, phase as "Bound", desired
 	// capacity and version details
-	cvc, err = CVCWithVersionDetails(cvc, volumeRef)
+	cvc, err = CVCWithVersionAndRefernceDetails(cvc, volumeRef)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cstorvolumeclaim/cstorvolumeclaim.go
+++ b/cmd/cstorvolumeclaim/cstorvolumeclaim.go
@@ -27,7 +27,6 @@ import (
 	cspi "github.com/openebs/maya/pkg/cstor/poolinstance/v1alpha3"
 	cv "github.com/openebs/maya/pkg/cstor/volume/v1alpha1"
 	cvr "github.com/openebs/maya/pkg/cstor/volumereplica/v1alpha1"
-	cvc "github.com/openebs/maya/pkg/cstorvolumeclaim/v1alpha1"
 	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 	svc "github.com/openebs/maya/pkg/kubernetes/service/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -441,28 +440,4 @@ func randomizePoolList(list *apis.CStorPoolInstanceList) *apis.CStorPoolInstance
 	}
 
 	return res
-}
-
-// CVCWithVersionAndRefernceDetails build cvc resource with required version
-// details, volume references and status capacity
-func CVCWithVersionAndRefernceDetails(
-	claim *apis.CStorVolumeClaim,
-	volumeRef *corev1.ObjectReference,
-) (*apis.CStorVolumeClaim, error) {
-
-	cvcObj, err := cvc.BuildFrom(claim).
-		WithClaimRef(volumeRef).
-		WithStatusCapacity(claim.Spec.Capacity).
-		WithStatusPhase(apis.CStorVolumeClaimPhaseBound).
-		WithNewVersion(version.GetVersion()).
-		WithDependentsUpgraded().
-		Build()
-	if err != nil {
-		return nil, errors.Wrapf(
-			err,
-			"failed to build cstorvolume with version details {%v}",
-			cvcObj,
-		)
-	}
-	return cvcObj, nil
 }

--- a/cmd/cstorvolumeclaim/cstorvolumeclaim.go
+++ b/cmd/cstorvolumeclaim/cstorvolumeclaim.go
@@ -443,9 +443,9 @@ func randomizePoolList(list *apis.CStorPoolInstanceList) *apis.CStorPoolInstance
 	return res
 }
 
-// CVCWithVersionDetails build cvc resource with required version
-// details and volume references
-func CVCWithVersionDetails(
+// CVCWithVersionAndRefernceDetails build cvc resource with required version
+// details, volume references and status capacity
+func CVCWithVersionAndRefernceDetails(
 	claim *apis.CStorVolumeClaim,
 	volumeRef *corev1.ObjectReference,
 ) (*apis.CStorVolumeClaim, error) {

--- a/cmd/maya-apiserver/cstor-operator/spc/handler.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/handler.go
@@ -541,6 +541,8 @@ func (c *Controller) populateVersion(spc *apis.StoragePoolClaim) (*apis.StorageP
 		spc.VersionDetails.Current = v
 		// For newly created spc Desired field will also be empty.
 		spc.VersionDetails.Desired = v
+		spc.VersionDetails.DependentsUpgraded = true
+
 		obj, err = c.clientset.OpenebsV1alpha1().StoragePoolClaims().
 			Update(spc)
 

--- a/pkg/algorithm/nodeselect/v1alpha2/build_csp.go
+++ b/pkg/algorithm/nodeselect/v1alpha2/build_csp.go
@@ -54,6 +54,8 @@ func (ac *Config) GetCSPSpec() (*apis.CStorPoolInstance, error) {
 		WithCSPCOwnerReference(ac.CSPC).
 		WithLabelsNew(csplabels).
 		WithFinalizer(apicspsc.CSPCFinalizer).
+		WithNewVersion(version.GetVersion()).
+		WithDependentsUpgraded().
 		Build()
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to build CSP object for node selector {%v}", poolSpec.NodeSelector)

--- a/pkg/cstor/poolcluster/v1alpha1/build.go
+++ b/pkg/cstor/poolcluster/v1alpha1/build.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	apisv1alpha1 "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	poolspec "github.com/openebs/maya/pkg/cstor/poolcluster/v1alpha1/cstorpoolspecs"
+
 	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 )
 

--- a/pkg/cstor/poolinstance/v1alpha3/build.go
+++ b/pkg/cstor/poolinstance/v1alpha3/build.go
@@ -285,3 +285,26 @@ func (b *Builder) WithCSPCOwnerReference(cspic *apis.CStorPoolCluster) *Builder 
 	b.CSPI.Object.OwnerReferences = append(b.CSPI.Object.OwnerReferences, reference)
 	return b
 }
+
+// WithNewVersion sets the current and desired version field of
+// CSPI with provided arguments
+func (b *Builder) WithNewVersion(version string) *Builder {
+	if version == "" {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build cspi object: version can't be empty",
+			),
+		)
+		return b
+	}
+	b.CSPI.Object.VersionDetails.Current = version
+	b.CSPI.Object.VersionDetails.Desired = version
+	return b
+}
+
+// WithDependentsUpgraded sets the field to true for new CSPI
+func (b *Builder) WithDependentsUpgraded() *Builder {
+	b.CSPI.Object.VersionDetails.DependentsUpgraded = true
+	return b
+}

--- a/pkg/cstor/volume/v1alpha1/build.go
+++ b/pkg/cstor/volume/v1alpha1/build.go
@@ -335,6 +335,29 @@ func (b *Builder) WithConsistencyFactor(consistencyfactor int) *Builder {
 	return b
 }
 
+// WithNewVersion sets the current and desired version field of
+// CStorVolume with provided arguments
+func (b *Builder) WithNewVersion(version string) *Builder {
+	if version == "" {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build cstorvolume object: version can't be empty",
+			),
+		)
+		return b
+	}
+	b.cstorvolume.object.VersionDetails.Current = version
+	b.cstorvolume.object.VersionDetails.Desired = version
+	return b
+}
+
+// WithDependentsUpgraded sets the field to true for new volume
+func (b *Builder) WithDependentsUpgraded() *Builder {
+	b.cstorvolume.object.VersionDetails.DependentsUpgraded = true
+	return b
+}
+
 // Build returns the CStorVolume API instance
 func (b *Builder) Build() (*apis.CStorVolume, error) {
 	if len(b.errs) > 0 {

--- a/pkg/cstor/volumereplica/v1alpha1/build.go
+++ b/pkg/cstor/volumereplica/v1alpha1/build.go
@@ -247,6 +247,29 @@ func (b *Builder) WithFinalizersNew(finalizers []string) *Builder {
 	return b
 }
 
+// WithNewVersion sets the current and desired version field of
+// CStorVolumeReplica with provided arguments
+func (b *Builder) WithNewVersion(version string) *Builder {
+	if version == "" {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build cvr object: version can't be empty",
+			),
+		)
+		return b
+	}
+	b.cvr.object.VersionDetails.Current = version
+	b.cvr.object.VersionDetails.Desired = version
+	return b
+}
+
+// WithDependentsUpgraded sets the field to true for new volume
+func (b *Builder) WithDependentsUpgraded() *Builder {
+	b.cvr.object.VersionDetails.DependentsUpgraded = true
+	return b
+}
+
 // Build returns the CStorVolumeReplica API instance
 func (b *Builder) Build() (*apis.CStorVolumeReplica, error) {
 	if len(b.errs) > 0 {

--- a/pkg/cstorvolumeclaim/v1alpha1/build.go
+++ b/pkg/cstorvolumeclaim/v1alpha1/build.go
@@ -21,7 +21,7 @@ import (
 
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	"github.com/pkg/errors"
-	metav1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	resource "k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -303,12 +303,24 @@ func (b *Builder) WithCapacity(capacity string) *Builder {
 	return b.WithCapacityQty(resCapacity)
 }
 
-// WithCapacityQty sets Capacity of CStorVOlumeClaim
+// WithCapacityQty sets Capacity of CStorVolumeClaim
 func (b *Builder) WithCapacityQty(resCapacity resource.Quantity) *Builder {
-	resourceList := metav1.ResourceList{
-		metav1.ResourceName(metav1.ResourceStorage): resCapacity,
+	resourceList := corev1.ResourceList{
+		corev1.ResourceName(corev1.ResourceStorage): resCapacity,
 	}
 	b.cvc.object.Spec.Capacity = resourceList
+	return b
+}
+
+// WithStatusCapacity sets status capacity of CStorVolumeClaim
+func (b *Builder) WithStatusCapacity(resCapacity corev1.ResourceList) *Builder {
+	b.cvc.object.Status.Capacity = resCapacity
+	return b
+}
+
+// WithClaimRef sets cstorvolumeReference of CStorVolumeClaim
+func (b *Builder) WithClaimRef(claimRef *corev1.ObjectReference) *Builder {
+	b.cvc.object.Spec.CStorVolumeRef = claimRef
 	return b
 }
 
@@ -343,6 +355,29 @@ func (b *Builder) WithNodeID(nodeID string) *Builder {
 		return b
 	}
 	b.cvc.object.Publish.NodeID = nodeID
+	return b
+}
+
+// WithNewVersion sets the current and desired version field of
+// CStorVolume with provided arguments
+func (b *Builder) WithNewVersion(version string) *Builder {
+	if version == "" {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build cstorvolume object: version can't be empty",
+			),
+		)
+		return b
+	}
+	b.cvc.object.VersionDetails.Current = version
+	b.cvc.object.VersionDetails.Desired = version
+	return b
+}
+
+// WithDependentsUpgraded sets the field to true for new volume
+func (b *Builder) WithDependentsUpgraded() *Builder {
+	b.cvc.object.VersionDetails.DependentsUpgraded = true
 	return b
 }
 

--- a/pkg/cstorvolumeclaim/v1alpha1/build.go
+++ b/pkg/cstorvolumeclaim/v1alpha1/build.go
@@ -312,18 +312,6 @@ func (b *Builder) WithCapacityQty(resCapacity resource.Quantity) *Builder {
 	return b
 }
 
-// WithStatusCapacity sets status capacity of CStorVolumeClaim
-func (b *Builder) WithStatusCapacity(resCapacity corev1.ResourceList) *Builder {
-	b.cvc.object.Status.Capacity = resCapacity
-	return b
-}
-
-// WithClaimRef sets cstorvolumeReference of CStorVolumeClaim
-func (b *Builder) WithClaimRef(claimRef *corev1.ObjectReference) *Builder {
-	b.cvc.object.Spec.CStorVolumeRef = claimRef
-	return b
-}
-
 // WithReplicaCount sets replica count of CStorVolumeClaim
 func (b *Builder) WithReplicaCount(count string) *Builder {
 
@@ -355,29 +343,6 @@ func (b *Builder) WithNodeID(nodeID string) *Builder {
 		return b
 	}
 	b.cvc.object.Publish.NodeID = nodeID
-	return b
-}
-
-// WithNewVersion sets the current and desired version field of
-// CStorVolume with provided arguments
-func (b *Builder) WithNewVersion(version string) *Builder {
-	if version == "" {
-		b.errs = append(
-			b.errs,
-			errors.New(
-				"failed to build cstorvolume object: version can't be empty",
-			),
-		)
-		return b
-	}
-	b.cvc.object.VersionDetails.Current = version
-	b.cvc.object.VersionDetails.Desired = version
-	return b
-}
-
-// WithDependentsUpgraded sets the field to true for new volume
-func (b *Builder) WithDependentsUpgraded() *Builder {
-	b.cvc.object.VersionDetails.DependentsUpgraded = true
 	return b
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

changes uses new spec versiondetails and set the current and
desired versions for cstorvolume,cstorvolumereplica, cspc and cstorpool
instances resources in case of csi based volume and pool provisioning.

more info #1448

Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->
