### PR TITLE
fix(cspc operator): fix bug while populating version details on cspc (#1483)

### DIFF
--- a/cmd/cspc-operator/app/handler.go
+++ b/cmd/cspc-operator/app/handler.go
@@ -122,12 +122,14 @@ func (c *Controller) syncCSPC(cspcGot *apis.CStorPoolCluster) error {
 		return nil
 	}
 
-	cspcGot, err := c.populateVersion(cspcGot)
+	cspcObj := cspcGot
+	cspcObj, err := c.populateVersion(cspcObj)
 	if err != nil {
 		klog.Errorf("failed to add versionDetails to CSPC %s:%s", cspcGot.Name, err.Error())
 		return nil
 	}
 
+	cspcGot = cspcObj
 	pc, err := c.NewPoolConfig(cspcGot, openebsNameSpace)
 	if err != nil {
 		message := fmt.Sprintf("Could not sync CSPC : failed to get pool config: {%s}", err.Error())


### PR DESCRIPTION


This PR fixes nil object fields access  when an error happens
while populating version details on cspc object

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests