### PR TITLE
fix(cspi): add timeout seconds in zfs cmd used for liveness probe and safe-evict annotation on CSP

### DIFF
--- a/cmd/cspc-operator/app/storagepool_create.go
+++ b/cmd/cspc-operator/app/storagepool_create.go
@@ -345,13 +345,13 @@ func getPoolLivenessProbe() *corev1.Probe {
 	probe := &corev1.Probe{
 		Handler: corev1.Handler{
 			Exec: &corev1.ExecAction{
-				Command: []string{"/bin/sh", "-c", "zfs set io.openebs:livenesstimestamp=\"$(date +%s)\" cstor-$OPENEBS_IO_POOL_NAME"},
+				Command: []string{"/bin/sh", "-c", "timeout 120 zfs set io.openebs:livenesstimestamp=\"$(date +%s)\" cstor-$OPENEBS_IO_POOL_NAME"},
 			},
 		},
 		FailureThreshold:    3,
 		InitialDelaySeconds: 300,
-		PeriodSeconds:       10,
-		TimeoutSeconds:      300,
+		PeriodSeconds:       60,
+		TimeoutSeconds:      150,
 	}
 	return probe
 }

--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -228,6 +228,7 @@ spec:
             prometheus.io/path: /metrics
             prometheus.io/port: "9500"
             prometheus.io/scrape: "true"
+            cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         spec:
           serviceAccountName: {{ .Config.ServiceAccountName.value }}
           nodeSelector:


### PR DESCRIPTION
**What this PR does / why we need it**:
- add 120 seconds cmd timeout value for zfs command which will
  kill the cmd process if it exceeds more than 120 seconds and
  returns non-zero exit status.
- Change Probe timeout seconds to 150 seconds.
- Change PeriodSeconds interval to 60 seconds
- add safe-to-evict to false to disable scaledown for CSP pods refer https://github.com/openebs/maya/pull/1481

```yaml
k get pods cspc-sparse-jbhs-666bcf6788-thtgf -oyaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
    openebs.io/monitoring: pool_exporter_prometheus
    prometheus.io/path: /metrics
    prometheus.io/port: "9500"
    prometheus.io/scrape: "true"
  creationTimestamp: "2019-12-11T10:02:06Z"
  generateName: cspc-sparse-jbhs-666bcf6788-
  labels:
    app: cstor-pool
    openebs.io/cstor-pool-cluster: cspc-sparse
    openebs.io/cstor-pool-instance: cspc-sparse-jbhs
    openebs.io/version: 1.5.0
    pod-template-hash: 666bcf6788
- env:
    - name: OPENEBS_IO_CSTOR_ID
      value: 83d34ac9-0e1a-4ef1-9260-0aef4b22dd18
    - name: OPENEBS_IO_POOL_NAME
      value: 8cfb0830-745c-4a26-8319-819675c29383
    image: openebs/cstor-pool:ci
    imagePullPolicy: IfNotPresent
    lifecycle:
      postStart:
        exec:
          command:
          - /bin/sh
          - -c
          - sleep 2
    livenessProbe:
      exec:
        command:
        - /bin/sh
        - -c
        - timeout 300 zfs set io.openebs:livenesstimestamp="$(date +%s)" cstor-$OPENEBS_IO_POOL_NAME
```

Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>
