### PR TITLE
refact(k8s-volumes): add configMap based volume builder 

### DIFF
--- a/pkg/kubernetes/job/v1alpha1/build.go
+++ b/pkg/kubernetes/job/v1alpha1/build.go
@@ -1,0 +1,8 @@
+package v1alpha1
+
+import (
+	container "github.com/openebs/maya/pkg/kubernetes/container/v1alpha1"
+	templatespec "github.com/openebs/maya/pkg/kubernetes/podtemplatespec/v1alpha1"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)

--- a/pkg/kubernetes/job/v1alpha1/build.go
+++ b/pkg/kubernetes/job/v1alpha1/build.go
@@ -1,8 +1,0 @@
-package v1alpha1
-
-import (
-	container "github.com/openebs/maya/pkg/kubernetes/container/v1alpha1"
-	templatespec "github.com/openebs/maya/pkg/kubernetes/podtemplatespec/v1alpha1"
-	batchv1 "k8s.io/api/batch/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)

--- a/pkg/kubernetes/volume/v1alpha1/build.go
+++ b/pkg/kubernetes/volume/v1alpha1/build.go
@@ -87,6 +87,7 @@ func (b *Builder) WithConfigMap(configMap *corev1.ConfigMap, defaultmode int32) 
 		},
 	}
 	b.volume.object.VolumeSource = volumeSource
+	b.volume.object.Name = configMap.Name
 	return b
 }
 

--- a/pkg/kubernetes/volume/v1alpha1/build.go
+++ b/pkg/kubernetes/volume/v1alpha1/build.go
@@ -64,7 +64,7 @@ func (b *Builder) WithHostDirectory(path string) *Builder {
 	b.volume.object.VolumeSource = volumeSource
 	return b
 }
-func (b *Builder) WithConfigMap(configMap *corev1.ConfigMap) *Builder {
+func (b *Builder) WithConfigMap(configMap *corev1.ConfigMap, defaultmode int32) *Builder {
 	if configMap == nil {
 		b.errs = append(
 			b.errs,
@@ -72,10 +72,15 @@ func (b *Builder) WithConfigMap(configMap *corev1.ConfigMap) *Builder {
 		)
 		return b
 	}
-	k := int32(420)
+	if defaultmode == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build volume object: missing defaultmode"),
+		)
+	}
 	volumeSource := corev1.VolumeSource{
 		ConfigMap: &corev1.ConfigMapVolumeSource{
-			DefaultMode: &k,
+			DefaultMode: &defaultmode,
 			LocalObjectReference: corev1.LocalObjectReference{
 				Name: configMap.Name,
 			},

--- a/pkg/kubernetes/volume/v1alpha1/build.go
+++ b/pkg/kubernetes/volume/v1alpha1/build.go
@@ -64,6 +64,26 @@ func (b *Builder) WithHostDirectory(path string) *Builder {
 	b.volume.object.VolumeSource = volumeSource
 	return b
 }
+func (b *Builder) WithConfigMap(configMap *corev1.ConfigMap) *Builder {
+	if configMap == nil {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build volume object: nil ConfigMap"),
+		)
+		return b
+	}
+	k := int32(420)
+	volumeSource := corev1.VolumeSource{
+		ConfigMap: &corev1.ConfigMapVolumeSource{
+			DefaultMode: &k,
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: configMap.Name,
+			},
+		},
+	}
+	b.volume.object.VolumeSource = volumeSource
+	return b
+}
 
 // WithHostPathAndType sets the VolumeSource field of Volume with provided
 // hostpath as directory path and type as directory type


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- This is a PR for builder functions present in pkg/kubernetes
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
- Some testing is done, by checking the creation of Volume
- Have set the volume name to be the configMaps Name (for right now,  please comment on the PR, if some modification is needed)


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests