### PR TITLE
fix(cStorVolumeReplica): reconciliation logic for volume replica creation failures

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -323,6 +323,7 @@ func (c *CStorVolumeReplicaController) cVRAddEventHandler(
 	fullVolName string,
 ) (string, error) {
 	var err error
+	var status string
 	// lock is to synchronize pool and volumereplica. Until certain pool related
 	// operations are over, the volumereplica threads will be held.
 	common.SyncResources.Mux.Lock()
@@ -348,7 +349,7 @@ func (c *CStorVolumeReplicaController) cVRAddEventHandler(
 			// If the volume already present then get the status of replica from ZFS
 			// and update it with corresponding status phase. If status gives error
 			// then return old phase.
-			status, err := volumereplica.Status(fullVolName)
+			status, err = volumereplica.Status(fullVolName)
 			if err != nil {
 				return string(cVR.Status.Phase), err
 			}
@@ -386,7 +387,7 @@ func (c *CStorVolumeReplicaController) cVRAddEventHandler(
 		}
 		// If the volume already present then get the status of replica from ZFS
 		// and update it with corresponding status
-		status, err := volumereplica.Status(fullVolName)
+		status, err = volumereplica.Status(fullVolName)
 		if err != nil {
 			return string(cVR.Status.Phase), err
 		}
@@ -447,7 +448,7 @@ func (c *CStorVolumeReplicaController) cVRAddEventHandler(
 			cVR.ObjectMeta.Name,
 			string(cVR.GetUID()),
 		)
-		status, err := volumereplica.Status(fullVolName)
+		status, err = volumereplica.Status(fullVolName)
 		if err != nil {
 			return string(cVR.Status.Phase), err
 		}


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR fixes the following changes:
1. Current code doesn't handle reconciliation logic for volume replica creation
   failures. This PR fixes this bug by returning the same status phase of CVR whatever currently held by CVR and during every sync call logic will checks whether volume replica needs to be created or not. If volume replica needs to be created it will trigger the call to create volume replica(Note: Before triggering zfs command it will also check in the pool whether replica already exists or not).
2. This PR also update with volume replica status by triggering `ZFS stats <dataset_name>`
   command whenever volume replica created or imported.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
It's a patch to code instead of rewriting the entire replica controller code.

**TODO:**
1. Volume replica creation tests via BDD(Will be done in different PR)[Done] #1530.

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests