### PR TITLE
[WIP]refact(bdd, resize): update the pvc verify timeout during resize tests

### DIFF
--- a/tests/operations.go
+++ b/tests/operations.go
@@ -43,7 +43,7 @@ import (
 	snap "github.com/openebs/maya/pkg/kubernetes/snapshot/v1alpha1"
 	sc "github.com/openebs/maya/pkg/kubernetes/storageclass/v1alpha1"
 	spc "github.com/openebs/maya/pkg/storagepoolclaim/v1alpha1"
-	"github.com/openebs/maya/pkg/templatefuncs/v1alpha1"
+	templatefuncs "github.com/openebs/maya/pkg/templatefuncs/v1alpha1"
 	unstruct "github.com/openebs/maya/pkg/unstruct/v1alpha2"
 	result "github.com/openebs/maya/pkg/upgrade/result/v1alpha1"
 	"github.com/openebs/maya/tests/artifacts"
@@ -387,7 +387,7 @@ func (ops *Operations) VerifyCapacity(pvcName, capacity string) bool {
 		desiredCapacity, _ := resource.ParseQuantity(capacity)
 		return (desiredCapacity.Cmp(actualCapacity) == 0)
 	},
-		120, 10).
+		180, 10).
 		Should(BeTrue())
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Change pvc verify timeout seconds from 120s to 180s to mitigate
the timeout issue for resize tests, which basically compare the updated
size with older size, which taking more time then expected in travis.

Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->



**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests