### PR TITLE
Issue #2150 | Lint the file maya/pkg/env/v1alpha1/env.go

### DIFF
--- a/pkg/env/v1alpha1/env.go
+++ b/pkg/env/v1alpha1/env.go
@@ -199,9 +199,9 @@ func GetOrDefault(e ENVKey, defaultValue string) (value string) {
 	if len(envValue) == 0 {
 		// ENV not defined or set to ""
 		return defaultValue
-	} else {
-		return envValue
 	}
+
+	return envValue
 }
 
 // Lookup looks up an environment variable


### PR DESCRIPTION
The else part is not redundant, so the codeblock is moved out.

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- This PR fixes linting issues with maya/pkg/env/v1alpha1/env.go file. It removes redundant else and moves the else block code out.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
This PR fixes linting issues issue #2150

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #2150
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests