### PR TITLE
 added test for incorrect number of block devices in CSPC

### DIFF
--- a/tests/cstor/cspc/positive/provisioning/cspc_provisioning_utils_test.go
+++ b/tests/cstor/cspc/positive/provisioning/cspc_provisioning_utils_test.go
@@ -39,6 +39,7 @@ func createCSPCObjectForRaidz2() {
 
 func createCSPCObject(blockDeviceCount int, poolType string) {
 	var err error
+	Expect(blockDeviceCount).To(Equal(DefaultBDCount[poolType]), "Mismatch Of BD Count")
 	cspcObj, err = cspc_v1alpha1.NewBuilder().
 		WithGenerateName(cspcName).
 		WithNamespace(ops.NameSpace).
@@ -88,4 +89,11 @@ func verifyDesiredCSPICount() {
 // This function is local to this package
 func getLabelSelector(cspc *apis.CStorPoolCluster) string {
 	return string(apis.CStorPoolClusterCPK) + "=" + cspc.Name
+}
+
+var DefaultBDCount = map[string]int{
+	"mirror": int(apis.MirroredBlockDeviceCountCPV),
+	"stripe": int(apis.StripedBlockDeviceCountCPV),
+	"raidz":  int(apis.RaidzBlockDeviceCountCPV),
+	"raidz2": int(apis.Raidz2BlockDeviceCountCPV),
 }


### PR DESCRIPTION
Signed-off-by: yuvrajsingh79 <singhyuvraj79@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
*This PR adds a BDD test to verify for invalid block device count in CSPC*

**Which issue this PR fixes**: fixes #[openebs/openebs/#2787](https://github.com/openebs/openebs/issues/2787/)