### PR TITLE
feat(disk-replacement, cspi): add disk replacement support in cspi mgmt

### DIFF
--- a/cmd/cspc-operator/app/handler.go
+++ b/cmd/cspc-operator/app/handler.go
@@ -358,7 +358,7 @@ func (pc *PoolConfig) removeSPCFinalizerOnAssociatedBDC() error {
 
 	for _, bdcObj := range bdcList.Items {
 		bdcObj := bdcObj
-		err := bdc.BuilderForAPIObject(&bdcObj).BDC.RemoveFinalizer(apiscspc.CSPCFinalizer)
+		_, err := bdc.BuilderForAPIObject(&bdcObj).BDC.RemoveFinalizer(apiscspc.CSPCFinalizer)
 		if err != nil {
 			return errors.Wrapf(err, "failed to remove CSPC finalizer on BDC %s", bdcObj.Name)
 		}

--- a/cmd/cspc-operator/app/operations.go
+++ b/cmd/cspc-operator/app/operations.go
@@ -18,6 +18,7 @@ package app
 
 import (
 	nodeselect "github.com/openebs/maya/pkg/algorithm/nodeselect/v1alpha2"
+	ndmapis "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	apisbd "github.com/openebs/maya/pkg/blockdevice/v1alpha2"
 	apiscsp "github.com/openebs/maya/pkg/cstor/poolinstance/v1alpha3"
@@ -248,6 +249,10 @@ func (pc *PoolConfig) ClaimBD(bdName string) error {
 		Get(bdName, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrapf(err, "could not get bd object %s", bdName)
+	}
+	// If blockdevice is already claimed no need of creating claim
+	if bdObj.Status.ClaimState == ndmapis.BlockDeviceClaimed {
+		return nil
 	}
 	err = pc.AlgorithmConfig.ClaimBD(bdObj)
 	if err != nil {

--- a/cmd/cstor-pool-mgmt/pool/v1alpha2/disk_operation.go
+++ b/cmd/cstor-pool-mgmt/pool/v1alpha2/disk_operation.go
@@ -163,6 +163,10 @@ func replacePoolVdev(cspi *apis.CStorPoolInstance, oldPaths, npath []string) (st
 		return usedPath, nil
 	}
 
+	if len(oldPaths) == 0 {
+		return "", nil
+	}
+
 	// Device path may got changed after imports. So let's get the path used by
 	// pool and trigger replace
 	if usedPath, isUsed = checkIfDeviceUsed(oldPaths, poolTopology); !isUsed {

--- a/cmd/cstor-pool-mgmt/pool/v1alpha2/disk_operation.go
+++ b/cmd/cstor-pool-mgmt/pool/v1alpha2/disk_operation.go
@@ -98,6 +98,14 @@ func addNewVdevFromCSP(csp *apis.CStorPoolInstance) error {
 			if er := addRaidGroup(csp, raidGroup); er != nil {
 				err = ErrorWrapf(err, "Failed to add raidGroup{%#v}.. %s", raidGroup, er.Error())
 			}
+		} else if len(devlist) != 0 && raidGroup.Type == string(apis.PoolStriped) {
+			if _, er := zfs.NewPoolExpansion().
+				WithDeviceType(getDeviceType(raidGroup)).
+				WithVdevList(devlist).
+				WithPool(PoolName(csp)).
+				Execute(); er != nil {
+				err = ErrorWrapf(err, "Failed to add devlist %v.. err {%s}", devlist, er.Error())
+			}
 		}
 	}
 	return err
@@ -135,7 +143,7 @@ func replacePoolVdev(cspi *apis.CStorPoolInstance, oldPaths, npath []string) (st
 	var usedPath string
 	var isUsed bool
 	if len(npath) == 0 {
-		return "", errors.Errorf("Empty path for bdev")
+		return "", errors.Errorf("Empty path for vdev")
 	}
 
 	// Wait! Device path may got changed due to import

--- a/cmd/cstor-pool-mgmt/pool/v1alpha2/disk_operation.go
+++ b/cmd/cstor-pool-mgmt/pool/v1alpha2/disk_operation.go
@@ -93,23 +93,13 @@ func addNewVdevFromCSP(csp *apis.CStorPoolInstance) error {
 				wholeGroup = false
 			}
 		}
+		/* Perform vertical Pool expansion only if entier raid group is added */
 		if wholeGroup {
 			if er := addRaidGroup(csp, raidGroup); er != nil {
 				err = ErrorWrapf(err, "Failed to add raidGroup{%#v}.. %s", raidGroup, er.Error())
 			}
 		}
-		/* Pool expansion adding in same raidGroup is invalid operation */
-		//else if len(devlist) != 0 {
-		//	if _, er := zfs.NewPoolExpansion().
-		//		WithDeviceType(getDeviceType(raidGroup)).
-		//		WithVdevList(devlist).
-		//		WithPool(PoolName(csp)).
-		//		Execute(); er != nil {
-		//		err = ErrorWrapf(err, "Failed to add devlist %v.. err {%s}", devlist, er.Error())
-		//	}
-		//}
 	}
-
 	return err
 }
 
@@ -180,15 +170,5 @@ func replacePoolVdev(cspi *apis.CStorPoolInstance, oldPaths, npath []string) (st
 		WithNewVdev(npath[0]).
 		WithPool(PoolName(cspi)).
 		Execute()
-		//if err == nil {
-		//	if _, err := zfs.NewPoolLabelClear().
-		//		WithForceFully(true).
-		//		WithVdev(bdev.DevLink).
-		//		Execute(); err != nil {
-		//		// Let's log the error
-		//		klog.Errorf("Failed to perform label clear for disk {%s}", bdev.DevLink)
-		//	}
-		//	return npath[0], nil
-		//}
 	return npath[0], err
 }

--- a/cmd/cstor-pool-mgmt/pool/v1alpha2/disk_operation.go
+++ b/cmd/cstor-pool-mgmt/pool/v1alpha2/disk_operation.go
@@ -97,15 +97,17 @@ func addNewVdevFromCSP(csp *apis.CStorPoolInstance) error {
 			if er := addRaidGroup(csp, raidGroup); er != nil {
 				err = ErrorWrapf(err, "Failed to add raidGroup{%#v}.. %s", raidGroup, er.Error())
 			}
-		} else if len(devlist) != 0 {
-			if _, er := zfs.NewPoolExpansion().
-				WithDeviceType(getDeviceType(raidGroup)).
-				WithVdevList(devlist).
-				WithPool(PoolName(csp)).
-				Execute(); er != nil {
-				err = ErrorWrapf(err, "Failed to add devlist %v.. err {%s}", devlist, er.Error())
-			}
 		}
+		/* Pool expansion adding in same raidGroup is invalid operation */
+		//else if len(devlist) != 0 {
+		//	if _, er := zfs.NewPoolExpansion().
+		//		WithDeviceType(getDeviceType(raidGroup)).
+		//		WithVdevList(devlist).
+		//		WithPool(PoolName(csp)).
+		//		Execute(); er != nil {
+		//		err = ErrorWrapf(err, "Failed to add devlist %v.. err {%s}", devlist, er.Error())
+		//	}
+		//}
 	}
 
 	return err
@@ -139,45 +141,50 @@ func removePoolVdev(csp *apis.CStorPoolInstance, bdev apis.CStorPoolClusterBlock
 // Note, if a new disk is already being used then we will
 // not perform disk replacement and function will return
 // the used disk path from given path(npath[])
-func replacePoolVdev(csp *apis.CStorPoolInstance, bdev apis.CStorPoolClusterBlockDevice, npath []string) (string, error) {
+func replacePoolVdev(cspi *apis.CStorPoolInstance, oldPaths, npath []string) (string, error) {
+	var usedPath string
+	var isUsed bool
 	if len(npath) == 0 {
 		return "", errors.Errorf("Empty path for bdev")
 	}
 
-	// Wait! Device patch may got changed due after import
+	// Wait! Device path may got changed due to import
 	// Let's check if a device, having path `npath`, is already present in pool
 	poolTopology, err := zfs.
 		NewPoolDump().
 		WithStripVdevPath().
-		WithPool(PoolName(csp)).
+		WithPool(PoolName(cspi)).
 		Execute()
 	if err != nil {
 		return "", errors.Errorf("Failed to fetch pool topology.. %s", err.Error())
 	}
 
-	if usedPath, isUsed := checkIfDeviceUsed(npath, poolTopology); isUsed {
+	if usedPath, isUsed = checkIfDeviceUsed(npath, poolTopology); isUsed {
 		return usedPath, nil
 	}
 
-	_ = bdev
+	// Device path may got changed after imports. So let's get the path used by
+	// pool and trigger replace
+	if usedPath, isUsed = checkIfDeviceUsed(oldPaths, poolTopology); !isUsed {
+		// Might be a case where paths in the old blockdevice are not up to date
+		return "", errors.Errorf("Old device links are not in use by pool")
+	}
+
 	// Replace the disk
-	/*
-		_, err = zfs.NewPoolDiskReplace().
-			WithOldVdev(bdev.DevLink).
-			WithNewVdev(npath[0]).
-			WithPool(PoolName(csp)).
-			WithForcefully(true).
-			Execute()
-				if err == nil {
-					if _, err := zfs.NewPoolLabelClear().
-						WithForceFully(true).
-						WithVdev(bdev.DevLink).
-						Execute(); err != nil {
-						// Let's log the error
-						klog.Errorf("Failed to perform label clear for disk {%s}", bdev.DevLink)
-					}
-					return npath[0], nil
-				}
-	*/
-	return "", err
+	_, err = zfs.NewPoolDiskReplace().
+		WithOldVdev(usedPath).
+		WithNewVdev(npath[0]).
+		WithPool(PoolName(cspi)).
+		Execute()
+		//if err == nil {
+		//	if _, err := zfs.NewPoolLabelClear().
+		//		WithForceFully(true).
+		//		WithVdev(bdev.DevLink).
+		//		Execute(); err != nil {
+		//		// Let's log the error
+		//		klog.Errorf("Failed to perform label clear for disk {%s}", bdev.DevLink)
+		//	}
+		//	return npath[0], nil
+		//}
+	return npath[0], err
 }

--- a/cmd/cstor-pool-mgmt/pool/v1alpha2/modify.go
+++ b/cmd/cstor-pool-mgmt/pool/v1alpha2/modify.go
@@ -77,7 +77,7 @@ func Update(cspi *apis.CStorPoolInstance) (*apis.CStorPoolInstance, error) {
 			// If current blockdevice is replaced blockdevice then get the
 			// predecesor from claim of current blockdevice and if current
 			// blockdevice is not replaced then predecesorBDName will be empty
-			predecesorBDName := bdClaim.GetAnnotations()[string(apis.ReplacementBlockDeviceCPK)]
+			predecesorBDName := bdClaim.GetAnnotations()[string(apis.PredecessorBlockDeviceCPK)]
 			oldPath := []string{}
 			if predecesorBDName != "" {
 				// Get device links from old block device

--- a/cmd/cstor-pool-mgmt/pool/v1alpha2/modify.go
+++ b/cmd/cstor-pool-mgmt/pool/v1alpha2/modify.go
@@ -112,9 +112,9 @@ func Update(cspi *apis.CStorPoolInstance) (*apis.CStorPoolInstance, error) {
 			//   2.2 Remove the annotation from blockdeviceclaim which is
 			//       inuse by cstor pool
 			if predecessorBDName != "" && !isResilveringInProgress(executeZpoolDump, cspi, diskPath) {
-				olbdClaim, _ := bdClaimList.GetBlockDeviceClaimFromBDName(
+				oldBDClaim, _ := bdClaimList.GetBlockDeviceClaimFromBDName(
 					predecessorBDName)
-				if er := cleanUpReplacementMarks(olbdClaim, bdClaim); er != nil {
+				if er := cleanUpReplacementMarks(oldBDClaim, bdClaim); er != nil {
 					err = ErrorWrapf(
 						err,
 						"Failed cleanup replacement marks of replaced blockdevice {%s}.. %s",

--- a/cmd/cstor-pool-mgmt/pool/v1alpha2/modify.go
+++ b/cmd/cstor-pool-mgmt/pool/v1alpha2/modify.go
@@ -18,13 +18,20 @@ package v1alpha2
 
 import (
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	"k8s.io/klog"
 )
 
 // Update will update the deployed pool according to given cspi object
 func Update(cspi *apis.CStorPoolInstance) (*apis.CStorPoolInstance, error) {
-	var err error
-	var isObjChanged bool
-	var isRaidGroupChanged bool
+	var isObjChanged, isRaidGroupChanged bool
+
+	bdClaimList, err := getBlockDeviceClaimList(
+		string(apis.CStorPoolClusterCPK),
+		cspi.GetLabels()[string(apis.CStorPoolClusterCPK)])
+	if err != nil {
+		// safe to return nil
+		return nil, err
+	}
 
 	// first we will check if there any bdev is replaced or removed
 	for raidIndex := 0; raidIndex < len(cspi.Spec.RaidGroups); raidIndex++ {
@@ -55,20 +62,69 @@ func Update(cspi *apis.CStorPoolInstance) (*apis.CStorPoolInstance, error) {
 						continue
 					}
 			*/
+			bdClaim, er := bdClaimList.GetBlockDeviceClaimFromBDName(
+				bdev.BlockDeviceName)
+			if er != nil {
+				// This case is not possible
+				err = ErrorWrapf(er,
+					"Failed to get claim of blockdevice {%s}.. %s",
+					bdev.BlockDeviceName,
+					er.Error())
+				// If claim doesn't exist for current blockdevice continue with
+				// other blockdevices in cspi
+				continue
+			}
+			// If current blockdevice is replaced blockdevice then get the
+			// predecesor from claim of current blockdevice and if current
+			// blockdevice is not replaced then predecesorBDName will be empty
+			predecesorBDName := bdClaim.GetAnnotations()[string(apis.ReplacementBlockDeviceCPK)]
+			oldPath := []string{}
+			if predecesorBDName != "" {
+				// Get device links from old block device
+				oldPath, er = getPathForBDev(predecesorBDName)
+				if er != nil {
+					err = ErrorWrapf(err, "Failed to check bdev change {%s}.. %s", bdev.BlockDeviceName, er.Error())
+					continue
+				}
+			}
 
+			diskPath := ""
 			// Let's check if any replacement is needed for this BDev
 			newpath, er := getPathForBDev(bdev.BlockDeviceName)
 			if er != nil {
 				err = ErrorWrapf(err, "Failed to check bdev change {%s}.. %s", bdev.BlockDeviceName, er.Error())
 			} else {
-				if diskPath, er := replacePoolVdev(cspi, bdev, newpath); er != nil {
+				if diskPath, er = replacePoolVdev(cspi, oldPath, newpath); er != nil {
 					err = ErrorWrapf(err, "Failed to replace bdev for {%s}.. %s", bdev.BlockDeviceName, er.Error())
+					continue
 				} else {
 					if !IsEmpty(diskPath) && diskPath != bdev.DevLink {
 						// Let's update devLink with new path for this bdev
 						raidGroup.BlockDevices[bdevIndex].DevLink = diskPath
 						isRaidGroupChanged = true
 					}
+				}
+			}
+			// If disk got replaced check resilvering status.
+			// 1. If resilvering is in progress don't do any thing.
+			// 2. If resilvering is completed then perform cleanup process
+			//   2.1 Unclaim the old blockdevice which was used by pool
+			//   2.2 Remove the annotation from blockdeviceclaim which is
+			//       inuse by cstor pool
+			if predecesorBDName != "" && !isResilveringInProgress(executeZpoolDump, cspi, diskPath) {
+				olbdClaim, _ := bdClaimList.GetBlockDeviceClaimFromBDName(
+					predecesorBDName)
+				if er := cleanUpReplacementMarks(olbdClaim, bdClaim); er != nil {
+					err = ErrorWrapf(
+						err,
+						"Failed cleanup replacement marks of replaced blockdevice {%s}.. %s",
+						bdev.BlockDeviceName,
+						er.Error(),
+					)
+				} else {
+					klog.Infof("Successfully completed the resilvering on blockdevice {%s}",
+						bdev.BlockDeviceName,
+					)
 				}
 			}
 		}

--- a/cmd/cstor-pool-mgmt/pool/v1alpha2/modify.go
+++ b/cmd/cstor-pool-mgmt/pool/v1alpha2/modify.go
@@ -76,12 +76,12 @@ func Update(cspi *apis.CStorPoolInstance) (*apis.CStorPoolInstance, error) {
 			}
 			// If current blockdevice is replaced blockdevice then get the
 			// predecessor from claim of current blockdevice and if current
-			// blockdevice is not replaced then predecesorBDName will be empty
-			predecesorBDName := bdClaim.GetAnnotations()[string(apis.PredecessorBlockDeviceCPK)]
+			// blockdevice is not replaced then predecessorBDName will be empty
+			predecessorBDName := bdClaim.GetAnnotations()[string(apis.PredecessorBlockDeviceCPK)]
 			oldPath := []string{}
-			if predecesorBDName != "" {
+			if predecessorBDName != "" {
 				// Get device links from old block device
-				oldPath, er = getPathForBDev(predecesorBDName)
+				oldPath, er = getPathForBDev(predecessorBDName)
 				if er != nil {
 					err = ErrorWrapf(err, "Failed to check bdev change {%s}.. %s", bdev.BlockDeviceName, er.Error())
 					continue
@@ -111,9 +111,9 @@ func Update(cspi *apis.CStorPoolInstance) (*apis.CStorPoolInstance, error) {
 			//   2.1 Unclaim the old blockdevice which was used by pool
 			//   2.2 Remove the annotation from blockdeviceclaim which is
 			//       inuse by cstor pool
-			if predecesorBDName != "" && !isResilveringInProgress(executeZpoolDump, cspi, diskPath) {
+			if predecessorBDName != "" && !isResilveringInProgress(executeZpoolDump, cspi, diskPath) {
 				olbdClaim, _ := bdClaimList.GetBlockDeviceClaimFromBDName(
-					predecesorBDName)
+					predecessorBDName)
 				if er := cleanUpReplacementMarks(olbdClaim, bdClaim); er != nil {
 					err = ErrorWrapf(
 						err,

--- a/cmd/cstor-pool-mgmt/pool/v1alpha2/modify.go
+++ b/cmd/cstor-pool-mgmt/pool/v1alpha2/modify.go
@@ -75,7 +75,7 @@ func Update(cspi *apis.CStorPoolInstance) (*apis.CStorPoolInstance, error) {
 				continue
 			}
 			// If current blockdevice is replaced blockdevice then get the
-			// predecesor from claim of current blockdevice and if current
+			// predecessor from claim of current blockdevice and if current
 			// blockdevice is not replaced then predecesorBDName will be empty
 			predecesorBDName := bdClaim.GetAnnotations()[string(apis.PredecessorBlockDeviceCPK)]
 			oldPath := []string{}

--- a/cmd/cstor-pool-mgmt/pool/v1alpha2/pool_utils.go
+++ b/cmd/cstor-pool-mgmt/pool/v1alpha2/pool_utils.go
@@ -280,6 +280,12 @@ func cleanUpReplacementMarks(oldBDClaimAPI, currentBDClaimAPI *ndmapis.BlockDevi
 	if oldBDClaimAPI != nil {
 		oldBDClaimAPI, err = blockdeviceclaim.
 			BuilderForAPIObject(oldBDClaimAPI).BDC.RemoveFinalizer(apiscspc.CSPCFinalizer)
+		if err != nil {
+			return errors.Wrapf(err,
+				"failed to remove finalizer on blockdeviceclaim {%s}",
+				oldBDClaimAPI.Name,
+			)
+		}
 		err = bdcClient.Delete(oldBDClaimAPI.Name, &metav1.DeleteOptions{})
 		if err != nil {
 			return errors.Wrapf(
@@ -290,14 +296,14 @@ func cleanUpReplacementMarks(oldBDClaimAPI, currentBDClaimAPI *ndmapis.BlockDevi
 		}
 	}
 	bdAnnotations := currentBDClaimAPI.GetAnnotations()
-	delete(bdAnnotations, string(apis.ReplacementBlockDeviceCPK))
+	delete(bdAnnotations, string(apis.PredecessorBlockDeviceCPK))
 	currentBDClaimAPI.SetAnnotations(bdAnnotations)
 	_, err = bdcClient.Update(currentBDClaimAPI)
 	if err != nil {
 		return errors.Wrapf(
 			err,
 			"Failed to remove annotation {%s} from blockdeviceclaim {%s}",
-			string(apis.ReplacementBlockDeviceCPK),
+			string(apis.PredecessorBlockDeviceCPK),
 			currentBDClaimAPI.Name,
 		)
 	}

--- a/cmd/cstor-pool-mgmt/pool/v1alpha2/pool_utils.go
+++ b/cmd/cstor-pool-mgmt/pool/v1alpha2/pool_utils.go
@@ -274,37 +274,37 @@ func getVdevFromPath(path string, topology zpool.Topology) (zpool.Vdev, bool) {
 // 1. RemoveFinalizer on old block device claim exists and delete the old block
 //   device claim.
 // 2. Remove link of old block device in new block device claim
-func cleanUpReplacementMarks(oldBDClaimAPIObj, currentBDClaimAPIObj *ndmapis.BlockDeviceClaim) error {
+func cleanUpReplacementMarks(oldBDClaimObj, currentBDClaimObj *ndmapis.BlockDeviceClaim) error {
 	var err error
-	bdcClient := blockdeviceclaim.NewKubeClient().WithNamespace(currentBDClaimAPIObj.Namespace)
-	if oldBDClaimAPIObj != nil {
-		oldBDClaimAPIObj, err = blockdeviceclaim.
-			BuilderForAPIObject(oldBDClaimAPIObj).BDC.RemoveFinalizer(apiscspc.CSPCFinalizer)
+	bdcClient := blockdeviceclaim.NewKubeClient().WithNamespace(currentBDClaimObj.Namespace)
+	if oldBDClaimObj != nil {
+		oldBDClaimObj, err = blockdeviceclaim.
+			BuilderForAPIObject(oldBDClaimObj).BDC.RemoveFinalizer(apiscspc.CSPCFinalizer)
 		if err != nil {
 			return errors.Wrapf(err,
 				"failed to remove finalizer on blockdeviceclaim {%s}",
-				oldBDClaimAPIObj.Name,
+				oldBDClaimObj.Name,
 			)
 		}
-		err = bdcClient.Delete(oldBDClaimAPIObj.Name, &metav1.DeleteOptions{})
+		err = bdcClient.Delete(oldBDClaimObj.Name, &metav1.DeleteOptions{})
 		if err != nil {
 			return errors.Wrapf(
 				err,
 				"Failed to unclaim old blockdevice {%s}",
-				oldBDClaimAPIObj.Spec.BlockDeviceName,
+				oldBDClaimObj.Spec.BlockDeviceName,
 			)
 		}
 	}
-	bdAnnotations := currentBDClaimAPIObj.GetAnnotations()
+	bdAnnotations := currentBDClaimObj.GetAnnotations()
 	delete(bdAnnotations, string(apis.PredecessorBlockDeviceCPK))
-	currentBDClaimAPIObj.SetAnnotations(bdAnnotations)
-	_, err = bdcClient.Update(currentBDClaimAPIObj)
+	currentBDClaimObj.SetAnnotations(bdAnnotations)
+	_, err = bdcClient.Update(currentBDClaimObj)
 	if err != nil {
 		return errors.Wrapf(
 			err,
 			"Failed to remove annotation {%s} from blockdeviceclaim {%s}",
 			string(apis.PredecessorBlockDeviceCPK),
-			currentBDClaimAPIObj.Name,
+			currentBDClaimObj.Name,
 		)
 	}
 	return nil

--- a/cmd/cstor-pool-mgmt/pool/v1alpha2/pool_utils_test.go
+++ b/cmd/cstor-pool-mgmt/pool/v1alpha2/pool_utils_test.go
@@ -55,13 +55,13 @@ func TestGetPathForBDevFromBlockDevice(t *testing.T) {
 			bd: &ndmapis.BlockDevice{
 				Spec: ndmapis.DeviceSpec{
 					DevLinks: []ndmapis.DeviceDevLink{
-						ndmapis.DeviceDevLink{"one",
-							[]string{
+						ndmapis.DeviceDevLink{Kind: "one",
+							Links: []string{
 								"/dev/by-uid/path1",
 								"/dev/by-uid/path2",
 							},
 						},
-						ndmapis.DeviceDevLink{"two", []string{"/dev/by-uid/path1"}},
+						ndmapis.DeviceDevLink{Kind: "two", Links: []string{"/dev/by-uid/path1"}},
 					},
 					Path: "/dev/sda",
 				},

--- a/cmd/cstor-pool-mgmt/pool/v1alpha2/pool_utils_test.go
+++ b/cmd/cstor-pool-mgmt/pool/v1alpha2/pool_utils_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2019 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	ndmapis "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	zpool "github.com/openebs/maya/pkg/apis/openebs.io/zpool/v1alpha1"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	testKey = "testJSON"
+)
+
+func testExecuteDumpCommand(cspi *apis.CStorPoolInstance) (zpool.Topology, error) {
+	valuesFromEnv := strings.TrimSpace(os.Getenv(testKey))
+	if valuesFromEnv == "" {
+		return zpool.Topology{}, errors.Errorf("failed to read the testJSON")
+	}
+	topology := zpool.Topology{}
+	err := json.Unmarshal([]byte(valuesFromEnv), &topology)
+	if err != nil {
+		return zpool.Topology{}, errors.Errorf("failed to unmarshal json output error: %v", err)
+	}
+	return topology, nil
+}
+
+func TestGetPathForBDevFromBlockDevice(t *testing.T) {
+	testBDPaths := map[string]struct {
+		bd         *ndmapis.BlockDevice
+		linksCount int
+	}{
+		"Blockdevice with only dev links": {
+			bd: &ndmapis.BlockDevice{
+				Spec: ndmapis.DeviceSpec{
+					DevLinks: []ndmapis.DeviceDevLink{
+						ndmapis.DeviceDevLink{"one",
+							[]string{
+								"/dev/by-uid/path1",
+								"/dev/by-uid/path2",
+							},
+						},
+						ndmapis.DeviceDevLink{"two", []string{"/dev/by-uid/path1"}},
+					},
+					Path: "/dev/sda",
+				},
+			},
+			linksCount: 4,
+		},
+		"Blockdevice with only path links": {
+			bd: &ndmapis.BlockDevice{
+				Spec: ndmapis.DeviceSpec{
+					Path: "/dev/sda",
+				},
+			},
+			linksCount: 1,
+		},
+	}
+	for name, test := range testBDPaths {
+		// pin it
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			paths := getPathForBDevFromBlockDevice(test.bd)
+			if len(paths) != test.linksCount {
+				t.Errorf("test: %s failed expected device links %d but got %d",
+					name,
+					test.linksCount,
+					len(paths),
+				)
+			}
+		})
+	}
+}
+
+func TestIsResilveringInProgress(t *testing.T) {
+	tests := map[string]struct {
+		jsonValues          string
+		cspi                *apis.CStorPoolInstance
+		path                string
+		expectedResilvering bool
+		executeFunc         func(cspi *apis.CStorPoolInstance) (zpool.Topology, error)
+	}{
+		"Resilvering In progress": {
+			//In jsonValues persistentDisk_sai-disk1 is replaced with
+			//persistentDisk_sai-disk3
+			jsonValues: `{"name":"cstor-e2a5f5ff-10d8-11ea-bf3b-42010a8001ff","state":0,"pool_guid":5658042564790239978,"vdev_children":1,"vdev_tree":{"type":"root","id":0,"guid":5658042564790239978,"vdev_stats":[1394692727542,7,0,4287558656,10670309376,10670309376,0,0,0,99018,1522020,0,0,0,0,796413952,21988136448,0,0,0,0,0,0,0,0,0,0],"scan_stats":[2,1,1574834545,0,4266596352,723547136,0,723547136,0,723547136,1574834545,0,0],"children":[{"type":"replacing","id":0,"guid":8250149513645842791,"whole_disk":0,"vdev_stats":[302482414371,7,0,0,0,0,10722213888,0,0,67394,841082,0,0,0,0,668213248,11584425984,0,0,0,0,0,0,0,0,128688640,0],"scan_stats":[2,1,1574834545,0,4266596352,723547136,0,723547136,0,723547136,1574834545,0,0],"children":[{"type":"disk","id":0,"guid":12875869339379092712,"path":"/dev/disk/by-id/scsi-0Google_PersistentDisk_sai-disk1","devid":"scsi-0Google_PersistentDisk_sai-disk1","phys_path":"pci-0000:00:03.0-scsi-0:0:2:0","whole_disk":1,"vdev_stats":[1394692769652,7,0,0,0,0,10726932480,0,0,67387,688754,0,0,0,0,667729920,10403712512,0,0,0,0,0,0,0,0,0,0],"scan_stats":[2,1,1574834545,0,4266596352,723547136,0,723547136,0,723547136,1574834545,0,0]},{"type":"disk","id":1,"guid":12895321627809657814,"path":"/dev/disk/by-id/scsi-0Google_PersistentDisk_sai-disk3","devid":"scsi-0Google_PersistentDisk_sai-disk3","phys_path":"pci-0000:00:03.0-scsi-0:0:4:0","whole_disk":1,"DTL":236,"create_txg":4,"com.delphix:vdev_zap_leaf":235,"vdev_stats":[302656212847,7,0,0,0,0,10726932480,0,0,7,152328,0,0,0,0,483328,1180713472,0,0,0,0,0,0,0,0,723547136,0],"scan_stats":[2,1,1574834545,0,4266596352,723547136,0,723547136,0,723547136,1574834545,0,0],"resilver_txg":243}]},{"type":"disk","id":1,"guid":10525056882961272669,"path":"/dev/disk/by-id/scsi-0Google_PersistentDisk_sai-disk4","devid":"scsi-0Google_PersistentDisk_sai-disk4","phys_path":"pci-0000:00:03.0-scsi-0:0:5:0","whole_disk":1,"vdev_stats":[1394692809521,7,0,0,0,0,10726932480,0,0,31624,680938,0,0,0,0,128200704,10403710464,0,0,0,0,0,0,0,0,0,0],"scan_stats":[2,1,1574834545,0,4266596352,723547136,0,723547136,0,723547136,1574834545,0,0]}]}}`,
+			cspi: &apis.CStorPoolInstance{
+				ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
+			},
+			expectedResilvering: true,
+			executeFunc:         testExecuteDumpCommand,
+			path:                "/dev/disk/by-id/scsi-0Google_PersistentDisk_sai-disk3",
+		},
+		"Without any stats": {
+			jsonValues: ``,
+			cspi: &apis.CStorPoolInstance{
+				ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
+			},
+			expectedResilvering: true,
+			executeFunc:         testExecuteDumpCommand,
+			path:                "path1",
+		},
+		"Invalid json": {
+			jsonValues: `{"name": "pool1","pool_guid":123,"vdev_stats":{]}`,
+			cspi: &apis.CStorPoolInstance{
+				ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
+			},
+			expectedResilvering: true,
+			executeFunc:         testExecuteDumpCommand,
+			path:                "path1",
+		},
+		"Without Scan Stats": {
+			jsonValues: `{"vdev_children":1,"vdev_tree":{"type":"root","vdev_stats":[1394692727542,7,0,4287558656,10670309376,10670309376,0,0,0,99018,1522020,0,0,0,0,796413952,21988136448,0,0,0,0,0,0,0,0,0,0],"children":[{"type":"disk","path":"/dev/disk/by-id/scsi-0Google_PersistentDisk_sai-disk4","whole_disk":1,"vdev_stats":[1394692809521,7,0,0,0,0,10726932480,0,0,31624,680938,0,0,0,0,128200704,10403710464,0,0,0,0,0,0,0,0,0,0]}]}}`,
+			cspi: &apis.CStorPoolInstance{
+				ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
+			},
+			expectedResilvering: false,
+			executeFunc:         testExecuteDumpCommand,
+			path:                "/dev/disk/by-id/scsi-0Google_PersistentDisk_sai-disk4",
+		},
+		"Resilvering success": {
+			jsonValues: `{"vdev_children":1,"vdev_tree":{"type":"root","vdev_stats":[1394692727542,7,0,4287558656,10670309376,10670309376,0,0,0,99018,1522020,0,0,0,0,796413952,21988136448,0,0,0,0,0,0,0,0,0,0],"scan_stats":[2,1,1574834545,0,4266596352,723547136,0,723547136,0,723547136,1574834545,0,0],"children":[{"type":"disk","path":"/dev/disk/by-id/scsi-0Google_PersistentDisk_sai-disk4","whole_disk":1,"vdev_stats":[302656212847,7,0,0,0,0,10726932480,0,0,7,152328,0,0,0,0,483328,1180713472,0,0,0,0,0,0,0,0,723547136,0],"scan_stats":[2,2,1574834545,0,4266596352,723547136,0,723547136,0,723547136,1574834545,0,0]}]}}`,
+			cspi: &apis.CStorPoolInstance{
+				ObjectMeta: metav1.ObjectMeta{Name: "pool1"},
+			},
+			expectedResilvering: false,
+			executeFunc:         testExecuteDumpCommand,
+			path:                "/dev/disk/by-id/scsi-0Google_PersistentDisk_sai-disk4",
+		},
+	}
+	// Don't change test to run in parallel
+	for name, test := range tests {
+		// pin it
+		name, test := name, test
+		os.Setenv(testKey, test.jsonValues)
+		isResilvering := isResilveringInProgress(test.executeFunc, test.cspi, test.path)
+		if test.expectedResilvering != isResilvering {
+			t.Errorf("test %s failed expected resilvering process: %t but got %t",
+				name,
+				test.expectedResilvering,
+				isResilvering,
+			)
+		}
+		os.Unsetenv(testKey)
+	}
+}

--- a/cmd/maya-apiserver/cstor-operator/spc/handler.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/handler.go
@@ -281,7 +281,7 @@ func removeSPCFinalizerOnAssociatedBDC(spc *apis.StoragePoolClaim) error {
 
 	for _, bdcObj := range bdcList.Items {
 		bdcObj := bdcObj
-		err := bdc.BuilderForAPIObject(&bdcObj).BDC.RemoveFinalizer(spcv1alpha1.SPCFinalizer)
+		_, err := bdc.BuilderForAPIObject(&bdcObj).BDC.RemoveFinalizer(spcv1alpha1.SPCFinalizer)
 		if err != nil {
 			return errors.Wrapf(err, "failed to remove SPC finalizer on BDC %s", bdcObj.Name)
 		}

--- a/pkg/apis/openebs.io/v1alpha1/cas_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_pool.go
@@ -37,6 +37,8 @@ const (
 	StoragePoolClaimCPK CasPoolKey = "openebs.io/storage-pool-claim"
 	// CStorPoolClusterCPK is the CStorPoolcluster label
 	CStorPoolClusterCPK CasPoolKey = "openebs.io/cstor-pool-cluster"
+	// ReplacementBlockDeviceCPK is the annotation on the block device claim
+	ReplacementBlockDeviceCPK CasPoolKey = "openebs.io/replacement-blockdevice"
 	// NdmDiskTypeCPK is the node-disk-manager disk type e.g. 'sparse' or 'disk'
 	NdmDiskTypeCPK CasPoolKey = "ndm.io/disk-type"
 	// NdmBlockDeviceTypeCPK is the node-disk-manager blockdevice type e.g. // 'blockdevice'

--- a/pkg/apis/openebs.io/v1alpha1/cas_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_pool.go
@@ -37,7 +37,7 @@ const (
 	StoragePoolClaimCPK CasPoolKey = "openebs.io/storage-pool-claim"
 	// CStorPoolClusterCPK is the CStorPoolcluster label
 	CStorPoolClusterCPK CasPoolKey = "openebs.io/cstor-pool-cluster"
-	// predecessorBlockDeviceCPK is the annotation on the block device claim
+	// PredecessorBlockDeviceCPK is the annotation on the block device claim
 	// holding previous block device name
 	PredecessorBlockDeviceCPK CasPoolKey = "openebs.io/bd-predecessor"
 	// NdmDiskTypeCPK is the node-disk-manager disk type e.g. 'sparse' or 'disk'

--- a/pkg/apis/openebs.io/v1alpha1/cas_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_pool.go
@@ -37,8 +37,9 @@ const (
 	StoragePoolClaimCPK CasPoolKey = "openebs.io/storage-pool-claim"
 	// CStorPoolClusterCPK is the CStorPoolcluster label
 	CStorPoolClusterCPK CasPoolKey = "openebs.io/cstor-pool-cluster"
-	// ReplacementBlockDeviceCPK is the annotation on the block device claim
-	ReplacementBlockDeviceCPK CasPoolKey = "openebs.io/replacement-blockdevice"
+	// predecessorBlockDeviceCPK is the annotation on the block device claim
+	// holding previous block device name
+	PredecessorBlockDeviceCPK CasPoolKey = "openebs.io/bd-predecessor"
 	// NdmDiskTypeCPK is the node-disk-manager disk type e.g. 'sparse' or 'disk'
 	NdmDiskTypeCPK CasPoolKey = "ndm.io/disk-type"
 	// NdmBlockDeviceTypeCPK is the node-disk-manager blockdevice type e.g. // 'blockdevice'

--- a/pkg/apis/openebs.io/zpool/v1alpha1/pool_topology.go
+++ b/pkg/apis/openebs.io/zpool/v1alpha1/pool_topology.go
@@ -34,31 +34,44 @@ import (
 *} dsl_scan_state_t;
  */
 
+//TODO: Improve comments during review process
+
 //PoolScanState states various pool scan states
 type PoolScanState uint64
 
 const (
+	// PoolScanNone represents pool scanning is not yet started
 	PoolScanNone PoolScanState = iota
+	// PoolScanScanning represents pool is undergoing scanning
 	PoolScanScanning
+	// PoolScanFinished represents pool scanning is finished
 	PoolScanFinished
+	// PoolScanCanceled represents pool scan is aborted
 	PoolScanCanceled
+	// PoolScanNumOfStates holds value 4
 	PoolScanNumOfStates
 )
 
+// PoolScanFunc holds various scanning functions
 type PoolScanFunc uint64
 
 const (
+	// PoolScanFuncNone holds value 0
 	PoolScanFuncNone PoolScanFunc = iota
+	// PoolScanFuncScrub holds value 1
 	PoolScanFuncScrub
+	// PoolScanFuncResilver holds value 2 which states device under went resilvering
 	PoolScanFuncResilver
+	// PoolScanFuncStates holds value 3
 	PoolScanFuncStates
 )
 
 const (
 	// PoolOperator is the name of the tool that makes pool-related operations.
 	PoolOperator = "zpool"
-	// VdevScanProcessedIndex is the index of scan processed bytes on disk
-	VdevScanProcessedIndex  = 25
+	// VdevScanProcessedIndex is index of scaned bytes on disk
+	VdevScanProcessedIndex = 25
+	// VdevScanStatsStateIndex represents the index of dataset scan state
 	VdevScanStatsStateIndex = 1
 	// VdevScanStatsScanFuncIndex point to index which inform whether device
 	// under went resilvering or not

--- a/pkg/apis/openebs.io/zpool/v1alpha1/pool_topology.go
+++ b/pkg/apis/openebs.io/zpool/v1alpha1/pool_topology.go
@@ -18,13 +18,51 @@ package zpool
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/openebs/maya/pkg/util"
 )
 
-// PoolOperator is the name of the tool that makes pool-related operations.
+/*
+* enum maintaing in cstor data plane side
+* typedef enum dsl_scan_state {
+*        DSS_NONE,
+*        DSS_SCANNING,
+*        DSS_FINISHED,
+*        DSS_CANCELED,
+*        DSS_NUM_STATES
+*} dsl_scan_state_t;
+ */
+
+//PoolScanState states various pool scan states
+type PoolScanState uint64
+
 const (
+	PoolScanNone PoolScanState = iota
+	PoolScanScanning
+	PoolScanFinished
+	PoolScanCanceled
+	PoolScanNumOfStates
+)
+
+type PoolScanFunc uint64
+
+const (
+	PoolScanFuncNone PoolScanFunc = iota
+	PoolScanFuncScrub
+	PoolScanFuncResilver
+	PoolScanFuncStates
+)
+
+const (
+	// PoolOperator is the name of the tool that makes pool-related operations.
 	PoolOperator = "zpool"
+	// VdevScanProcessedIndex is the index of scan processed bytes on disk
+	VdevScanProcessedIndex  = 25
+	VdevScanStatsStateIndex = 1
+	// VdevScanStatsScanFuncIndex point to index which inform whether device
+	// under went resilvering or not
+	VdevScanStatsScanFuncIndex = 0
 )
 
 // Topology contains the topology strucure of disks used in backend
@@ -50,6 +88,12 @@ type VdevTree struct {
 
 	// list of spare devices
 	Spares []Vdev `json:"spares,omitempty"`
+
+	// vdev indetailed statistics
+	VdevStats []uint64 `json:"vdev_stats,omitempty"`
+
+	// ScanStats states replaced device scan state
+	ScanStats []uint64 `json:"scan_stats,omitempty"`
 }
 
 // Vdev relates to a logical or physical disk in backend
@@ -70,9 +114,17 @@ type Vdev struct {
 	// 0 means partitioned disk, 1 means whole disk
 	IsWholeDisk int `json:"whole_disk,omitempty"`
 
+	// vdev indetailed statistics
+	VdevStats []uint64 `json:"vdev_stats,omitempty"`
+
+	ScanStats []uint64 `json:"scan_stats,omitempty"`
+
 	// child vdevs of the logical disk or null for physical disk/sparse
 	Children []Vdev `json:"children,omitempty"`
 }
+
+// VdevList is alias of list of Vdevs
+type VdevList []Vdev
 
 // Dump runs 'zpool dump' command and unmarshal the output in above schema
 func Dump() (Topology, error) {
@@ -84,4 +136,22 @@ func Dump() (Topology, error) {
 	}
 	err = json.Unmarshal(out, &t)
 	return t, err
+}
+
+// GetVdevFromPath returns vdev if provided path exists in vdev topology
+func (l VdevList) GetVdevFromPath(path string) (Vdev, bool) {
+	for _, v := range l {
+		if strings.EqualFold(path, v.Path) {
+			return v, true
+		}
+		for _, p := range v.Children {
+			if strings.EqualFold(path, p.Path) {
+				return p, true
+			}
+			if vdev, r := VdevList(p.Children).GetVdevFromPath(path); r {
+				return vdev, true
+			}
+		}
+	}
+	return Vdev{}, false
 }

--- a/pkg/apis/openebs.io/zpool/v1alpha1/pool_topology_test.go
+++ b/pkg/apis/openebs.io/zpool/v1alpha1/pool_topology_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2019 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package zpool
+
+import (
+	"testing"
+)
+
+func TestGetVdevFromPath(t *testing.T) {
+	tests := map[string]struct {
+		devList            VdevList
+		path               string
+		expectedVdevExists bool
+	}{
+		"vdev exists in the list": {
+			devList: VdevList([]Vdev{
+				{
+					VdevType: "root",
+					Children: []Vdev{
+						{
+							VdevType: "replacing",
+							Children: []Vdev{
+								{
+									VdevType: "disk",
+									Path:     "/dev/by-id/path1",
+								},
+							},
+						},
+					},
+				},
+			},
+			),
+			path:               "/dev/by-id/path1",
+			expectedVdevExists: true,
+		},
+		"vdev doesn't exist in the list": {
+			devList: VdevList([]Vdev{
+				{
+					VdevType: "root",
+					Children: []Vdev{
+						{
+							VdevType: "replacing",
+							Children: []Vdev{
+								{
+									VdevType: "disk",
+									Path:     "/dev/by-id/path2",
+								},
+								{
+									VdevType: "disk",
+									Path:     "/dev/by-id/path3",
+								},
+							},
+						},
+						{
+							VdevType: "disk",
+							Path:     "/dev/by-id/path4",
+						},
+					},
+				},
+			},
+			),
+			path:               "/dev/path1",
+			expectedVdevExists: false,
+		},
+		"Without any Vdev list": {
+			devList:            VdevList([]Vdev{}),
+			path:               "/dev/path1",
+			expectedVdevExists: false,
+		},
+	}
+	for name, test := range tests {
+		// pin it
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			_, isVdevExists := test.devList.GetVdevFromPath(test.path)
+			if isVdevExists != test.expectedVdevExists {
+				t.Errorf("test %s failed expected isVdev exists %t but got %t",
+					name,
+					test.expectedVdevExists,
+					isVdevExists,
+				)
+			}
+		})
+	}
+
+}

--- a/pkg/blockdeviceclaim/v1alpha1/kubernetes.go
+++ b/pkg/blockdeviceclaim/v1alpha1/kubernetes.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
 	"sync"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	errors "github.com/openebs/maya/pkg/errors/v1alpha1"
 	kclient "github.com/openebs/maya/pkg/kubernetes/client/v1alpha1"

--- a/pkg/env/v1alpha1/env.go
+++ b/pkg/env/v1alpha1/env.go
@@ -45,6 +45,11 @@ const (
 	// This environment variable is set via kubernetes downward API
 	OpenEBSNamespace ENVKey = "OPENEBS_NAMESPACE"
 
+	// Namespace is the environment variable to get resource namespace
+	//
+	// This environment variable is set via kubernetes downward API
+	Namespace ENVKey = "NAMESPACE"
+
 	// OpenEBSMayaPodName is the environment variable to get maya-apiserver pod
 	// name
 	//

--- a/tests/localpv/hostdevice_test.go
+++ b/tests/localpv/hostdevice_test.go
@@ -145,7 +145,7 @@ var _ = Describe("TEST HOSTDEVICE LOCAL PV", func() {
 				metav1.GetOptions{})
 			Expect(err).To(BeNil())
 
-			err = blockdeviceclaim.BuilderForAPIObject(bdcObj).WithConfigPath(ops.KubeConfigPath).
+			_, err = blockdeviceclaim.BuilderForAPIObject(bdcObj).WithConfigPath(ops.KubeConfigPath).
 				BDC.RemoveFinalizer(localpv_app.LocalPVFinalizer)
 			Expect(err).To(BeNil())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds a feature to support disk replacement in CSPI-Mgmt. CSPI-Mgmt
    does in the following way
    1. Verifies whether the modified device is already in use by the pool. If yes mgmt
       will return without triggering any zpool commands. If not in use by pool
       then mgmt will trigger `zpool <replace pool_name> <old_path> <new_path>`
    2. After initiating the replacement process CSPI-Mgmt will look for resilvering
       process. On successful completion of resilvering cspi-mgmt will unclaim
       old block device and remove the `openebs.io/bd-predecessor` annotation from the new block device claim.

**Design PR for disk replacement**
In openebs: https://github.com/openebs/openebs/pull/2846

**This PR touches below production code:**
1. While getting the zpool dump output added a few more stats related to replacement work but existing CSP is also using `zpool dump` but it will not have any problem.
2. `RemoveFinalizer` returns an error but now function signature is updated to return blockdeviceclaim object and error(Safely handled in all caller code).
Files changes:
1. github.com/openebs/maya/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim.go
2. github.com/openebs/maya/pkg/apis/openebs.io/zpool/v1alpha1/pool_topology.go



**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
**TODO**
1. Improve comments in detailed about complex operations.

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests