### PR TITLE
feat(cstor-volume-mgmt): add replica scale down support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -97,6 +97,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:1ba1d79f2810270045c328ae5d674321db34e3aae468eb4233883b473c5c0467"
+  name = "github.com/golang/glog"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
+
+[[projects]]
+  branch = "master"
   digest = "1:b7cb6054d3dff43b38ad2e92492f220f57ae6087ee797dca298139776749ace8"
   name = "github.com/golang/groupcache"
   packages = ["lru"]
@@ -1090,6 +1098,7 @@
     "github.com/Masterminds/sprig",
     "github.com/docker/go-units",
     "github.com/ghodss/yaml",
+    "github.com/golang/glog",
     "github.com/golang/protobuf/proto",
     "github.com/google/gofuzz",
     "github.com/hashicorp/hcl",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -97,14 +97,6 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:1ba1d79f2810270045c328ae5d674321db34e3aae468eb4233883b473c5c0467"
-  name = "github.com/golang/glog"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
-
-[[projects]]
-  branch = "master"
   digest = "1:b7cb6054d3dff43b38ad2e92492f220f57ae6087ee797dca298139776749ace8"
   name = "github.com/golang/groupcache"
   packages = ["lru"]
@@ -1098,7 +1090,6 @@
     "github.com/Masterminds/sprig",
     "github.com/docker/go-units",
     "github.com/ghodss/yaml",
-    "github.com/golang/glog",
     "github.com/golang/protobuf/proto",
     "github.com/google/gofuzz",
     "github.com/hashicorp/hcl",

--- a/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
+++ b/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
@@ -18,10 +18,11 @@ package volumereplica
 
 import (
 	"fmt"
-	"github.com/openebs/maya/pkg/alertlog"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/openebs/maya/pkg/alertlog"
 
 	"encoding/json"
 

--- a/cmd/cstor-volume-mgmt/controller/volume-controller/handler.go
+++ b/cmd/cstor-volume-mgmt/controller/volume-controller/handler.go
@@ -504,13 +504,13 @@ func (c *CStorVolumeController) updateCStorVolumeDRF(
 		)
 		return
 	}
+	cStorVolume = copyCV
 	c.recorder.Event(cStorVolume,
 		corev1.EventTypeNormal,
 		string(common.SuccessUpdated),
 		fmt.Sprintf("Successfully updated the desiredReplicationFactor to %d",
 			cStorVolume.Spec.DesiredReplicationFactor),
 	)
-	cStorVolume = copyCV
 }
 
 // triggerScaleUpProcess returns error incase of any error during scaleup
