### PR TITLE
fix(exporter): modify zfs get command

### DIFF
--- a/cmd/maya-exporter/app/collector/zvol/metrics.go
+++ b/cmd/maya-exporter/app/collector/zvol/metrics.go
@@ -493,7 +493,7 @@ func listParser(stdout []byte, m *listMetrics) []fields {
 	return list
 }
 
-// poolMetricParser is used to parse output from zfs get openebs.io:livenesstimestamp
+// poolMetricParser is used to parse output from zfs get io.openebs:livenesstimestamp
 func poolMetricParser(stdout []byte) *poolfields {
 	if len(string(stdout)) == 0 {
 		pool := poolfields{

--- a/cmd/maya-exporter/app/collector/zvol/pool_synctime.go
+++ b/cmd/maya-exporter/app/collector/zvol/pool_synctime.go
@@ -86,7 +86,7 @@ func (p *poolMetrics) get() *poolfields {
 	p.Lock()
 	defer p.Unlock()
 
-	klog.V(2).Info("Run zfs get openebs.io:livenesstimestamp")
+	klog.V(2).Info("Run zfs get io.openebs:livenesstimestamp")
 	stdout, err := zvol.Run(p.runner)
 	if err != nil {
 		pool := poolfields{
@@ -101,7 +101,7 @@ func (p *poolMetrics) get() *poolfields {
 	if pool := p.checkError(stdout); pool != nil {
 		return pool
 	}
-	klog.V(2).Infof("Parse stdout of zfs get openebs.io:livenesstimestamp command, got stdout: \n%v", string(stdout))
+	klog.V(2).Infof("Parse stdout of zfs get io.openebs:livenesstimestamp command, got stdout: \n%v", string(stdout))
 	pool := poolMetricParser(stdout)
 
 	return pool

--- a/cmd/maya-exporter/app/collector/zvol/pool_synctime_test.go
+++ b/cmd/maya-exporter/app/collector/zvol/pool_synctime_test.go
@@ -34,8 +34,8 @@ func TestPoolSyncTimeMetricCollector(t *testing.T) {
 	}{
 		"Test0": {
 			// expected output if there is openebs.io:timestamp set
-			zpoolLastSyncTimeOutput: `cstor-c6f17743-e5d7-11e9-b673-42010a800112      openebs.io:livenesstimestamp    1570625404      local
-			cstor-c6f17743-e5d7-11e9-b673-42010a800112/pvc-053647ca-e5d8-11e9-b673-42010a800112     openebs.io:livenesstimestamp    1570625404      inherited from cstor-c6f17743-e5d7-11e9-b673-42010a800112`,
+			zpoolLastSyncTimeOutput: `cstor-c6f17743-e5d7-11e9-b673-42010a800112      io.openebs:livenesstimestamp    1570625404      local
+			cstor-c6f17743-e5d7-11e9-b673-42010a800112/pvc-053647ca-e5d8-11e9-b673-42010a800112     io.openebs:livenesstimestamp    1570625404      inherited from cstor-c6f17743-e5d7-11e9-b673-42010a800112`,
 			expectedOutput: []string{
 				`openebs_zpool_last_sync_time{pool="cstor-c6f17743-e5d7-11e9-b673-42010a800112"} 1.570625404e\+09`,
 				`openebs_zpool_state_unknown{pool="cstor-c6f17743-e5d7-11e9-b673-42010a800112"} 0`,
@@ -71,8 +71,8 @@ func TestPoolSyncTimeMetricCollector(t *testing.T) {
 		},
 		"Test4": {
 			// if there is unexpected output of last sync time  which cannot be parsed
-			zpoolLastSyncTimeOutput: `cstor-c6d62069-e5d7-11e9-b673-42010a800112      openebs.io:livenesstimestamp    -       -
-			cstor-c6d62069-e5d7-11e9-b673-42010a800112/pvc-053647ca-e5d8-11e9-b673-42010a800112     openebs.io:livenesstimestamp    -       -`,
+			zpoolLastSyncTimeOutput: `cstor-c6d62069-e5d7-11e9-b673-42010a800112      io.openebs:livenesstimestamp    -       -
+			cstor-c6d62069-e5d7-11e9-b673-42010a800112/pvc-053647ca-e5d8-11e9-b673-42010a800112     io.openebs:livenesstimestamp    -       -`,
 			expectedOutput: []string{
 				`openebs_zpool_last_sync_time{pool="cstor-c6d62069-e5d7-11e9-b673-42010a800112"} 0`,
 				`openebs_zpool_state_unknown{pool="cstor-c6d62069-e5d7-11e9-b673-42010a800112"} 0`,

--- a/cmd/maya-exporter/app/command/command.go
+++ b/cmd/maya-exporter/app/command/command.go
@@ -170,7 +170,7 @@ func (o *VolumeExporterOptions) RegisterPool() {
 	p := pool.New(buildRunner(timeout, "zpool", "list", "-Hp"))
 	z := zvol.New(buildRunner(timeout, "zfs", "stats"))
 	l := zvol.NewVolumeList(buildRunner(timeout, "zfs", "list", "-Hp"))
-	s := zvol.NewPoolSyncMetric(buildRunner(timeout, "zfs", "get", "openebs.io:livenesstimestamp", "-Hp"))
+	s := zvol.NewPoolSyncMetric(buildRunner(timeout, "zfs", "get", "io.openebs:livenesstimestamp", "-Hp"))
 	prometheus.MustRegister(p, z, l, s)
 	klog.Info("Registered maya exporter for cstor pool")
 	return


### PR DESCRIPTION
The liveness probe sets io.openebs:livenesstimestamp zfs property but in exporter we were fetching openebs.io:livenesstimestamp, due to which the correct timestamp was not set in last_sync_metric. So, this commit fixes the same.
Signed-off-by: Meghna Singh <singhmegna79@gmail.com>

