### PR TITLE
fix(tools): set default helper pod image to latest

### DIFF
--- a/cmd/provisioner-localpv/app/env.go
+++ b/cmd/provisioner-localpv/app/env.go
@@ -40,7 +40,7 @@ const (
 )
 
 var (
-	defaultHelperImage = "quay.io/openebs/openebs-tools:3.8"
+	defaultHelperImage = "quay.io/openebs/linux-utils:latest"
 	defaultBasePath    = "/var/openebs/local"
 )
 

--- a/pkg/install/v1alpha1/jiva_volume.go
+++ b/pkg/install/v1alpha1/jiva_volume.go
@@ -259,7 +259,7 @@ spec:
   - name: OpenEBSNamespace
     value: {{env "OPENEBS_NAMESPACE"}}
   - name: ScrubImage
-    value: "quay.io/openebs/openebs-tools:3.8"
+    value: "quay.io/openebs/linux-utils:latest"
   # RetainReplicaData specifies whether jiva replica data folder
   # should be cleared or retained.
   - name: RetainReplicaData


### PR DESCRIPTION
Helper pods are used to run tasks like:
- cleaning up of jiva files after jiva PV is deleted or
- create or remove host path directories for hostpath Local PV.

A similar helper pod is used by NDM to scrub the block devices
after they have been released. The only addition in case of NDM
helper pod is to have `linux-utils` package on top 
of the alpine linux. As the jiva and hostpath Local PV can also use
the linux utils package, and to reduce the dependency on number
of images to be maintained, changing the default image to be
`openebs/linux-utils`

This PR helps with:
- making sure the same linux-utils image is used across all the components of openebs. 
- set the default help image to use the latest tag, so new version of OpenEBS will automatically get updated with new images. 
- use the latest image built using the source code present within the openebs org at:  https://github.com/openebs/linux-utils/tree/master

Note that users can always override this default image by passing
in their custom image via the ENV/helm values or StorageClass
annotations.

Signed-off-by: kmova <kiran.mova@mayadata.io>
