### PR TITLE
refactor(build): setup arm builds for apiserver and local provisioner

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -95,6 +95,11 @@ endif
 
 CSTOR_BASE_IMAGE= openebs/cstor-base:${BASE_TAG}
 
+ifeq (${BASE_DOCKER_IMAGEARM64}, )
+  BASE_DOCKER_IMAGEARM64 = "arm64v8/ubuntu:18.04"
+  export BASE_DOCKER_IMAGEARM64
+endif
+
 # Specify the name for the binaries
 WEBHOOK=admission-server
 POOL_MGMT=cstor-pool-mgmt
@@ -114,7 +119,10 @@ include ./buildscripts/upgrade/Makefile.mk
 include ./buildscripts/upgrade-082090/Makefile.mk
 
 .PHONY: all
-all: compile-tests mayactl apiserver-image exporter-image pool-mgmt-image volume-mgmt-image admission-server-image cspc-operator-image cspi-mgmt-image upgrade-image provisioner-localpv-image
+all: compile-tests apiserver-image exporter-image pool-mgmt-image volume-mgmt-image admission-server-image cspc-operator-image cspi-mgmt-image upgrade-image provisioner-localpv-image
+
+.PHONY: all.arm64
+all.arm64: apiserver-image.arm64 provisioner-localpv-image.arm64
 
 .PHONY: initialize
 initialize: bootstrap

--- a/buildscripts/apiserver/Dockerfile.arm64
+++ b/buildscripts/apiserver/Dockerfile.arm64
@@ -1,0 +1,40 @@
+#
+# This Dockerfile builds a recent maya api server using the latest binary from
+# maya api server's releases.
+#
+
+FROM arm64v8/ubuntu:18.04
+
+# TODO: The following env variables should be auto detected.
+ENV MAYA_API_SERVER_NETWORK="eth0"
+
+RUN apt update && apt install -y \
+    iproute2 \
+    bash \
+    curl \
+    net-tools \
+    procps \
+    ca-certificates
+
+RUN mkdir -p /etc/apiserver/orchprovider
+RUN mkdir -p /etc/apiserver/specs
+
+COPY demo-vol1.yaml /etc/apiserver/specs/
+COPY maya-apiserver /usr/local/bin/
+COPY mayactl /usr/local/bin/
+
+COPY entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ARG BUILD_DATE
+
+LABEL org.label-schema.name="m-apiserver"
+LABEL org.label-schema.description="API server for OpenEBS"
+LABEL org.label-schema.url="http://www.openebs.io/"
+LABEL org.label-schema.vcs-url="https://github.com/openebs/maya"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=$BUILD_DATE
+
+ENTRYPOINT entrypoint.sh "${MAYA_API_SERVER_NETWORK}"
+
+EXPOSE 5656

--- a/buildscripts/apiserver/Dockerfile.arm64
+++ b/buildscripts/apiserver/Dockerfile.arm64
@@ -3,7 +3,10 @@
 # maya api server's releases.
 #
 
-FROM arm64v8/ubuntu:18.04
+#Make the base image configurable. If BASE IMAGES is not provided
+#docker command will fail
+ARG BASE_IMAGE=arm64v8/ubuntu:18.04
+FROM $BASE_IMAGE
 
 # TODO: The following env variables should be auto detected.
 ENV MAYA_API_SERVER_NETWORK="eth0"

--- a/buildscripts/apiserver/Makefile.mk
+++ b/buildscripts/apiserver/Makefile.mk
@@ -1,0 +1,76 @@
+# Copyright © 2017 The OpenEBS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Specify the name for the binaries
+APISERVER=maya-apiserver
+
+# Specify the name of the docker repo for amd64
+M_APISERVER_REPO_NAME?=m-apiserver
+
+# Specify the name of the docker repo for arm64
+M_APISERVER_REPO_NAME_ARM64?=m-apiserver-arm64
+
+.PHONY: mayactl
+mayactl:
+	@echo "----------------------------"
+	@echo "--> mayactl                    "
+	@echo "----------------------------"
+	@PNAME="maya" CTLNAME=${MAYACTL} sh -c "'$(PWD)/buildscripts/build.sh'"
+
+# Use this to build only the maya apiserver.
+.PHONY: apiserver
+apiserver:
+	@echo "----------------------------"
+	@echo "--> maya-apiserver               "
+	@echo "----------------------------"
+	@PNAME="apiserver" CTLNAME=${APISERVER} sh -c "'$(PWD)/buildscripts/build.sh'"
+
+# Currently both mayactl & apiserver binaries are pushed into
+# m-apiserver image. This is going to be decoupled soon.
+.PHONY: apiserver-image
+apiserver-image: mayactl apiserver
+	@echo "----------------------------"
+	@echo -n "--> apiserver image "
+	@echo "${HUB_USER}/${M_APISERVER_REPO_NAME}:${IMAGE_TAG}"
+	@echo "----------------------------"
+	@cp bin/apiserver/${APISERVER} buildscripts/apiserver/
+	@cp bin/maya/${MAYACTL} buildscripts/apiserver/
+	@cd buildscripts/apiserver && sudo docker build -t ${HUB_USER}/${M_APISERVER_REPO_NAME}:${IMAGE_TAG} --build-arg BUILD_DATE=${BUILD_DATE} .
+	@rm buildscripts/apiserver/${APISERVER}
+	@rm buildscripts/apiserver/${MAYACTL}
+
+.PHONY: rhel-apiserver-image
+rhel-apiserver-image: mayactl apiserver
+	@echo "----------------------------"
+	@echo -n "--> rhel based apiserver image "
+	@echo "${HUB_USER}/${M_APISERVER_REPO_NAME}:${IMAGE_TAG}"
+	@echo "----------------------------"
+	@cp bin/apiserver/${APISERVER} buildscripts/apiserver/
+	@cp bin/maya/${MAYACTL} buildscripts/apiserver/
+	@cd buildscripts/apiserver && sudo docker build -t ${HUB_USER}/${M_APISERVER_REPO_NAME}:${IMAGE_TAG} -f Dockerfile.rhel --build-arg VERSION=${VERSION} .
+	@rm buildscripts/apiserver/${APISERVER}
+	@rm buildscripts/apiserver/${MAYACTL}
+
+.PHONY: arm64-apiserver-image
+arm64-apiserver-image: mayactl apiserver
+	@echo "----------------------------"
+	@echo -n "--> apiserver image "
+	@echo "${HUB_USER}/${M_APISERVER_REPO_NAME_ARM64}:${IMAGE_TAG}"
+	@echo "----------------------------"
+	@cp bin/apiserver/${APISERVER} buildscripts/apiserver/
+	@cp bin/maya/${MAYACTL} buildscripts/apiserver/
+	@cd buildscripts/apiserver && sudo docker build -t ${HUB_USER}/${M_APISERVER_REPO_NAME_ARM64}:${IMAGE_TAG} -f Dockerfile.arm64 --build-arg BUILD_DATE=${BUILD_DATE} .
+	@rm buildscripts/apiserver/${APISERVER}
+	@rm buildscripts/apiserver/${MAYACTL}
+

--- a/buildscripts/apiserver/Makefile.mk
+++ b/buildscripts/apiserver/Makefile.mk
@@ -21,13 +21,6 @@ M_APISERVER_REPO_NAME?=m-apiserver
 # Specify the name of the docker repo for arm64
 M_APISERVER_REPO_NAME_ARM64?=m-apiserver-arm64
 
-.PHONY: mayactl
-mayactl:
-	@echo "----------------------------"
-	@echo "--> mayactl                    "
-	@echo "----------------------------"
-	@PNAME="maya" CTLNAME=${MAYACTL} sh -c "'$(PWD)/buildscripts/build.sh'"
-
 # Use this to build only the maya apiserver.
 .PHONY: apiserver
 apiserver:

--- a/buildscripts/apiserver/Makefile.mk
+++ b/buildscripts/apiserver/Makefile.mk
@@ -62,15 +62,15 @@ rhel-apiserver-image: mayactl apiserver
 	@rm buildscripts/apiserver/${APISERVER}
 	@rm buildscripts/apiserver/${MAYACTL}
 
-.PHONY: arm64-apiserver-image
-arm64-apiserver-image: mayactl apiserver
+.PHONY: apiserver-image.arm64
+apiserver-image.arm64: mayactl apiserver
 	@echo "----------------------------"
 	@echo -n "--> apiserver image "
 	@echo "${HUB_USER}/${M_APISERVER_REPO_NAME_ARM64}:${IMAGE_TAG}"
 	@echo "----------------------------"
 	@cp bin/apiserver/${APISERVER} buildscripts/apiserver/
 	@cp bin/maya/${MAYACTL} buildscripts/apiserver/
-	@cd buildscripts/apiserver && sudo docker build -t ${HUB_USER}/${M_APISERVER_REPO_NAME_ARM64}:${IMAGE_TAG} -f Dockerfile.arm64 --build-arg BUILD_DATE=${BUILD_DATE} .
+	@cd buildscripts/apiserver && sudo docker build -t ${HUB_USER}/${M_APISERVER_REPO_NAME_ARM64}:${IMAGE_TAG} -f Dockerfile.arm64 --build-arg BUILD_DATE=${BUILD_DATE} --build-arg BASE_IMAGE=${BASE_DOCKER_IMAGEARM64} .
 	@rm buildscripts/apiserver/${APISERVER}
 	@rm buildscripts/apiserver/${MAYACTL}
 

--- a/buildscripts/build.sh
+++ b/buildscripts/build.sh
@@ -46,6 +46,8 @@ if [ "${ARCH}" = "i686" ] ; then
     XC_ARCH='386'
 elif [ "${ARCH}" = "x86_64" ] ; then
     XC_ARCH='amd64'
+elif [ "${ARCH}" = "aarch64" ] ; then
+    XC_ARCH='arm64'
 else
     echo "Unusable architecture: ${ARCH}"
     exit 1

--- a/buildscripts/mayactl/Makefile.mk
+++ b/buildscripts/mayactl/Makefile.mk
@@ -1,0 +1,23 @@
+# Copyright © 2017 The OpenEBS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Specify the name for the binaries
+MAYACTL=mayactl
+
+.PHONY: mayactl
+mayactl:
+	@echo "----------------------------"
+	@echo "--> mayactl                    "
+	@echo "----------------------------"
+	@PNAME="maya" CTLNAME=${MAYACTL} sh -c "'$(PWD)/buildscripts/build.sh'"

--- a/buildscripts/provisioner-localpv/Dockerfile.arm64
+++ b/buildscripts/provisioner-localpv/Dockerfile.arm64
@@ -1,4 +1,7 @@
-FROM arm64v8/ubuntu:18.04
+#Make the base image configurable. If BASE IMAGES is not provided
+#docker command will fail
+ARG BASE_IMAGE=arm64v8/ubuntu:18.04
+FROM $BASE_IMAGE
 
 RUN apt update && apt install -y \
     iproute2 \

--- a/buildscripts/provisioner-localpv/Dockerfile.arm64
+++ b/buildscripts/provisioner-localpv/Dockerfile.arm64
@@ -1,0 +1,22 @@
+FROM arm64v8/ubuntu:18.04
+
+RUN apt update && apt install -y \
+    iproute2 \
+    bash \
+    curl \
+    net-tools \
+    procps \
+    ca-certificates
+
+COPY provisioner-localpv /
+
+ARG BUILD_DATE
+
+LABEL org.label-schema.name="provisioner-localpv"
+LABEL org.label-schema.description="Dynamic Local PV Provisioner for OpenEBS"
+LABEL org.label-schema.url="http://www.openebs.io/"
+LABEL org.label-schema.vcs-url="https://github.com/openebs/maya"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=$BUILD_DATE
+
+CMD ["/provisioner-localpv"]

--- a/buildscripts/provisioner-localpv/Makefile.mk
+++ b/buildscripts/provisioner-localpv/Makefile.mk
@@ -3,16 +3,27 @@
 PROVISIONER_LOCALPV=provisioner-localpv
 
 #Use this to build provisioner-localpv
+.PHONY: provisioner-localpv
 provisioner-localpv:
 	@echo "----------------------------"
 	@echo "--> provisioner-localpv    "
 	@echo "----------------------------"
 	@PNAME=${PROVISIONER_LOCALPV} CTLNAME=${PROVISIONER_LOCALPV} sh -c "'$(PWD)/buildscripts/build.sh'"
 
+.PHONY: provisioner-localpv-image
 provisioner-localpv-image: provisioner-localpv
 	@echo "-------------------------------"
 	@echo "--> provisioner-localpv image "
 	@echo "-------------------------------"
 	@cp bin/provisioner-localpv/${PROVISIONER_LOCALPV} buildscripts/provisioner-localpv/
 	@cd buildscripts/provisioner-localpv && sudo docker build -t openebs/provisioner-localpv:${IMAGE_TAG} --build-arg BUILD_DATE=${BUILD_DATE} . --no-cache
+	@rm buildscripts/provisioner-localpv/${PROVISIONER_LOCALPV}
+
+.PHONY: arm64-provisioner-localpv-image
+arm64-provisioner-localpv-image: provisioner-localpv
+	@echo "-------------------------------"
+	@echo "--> provisioner-localpv image "
+	@echo "-------------------------------"
+	@cp bin/provisioner-localpv/${PROVISIONER_LOCALPV} buildscripts/provisioner-localpv/
+	@cd buildscripts/provisioner-localpv && sudo docker build -t openebs/provisioner-localpv-arm64:${IMAGE_TAG} -f Dockerfile.arm64 --build-arg BUILD_DATE=${BUILD_DATE} . --no-cache
 	@rm buildscripts/provisioner-localpv/${PROVISIONER_LOCALPV}

--- a/buildscripts/provisioner-localpv/Makefile.mk
+++ b/buildscripts/provisioner-localpv/Makefile.mk
@@ -19,11 +19,11 @@ provisioner-localpv-image: provisioner-localpv
 	@cd buildscripts/provisioner-localpv && sudo docker build -t openebs/provisioner-localpv:${IMAGE_TAG} --build-arg BUILD_DATE=${BUILD_DATE} . --no-cache
 	@rm buildscripts/provisioner-localpv/${PROVISIONER_LOCALPV}
 
-.PHONY: arm64-provisioner-localpv-image
-arm64-provisioner-localpv-image: provisioner-localpv
+.PHONY: provisioner-localpv-image.arm64
+provisioner-localpv-image.arm64: provisioner-localpv
 	@echo "-------------------------------"
 	@echo "--> provisioner-localpv image "
 	@echo "-------------------------------"
 	@cp bin/provisioner-localpv/${PROVISIONER_LOCALPV} buildscripts/provisioner-localpv/
-	@cd buildscripts/provisioner-localpv && sudo docker build -t openebs/provisioner-localpv-arm64:${IMAGE_TAG} -f Dockerfile.arm64 --build-arg BUILD_DATE=${BUILD_DATE} . --no-cache
+	@cd buildscripts/provisioner-localpv && sudo docker build -t openebs/provisioner-localpv-arm64:${IMAGE_TAG} -f Dockerfile.arm64 --build-arg BUILD_DATE=${BUILD_DATE} --build-arg BASE_IMAGE=${BASE_DOCKER_IMAGEARM64} . --no-cache
 	@rm buildscripts/provisioner-localpv/${PROVISIONER_LOCALPV}


### PR DESCRIPTION
Modularize the Makefile by pushing the mayactl, apiserver targets
to their specific folders in order to make it easier to modify/enhance
and for better readability.

Added the build check for arm64 as well as added Dockerfile for
creating arm64 based apiserver and local provisioner.

The following command can be used to build arm64 images for 
apiserver and local provisioner. 

```
make all.arm64
```

The images will be built on top of `arm64v8/ubuntu:18.04`.

For building with a different base, the following command can be used. 
```
export BASE_DOCKER_IMAGEARM64=arm64v8/ubuntu:16.04;make all.arm64
```

Signed-off-by: kmova <kiran.mova@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests