### PR TITLE
feat(CA): safe-to-evict to false to disable scaledown for CSPI pods

### DIFF
--- a/cmd/cspc-operator/app/storagepool_create.go
+++ b/cmd/cspc-operator/app/storagepool_create.go
@@ -225,10 +225,11 @@ func getPodLabels(csp *apis.CStorPoolInstance) map[string]string {
 
 func getPodAnnotations() map[string]string {
 	return map[string]string{
-		"openebs.io/monitoring": "pool_exporter_prometheus",
-		"prometheus.io/path":    "/metrics",
-		"prometheus.io/port":    "9500",
-		"prometheus.io/scrape":  "true",
+		"openebs.io/monitoring":                          "pool_exporter_prometheus",
+		"prometheus.io/path":                             "/metrics",
+		"prometheus.io/port":                             "9500",
+		"prometheus.io/scrape":                           "true",
+		"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
 	}
 }
 


### PR DESCRIPTION
CStor pool pods have stickiness to nodes.
But, if cluster autoscaler decides to scale down the node where pool pod is running, data won't be available to application.
This PR is to let CA NOT to scale down nodes where CSPI related pods are running.

Signed-off-by: Vitta <vitta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests