### PR TITLE
fix(golangci-lint): Added version to golangci config file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -339,3 +339,6 @@ issues:
 
   # Show only new issues created in git patch with set file path.
   #new-from-patch: path/to/patch/file
+
+service:
+  golangci-lint-version: 1.18.x # use the fixed version to not introduce new linters unexpectedly

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ services:
   - docker
 language: go
 go:
-  - 1.11.2
+  - 1.12.10
 
 addons:
   apt:


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds version to the golangci config yaml to fix the golangci-lint internal error.
This PR also bumps the golang version of travis to 1.12.10.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests