### PR TITLE
chore(cStorVolume_bdd): add negative test cases for cStorVolumeProvisioning

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -108,6 +108,7 @@ VOLUME_MGMT=cstor-volume-mgmt
 EXPORTER=maya-exporter
 CSPC_OPERATOR=cspc-operator
 CSPC_OPERATOR_DEBUG=cspc-operator-debug
+CSP_OPERATOR_DEBUG=cstor-pool-mgmt-debug
 
 
 # Specify the date o build
@@ -310,6 +311,18 @@ pool-mgmt-image: cstor-pool-mgmt
 	@cp bin/cstor-pool-mgmt/${POOL_MGMT} buildscripts/cstor-pool-mgmt/
 	@cd buildscripts/cstor-pool-mgmt && sudo docker build -t ${HUB_USER}/${CSTOR_POOL_MGMT_REPO_NAME}:${IMAGE_TAG} --build-arg BASE_IMAGE=${CSTOR_BASE_IMAGE} --build-arg BUILD_DATE=${BUILD_DATE} . --no-cache
 	@rm buildscripts/cstor-pool-mgmt/${POOL_MGMT}
+
+#Use this to build debug image of cstor-pool-mgmt
+.PHONY: pool-mgmt-debug-image
+pool-mgmt-debug-image:
+	@echo "----------------------------"
+	@echo -n "--> cstor-pool-mgmt debug image "
+	@echo "${HUB_USER}/${CSTOR_POOL_MGMT_REPO_NAME}:inject"
+	@echo "----------------------------"
+	@PNAME=${CSP_OPERATOR_DEBUG} CTLNAME=${POOL_MGMT} BUILD_TAG="-tags=debug" sh -c "'$(PWD)/buildscripts/build.sh'"
+	@cp bin/${CSP_OPERATOR_DEBUG}/${POOL_MGMT} buildscripts/${CSP_OPERATOR_DEBUG}/
+	@cd buildscripts/${CSP_OPERATOR_DEBUG} && sudo docker build -t ${HUB_USER}/${CSTOR_POOL_MGMT_REPO_NAME}:inject --build-arg BASE_IMAGE=${CSTOR_BASE_IMAGE} --build-arg BUILD_DATE=${BUILD_DATE} . --no-cache
+	@rm buildscripts/${CSP_OPERATOR_DEBUG}/${POOL_MGMT}
 
 #Use this to build cspi-mgmt
 .PHONY: cspi-mgmt

--- a/buildscripts/cstor-pool-mgmt-debug/Dockerfile
+++ b/buildscripts/cstor-pool-mgmt-debug/Dockerfile
@@ -1,0 +1,30 @@
+#
+# This Dockerfile builds a recent cstor-pool-mgmt-debug using the latest binary from
+# cstor-pool-mgmt  releases.
+#
+
+#openebs/cstor-base is the image that contains cstor related binaries and
+#libraries - zpool, zfs, zrepl
+#FROM openebs/cstor-base:ci
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
+
+COPY cstor-pool-mgmt /usr/local/bin/
+COPY entrypoint.sh /usr/local/bin/
+
+RUN echo '#!/bin/bash\nif [ $# -lt 1 ]; then\n\techo "argument missing"\n\texit 1\nfi\neval "$*"\n' >> /usr/local/bin/execute.sh
+
+RUN chmod +x /usr/local/bin/execute.sh
+RUN apt install netcat -y
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ARG BUILD_DATE
+LABEL org.label-schema.name="cstor-pool-mgmt"
+LABEL org.label-schema.description="OpenEBS"
+LABEL org.label-schema.url="http://www.openebs.io/"
+LABEL org.label-schema.vcs-url="https://github.com/openebs/maya"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=$BUILD_DATE
+
+ENTRYPOINT entrypoint.sh
+EXPOSE 7676

--- a/buildscripts/cstor-pool-mgmt-debug/Dockerfile
+++ b/buildscripts/cstor-pool-mgmt-debug/Dockerfile
@@ -12,7 +12,7 @@ FROM $BASE_IMAGE
 COPY cstor-pool-mgmt /usr/local/bin/
 COPY entrypoint.sh /usr/local/bin/
 
-RUN echo '#!/bin/bash\nif [ $# -lt 1 ]; then\n\techo "argument missing"\n\texit 1\nfi\neval "$*"\n' >> /usr/local/bin/execute.sh
+RUN printf '#!/bin/bash\nif [ $# -lt 1 ]; then\n\techo "argument missing"\n\texit 1\nfi\neval "$*"\n' >> /usr/local/bin/execute.sh
 
 RUN chmod +x /usr/local/bin/execute.sh
 RUN apt install netcat -y

--- a/buildscripts/cstor-pool-mgmt-debug/entrypoint.sh
+++ b/buildscripts/cstor-pool-mgmt-debug/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -ex
+
+rm /usr/local/bin/zrepl
+exec /usr/local/bin/cstor-pool-mgmt start
+exec service ssh start
+exec service rsyslog start

--- a/cmd/cstor-pool-mgmt/controller/pool-controller/run_pool_controller.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/run_pool_controller.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/openebs/maya/cmd/cstor-pool-mgmt/controller/common"
+	"github.com/openebs/maya/pkg/debug"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
@@ -33,6 +34,10 @@ import (
 func (c *CStorPoolController) Run(threadiness int, stopCh <-chan struct{}) error {
 	defer runtime.HandleCrash()
 	defer c.workqueue.ShutDown()
+
+	// Start server only in debug build
+	debug.LogBuildDetails()
+	debug.StartInjectionServer()
 
 	// Start the informer factories to begin populating the informer caches
 	klog.Info("Starting CStorPool controller")

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openebs/maya/cmd/cstor-pool-mgmt/volumereplica"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	clientset "github.com/openebs/maya/pkg/client/generated/clientset/versioned"
+	"github.com/openebs/maya/pkg/debug"
 	merrors "github.com/openebs/maya/pkg/errors/v1alpha1"
 	pkg_errors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -146,6 +147,9 @@ func (c *CStorVolumeReplicaController) syncHandler(
 
 	// need to update cvr before returning this error
 	if err != nil {
+		if debug.EI.IsCVRUpdateErrorInjected() {
+			return merrors.Errorf("CVR update error via injection")
+		}
 		_, err1 := c.clientset.
 			OpenebsV1alpha1().
 			CStorVolumeReplicas(cvrGot.Namespace).

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -22,10 +22,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/klog"
 	"log"
 	"net/http"
 	"time"
+
+	"k8s.io/klog"
 )
 
 // LogBuildDetails logs the build details when the cspc-operator starts.
@@ -285,5 +286,51 @@ func (ei *ErrorInjection) IsDeploymentPatchErrorInjected() bool {
 	if ei.DeploymentError.CRUDErrorInjection.InjectPatchError == Inject {
 		return true
 	}
+	return false
+}
+
+// IsZFSGetErrorInjected returns true if error is injected for ZFS get command
+func (ei *ErrorInjection) IsZFSGetErrorInjected() bool {
+	if ei.ZFSError.CRUDErrorInjection.InjectGetError == Inject {
+		return true
+	}
+	return false
+}
+
+// IsZFSDeleteErrorInjected returns true if error is injected for ZFS delete command
+func (ei *ErrorInjection) IsZFSDeleteErrorInjected() bool {
+	if ei.ZFSError.CRUDErrorInjection.InjectDeleteError == Inject {
+		return true
+	}
+	return false
+}
+
+// IsZFSCreateErrorInjected returns true if error is injected for ZFS create command
+func (ei *ErrorInjection) IsZFSCreateErrorInjected() bool {
+	if ei.ZFSError.CRUDErrorInjection.InjectCreateError == Inject {
+		return true
+	}
+	return false
+}
+
+// IsCVRCreateErrorInjected returns true if error is injected for CVR create
+// command
+func (ei *ErrorInjection) IsCVRCreateErrorInjected() bool {
+	return false
+}
+
+// IsCVRDeleteErrorInjected returns true if error is injected for CVR delete
+// command
+func (ei *ErrorInjection) IsCVRDeleteErrorInjected() bool {
+	return false
+}
+
+// IsCVRGetErrorInjected returns true if error is injected for CVR get command
+func (ei *ErrorInjection) IsCVRGetErrorInjected() bool {
+	return false
+}
+
+// IsCVRUpdateErrorInjected returns true if error is injected for CVR update command
+func (ei *ErrorInjection) IsCVRUpdateErrorInjected() bool {
 	return false
 }

--- a/pkg/debug/release.go
+++ b/pkg/debug/release.go
@@ -128,3 +128,45 @@ func (ei *ErrorInjection) IsDeploymentUpdateErrorInjected() bool {
 func (ei *ErrorInjection) IsDeploymentPatchErrorInjected() bool {
 	return false
 }
+
+// IsZFSGetErrorInjected is production alternative for the same function that
+// exists in debug build
+func (ei *ErrorInjection) IsZFSGetErrorInjected() bool {
+	return false
+}
+
+// IsZFSCreateErrorInjected is production alternative for the same function that
+// exists in debug build
+func (ei *ErrorInjection) IsZFSCreateErrorInjected() bool {
+	return false
+}
+
+// IsZFSDeleteErrorInjected is production alternative for the same function that
+// exists in debug build
+func (ei *ErrorInjection) IsZFSDeleteErrorInjected() bool {
+	return false
+}
+
+// IsCVRCreateErrorInjected is production alternative for the same function that
+// exists in debug build
+func (ei *ErrorInjection) IsCVRCreateErrorInjected() bool {
+	return false
+}
+
+// IsCVRDeleteErrorInjected is production alternative for the same function that
+// exists in debug build
+func (ei *ErrorInjection) IsCVRDeleteErrorInjected() bool {
+	return false
+}
+
+// IsCVRGetErrorInjected is production alternative for the same function that
+// exists in debug build
+func (ei *ErrorInjection) IsCVRGetErrorInjected() bool {
+	return false
+}
+
+// IsCVRUpdateErrorInjected is production alternative for the same function that
+// exists in debug build
+func (ei *ErrorInjection) IsCVRUpdateErrorInjected() bool {
+	return false
+}

--- a/pkg/debug/types.go
+++ b/pkg/debug/types.go
@@ -41,38 +41,54 @@ var EI = &ErrorInjection{}
 
 // ErrorInjection schema to inject errors.
 type ErrorInjection struct {
-	CSPIError       CSPIErrorInjection       `json:"cspi_error"`
-	CSPCError       CSPCErrorInjection       `json:"cspc_error"`
-	DeploymentError DeploymentErrorInjection `json:"deployment_error"`
+	CSPIError       CSPIErrorInjection       `json:"cspiError"`
+	CSPCError       CSPCErrorInjection       `json:"cspcError"`
+	DeploymentError DeploymentErrorInjection `json:"deploymentError"`
+	ZFSError        ZFSErrorInjection        `json:"zfsError"`
+	CVRError        CVRErrorInjection        `json:"cvrError"`
 }
 
 // CSPIErrorInjection is used to inject errors for CSPI related operations.
 type CSPIErrorInjection struct {
-	CRUDErrorInjection CRUDErrorInjection       `json:"crud_error_injection"`
-	ErrorPercentage    ErrorPercentageThreshold `json:"error_percentage"`
+	CRUDErrorInjection CRUDErrorInjection       `json:"crudErrorInjection"`
+	ErrorPercentage    ErrorPercentageThreshold `json:"errorPercentage"`
 }
 
 // CSPCErrorInjection is used to inject errors for CSPC related operations.
 type CSPCErrorInjection struct {
-	CRUDErrorInjection CRUDErrorInjection       `json:"crud_error_injection"`
-	ErrorPercentage    ErrorPercentageThreshold `json:"error_percentage"`
+	CRUDErrorInjection CRUDErrorInjection       `json:"crudErrorInjection"`
+	ErrorPercentage    ErrorPercentageThreshold `json:"errorPercentage"`
 }
 
 // DeploymentErrorInjection is used to inject errors for CSPC related operations.
 type DeploymentErrorInjection struct {
-	CRUDErrorInjection CRUDErrorInjection       `json:"crud_error_injection"`
-	ErrorPercentage    ErrorPercentageThreshold `json:"error_percentage"`
+	CRUDErrorInjection CRUDErrorInjection       `json:"crudErrorInjection"`
+	ErrorPercentage    ErrorPercentageThreshold `json:"errorPercentage"`
+}
+
+// ZFSErrorInjection is used to inject errors for Volume Replica related
+// operations.
+type ZFSErrorInjection struct {
+	CRUDErrorInjection CRUDErrorInjection       `json:"crudErrorInjection"`
+	ErrorPercentage    ErrorPercentageThreshold `json:"errorPercentage"`
+}
+
+// CVRErrorInjection is used to inject errors in API calls for Volume Replica
+// related operations
+type CVRErrorInjection struct {
+	CRUDErrorInjection CRUDErrorInjection       `json:"crudErrorInjection"`
+	ErrorPercentage    ErrorPercentageThreshold `json:"errorPercentage"`
 }
 
 // CRUDErrorInjection is used to inject CRUD errors.
 type CRUDErrorInjection struct {
-	InjectDeleteCollectionError string `json:"inject_delete_collection_error"`
-	InjectDeleteError           string `json:"inject_delete_error"`
-	InjectListError             string `json:"inject_list_error"`
-	InjectGetError              string `json:"inject_get_error"`
-	InjectCreateError           string `json:"inject_create_error"`
-	InjectUpdateError           string `json:"inject_update_error"`
-	InjectPatchError            string `json:"inject_patch_error"`
+	InjectDeleteCollectionError string `json:"injectDeleteCollectionError"`
+	InjectDeleteError           string `json:"injectDeleteError"`
+	InjectListError             string `json:"injectListError"`
+	InjectGetError              string `json:"injectGetError"`
+	InjectCreateError           string `json:"injectCreateError"`
+	InjectUpdateError           string `json:"injectUpdateError"`
+	InjectPatchError            string `json:"injectPatchError"`
 }
 
 // ErrorPercentageThreshold is the threshold value above which the error will not be injected.
@@ -135,6 +151,29 @@ func (ei *ErrorInjection) WithDeploymentThreshold(threshold int) *ErrorInjection
 			WithDeploymentListError(Inject).
 			WithDeploymentPatchError(Inject).
 			WithDeploymentUpdateError(Inject)
+	}
+	return ei
+}
+
+// WithZFSThreshold injects ZFS errors depending on passed error threshold value
+func (ei *ErrorInjection) WithZFSThreshold(threshold int) *ErrorInjection {
+	ei.ZFSError.ErrorPercentage.Threshold = threshold
+	if GetRandomErrorPercentage() > threshold {
+		ei.WithZFSCreateError(Inject).
+			WithZFSDeleteError(Inject).
+			WithZFSGetError(Inject)
+	}
+	return ei
+}
+
+// WithCVRThreshold injects CVR error depending on passed error threshold value
+func (ei *ErrorInjection) WithCVRThreshold(threshold int) *ErrorInjection {
+	ei.CVRError.ErrorPercentage.Threshold = threshold
+	if GetRandomErrorPercentage() > threshold {
+		ei.WithCVRCreateError(Inject).
+			WithCVRDeleteError(Inject).
+			WithCVRGetError(Inject).
+			WithCVRUpdateError(Inject)
 	}
 	return ei
 }
@@ -262,5 +301,47 @@ func (ei *ErrorInjection) WithDeploymentUpdateError(ejectOrInject string) *Error
 // WithDeploymentPatchError injects/ejects  Deployment patch error.
 func (ei *ErrorInjection) WithDeploymentPatchError(ejectOrInject string) *ErrorInjection {
 	ei.DeploymentError.CRUDErrorInjection.InjectPatchError = ejectOrInject
+	return ei
+}
+
+// WithZFSGetError injects/ejects ZFS get error.
+func (ei *ErrorInjection) WithZFSGetError(ejectOrInject string) *ErrorInjection {
+	ei.ZFSError.CRUDErrorInjection.InjectGetError = ejectOrInject
+	return ei
+}
+
+// WithZFSCreateError injects/ejects ZFS create error.
+func (ei *ErrorInjection) WithZFSCreateError(ejectOrInject string) *ErrorInjection {
+	ei.ZFSError.CRUDErrorInjection.InjectCreateError = ejectOrInject
+	return ei
+}
+
+// WithZFSDeleteError injects/ejects ZFS delete error.
+func (ei *ErrorInjection) WithZFSDeleteError(ejectOrInject string) *ErrorInjection {
+	ei.ZFSError.CRUDErrorInjection.InjectDeleteError = ejectOrInject
+	return ei
+}
+
+// WithCVRCreateError injects/ejects CVR create error.
+func (ei *ErrorInjection) WithCVRCreateError(ejectOrInject string) *ErrorInjection {
+	ei.CVRError.CRUDErrorInjection.InjectCreateError = ejectOrInject
+	return ei
+}
+
+// WithCVRGetError injects/ejects CVR get error.
+func (ei *ErrorInjection) WithCVRGetError(ejectOrInject string) *ErrorInjection {
+	ei.CVRError.CRUDErrorInjection.InjectGetError = ejectOrInject
+	return ei
+}
+
+// WithCVRDeleteError injects/ejects CVR delete error.
+func (ei *ErrorInjection) WithCVRDeleteError(ejectOrInject string) *ErrorInjection {
+	ei.CVRError.CRUDErrorInjection.InjectDeleteError = ejectOrInject
+	return ei
+}
+
+// WithCVRUpdateError injects/ejects CVR update error.
+func (ei *ErrorInjection) WithCVRUpdateError(ejectOrInject string) *ErrorInjection {
+	ei.CVRError.CRUDErrorInjection.InjectUpdateError = ejectOrInject
 	return ei
 }

--- a/pkg/kubernetes/service/v1alpha1/build.go
+++ b/pkg/kubernetes/service/v1alpha1/build.go
@@ -240,6 +240,21 @@ func (b *Builder) WithPorts(ports []corev1.ServicePort) *Builder {
 	return b
 }
 
+// WithType sets the Type field of Service with provided arguments
+func (b *Builder) WithType(svcType corev1.ServiceType) *Builder {
+	if len(svcType) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.
+				New("failed to build service object: missing service type"),
+		)
+		return b
+	}
+
+	b.service.object.Spec.Type = svcType
+	return b
+}
+
 // Build returns the Service API instance
 func (b *Builder) Build() (*corev1.Service, error) {
 	if len(b.errs) > 0 {

--- a/tests/cstor/volume/provision_bulk_test.go
+++ b/tests/cstor/volume/provision_bulk_test.go
@@ -32,7 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = Describe("[cstor] TEST BULK VOLUME PROVISIONING", func() {
+var _ = Describe("[Cstor Volume Provisioning Positive] TEST BULK VOLUME PROVISIONING", func() {
 	var (
 		err           error
 		pvcNamePrefix = "cstor-volume-claim-"

--- a/tests/cstor/volume/provision_negative_test.go
+++ b/tests/cstor/volume/provision_negative_test.go
@@ -1,0 +1,186 @@
+package volume
+
+import (
+	"strconv"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	"github.com/openebs/maya/pkg/debug"
+	sc "github.com/openebs/maya/pkg/kubernetes/storageclass/v1alpha1"
+	"github.com/openebs/maya/tests"
+	"github.com/openebs/maya/tests/cstor"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	// auth plugins
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+)
+
+var _ = Describe("[Cstor Volume Provisioning Negative] Volume Provisioning", func() {
+	When("SPC is created", func() {
+		It("cStor Pools Should be Provisioned ", func() {
+			By("Build And Create StoragePoolClaim object")
+			// Populate configurations and create
+			spcConfig := &tests.SPCConfig{
+				Name:               spcName,
+				DiskType:           "sparse",
+				PoolCount:          cstor.PoolCount,
+				IsOverProvisioning: false,
+				PoolType:           "striped",
+			}
+			ops.Config = spcConfig
+			spcObj = ops.BuildAndCreateSPC()
+			By("Creating SPC, Desired Number of CSP Should Be Created", func() {
+				ops.VerifyDesiredCSPCount(spcObj, cstor.PoolCount)
+			})
+			By("Build And Create StorageClass", buildAndCreateSC)
+		})
+	})
+	When("Service is Applied", func() {
+		It("Should Create Service", func() {
+			var nodeIP string
+			var err error
+			By("Creating Service To Inject Errors During Volume Provisioning")
+			spcLabel := SPCLabel + "=" + spcObj.Name
+			poolPodList, err = ops.PodClient.
+				WithNamespace(openebsNamespace).
+				List(metav1.ListOptions{LabelSelector: spcLabel})
+			Expect(err).To(BeNil())
+
+			Expect(len(poolPodList.Items)).Should(BeNumerically(">=", 1),
+				"Pool Pods are not yet created")
+			servicePort := []corev1.ServicePort{
+				corev1.ServicePort{
+					Name:     "http",
+					Port:     int32(8080),
+					Protocol: "TCP",
+					NodePort: int32(30031),
+				},
+			}
+			nodeName := poolPodList.Items[0].Spec.NodeSelector[hostLabel]
+			nodeObj, err := ops.NodeClient.Get(nodeName, metav1.GetOptions{})
+			Expect(err).To(BeNil())
+
+			//GetNode Ip
+			for _, address := range nodeObj.Status.Addresses {
+				if address.Type == corev1.NodeExternalIP {
+					nodeIP = address.Address
+					break
+				}
+			}
+			Expect(nodeIP).NotTo(BeEmpty())
+			hostIpPort = nodeIP + ":30031"
+			serviceConfig := &tests.ServiceConfig{
+				Name:        svcName,
+				Namespace:   openebsNamespace,
+				Selectors:   poolPodList.Items[0].Labels,
+				ServicePort: servicePort,
+			}
+			ops.Config = serviceConfig
+			serviceObj = ops.BuildAndCreateService()
+		})
+	})
+
+	When("PersistentVolumeClaim Is Created", func() {
+		It("Volume Should be Created and Provisioned", func() {
+			// Populate PVC configurations
+			pvcConfig := &tests.PVCConfig{
+				Name:        pvcName,
+				Namespace:   nsObj.Name,
+				SCName:      scObj.Name,
+				Capacity:    "5G",
+				AccessModes: accessModes,
+			}
+			ops.Config = pvcConfig
+
+			//Injecting Errors During CVRUpdate and ZFS Creation Time
+			injectError := debug.NewClient(hostIpPort)
+			err := injectError.PostInject(
+				debug.NewErrorInjection().
+					WithZFSCreateError(debug.Inject).
+					WithCVRUpdateError(debug.Inject))
+			Expect(err).To(BeNil())
+
+			pvcObj = ops.BuildAndCreatePVC()
+			// n-1 Replicas should be Healthy
+			By("Creating PVC, Desired Number of CVR Should Be Created", func() {
+				ops.VerifyVolumeStatus(pvcObj, cstor.ReplicaCount-1)
+			})
+
+			// GetLatest PVC object
+			pvcObj, err = ops.PVCClient.
+				WithNamespace(nsObj.Name).
+				Get(pvcObj.Name, metav1.GetOptions{})
+			Expect(err).To(BeNil())
+		})
+	})
+
+	When("PVC Created During Error Injection", func() {
+		It("All Volume Replicas Should Not Be Healthy", func() {
+			By("Verify Volume Status after Injecting Errors", func() {
+				command := "zfs get guid | grep " + pvcObj.Spec.VolumeName + " | awk '{print $3}'"
+				_ = ops.ExecuteCMDEventually(
+					&poolPodList.Items[0],
+					"cstor-pool-mgmt", command, false)
+
+				// Eject the ZFSCreate error
+				injectError := debug.NewClient(hostIpPort)
+				err := injectError.PostInject(
+					debug.NewErrorInjection().
+						WithZFSCreateError(debug.Eject).
+						WithCVRUpdateError(debug.Inject))
+				Expect(err).To(BeNil())
+
+				//After ejecting the ZFS Create volume dataset should be created
+				zvolGUID := ops.ExecuteCMDEventually(
+					&poolPodList.Items[0],
+					"cstor-pool-mgmt", command, true)
+				Expect(zvolGUID).NotTo(BeEmpty())
+				// CVR Update will error due to error injection. So replica count
+				// should be n-1
+				ops.VerifyVolumeStatus(pvcObj, cstor.ReplicaCount-1)
+
+				//Eject CVRUpdate error then CVR should become Healthy
+				err = injectError.PostInject(
+					debug.NewErrorInjection().
+						WithCVRUpdateError(debug.Eject))
+				Expect(err).To(BeNil())
+
+				ops.VerifyVolumeStatus(pvcObj, cstor.ReplicaCount)
+			})
+		})
+	})
+
+	When("CleanUp Negative Volume Provisioned Resources", func() {
+		It("Should Delete All The Resources Related To Test", func() {
+			By("Delete persistentVolumeClaim then volume resources should be deleted", func() {
+				ops.DeleteVolumeResources(pvcObj, scObj)
+			})
+			By("Delete StoragePoolClaim then pool related resources should be deleted", func() {
+				ops.DeleteStoragePoolClaim(spcObj.Name)
+			})
+		})
+	})
+})
+
+func buildAndCreateSC() {
+	var err error
+	casConfig := strings.Replace(
+		openebsCASConfigValue, "$spcName", spcObj.Name, 1)
+	casConfig = strings.Replace(
+		casConfig, "$count", strconv.Itoa(cstor.ReplicaCount), 1)
+	annotations[string(apis.CASTypeKey)] = string(apis.CstorVolume)
+	annotations[string(apis.CASConfigKey)] = casConfig
+	scObj, err = sc.NewBuilder().
+		WithGenerateName(scName).
+		WithAnnotations(annotations).
+		WithProvisioner(openebsProvisioner).Build()
+	Expect(err).ShouldNot(HaveOccurred(), "while building storageclass obj for storageclass {%s}", scName)
+
+	By("creating storageclass")
+	scObj, err = ops.SCClient.Create(scObj)
+	Expect(err).To(BeNil(), "while creating storageclass", scName)
+}

--- a/tests/cstor/volume/provision_negative_test.go
+++ b/tests/cstor/volume/provision_negative_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package volume
 
 import (

--- a/tests/cstor/volume/provision_negative_test.go
+++ b/tests/cstor/volume/provision_negative_test.go
@@ -156,6 +156,8 @@ var _ = Describe("[Cstor Volume Provisioning Negative] Volume Provisioning", fun
 
 	When("CleanUp Negative Volume Provisioned Resources", func() {
 		It("Should Delete All The Resources Related To Test", func() {
+			err := ops.SVCClient.Delete(serviceObj.Name, &metav1.DeleteOptions{})
+			Expect(err).To(BeNil())
 			By("Delete persistentVolumeClaim then volume resources should be deleted", func() {
 				ops.DeleteVolumeResources(pvcObj, scObj)
 			})

--- a/tests/cstor/volume/provision_negative_test.go
+++ b/tests/cstor/volume/provision_negative_test.go
@@ -88,7 +88,7 @@ var _ = Describe("[Cstor Volume Provisioning Negative] Volume Provisioning", fun
 				}
 			}
 			Expect(nodeIP).NotTo(BeEmpty())
-			hostIpPort = nodeIP + ":30031"
+			hostIPPort = nodeIP + ":30031"
 			serviceConfig := &tests.ServiceConfig{
 				Name:        svcName,
 				Namespace:   openebsNamespace,
@@ -113,7 +113,7 @@ var _ = Describe("[Cstor Volume Provisioning Negative] Volume Provisioning", fun
 			ops.Config = pvcConfig
 
 			//Injecting Errors During CVRUpdate and ZFS Creation Time
-			injectError := debug.NewClient(hostIpPort)
+			injectError := debug.NewClient(hostIPPort)
 			err := injectError.PostInject(
 				debug.NewErrorInjection().
 					WithZFSCreateError(debug.Inject).
@@ -143,7 +143,7 @@ var _ = Describe("[Cstor Volume Provisioning Negative] Volume Provisioning", fun
 					"cstor-pool-mgmt", command, false)
 
 				// Eject the ZFSCreate error
-				injectError := debug.NewClient(hostIpPort)
+				injectError := debug.NewClient(hostIPPort)
 				err := injectError.PostInject(
 					debug.NewErrorInjection().
 						WithZFSCreateError(debug.Eject).

--- a/tests/cstor/volume/provision_test.go
+++ b/tests/cstor/volume/provision_test.go
@@ -31,7 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = Describe("[cstor] TEST VOLUME PROVISIONING", func() {
+var _ = Describe("[Cstor Volume Provisioning Positive] TEST VOLUME PROVISIONING", func() {
 	var (
 		err     error
 		pvcName = "cstor-volume-claim"
@@ -189,5 +189,4 @@ var _ = Describe("[cstor] TEST VOLUME PROVISIONING", func() {
 			Expect(cvCount).To(Equal(true), "while checking cstorvolume count")
 		})
 	})
-
 })

--- a/tests/cstor/volume/suite_test.go
+++ b/tests/cstor/volume/suite_test.go
@@ -59,7 +59,7 @@ var (
 	svcName            = "volume-provision-svc-injector"
 	serviceObj         *corev1.Service
 	pvcName            = "volume-claim1"
-	hostIpPort         string
+	hostIPPort         string
 	hostLabel          = "kubernetes.io/hostname"
 	poolPodList        *corev1.PodList
 )

--- a/tests/cstor/volume/suite_test.go
+++ b/tests/cstor/volume/suite_test.go
@@ -52,9 +52,16 @@ var (
 	targetLabel        = "openebs.io/target=cstor-target"
 	pvLabel            = "openebs.io/persistent-volume="
 	pvcLabel           = "openebs.io/persistent-volume-claim="
+	SPCLabel           = "openebs.io/storage-pool-claim"
 	accessModes        = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
 	capacity           = "5G"
 	annotations        = map[string]string{}
+	svcName            = "volume-provision-svc-injector"
+	serviceObj         *corev1.Service
+	pvcName            = "volume-claim1"
+	hostIpPort         string
+	hostLabel          = "kubernetes.io/hostname"
+	poolPodList        *corev1.PodList
 )
 
 func TestSource(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR does the following changes
1. This PR provides the capability to get debug build for the cstor-pool-mgmt.
2. Debug build has an injection server running on port 8080 on all the cstor-pool-mgmgt
   which can be used to inject the errors for CR's and ZFS operations for negative path testing.

**Test Process Covered In BDD:**
- Inject ZFS Creation error and CVR updated Error by selecting one random Pool(volume dataset won't be created and CVR update will not be done).
- Eject the ZFS Creation error and check whether the dataset is created or not.
- Eject the CVR update Error and check the CVR status it should be `Healthy`.

**To Run Positive Volume Provisioning BDD:**
1. Navigate to tests/cstor/volume using cd.
2. In your command line run the following command to execute negative BDD.
```sh
cmd: ginkgo -v -focus="\[Cstor Volume Provisioning Positive\]" -- -kubeconfig=/home/sai/.kube/config -cstor-maxpools=3 -cstor-replicas=3
```

**To Run Negative Volume Provisioning BDD:**
**Perform the following steps to run the negative tests on your local machine:**
1. Navigate to tests/cstor/volume using cd.
2. In your command line run the following command to execute negative BDD
```sh
   CMD: ginkgo -v  -focus="\[Cstor Volume Provisioning Negative\]" -- -kubeconfig=/home/sai/.kube/config -cstor-maxpools=3 -cstor-replicas=3
```

**Special notes for your reviewer**:
- This PR is the negative flow BDD for CVR reconciliation fix i.e PR #1525 
**TODO**
1. Need to write autogenerated code for debug build[Will be picked once the other priority items are completed].

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests