### PR TITLE
chore(CVR status): add CVR phases based on scenarios

### DIFF
--- a/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
+++ b/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
@@ -530,27 +530,24 @@ func GetVolumeName(cVR *apis.CStorVolumeReplica) (string, error) {
 
 // ZfsToCvrStatusMapper maps zfs status to defined cvr status.
 func ZfsToCvrStatusMapper(zfsstatus string, quorum int) string {
-	if zfsstatus == ZfsStatusHealthy {
+	switch zfsstatus {
+	case ZfsStatusHealthy:
 		return string(apis.CVRStatusOnline)
-	}
-	if zfsstatus == ZfsStatusOffline {
+	case ZfsStatusOffline:
 		return string(apis.CVRStatusOffline)
-	}
-	if quorum == 1 {
-		if zfsstatus == ZfsStatusDegraded {
+	case ZfsStatusDegraded:
+		if quorum == 1 {
 			return string(apis.CVRStatusDegraded)
 		}
-		if zfsstatus == ZfsStatusRebuilding {
+		return string(apis.CVRStatusNewReplicaDegraded)
+	case ZfsStatusRebuilding:
+		if quorum == 1 {
 			return string(apis.CVRStatusRebuilding)
 		}
+		return string(apis.CVRStatusReconstructingNewReplica)
+	default:
+		return string(apis.CVRStatusError)
 	}
-	if zfsstatus == ZfsStatusDegraded {
-		return string(apis.CVRStatusNonQuorumDegraded)
-	}
-	if zfsstatus == ZfsStatusRebuilding {
-		return string(apis.CVRStatusReconstructing)
-	}
-	return string(apis.CVRStatusError)
 }
 
 /*

--- a/cmd/cstor-pool-mgmt/volumereplica/volumereplica_test.go
+++ b/cmd/cstor-pool-mgmt/volumereplica/volumereplica_test.go
@@ -549,12 +549,12 @@ func TestVolumeStatus(t *testing.T) {
 		"#6 ReconstructingVolumeStatus": {
 			volumeName:       "cstor-183f17c6-ed8b-11e8-87fd-42010a800087/pvc-9e91f938-ee23-11e8-87fd-42010a800087",
 			mockedOutputType: testZfsReconstructing,
-			expectedStatus:   apis.CVRStatusReconstructing,
+			expectedStatus:   apis.CVRStatusReconstructingNewReplica,
 		},
 		"#7 NonQuorumDegradedStatus": {
 			volumeName:       "cstor-183f17c6-ed8b-11e8-87fd-42010a800087/pvc-9e91f938-ee23-11e8-87fd-42010a800087",
 			mockedOutputType: testNonQuorumDegraded,
-			expectedStatus:   apis.CVRStatusNonQuorumDegraded,
+			expectedStatus:   apis.CVRStatusNewReplicaDegraded,
 		},
 	}
 	for name, test := range testPoolResource {

--- a/cmd/cstor-pool-mgmt/volumereplica/volumereplica_test.go
+++ b/cmd/cstor-pool-mgmt/volumereplica/volumereplica_test.go
@@ -139,6 +139,7 @@ func TestStatusHelperProcess(*testing.T) {
       "runningIONum": 0,
       "checkpointedIONum": 0,
       "degradedCheckpointedIONum": 0,
+      "quorum": 1,
       "checkpointedTime": 0,
       "rebuildBytes": 0,
       "rebuildCnt": 0,
@@ -158,6 +159,7 @@ func TestStatusHelperProcess(*testing.T) {
       "runningIONum": 0,
       "checkpointedIONum": 0,
       "degradedCheckpointedIONum": 0,
+      "quorum": 1,
       "checkpointedTime": 0,
       "rebuildBytes": 0,
       "rebuildCnt": 0,
@@ -177,6 +179,7 @@ func TestStatusHelperProcess(*testing.T) {
       "runningIONum": 0,
       "checkpointedIONum": 0,
       "degradedCheckpointedIONum": 0,
+      "quorum": 1,
       "checkpointedTime": 0,
       "rebuildBytes": 0,
       "rebuildCnt": 0,
@@ -196,11 +199,32 @@ func TestStatusHelperProcess(*testing.T) {
       "runningIONum": 0,
       "checkpointedIONum": 0,
       "degradedCheckpointedIONum": 0,
+      "quorum": 1,
       "checkpointedTime": 0,
       "rebuildBytes": 0,
       "rebuildCnt": 0,
       "rebuildDoneCnt": 0,
       "rebuildFailedCnt": 0
+    }
+  ]
+}`
+		mockedStatusOutputReconstructing = `{
+  "stats": [
+    {
+      "name": "cstor-183f17c6-ed8b-11e8-87fd-42010a800087/pvc-9e91f938-ee23-11e8-87fd-42010a800087",
+      "status": "Rebuilding",
+      "rebuildStatus": "SNAP REBUILD INPROGRESS",
+      "quorum": 0
+    }
+  ]
+}`
+		mockedStatusOutputNonQuorumDegraded = `{
+  "stats": [
+    {
+      "name": "cstor-183f17c6-ed8b-11e8-87fd-42010a800087/pvc-9e91f938-ee23-11e8-87fd-42010a800087",
+      "status": "Degraded",
+      "rebuildStatus": "INIT",
+      "quorum": 0
     }
   ]
 }`
@@ -220,6 +244,12 @@ func TestStatusHelperProcess(*testing.T) {
 	}
 	if os.Getenv("StatusType") == ZfsStatusRebuilding {
 		fmt.Fprint(os.Stdout, mockedStatusOutputRebuilding)
+	}
+	if os.Getenv("StatusType") == "Reconstructing" {
+		fmt.Fprint(os.Stdout, mockedStatusOutputReconstructing)
+	}
+	if os.Getenv("StatusType") == "NonQuorumDegraded" {
+		fmt.Fprint(os.Stdout, mockedStatusOutputNonQuorumDegraded)
 	}
 
 	defer os.Exit(0)
@@ -459,7 +489,7 @@ func TestParseCapacityUnit(t *testing.T) {
 	}
 }
 
-// TestPoolStatus tests Status function which retunr cvr status.
+// TestVolumeStatus tests Status function which retunr cvr status.
 func TestVolumeStatus(t *testing.T) {
 	testPoolResource := map[string]struct {
 		// cvrName holds the name of zfs volume(not the cvr object name).
@@ -495,6 +525,16 @@ func TestVolumeStatus(t *testing.T) {
 			volumeName:       "cstor-183f17c6-ed8b-11e8-87fd-42010a800087/pvc-9e91f938-ee23-11e8-87fd-42010a800087",
 			mockedOutputType: ZfsStatusRebuilding,
 			expectedStatus:   "Rebuilding",
+		},
+		"#6 ReconstructingVolumeStatus": {
+			volumeName:       "cstor-183f17c6-ed8b-11e8-87fd-42010a800087/pvc-9e91f938-ee23-11e8-87fd-42010a800087",
+			mockedOutputType: "Reconstructing",
+			expectedStatus:   "Reconstructing",
+		},
+		"#7 NonQuorumDegradedStatus": {
+			volumeName:       "cstor-183f17c6-ed8b-11e8-87fd-42010a800087/pvc-9e91f938-ee23-11e8-87fd-42010a800087",
+			mockedOutputType: "NonQuorumDegraded",
+			expectedStatus:   "NonQuorumDegraded",
 		},
 	}
 	for name, test := range testPoolResource {

--- a/cmd/cstor-pool-mgmt/volumereplica/volumereplica_test.go
+++ b/cmd/cstor-pool-mgmt/volumereplica/volumereplica_test.go
@@ -558,6 +558,8 @@ func TestVolumeStatus(t *testing.T) {
 		},
 	}
 	for name, test := range testPoolResource {
+		test := test
+		name := name
 		t.Run(name, func(t *testing.T) {
 			// Set env variable "StatusType" to "mockedOutputType"
 			// It will help to decide which mocked output should be considered as a std output.

--- a/cmd/upgrade/executor/cstor_spc.go
+++ b/cmd/upgrade/executor/cstor_spc.go
@@ -34,7 +34,7 @@ type CStorSPCOptions struct {
 
 var (
 	cstorSPCUpgradeCmdHelpText = `
-This command upgrades the cStor SPC 
+This command upgrades the cStor SPC
 
 Usage: upgrade cstor-spc --spc-name <spc-name> --options...
 `

--- a/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
@@ -82,11 +82,12 @@ const (
 	// IO's
 	CVRStatusDegraded CStorVolumeReplicaPhase = "Degraded"
 
-	// CVRStatusNewReplicaDegraded describes replica is recreated due to pool
-	// recreation(under lying disk got changed)/volume replica scaleup case and
-	// replica has to start reconstructing entier data from other available
-	// healthy replica until replica becomes healthy whatever data written to it
-	// is lost(replica also not part of quorum decision)
+	// CVRStatusNewReplicaDegraded describes replica is recreated (due to pool
+	// recreation[underlying disk got changed]/volume replica scaleup cases) and
+	// just connected to the target. Volume replica has to start reconstructing
+	// entier data from another available healthy replica. Until volume replica
+	// becomes healthy whatever data written to it is lost(NewReplica also not part
+	// of any quorum decision)
 	CVRStatusNewReplicaDegraded CStorVolumeReplicaPhase = "NewReplicaDegraded"
 
 	// CVRStatusRebuilding describes volume replica has missing data and it

--- a/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
@@ -82,21 +82,20 @@ const (
 	// IO's
 	CVRStatusDegraded CStorVolumeReplicaPhase = "Degraded"
 
-	// CVRStatusNonQuorumDegraded describes replica is recreated due to pool
-	// recreation(might be ephemeral or scaleup case). Replica has to start
-	// rebuild entier data from other available healthy replica until replica
-	// becomes healthy whatever data written to it is lost(not part of quorum
-	// decision)
-	//TODO: Rename this phase based on suggestion
-	CVRStatusNonQuorumDegraded CStorVolumeReplicaPhase = "NonQuorumDegraded"
+	// CVRStatusNewReplicaDegraded describes replica is recreated due to pool
+	// recreation(under lying disk got changed)/volume replica scaleup case and
+	// replica has to start reconstructing entier data from other available
+	// healthy replica until replica becomes healthy whatever data written to it
+	// is lost(replica also not part of quorum decision)
+	CVRStatusNewReplicaDegraded CStorVolumeReplicaPhase = "NewReplicaDegraded"
 
 	// CVRStatusRebuilding describes volume replica has missing data and it
 	// started rebuilding missing data from other replicas
 	CVRStatusRebuilding CStorVolumeReplicaPhase = "Rebuilding"
 
-	// CVRStatusReconstructing describes volume replica is recreated and it
-	// started reconstructing entier data from other healthy replica
-	CVRStatusReconstructing CStorVolumeReplicaPhase = "Reconstructing"
+	// CVRStatusReconstructingNewReplica describes volume replica is recreated
+	// and it started reconstructing entier data from other healthy replica
+	CVRStatusReconstructingNewReplica CStorVolumeReplicaPhase = "ReconstructingNewReplica"
 
 	// CVRStatusError describes either volume replica is not exist in cstor pool
 	CVRStatusError CStorVolumeReplicaPhase = "Error"

--- a/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
@@ -64,31 +64,55 @@ type CStorVolumeReplicaPhase string
 
 // Status written onto CStorVolumeReplica objects.
 const (
-	// CVRStatusEmpty ensures the create operation is to be done, if import fails.
+
+	// CVRStatusEmpty describes CVR resource is created but not yet monitored by
+	// controller(i.e resource is just created)
 	CVRStatusEmpty CStorVolumeReplicaPhase = ""
-	// CVRStatusOnline ensures the resource is available.
+
+	// CVRStatusOnline describes volume replica is Healthy and data existing on
+	// the healthy replica is up to date
 	CVRStatusOnline CStorVolumeReplicaPhase = "Healthy"
-	// CVRStatusOffline ensures the resource is not available.
+
+	// CVRStatusOffline describes volume replica is created but not yet connected
+	// to the target
 	CVRStatusOffline CStorVolumeReplicaPhase = "Offline"
-	// CVRStatusDegraded means that the rebuilding has not yet started.
+
+	// CVRStatusDegraded describes volume replica is connected to the target and
+	// rebuilding from other replicas is not yet started but ready for serving
+	// IO's
 	CVRStatusDegraded CStorVolumeReplicaPhase = "Degraded"
-	// CVRStatusNonQuorumDegraded means that replica(i.e recreated/scaledup
-	// replica) has not yet started reconstructing data from other replicas
+
+	// CVRStatusNonQuorumDegraded describes replica is recreated due to pool
+	// recreation(might be ephemeral or scaleup case). Replica has to start
+	// rebuild entier data from other available healthy replica until replica
+	// becomes healthy whatever data written to it is lost(not part of quorum
+	// decision)
+	//TODO: Rename this phase based on suggestion
 	CVRStatusNonQuorumDegraded CStorVolumeReplicaPhase = "NonQuorumDegraded"
-	// CVRStatusRebuilding means that the volume is in re-building phase
+
+	// CVRStatusRebuilding describes volume replica has missing data and it
+	// started rebuilding missing data from other replicas
 	CVRStatusRebuilding CStorVolumeReplicaPhase = "Rebuilding"
-	// CVRStatusReconstructing means that non quorum volume replica is
-	// reconstructing data from other available replicas
+
+	// CVRStatusReconstructing describes volume replica is recreated and it
+	// started reconstructing entier data from other healthy replica
 	CVRStatusReconstructing CStorVolumeReplicaPhase = "Reconstructing"
-	// CVRStatusError means that the volume status could not be found.
+
+	// CVRStatusError describes either volume replica is not exist in cstor pool
 	CVRStatusError CStorVolumeReplicaPhase = "Error"
-	// CVRStatusDeletionFailed ensures the resource deletion has failed.
+
+	// CVRStatusDeletionFailed describes volume replica deletion is failed
 	CVRStatusDeletionFailed CStorVolumeReplicaPhase = "DeletionFailed"
-	// CVRStatusInvalid ensures invalid resource.
+
+	// CVRStatusInvalid ensures invalid resource(currently not honoring)
 	CVRStatusInvalid CStorVolumeReplicaPhase = "Invalid"
-	// CVRStatusInit ensures Init task of cvr resource.
+
+	// CVRStatusInit describes CVR resource is newly created but it is not yet
+	// created zfs dataset
 	CVRStatusInit CStorVolumeReplicaPhase = "Init"
-	// CVRStatusRecreate ensures recreation task of cvr resource.
+
+	// CVRStatusRecreate describes the volume replica is recreated due to pool
+	// recreation/scaleup
 	CVRStatusRecreate CStorVolumeReplicaPhase = "Recreate"
 )
 

--- a/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
@@ -72,9 +72,15 @@ const (
 	CVRStatusOffline CStorVolumeReplicaPhase = "Offline"
 	// CVRStatusDegraded means that the rebuilding has not yet started.
 	CVRStatusDegraded CStorVolumeReplicaPhase = "Degraded"
-	// CVRStatusRebuilding means that the volume is in re-building phase.
+	// CVRStatusNonQuorumDegraded means that replica(i.e recreated/scaledup
+	// replica) has not yet started reconstructing data from other replicas
+	CVRStatusNonQuorumDegraded CStorVolumeReplicaPhase = "NonQuorumDegraded"
+	// CVRStatusRebuilding means that the volume is in re-building phase
 	CVRStatusRebuilding CStorVolumeReplicaPhase = "Rebuilding"
-	// CVRStatusRebuilding means that the volume status could not be found.
+	// CVRStatusReconstructing means that non quorum volume replica is
+	// reconstructing data from other available replicas
+	CVRStatusReconstructing CStorVolumeReplicaPhase = "Reconstructing"
+	// CVRStatusError means that the volume status could not be found.
 	CVRStatusError CStorVolumeReplicaPhase = "Error"
 	// CVRStatusDeletionFailed ensures the resource deletion has failed.
 	CVRStatusDeletionFailed CStorVolumeReplicaPhase = "DeletionFailed"


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds the `NewReplicaDegraded` and
`ReconstructingNewReplica` status phase to cStorVolumeReplica(CVR).

Explanation:
**NewReplicaDegraded**: 
CVRStatusNewReplicaDegraded describes replica is recreated (due to pool
recreation[underlying disk got changed]/volume replica scaleup cases) and
just connected to the target. Volume replica has to start reconstructing
data from another available healthy replica. Until volume replica
becomes healthy whatever data written to it is lost(NewReplica also not part
of any quorum decision).

**ReconstructingNewReplica**:
CVRStatusReconstructingNewReplica describes volume replica is recreated
and it started reconstructing entier data from another healthy replica.

Sample CVR O/P:
```sh
sai_chaithanya@cloudshell:~ (strong-eon-153112)$ kubectl get cvr -n openebs
NAME                                                              USED   ALLOCATED   STATUS           AGE
pvc-ceffba3d-0156-11ea-9275-42010a80014d-cstor-sparse-pool-bly6   925M   838M        ReconstructingNewReplica   1h
pvc-ceffba3d-0156-11ea-9275-42010a80014d-cstor-sparse-pool-izs9   969M   843M        Healthy          1h
pvc-ceffba3d-0156-11ea-9275-42010a80014d-cstor-sparse-pool-jc0f   957M   842M        Healthy          1h
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests