### PR TITLE
refact(upgrade): updated cstor pool deployment template

### DIFF
--- a/pkg/upgrade/templates/v1/cstor_pool.go
+++ b/pkg/upgrade/templates/v1/cstor_pool.go
@@ -41,7 +41,7 @@ var (
                                 "command": [
                                     "/bin/sh",
                                     "-c",
-                                    "zfs set io.openebs:livenesstimestamp=\"$(date +%s)\" cstor-$OPENEBS_IO_CSTOR_ID"
+                                    "timeout 30 zfs set io.openebs:livenesstimestamp=\"$(date +%s)\" cstor-$OPENEBS_IO_CSTOR_ID"
                                 ]
                             }
                         }

--- a/pkg/upgrade/templates/v1/cstor_pool.go
+++ b/pkg/upgrade/templates/v1/cstor_pool.go
@@ -44,9 +44,14 @@ var (
                                 "command": [
                                     "/bin/sh",
                                     "-c",
-                                    "timeout 30 zfs set io.openebs:livenesstimestamp=\"$(date +%s)\" cstor-$OPENEBS_IO_CSTOR_ID"
+                                    "timeout 120 zfs set io.openebs:livenesstimestamp=\"$(date +%s)\" cstor-$OPENEBS_IO_CSTOR_ID"
                                 ]
-                            }
+                            },
+														"failureThreshold": 3,
+                            "initialDelaySeconds": 300,
+                            "periodSeconds": 60,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 150
                         }
 					},
 					{

--- a/pkg/upgrade/templates/v1/cstor_pool.go
+++ b/pkg/upgrade/templates/v1/cstor_pool.go
@@ -22,7 +22,10 @@ var (
 		"metadata": {
 		   "labels": {
 			  "openebs.io/version": "{{.UpgradeVersion}}"
-		   }
+			},
+			 "annotations":{
+				 "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
+			 }
 		},
 		"spec": {
 		   "template": {

--- a/pkg/upgrade/templates/v1/cstor_pool.go
+++ b/pkg/upgrade/templates/v1/cstor_pool.go
@@ -47,7 +47,7 @@ var (
                                     "timeout 120 zfs set io.openebs:livenesstimestamp=\"$(date +%s)\" cstor-$OPENEBS_IO_CSTOR_ID"
                                 ]
                             },
-														"failureThreshold": 3,
+                            "failureThreshold": 3,
                             "initialDelaySeconds": 300,
                             "periodSeconds": 60,
                             "successThreshold": 1,


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR appends `timeout 120` to the command and `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` to the annotations in the cstor pool deployment. 
Refer : https://github.com/openebs/maya/pull/1544 https://github.com/openebs/maya/pull/1546

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests