### PR TITLE
fix(upgrade): avoided restart of target pod while upgrade

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
@@ -92,7 +92,7 @@ func (c *CStorPoolController) syncHandler(key string, operation common.QueueOper
 		)
 		return nil
 	}
-	cspObject = cspGot
+	cspObject = cspGot.DeepCopy()
 	cspGot, err = c.reconcileVersion(cspGot)
 	if err != nil {
 		klog.Errorf("failed to upgrade csp %s:%s", cspObject.Name, err.Error())
@@ -109,7 +109,9 @@ func (c *CStorPoolController) syncHandler(key string, operation common.QueueOper
 		cspObject.VersionDetails.Status.Reason = err.Error()
 		cspObject.VersionDetails.Status.LastUpdateTime = metav1.Now()
 		_, err = c.clientset.OpenebsV1alpha1().CStorPools().Update(cspObject)
-		klog.Errorf("failed to update versionDetails status for csp %s:%s", cspObject.Name, err.Error())
+		if err != nil {
+			klog.Errorf("failed to update versionDetails status for csp %s:%s", cspObject.Name, err.Error())
+		}
 		return nil
 	}
 	cspObject = cspGot

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -108,7 +108,7 @@ func (c *CStorVolumeReplicaController) syncHandler(
 		)
 		return nil
 	}
-	cvrGot = cvrObj
+	cvrGot = cvrObj.DeepCopy()
 	cvrObj, err = c.reconcileVersion(cvrObj)
 	if err != nil {
 		klog.Errorf("failed to upgrade cvr %s:%s", cvrGot.Name, err.Error())
@@ -126,7 +126,9 @@ func (c *CStorVolumeReplicaController) syncHandler(
 		cvrGot.VersionDetails.Status.LastUpdateTime = metav1.Now()
 		_, err = c.clientset.OpenebsV1alpha1().
 			CStorVolumeReplicas(cvrGot.Namespace).Update(cvrGot)
-		klog.Errorf("failed to update versionDetails status for cvr %s:%s", cvrGot.Name, err.Error())
+		if err != nil {
+			klog.Errorf("failed to update versionDetails status for cvr %s:%s", cvrGot.Name, err.Error())
+		}
 		return nil
 	}
 	cvrGot = cvrObj

--- a/cmd/cstor-volume-mgmt/volume/volume.go
+++ b/cmd/cstor-volume-mgmt/volume/volume.go
@@ -197,6 +197,9 @@ func extractReplicaStatusFromJSON(str string) (*apis.CVStatus, error) {
 func CreateIstgtConf(cStorVolume *apis.CStorVolume) ([]byte, error) {
 	var dataBytes []byte
 	buffer := &bytes.Buffer{}
+	if cStorVolume == nil {
+		return dataBytes, errors.Errorf("nil cstorvolume object")
+	}
 	tmpl, err := template.New("").Funcs(template.FuncMap{
 		"CapacityStr": func(q resource.Quantity) string { return q.String() },
 	}).Parse(istgtConfFile)

--- a/cmd/cstor-volume-mgmt/volume/volume_test.go
+++ b/cmd/cstor-volume-mgmt/volume/volume_test.go
@@ -264,6 +264,33 @@ func TestCheckValidVolume(t *testing.T) {
 					ConsistencyFactor:        2,
 					DesiredReplicationFactor: 0,
 				},
+				VersionDetails: apis.VersionDetails{
+					Status: apis.VersionStatus{
+						Current: "1.3.0",
+					},
+				},
+			},
+		},
+		"empty desired replication factor for old volume": {
+			expectedError: false,
+			test: &apis.CStorVolume{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "testvol1",
+					UID:  types.UID("123456"),
+				},
+				Spec: apis.CStorVolumeSpec{
+					TargetIP:                 "0.0.0.0",
+					Capacity:                 fakeStrToQuantity("5G"),
+					Status:                   "init",
+					ReplicationFactor:        3,
+					ConsistencyFactor:        2,
+					DesiredReplicationFactor: 0,
+				},
+				VersionDetails: apis.VersionDetails{
+					Status: apis.VersionStatus{
+						Current: "1.2.0",
+					},
+				},
 			},
 		},
 		"invalid desiredreplicationfactor/replicationfactor": {
@@ -280,6 +307,11 @@ func TestCheckValidVolume(t *testing.T) {
 					ReplicationFactor:        4,
 					ConsistencyFactor:        2,
 					DesiredReplicationFactor: 3,
+				},
+				VersionDetails: apis.VersionDetails{
+					Status: apis.VersionStatus{
+						Current: "1.3.0",
+					},
 				},
 			},
 		},

--- a/cmd/maya-apiserver/cstor-operator/spc/handler.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/handler.go
@@ -146,7 +146,7 @@ func (c *Controller) syncSpc(spc *apis.StoragePoolClaim) error {
 		)
 		return nil
 	}
-	gotSPC = spcObj
+	gotSPC = spcObj.DeepCopy()
 	spcObj, err = c.reconcileVersion(spcObj)
 	if err != nil {
 		klog.Errorf("failed to upgrade spc %s:%s", gotSPC.Name, err.Error())
@@ -163,7 +163,9 @@ func (c *Controller) syncSpc(spc *apis.StoragePoolClaim) error {
 		gotSPC.VersionDetails.Status.Reason = err.Error()
 		gotSPC.VersionDetails.Status.LastUpdateTime = metav1.Now()
 		_, err = c.clientset.OpenebsV1alpha1().StoragePoolClaims().Update(gotSPC)
-		klog.Errorf("failed to update versionDetails status for spc %s:%s", gotSPC.Name, err.Error())
+		if err != nil {
+			klog.Errorf("failed to update versionDetails status for spc %s:%s", gotSPC.Name, err.Error())
+		}
 		return nil
 	}
 	// assinging the latest spc object

--- a/pkg/upgrade/upgrader/csp_upgrade.go
+++ b/pkg/upgrade/upgrader/csp_upgrade.go
@@ -237,7 +237,7 @@ func (c *cstorCSPOptions) waitForCSPCurrentVersion() error {
 	for c.cspObj.VersionDetails.Status.Current == "" {
 		klog.Infof("Waiting for csp current version to get populated.")
 		// Sleep equal to the default sync time
-		time.Sleep(30 * time.Second)
+		time.Sleep(10 * time.Second)
 		obj, err := cspClient.Get(c.cspObj.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
@@ -255,7 +255,7 @@ func (c *cstorCSPOptions) verifyCSPVersionReconcile(openebsNamespace string) err
 	for c.cspObj.VersionDetails.Status.Current != upgradeVersion {
 		klog.Infof("Verifying the reconciliation of version for %s", c.cspObj.Name)
 		// Sleep equal to the default sync time
-		time.Sleep(30 * time.Second)
+		time.Sleep(10 * time.Second)
 		obj, err := cspClient.Get(c.cspObj.Name, metav1.GetOptions{})
 		if err != nil {
 			statusObj.Message = "failed to get cstor pool"

--- a/pkg/upgrade/upgrader/cstor_volume_upgrade.go
+++ b/pkg/upgrade/upgrader/cstor_volume_upgrade.go
@@ -343,7 +343,7 @@ func (c *cstorVolumeOptions) verifyCVVersionReconcile(openebsNamespace string) e
 	for c.cv.VersionDetails.Status.Current != upgradeVersion {
 		klog.Infof("Verifying the reconciliation of version for %s", c.cv.Name)
 		// Sleep equal to the default sync time
-		time.Sleep(30 * time.Second)
+		time.Sleep(10 * time.Second)
 		obj, err := cvClient.Get(c.cv.Name, metav1.GetOptions{})
 		if err != nil {
 			statusObj.Message = "failed to get cstor volume"
@@ -378,7 +378,7 @@ func (c *cstorVolumeOptions) waitForCVCurrentVersion(pvLabel, namespace string) 
 	for c.cv.VersionDetails.Status.Current == "" {
 		// Sleep equal to the default sync time
 		klog.Infof("Waiting for cv current version to get populated.")
-		time.Sleep(30 * time.Second)
+		time.Sleep(10 * time.Second)
 		obj, err := cvClient.Get(c.cv.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
@@ -470,7 +470,7 @@ func waitForCVRCurrentVersion(name, openebsNamespace string) error {
 	for cvrObj.VersionDetails.Status.Current == "" {
 		klog.Infof("Waiting for cvr current version to get populated.")
 		// Sleep equal to the default sync time
-		time.Sleep(30 * time.Second)
+		time.Sleep(10 * time.Second)
 		cvrObj, err = cvrClient.WithNamespace(openebsNamespace).
 			Get(name, metav1.GetOptions{})
 		if err != nil {
@@ -499,7 +499,7 @@ func (c *cstorVolumeOptions) verifyCVRVersionReconcile(name, openebsNamespace st
 	for cvrObj.VersionDetails.Status.Current != upgradeVersion {
 		klog.Infof("Verifying the reconciliation of version for %s", cvrObj.Name)
 		// Sleep equal to the default sync time
-		time.Sleep(30 * time.Second)
+		time.Sleep(10 * time.Second)
 		cvrObj, err = cvrClient.WithNamespace(openebsNamespace).
 			Get(name, metav1.GetOptions{})
 		if err != nil {
@@ -576,14 +576,14 @@ func cstorVolumeUpgrade(pvName, openebsNamespace string) (*utask.UpgradeTask, er
 		return options.utaskObj, err
 	}
 
-	// TargetUpgrade
-	err = options.targetUpgrade(pvName, openebsNamespace)
+	// ReplicaUpgrade
+	err = options.replicaUpgrade(openebsNamespace)
 	if err != nil {
 		return options.utaskObj, err
 	}
 
-	// ReplicaUpgrade
-	err = options.replicaUpgrade(openebsNamespace)
+	// TargetUpgrade
+	err = options.targetUpgrade(pvName, openebsNamespace)
 	if err != nil {
 		return options.utaskObj, err
 	}

--- a/pkg/upgrade/upgrader/spc_upgrade.go
+++ b/pkg/upgrade/upgrader/spc_upgrade.go
@@ -116,7 +116,7 @@ func waitForSPCCurrentVersion(name string) error {
 	for spcObj.VersionDetails.Status.Current == "" {
 		klog.Infof("Waiting for spc current version to get populated.")
 		// Sleep equal to the default sync time
-		time.Sleep(30 * time.Second)
+		time.Sleep(10 * time.Second)
 		spcObj, err = client.Get(name, metav1.GetOptions{})
 		if err != nil {
 			return err
@@ -135,7 +135,7 @@ func verifySPCVersionReconcile(name string) error {
 	for spcObj.VersionDetails.Status.Current != upgradeVersion {
 		klog.Infof("Verifying the reconciliation of version for %s", spcObj.Name)
 		// Sleep equal to the default sync time
-		time.Sleep(30 * time.Second)
+		time.Sleep(10 * time.Second)
 		spcObj, err = client.Get(name, metav1.GetOptions{})
 		if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR stops the upgrade code from restarting the target pod while setting the `DesiredReplicationFactor` for older volumes.
This PR also handles the nil `err.Error()` panic.
It also reduce the wait time for verification functions in upgrade-job to make the job faster.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests