### PR TITLE
fix(provisioner, localpv): add service account to helper pods

### DIFF
--- a/cmd/provisioner-localpv/app/env.go
+++ b/cmd/provisioner-localpv/app/env.go
@@ -25,6 +25,7 @@ import (
 // provisioner also uses the following:
 //   OPENEBS_NAMESPACE
 //   NODE_NAME
+//   OPENEBS_SERVICE_ACCOUNT
 //   OPENEBS_IO_K8S_MASTER
 //   OPENEBS_IO_KUBE_CONFIG
 
@@ -53,4 +54,8 @@ func getDefaultHelperImage() string {
 
 func getDefaultBasePath() string {
 	return menv.GetOrDefault(ProvisionerBasePath, string(defaultBasePath))
+}
+
+func getOpenEBSServiceAccountName() string {
+	return menv.Get(menv.OpenEBSServiceAccount)
 }

--- a/cmd/provisioner-localpv/app/env_test.go
+++ b/cmd/provisioner-localpv/app/env_test.go
@@ -124,3 +124,36 @@ func TestGetDefaultBasePath(t *testing.T) {
 		})
 	}
 }
+
+func TestGetOpenEBSServiceAccountName(t *testing.T) {
+	testCases := map[string]struct {
+		value         string
+		expectedValue string
+	}{
+		"Missing env variable": {
+			value:         "",
+			expectedValue: "",
+		},
+		"Present env variable with value": {
+			value:         "value1",
+			expectedValue: "value1",
+		},
+		"Present env variable with whitespaces": {
+			value:         " ",
+			expectedValue: "",
+		},
+	}
+	for k, v := range testCases {
+		v := v
+		t.Run(k, func(t *testing.T) {
+			if len(v.value) != 0 {
+				os.Setenv(string(menv.OpenEBSServiceAccount), v.value)
+			}
+			actualValue := getOpenEBSServiceAccountName()
+			if !reflect.DeepEqual(actualValue, v.expectedValue) {
+				t.Errorf("expected %s got %s", v.expectedValue, actualValue)
+			}
+			os.Unsetenv(string(menv.OpenEBSServiceAccount))
+		})
+	}
+}

--- a/cmd/provisioner-localpv/app/provisioner_hostpath.go
+++ b/cmd/provisioner-localpv/app/provisioner_hostpath.go
@@ -35,6 +35,7 @@ func (p *Provisioner) ProvisionHostPath(opts pvController.VolumeOptions, volumeC
 	nodeHostname := GetNodeHostname(opts.SelectedNode)
 	name := opts.PVName
 	stgType := volumeConfig.GetStorageType()
+	saName := getOpenEBSServiceAccountName()
 
 	path, err := volumeConfig.GetPath()
 	if err != nil {
@@ -53,10 +54,11 @@ func (p *Provisioner) ProvisionHostPath(opts pvController.VolumeOptions, volumeC
 	//Before using the path for local PV, make sure it is created.
 	initCmdsForPath := []string{"mkdir", "-m", "0777", "-p"}
 	podOpts := &HelperPodOptions{
-		cmdsForPath:  initCmdsForPath,
-		name:         name,
-		path:         path,
-		nodeHostname: nodeHostname,
+		cmdsForPath:        initCmdsForPath,
+		name:               name,
+		path:               path,
+		nodeHostname:       nodeHostname,
+		serviceAccountName: saName,
 	}
 
 	iErr := p.createInitPod(podOpts)

--- a/pkg/kubernetes/pod/v1alpha1/build.go
+++ b/pkg/kubernetes/pod/v1alpha1/build.go
@@ -175,6 +175,20 @@ func (b *Builder) WithVolume(volume corev1.Volume) *Builder {
 	return b.WithVolumes([]corev1.Volume{volume})
 }
 
+// WithServiceAccountName sets the ServiceAccountName of Pod spec with
+// the provided value
+func (b *Builder) WithServiceAccountName(serviceAccountName string) *Builder {
+	if len(serviceAccountName) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build Pod object: missing Pod service account name"),
+		)
+		return b
+	}
+	b.pod.object.Spec.ServiceAccountName = serviceAccountName
+	return b
+}
+
 // Build returns the Pod API instance
 func (b *Builder) Build() (*corev1.Pod, error) {
 	if len(b.errs) > 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds openebs service account to the pods launched by local-pv provisioner. This is because in Openshift / CoreOS clusters, the pods need to be in privileged security context and should use the openebs service account which has a privileged SCC in openshift.