@@ -574,7 +574,7 @@ func (c *CStorVolumeController) triggerScaleDownProcess(
 		configData := cStorVolume.BuildScaleDownConfigData(replicaID)
 		fileOperator := util.RealFileOperator{}
 		cstorvolume_v1alpha1.ConfFileMutex.Lock()
-		err := fileOperator.UpdateOrAppendMultipleLines(
+		err = fileOperator.UpdateOrAppendMultipleLines(
 			cstorvolume_v1alpha1.IstgtConfPath,
 			configData,
 			0644)

--- a/cmd/cstor-volume-mgmt/controller/volume-controller/new_volume_controller.go
+++ b/cmd/cstor-volume-mgmt/controller/volume-controller/new_volume_controller.go
@@ -126,11 +126,9 @@ func NewCStorVolumeController(
 			} else if IsDestroyEvent(newCStorVolume) {
 				q.Operation = common.QOpDestroy
 				klog.Infof("cStorVolume Destroy event : %v, %v", newCStorVolume.ObjectMeta.Name, string(newCStorVolume.ObjectMeta.UID))
-				controller.recorder.Event(newCStorVolume, corev1.EventTypeNormal, string(common.SuccessSynced), string(common.MessageDestroySynced))
 			} else {
 				q.Operation = common.QOpModify
 				klog.Infof("cStorVolume Modify event : %v, %v", newCStorVolume.ObjectMeta.Name, string(newCStorVolume.ObjectMeta.UID))
-				controller.recorder.Event(newCStorVolume, corev1.EventTypeNormal, string(common.SuccessSynced), string(common.MessageModifySynced))
 			}
 			controller.enqueueCStorVolume(newCStorVolume, q)
 		},

--- a/cmd/cstor-volume-mgmt/volume/volume_test.go
+++ b/cmd/cstor-volume-mgmt/volume/volume_test.go
@@ -294,7 +294,7 @@ func TestCheckValidVolume(t *testing.T) {
 			},
 		},
 		"invalid desiredreplicationfactor/replicationfactor": {
-			expectedError: true,
+			expectedError: false,
 			test: &apis.CStorVolume{
 				ObjectMeta: v1.ObjectMeta{
 					Name: "testvol1",

--- a/pkg/cstor/volume/v1alpha1/cstorvolume.go
+++ b/pkg/cstor/volume/v1alpha1/cstorvolume.go
@@ -254,7 +254,7 @@ func (c *CStorVolume) GetRemovingReplicaID() string {
 }
 
 // BuildScaleDownConfigData build data based on replica that needs to remove
-func (c *CStorVolume) BuildScaleDownConfigData(repId string) map[string]string {
+func (c *CStorVolume) BuildScaleDownConfigData(repID string) map[string]string {
 	configData := map[string]string{}
 	newReplicationFactor := c.object.Spec.ReplicationFactor
 	newConsistencyFactor := (newReplicationFactor / 2) + 1
@@ -264,7 +264,7 @@ func (c *CStorVolume) BuildScaleDownConfigData(repId string) map[string]string {
 	key = fmt.Sprintf("  ConsistencyFactor")
 	value = fmt.Sprintf("  ConsistencyFactor %d", newConsistencyFactor)
 	configData[key] = value
-	key = fmt.Sprintf("  Replica %s", repId)
+	key = fmt.Sprintf("  Replica %s", repID)
 	value = fmt.Sprintf("")
 	configData[key] = value
 	return configData

--- a/pkg/cstor/volume/v1alpha1/cstorvolume.go
+++ b/pkg/cstor/volume/v1alpha1/cstorvolume.go
@@ -256,13 +256,17 @@ func (c *CStorVolume) GetRemovingReplicaID() string {
 // BuildScaleDownConfigData build data based on replica that needs to remove
 func (c *CStorVolume) BuildScaleDownConfigData(repID string) map[string]string {
 	configData := map[string]string{}
-	newReplicationFactor := c.object.Spec.ReplicationFactor
+	newReplicationFactor := c.object.Spec.DesiredReplicationFactor
 	newConsistencyFactor := (newReplicationFactor / 2) + 1
 	key := fmt.Sprintf("  ReplicationFactor")
 	value := fmt.Sprintf("  ReplicationFactor %d", newReplicationFactor)
 	configData[key] = value
 	key = fmt.Sprintf("  ConsistencyFactor")
 	value = fmt.Sprintf("  ConsistencyFactor %d", newConsistencyFactor)
+	configData[key] = value
+	key = fmt.Sprintf("  DesiredReplicationFactor")
+	value = fmt.Sprintf("  DesiredReplicationFactor %d",
+		c.object.Spec.DesiredReplicationFactor)
 	configData[key] = value
 	key = fmt.Sprintf("  Replica %s", repID)
 	value = fmt.Sprintf("")

--- a/pkg/util/fileoperator.go
+++ b/pkg/util/fileoperator.go
@@ -87,6 +87,8 @@ func (r RealFileOperator) Updatefile(fileName, updatedVal, searchString string, 
 func (r RealFileOperator) UpdateOrAppendMultipleLines(fileName string,
 	keyUpdateValue map[string]string, perm os.FileMode) error {
 	var newLines []string
+	var index int
+	var line string
 	buffer, err := ioutil.ReadFile(filepath.Clean(fileName))
 	if err != nil {
 		return errors.Wrapf(err, "failed to read %s file", fileName)
@@ -105,12 +107,17 @@ func (r RealFileOperator) UpdateOrAppendMultipleLines(fileName string,
 	// will be doing after current blockers
 	for key, updatedValue := range keyUpdateValue {
 		found := false
-		for index, line := range newLines {
+		for index, line = range newLines {
 			if strings.HasPrefix(line, key) {
 				newLines[index] = updatedValue
 				found = true
 				break
 			}
+		}
+		// To remove particular line that matched with key
+		if found && updatedValue == "" {
+			newLines = append(newLines[:index], newLines[index+1:]...)
+			continue
 		}
 		if found == false {
 			newLines = append(newLines, updatedValue)


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds replica scale down support in the cstor-volume-mgmt(sidecar of cstor-istgt).

**Note:**
1. Only one replica at a time should be removed.

**Pre-requisites:**
1. All the cstorvolume replicas(CVR) should be in a `Healthy` state except the cstorvolume replica that is going to delete(i.e deleting CVR can be in any state).
2. There shouldn't be any ongoing scaleup process(Verify using cstorvolume CR replicationFactor should be equal to the desiredReplicationFactor).

**Steps to execute by the user/operator:**
1. The user will decrease the value of the desired replication factor and remove the replicaID entry from cstorvolume which will under cstorvolume.Spec.ReplicaDeatails by using `Kubectl edit cstorvolume <cstorvolume_name> -n openebs`(both should be updated at a time).
2. Upon successful removal of the replica user/operator will delete the corresponding CVR(CVR whose replicaID entry removed in step1).

User has the following PVC setup
```sh
sai@sai:~$ kubectl get pvc
NAME             STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
demo-vol-claim   Bound    pvc-79ba260d-fad6-11e9-8791-42010a8000c5   5G         RWO            cstor-sc       10m
```
Following are cstorvolume and CVRs related to above PVC 
```sh
sai@sai:~$ kubectl get cstorvolume -n openebs -l openebs.io/persistent-volume=pvc-79ba260d-fad6-11e9-8791-42010a8000c5
NAME                                       STATUS    AGE   CAPACITY
pvc-79ba260d-fad6-11e9-8791-42010a8000c5   Healthy   11m   5G

sai@sai:~$ kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-79ba260d-fad6-11e9-8791-42010a8000c5
NAME                                                              USED   ALLOCATED   STATUS    AGE
pvc-79ba260d-fad6-11e9-8791-42010a8000c5-cstor-sparse-pool-7jsv   6K     6K          Healthy   11m
pvc-79ba260d-fad6-11e9-8791-42010a8000c5-cstor-sparse-pool-mch2   6K     6K          Healthy   11m
pvc-79ba260d-fad6-11e9-8791-42010a8000c5-cstor-sparse-pool-qa5i   6K     6K          Healthy   11m
```

**Explanation for the above steps:**
- Assume from above o/p if user need to delete `pvc-79ba260d-fad6-11e9-8791-42010a8000c5-cstor-sparse-pool-mch2` CVR. User should follow the mentioned steps.
- Note the replicaID of above CVR under `.spec.replicaID` in this case replicaID is `AEB135CD6AA1E65EF2DAEA085A4C9BA7`.

Following is a snippet of cstorvolume:
```yaml
apiVersion: openebs.io/v1alpha1
kind: CStorVolume
name: pvc-79ba260d-fad6-11e9-8791-42010a8000c5
spec:
    consistencyFactor: 2 ## Minimum no.of replicas required to say IO(read/write) is successfull
    desiredReplicationFactor: 3 ## Maximum no.of replicas are allowed to connect
    replicaDetails:
      ## knownReplicas contains map[string]string key as cvr replicaID and value as replica ZVOL_GUID
      knownReplicas:
        44253781C6BD1384DDF024C643B60E26: "6475964221803202402"
        AEB135CD6AA1E65EF2DAEA085A4C9BA7: "1440900316001731961"
        B2EEE0A0E4C9439926AD544D0E134D90: "8420817958580332064"
    replicationFactor: 3 ## Maximum no.of quorum replicas that can allowed to connect
    ...
    ...
  status:
    ...
    ...
    replicaDetails:
      knownReplicas:
        44253781C6BD1384DDF024C643B60E26: "6475964221803202402"
        AEB135CD6AA1E65EF2DAEA085A4C9BA7: "1440900316001731961"
        B2EEE0A0E4C9439926AD544D0E134D90: "8420817958580332064"
```
Above snippet will be updated as follows using kubectl edit
```yaml
apiVersion: openebs.io/v1alpha1
kind: CStorVolume
name: pvc-79ba260d-fad6-11e9-8791-42010a8000c5
spec:
    consistencyFactor: 2
    desiredReplicationFactor: 2
    replicaDetails:
      knownReplicas:
        44253781C6BD1384DDF024C643B60E26: "6475964221803202402"
        B2EEE0A0E4C9439926AD544D0E134D90: "8420817958580332064"
    replicationFactor: 3
    ...
    ...
  status:
    ...
    ...
    replicaDetails:
      knownReplicas:
        44253781C6BD1384DDF024C643B60E26: "6475964221803202402"
        AEB135CD6AA1E65EF2DAEA085A4C9BA7: "1440900316001731961"
        B2EEE0A0E4C9439926AD544D0E134D90: "8420817958580332064"
```
After editing snippet 1 will looks as snippet 2( updated the desired replication factor to 2 and removed replicaID entry[AEB135CD...] from spec.replicaDetails.knownreplicas).
- Upon success removal events will be generated and spec & status of cstorvolume will be updated as follows(replica scaledown verification steps)
**Events on cstorvolume:**
```sh
 Normal   Updated     12m (x2 over 12m)  pvc-79ba260d-fad6-11e9-8791-42010a8000c5-target-8c76ff8f6-ssw67, gke-sai-bdd-test-pool-1-775ad7d7-j5jj  Successfully updated the desiredReplicationFactor to 2
```
```yaml
  spec:
    ....
    ....
    consistencyFactor: 2
    desiredReplicationFactor: 2
    replicaDetails:
      knownReplicas:
        44253781C6BD1384DDF024C643B60E26: "6475964221803202402"
        B2EEE0A0E4C9439926AD544D0E134D90: "8420817958580332064"
    replicationFactor: 2
  status:
    ...
    ...
    replicaDetails:
      knownReplicas:
        44253781C6BD1384DDF024C643B60E26: "6475964221803202402"
        B2EEE0A0E4C9439926AD544D0E134D90: "8420817958580332064"
```
If you observe status.replicadetails.knownreplicas is updated with latest info. ReplicationFactor and consistencyFactor is updated to 2.

Now, delete the CVR `pvc-79ba260d-fad6-11e9-8791-42010a8000c5-cstor-sparse-pool-mch2` using kubectl delete command.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests