### PR TITLE
refact(admission): automate deletion of older config

### DIFF
--- a/cmd/admission-server/main.go
+++ b/cmd/admission-server/main.go
@@ -75,12 +75,6 @@ func main() {
 		klog.Fatalf("Error building openebs snapshot clientset: %s", err.Error())
 	}
 
-	// Cleaning up older configuration before 1.4.0
-	err = webhook.Preupgrade(kubeClient)
-	if err != nil {
-		klog.Fatalf("Error cleaning older config: %s", err.Error())
-	}
-
 	// Fetch a reference to the admission server deployment object
 	ownerReference, err := webhook.GetAdmissionReference()
 	if err != nil {

--- a/cmd/admission-server/main.go
+++ b/cmd/admission-server/main.go
@@ -75,6 +75,12 @@ func main() {
 		klog.Fatalf("Error building openebs snapshot clientset: %s", err.Error())
 	}
 
+	// Cleaning up older configuration before 1.4.0
+	err = webhook.Preupgrade(kubeClient)
+	if err != nil {
+		klog.Fatalf("Error cleaning older config: %s", err.Error())
+	}
+
 	// Fetch a reference to the admission server deployment object
 	ownerReference, err := webhook.GetAdmissionReference()
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR automates the deletion of older admission webhook configurations. It also adds version label to new configs to differentiate between old and new configs.
This will require addition of `list` clusterrole for `validatingwebhookconfig`. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests