### PR TITLE
fix(provisioner,localpv,cmd): add klog flags to flag set

### DIFF
--- a/cmd/provisioner-localpv/app/start.go
+++ b/cmd/provisioner-localpv/app/start.go
@@ -19,9 +19,9 @@ package app
 import (
 	"flag"
 	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"k8s.io/klog"
 
 	pvController "sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
@@ -49,6 +49,10 @@ func StartProvisioner() (*cobra.Command, error) {
 			util.CheckErr(Start(cmd), util.Fatal)
 		},
 	}
+
+	// add the default command line flags as global flags to cobra command
+	// flagset
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 
 	// Hack: Without the following line, the logs will be prefixed with Error
 	_ = flag.CommandLine.Parse([]string{})


### PR DESCRIPTION
klog flags for levelled verbose logging is added to the flagset.

**What this PR does / why we need it**:
localpv provisioner extensively uses the levelled verbose logging mechanism of klog. But the flag to specify the log level is missing. It was not added to the cobra command flag set. This PR adds all the associated flags of klog as global flags to the cobra command flag set.

From the user perspective there will be no change. If the user wants to get more verbose logging, the flag can be used along with the command to the container.

**Without klog flags**
```
akhil@MayaData:~/openebs/maya$ bin/provisioner-localpv/provisioner-localpv --help
Manage the Host Path PVs that includes: validating, creating,
			deleting and cleanup tasks. Host Path PVs are setup with
			node affinity

Usage:
  provisioner [flags]

Flags:
  -h, --help                           help for provisioner
      --log-flush-frequency duration   Maximum number of seconds between log flushes (default 5s)

```

**With klog flags**
```
akhil@MayaData:~/openebs/maya$ bin/provisioner-localpv/provisioner-localpv --help
Manage the Host Path PVs that includes: validating, creating,
			deleting and cleanup tasks. Host Path PVs are setup with
			node affinity

Usage:
  provisioner [flags]

Flags:
      --add_dir_header                   If true, adds the file directory to the header
      --alsologtostderr                  log to standard error as well as files
  -h, --help                             help for provisioner
      --log-flush-frequency duration     Maximum number of seconds between log flushes (default 5s)
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --log_file string                  If non-empty, use this log file
      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
      --logtostderr                      log to standard error instead of files (default true)
      --skip_headers                     If true, avoid header prefixes in the log messages
      --skip_log_headers                 If true, avoid headers when opening log files
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
  -v, --v Level                          number for the log level verbosity
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
```

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>