### PR TITLE
chore(cspc, validation webhook): add a support for CSPC general validation in admission server

### DIFF
--- a/cmd/cstor-pool-mgmt/pool/v1alpha2/modify.go
+++ b/cmd/cstor-pool-mgmt/pool/v1alpha2/modify.go
@@ -77,7 +77,7 @@ func Update(cspi *apis.CStorPoolInstance) (*apis.CStorPoolInstance, error) {
 			// If current blockdevice is replaced blockdevice then get the
 			// predecessor from claim of current blockdevice and if current
 			// blockdevice is not replaced then predecessorBDName will be empty
-			predecessorBDName := bdClaim.GetAnnotations()[string(apis.PredecessorBlockDeviceCPK)]
+			predecessorBDName := bdClaim.GetAnnotations()[apis.PredecessorBDKey]
 			oldPath := []string{}
 			if predecessorBDName != "" {
 				// Get device links from old block device

--- a/cmd/cstor-pool-mgmt/pool/v1alpha2/pool_utils.go
+++ b/cmd/cstor-pool-mgmt/pool/v1alpha2/pool_utils.go
@@ -299,14 +299,14 @@ func cleanUpReplacementMarks(oldObj, newObj *ndmapis.BlockDeviceClaim) error {
 		}
 	}
 	bdAnnotations := newObj.GetAnnotations()
-	delete(bdAnnotations, string(apis.PredecessorBlockDeviceCPK))
+	delete(bdAnnotations, apis.PredecessorBDKey)
 	newObj.SetAnnotations(bdAnnotations)
 	_, err := bdcClient.Update(newObj)
 	if err != nil {
 		return errors.Wrapf(
 			err,
 			"Failed to remove annotation {%s} from blockdeviceclaim {%s}",
-			string(apis.PredecessorBlockDeviceCPK),
+			apis.PredecessorBDKey,
 			newObj.Name,
 		)
 	}

--- a/pkg/algorithm/nodeselect/v1alpha2/build_csp.go
+++ b/pkg/algorithm/nodeselect/v1alpha2/build_csp.go
@@ -58,7 +58,7 @@ func (ac *Config) GetCSPSpec() (*apis.CStorPoolInstance, error) {
 		WithDependentsUpgraded().
 		Build()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to build CSP object for node selector {%v}", poolSpec.NodeSelector)
+		return nil, errors.Wrapf(err, "failed to build CSPI object for node selector {%v}", poolSpec.NodeSelector)
 	}
 
 	err = ac.ClaimBDsForNode(ac.GetBDListForNode(poolSpec))

--- a/pkg/algorithm/nodeselect/v1alpha2/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha2/select_node.go
@@ -67,7 +67,7 @@ func GetNodeFromLabelSelector(labels map[string]string) (string, error) {
 		return "", errors.Wrap(err, "failed to get node list from the node selector")
 	}
 	if len(nodeList.Items) != 1 {
-		return "", errors.Errorf("could not get a node or unique node from the given node selectors")
+		return "", errors.Errorf("invalid no.of nodes %d from the given node selectors", len(nodeList.Items))
 	}
 	return nodeList.Items[0].Name, nil
 }

--- a/pkg/algorithm/nodeselect/v1alpha2/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha2/select_node.go
@@ -67,7 +67,7 @@ func GetNodeFromLabelSelector(labels map[string]string) (string, error) {
 		return "", errors.Wrap(err, "failed to get node list from the node selector")
 	}
 	if len(nodeList.Items) != 1 {
-		return "", errors.Errorf("could not get a unique node from the given node selectors")
+		return "", errors.Errorf("could not get a node or unique node from the given node selectors")
 	}
 	return nodeList.Items[0].Name, nil
 }

--- a/pkg/apis/openebs.io/v1alpha1/cas_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_pool.go
@@ -37,9 +37,6 @@ const (
 	StoragePoolClaimCPK CasPoolKey = "openebs.io/storage-pool-claim"
 	// CStorPoolClusterCPK is the CStorPoolcluster label
 	CStorPoolClusterCPK CasPoolKey = "openebs.io/cstor-pool-cluster"
-	// PredecessorBlockDeviceCPK is the annotation on the block device claim
-	// holding previous block device name
-	PredecessorBlockDeviceCPK CasPoolKey = "openebs.io/bd-predecessor"
 	// NdmDiskTypeCPK is the node-disk-manager disk type e.g. 'sparse' or 'disk'
 	NdmDiskTypeCPK CasPoolKey = "ndm.io/disk-type"
 	// NdmBlockDeviceTypeCPK is the node-disk-manager blockdevice type e.g. // 'blockdevice'

--- a/pkg/blockdevice/v1alpha2/blockdevice.go
+++ b/pkg/blockdevice/v1alpha2/blockdevice.go
@@ -203,16 +203,16 @@ func (bd *BlockDevice) GetNodeName() string {
 	return bd.Object.Spec.NodeAttributes.NodeName
 }
 
-// IsActiveWithMsg validates the block device based on status
-func IsActiveWithMsg() Validate {
+// CheckIfBDIsActive validates the block device based on status
+func CheckIfBDIsActive() Validate {
 	return func(bd *BlockDevice) error {
-		return bd.IsActiveWithMsg()
+		return bd.CheckIfBDIsActive()
 	}
 }
 
-// IsActiveWithMsg returns error only when block device presents in other than
+// CheckIfBDIsActive returns error only when block device presents in other than
 // active state or else return nil
-func (bd *BlockDevice) IsActiveWithMsg() error {
+func (bd *BlockDevice) CheckIfBDIsActive() error {
 	if !bd.IsActive() {
 		return errors.Errorf(
 			"block device is in not in active state",
@@ -221,17 +221,17 @@ func (bd *BlockDevice) IsActiveWithMsg() error {
 	return nil
 }
 
-// IsBelongsToNodeWithMsg validates the block device based on nodeName provided
+// CheckIfBDBelongsToNode validates the block device based on nodeName provided
 // via argument
-func IsBelongsToNodeWithMsg(nodeName string) Validate {
+func CheckIfBDBelongsToNode(nodeName string) Validate {
 	return func(bd *BlockDevice) error {
-		return bd.IsBelongsToNodeWithMsg(nodeName)
+		return bd.CheckIfBDBelongsToNode(nodeName)
 	}
 }
 
-// IsBelongsToNodeWithMsg returns error only when the block device node name
+// CheckIfBDBelongsToNode returns error only when the block device node name
 // doesn't matched with provided node name
-func (bd *BlockDevice) IsBelongsToNodeWithMsg(nodeName string) error {
+func (bd *BlockDevice) CheckIfBDBelongsToNode(nodeName string) error {
 	if !bd.IsBelongToNode(nodeName) {
 		return errors.Errorf(
 			"block device doesn't belongs to node %s",
@@ -241,15 +241,15 @@ func (bd *BlockDevice) IsBelongsToNodeWithMsg(nodeName string) error {
 	return nil
 }
 
-// IsNonFSTypeWithMsg validates the block device based on filesystem type
-func IsNonFSTypeWithMsg() Validate {
+// CheckIfBDIsNonFsType validates the block device based on filesystem type
+func CheckIfBDIsNonFsType() Validate {
 	return func(bd *BlockDevice) error {
-		return bd.IsNonFSTypeWithMsg()
+		return bd.CheckIfBDIsNonFsType()
 	}
 }
 
-// IsNonFSTypeWithMsg return error only when the block device has filesystem
-func (bd *BlockDevice) IsNonFSTypeWithMsg() error {
+// CheckIfBDIsNonFsType return error only when the block device has filesystem
+func (bd *BlockDevice) CheckIfBDIsNonFsType() error {
 	if bd.HasFileSystem() {
 		return errors.Errorf("block device has file system {%s}",
 			bd.Object.Spec.FileSystem.Type,

--- a/pkg/blockdevice/v1alpha2/blockdevice_test.go
+++ b/pkg/blockdevice/v1alpha2/blockdevice_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2019 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"testing"
+
+	ndmapis "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
+)
+
+func TestValidateBlockDevice(t *testing.T) {
+	tests := map[string]struct {
+		bd            *BlockDevice
+		expectedError bool
+		validateList  []Validate
+	}{
+		"BlockDevice with filesystem": {
+			bd: &BlockDevice{
+				Object: &ndmapis.BlockDevice{
+					Spec: ndmapis.DeviceSpec{
+						FileSystem: ndmapis.FileSystemInfo{
+							Type: "xfs",
+						},
+					},
+				},
+			},
+			expectedError: true,
+			validateList:  []Validate{IsNonFSTypeWithMsg()},
+		},
+		"BlockDevice with different node name": {
+			bd: &BlockDevice{
+				Object: &ndmapis.BlockDevice{
+					Spec: ndmapis.DeviceSpec{
+						NodeAttributes: ndmapis.NodeAttribute{
+							NodeName: "node1",
+						},
+					},
+				},
+			},
+			expectedError: true,
+			validateList:  []Validate{IsBelongsToNodeWithMsg("node2")},
+		},
+		"BlockDevice with InActive state": {
+			bd: &BlockDevice{
+				Object: &ndmapis.BlockDevice{
+					Status: ndmapis.DeviceStatus{
+						State: "InActive",
+					},
+				},
+			},
+			expectedError: true,
+			validateList:  []Validate{IsActiveWithMsg()},
+		},
+		"Validate all the changes": {
+			bd: &BlockDevice{
+				Object: &ndmapis.BlockDevice{
+					Spec: ndmapis.DeviceSpec{
+						NodeAttributes: ndmapis.NodeAttribute{
+							NodeName: "node1",
+						},
+					},
+					Status: ndmapis.DeviceStatus{
+						State: "Active",
+					},
+				},
+			},
+			expectedError: false,
+			validateList:  []Validate{IsNonFSTypeWithMsg(), IsBelongsToNodeWithMsg("node1"), IsActiveWithMsg()},
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			err := test.bd.ValidateBlockDevice(test.validateList...)
+			if test.expectedError && err == nil {
+				t.Errorf("test %s failed expected error but got nil", name)
+			}
+			if !test.expectedError && err != nil {
+				t.Errorf("test %s failed expected error to be nil but got %v", name, err)
+			}
+		})
+	}
+}

--- a/pkg/blockdevice/v1alpha2/blockdevice_test.go
+++ b/pkg/blockdevice/v1alpha2/blockdevice_test.go
@@ -39,7 +39,7 @@ func TestValidateBlockDevice(t *testing.T) {
 				},
 			},
 			expectedError: true,
-			validateList:  []Validate{IsNonFSTypeWithMsg()},
+			validateList:  []Validate{CheckIfBDIsNonFsType()},
 		},
 		"BlockDevice with different node name": {
 			bd: &BlockDevice{
@@ -52,7 +52,7 @@ func TestValidateBlockDevice(t *testing.T) {
 				},
 			},
 			expectedError: true,
-			validateList:  []Validate{IsBelongsToNodeWithMsg("node2")},
+			validateList:  []Validate{CheckIfBDBelongsToNode("node2")},
 		},
 		"BlockDevice with InActive state": {
 			bd: &BlockDevice{
@@ -63,7 +63,7 @@ func TestValidateBlockDevice(t *testing.T) {
 				},
 			},
 			expectedError: true,
-			validateList:  []Validate{IsActiveWithMsg()},
+			validateList:  []Validate{CheckIfBDIsActive()},
 		},
 		"Validate all the changes": {
 			bd: &BlockDevice{
@@ -79,7 +79,7 @@ func TestValidateBlockDevice(t *testing.T) {
 				},
 			},
 			expectedError: false,
-			validateList:  []Validate{IsNonFSTypeWithMsg(), IsBelongsToNodeWithMsg("node1"), IsActiveWithMsg()},
+			validateList:  []Validate{CheckIfBDIsNonFsType(), CheckIfBDBelongsToNode("node1"), CheckIfBDIsActive()},
 		},
 	}
 	for name, test := range tests {

--- a/pkg/webhook/bd_replacement.go
+++ b/pkg/webhook/bd_replacement.go
@@ -33,7 +33,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//TODO: Update BlockDeviceReplacemen to generic name
+//TODO: Update BlockDeviceReplacement to generic name
 
 // BlockDeviceReplacement contains old and new CSPC to validate for block device replacement
 type BlockDeviceReplacement struct {

--- a/pkg/webhook/bd_replacement.go
+++ b/pkg/webhook/bd_replacement.go
@@ -33,7 +33,8 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//TODO: Update to generic name
+//TODO: Update BlockDeviceReplacemen to generic name
+
 // BlockDeviceReplacement contains old and new CSPC to validate for block device replacement
 type BlockDeviceReplacement struct {
 	// OldCSPC is the persisted CSPC in etcd.
@@ -117,10 +118,13 @@ func getCommonPoolSpecs(cspcNew, cspcOld *apis.CStorPoolCluster) (*poolspecs, er
 // devices(for other than strip type) to existing raid group or else it will
 // return nil
 func validateRaidGroupChanges(oldRg, newRg *apis.RaidGroup) error {
+	// return error when block devices are removed from new raid group
 	if len(newRg.BlockDevices) < len(oldRg.BlockDevices) {
 		return errors.Errorf("removing block device from %s raid group is not valid operation",
 			oldRg.Type)
 	}
+	// return error when block device are added to new raid group other than
+	// stripe
 	if apis.PoolType(oldRg.Type) != apis.PoolStriped &&
 		len(newRg.BlockDevices) > len(oldRg.BlockDevices) {
 		return errors.Errorf("adding block devices to existing %s raid group is "+

--- a/pkg/webhook/bd_replacement_test.go
+++ b/pkg/webhook/bd_replacement_test.go
@@ -695,3 +695,74 @@ func TestBlockDeviceReplacement_IsNewBDPresentOnCurrentCSPC(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateRaidGroupChanges(t *testing.T) {
+	tests := map[string]struct {
+		oldRG         *apis.RaidGroup
+		newRG         *apis.RaidGroup
+		expectedError bool
+	}{
+		"removing block devices": {
+			oldRG: &apis.RaidGroup{
+				BlockDevices: []apis.CStorPoolClusterBlockDevice{
+					{BlockDeviceName: "bd-1"},
+					{BlockDeviceName: "bd-2"},
+				},
+			},
+			newRG: &apis.RaidGroup{
+				BlockDevices: []apis.CStorPoolClusterBlockDevice{
+					{BlockDeviceName: "bd-1"},
+				},
+			},
+			expectedError: true,
+		},
+		"adding block devices for raid groups": {
+			oldRG: &apis.RaidGroup{
+				Type: "raidz",
+				BlockDevices: []apis.CStorPoolClusterBlockDevice{
+					{BlockDeviceName: "bd-1"},
+					{BlockDeviceName: "bd-2"},
+				},
+			},
+			newRG: &apis.RaidGroup{
+				Type: "raidz",
+				BlockDevices: []apis.CStorPoolClusterBlockDevice{
+					{BlockDeviceName: "bd-1"},
+					{BlockDeviceName: "bd-2"},
+					{BlockDeviceName: "bd-3"},
+				},
+			},
+			expectedError: true,
+		},
+		"adding block devices for stripe raid groups": {
+			oldRG: &apis.RaidGroup{
+				Type: "stripe",
+				BlockDevices: []apis.CStorPoolClusterBlockDevice{
+					{BlockDeviceName: "bd-1"},
+					{BlockDeviceName: "bd-2"},
+				},
+			},
+			newRG: &apis.RaidGroup{
+				Type: "stripe",
+				BlockDevices: []apis.CStorPoolClusterBlockDevice{
+					{BlockDeviceName: "bd-1"},
+					{BlockDeviceName: "bd-2"},
+					{BlockDeviceName: "bd-3"},
+				},
+			},
+			expectedError: false,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			err := validateRaidGroupChanges(test.oldRG, test.newRG)
+			if test.expectedError && err == nil {
+				t.Errorf("test %s failed expectedError to be error but got nil", name)
+			}
+			if !test.expectedError && err != nil {
+				t.Errorf("test %s failed expectedError not to be error but got error %v", name, err)
+			}
+		})
+	}
+}

--- a/pkg/webhook/cspc.go
+++ b/pkg/webhook/cspc.go
@@ -303,7 +303,7 @@ func (poolValidator *PoolValidator) blockDeviceClaimValidation(bdcName, bdName s
 	}
 	cspcName := bdcObject.
 		GetAnnotations()[string(apis.CStorPoolClusterCPK)]
-	if cspcName != cspcName {
+	if cspcName != poolValidator.cspcName {
 		return errors.Wrapf(err,
 			"cann't use claimed blockdevice %s",
 			bdName,
@@ -335,7 +335,8 @@ func (wh *webhook) validateCSPCUpdateRequest(req *v1beta1.AdmissionRequest) *v1b
 		response = BuildForAPIObject(response).UnSetAllowed().WithResultAsFailure(err, http.StatusInternalServerError).AR
 		return response
 	}
-	if !reflect.DeepEqual(cspcNew.Spec, cspcOld.Spec) {
+	// return success from here when there is no change in spec
+	if reflect.DeepEqual(cspcNew.Spec, cspcOld.Spec) {
 		return response
 	}
 

--- a/pkg/webhook/cspc.go
+++ b/pkg/webhook/cspc.go
@@ -264,7 +264,17 @@ func (poolValidator *PoolValidator) blockDeviceValidation(
 			err,
 		)
 	}
-	if bdObj.Name != poolValidator.nodeName {
+	err = blockdevice.
+		BuilderForAPIObject(bdObj).
+		BlockDevice.
+		ValidateBlockDevice(
+			blockdevice.IsActiveWithMsg(),
+			blockdevice.IsNonFSTypeWithMsg(),
+			blockdevice.IsBelongsToNodeWithMsg(poolValidator.nodeName))
+	if err != nil {
+		return false, fmt.Sprintf("%v", err)
+	}
+	if bdObj.Spec.NodeAttributes.NodeName != poolValidator.nodeName {
 		return false, fmt.Sprintf(
 			"pool validation failed: block device %s doesn't belongs to pool node %s",
 			bd.BlockDeviceName,

--- a/pkg/webhook/cspc.go
+++ b/pkg/webhook/cspc.go
@@ -36,7 +36,7 @@ import (
 	"k8s.io/klog"
 )
 
-// TODO: Get better naming convertion from review comments
+// TODO: Make better naming conventions from review comments
 
 // PoolValidator is build to validate pool spec, raid groups and blockdevices
 type PoolValidator struct {

--- a/pkg/webhook/cspc.go
+++ b/pkg/webhook/cspc.go
@@ -268,9 +268,9 @@ func (poolValidator *PoolValidator) blockDeviceValidation(
 		BuilderForAPIObject(bdObj).
 		BlockDevice.
 		ValidateBlockDevice(
-			blockdevice.IsActiveWithMsg(),
-			blockdevice.IsNonFSTypeWithMsg(),
-			blockdevice.IsBelongsToNodeWithMsg(poolValidator.nodeName))
+			blockdevice.CheckIfBDIsActive(),
+			blockdevice.CheckIfBDIsNonFsType(),
+			blockdevice.CheckIfBDBelongsToNode(poolValidator.nodeName))
 	if err != nil {
 		return false, fmt.Sprintf("%v", err)
 	}

--- a/pkg/webhook/cspc_test.go
+++ b/pkg/webhook/cspc_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2019 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"testing"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+)
+
+func TestValidateSpecChanges(t *testing.T) {
+	tests := map[string]struct {
+		commonPoolSpecs *poolspecs
+		bdr             *BlockDeviceReplacement
+		expectedOutput  bool
+	}{
+		"No change in poolSpecs": {
+			commonPoolSpecs: &poolspecs{
+				oldSpec: []apis.PoolSpec{
+					apis.PoolSpec{
+						RaidGroups: []apis.RaidGroup{
+							apis.RaidGroup{
+								Type: "mirror",
+								BlockDevices: []apis.CStorPoolClusterBlockDevice{
+									apis.CStorPoolClusterBlockDevice{
+										BlockDeviceName: "bd1",
+									},
+									apis.CStorPoolClusterBlockDevice{
+										BlockDeviceName: "bd2",
+									},
+								},
+							},
+						},
+					},
+				},
+				newSpec: []apis.PoolSpec{
+					apis.PoolSpec{
+						RaidGroups: []apis.RaidGroup{
+							apis.RaidGroup{
+								Type: "mirror",
+								BlockDevices: []apis.CStorPoolClusterBlockDevice{
+									apis.CStorPoolClusterBlockDevice{
+										BlockDeviceName: "bd1",
+									},
+									apis.CStorPoolClusterBlockDevice{
+										BlockDeviceName: "bd2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			bdr: &BlockDeviceReplacement{
+				OldCSPC: &apis.CStorPoolCluster{},
+				NewCSPC: &apis.CStorPoolCluster{},
+			},
+			expectedOutput: true,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			isValid, _ := ValidateSpecChanges(test.commonPoolSpecs, test.bdr)
+			if isValid != test.expectedOutput {
+				t.Errorf("test: %s failed expected output %t but got %t", name, isValid, test.expectedOutput)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds general validation in the admission server to validate CSPC.

**Below are the validations added to admission server:**
1. Adds validation to verify the duplicate block devices in CSPC.
2. Adds validation to verify the duplicate nodes in CSPC.
3. Adds validation to verify block devices mentioned on pool spec should belong to the same node where node selector is pointing.
4. Adds validation to verify block device should not be claimed by other CSPC/third party.
5. Adds validation to verify Raid Group or Block Device alone shouldn’t be removed.
6. Adds validation to verify block device should not have a fstype and it should be active. 
7. Adds validation to verify the capacity of replacing block device(Changes will be adopted only if capacity is >= existing block device).

**TODO:**
1. Added raid group block devices should not be in use by the same CSPC(Resilvering block device also).


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests