### PR TITLE
fix(cstor-pool-mgmt): fix livenessprobe in cStor pool deployment

### DIFF
--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -260,6 +260,8 @@ spec:
                 command:
                 - /bin/sh
                 - -c
+                ## timeout 30 is added to exit the command forcefully with non-zero exit code if command takes
+                ## more than 30 seconds
                 - timeout 30 zfs set io.openebs:livenesstimestamp="$(date +%s)" cstor-$OPENEBS_IO_CSTOR_ID
               failureThreshold: 3
               initialDelaySeconds: 300

--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -260,7 +260,7 @@ spec:
                 command:
                 - /bin/sh
                 - -c
-                - zfs set io.openebs:livenesstimestamp="$(date +%s)" cstor-$OPENEBS_IO_CSTOR_ID
+                - timeout 30 zfs set io.openebs:livenesstimestamp="$(date +%s)" cstor-$OPENEBS_IO_CSTOR_ID
               failureThreshold: 3
               initialDelaySeconds: 300
               periodSeconds: 10

--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -261,7 +261,7 @@ spec:
                 - /bin/sh
                 - -c
                 ## timeout 120 is added to exit the command forcefully with non-zero exit code if command takes
-                ## more than 120 seconds to process it.
+                ## more than 120 seconds.
                 - timeout 120 zfs set io.openebs:livenesstimestamp="$(date +%s)" cstor-$OPENEBS_IO_CSTOR_ID
               failureThreshold: 3
               initialDelaySeconds: 300

--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -260,13 +260,17 @@ spec:
                 command:
                 - /bin/sh
                 - -c
-                ## timeout 30 is added to exit the command forcefully with non-zero exit code if command takes
-                ## more than 30 seconds
-                - timeout 30 zfs set io.openebs:livenesstimestamp="$(date +%s)" cstor-$OPENEBS_IO_CSTOR_ID
+                ## timeout 120 is added to exit the command forcefully with non-zero exit code if command takes
+                ## more than 120 seconds to process it.
+                - timeout 120 zfs set io.openebs:livenesstimestamp="$(date +%s)" cstor-$OPENEBS_IO_CSTOR_ID
               failureThreshold: 3
               initialDelaySeconds: 300
-              periodSeconds: 10
-              timeoutSeconds: 30
+              ## how often (in seconds) to perform the probe
+              periodSeconds: 60
+              ## Number of seconds after which the probe times out. i.e informing
+              ## to kubelet probe should timeout after 150 seconds(Note: It will
+              ## not honour because of timeout 120 value before command)
+              timeoutSeconds: 150
             securityContext:
               privileged: true
             volumeMounts:


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR fixes the liveness probe on cstor-pool container by adding `timeout` setting for command execution(run a command with a time limit). `timeout` will be helpful in a case when the disks are detached from the node and when liveness triggers command(zfs set... command) it will be hung forever and kubelet will not treat them as a failures. Kubelet also retries execute the same command after `timeoutSeconds` mentioned in the liveness probe. By triggering `timeout 30 zfs set io.openebs:livenesstimestamp="$(date +%s)" cstor-<pool_name>` will kill the process if it exceeds more than 30 seconds and returns non-zero exit status.

**Note:**
1. When the disks are detached from the node cStor pool container will restart after 480 seconds i.e 8 minutes(tested in 1.4.8 Kubernetes version).
 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #https://github.com/openebs/openebs/issues/2852

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests