### PR TITLE
feat(cspc): add capability to pass tolerations to pool pods via cspc

### DIFF
--- a/pkg/algorithm/nodeselect/v1alpha2/build_csp.go
+++ b/pkg/algorithm/nodeselect/v1alpha2/build_csp.go
@@ -42,6 +42,10 @@ func (ac *Config) GetCSPSpec() (*apis.CStorPoolInstance, error) {
 		poolSpec.PoolConfig.Resources = ac.CSPC.Spec.DefaultResources
 	}
 
+	if len(poolSpec.PoolConfig.Tolerations) == 0 {
+		poolSpec.PoolConfig.Tolerations = ac.CSPC.Spec.Tolerations
+	}
+
 	csplabels := ac.buildLabelsForCSPI(nodeName)
 	cspObj, err := apiscsp.NewBuilder().
 		WithName(ac.CSPC.Name + "-" + rand.String(4)).

--- a/pkg/apis/openebs.io/v1alpha1/cstorpool_cluster.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstorpool_cluster.go
@@ -76,6 +76,10 @@ type CStorPoolClusterSpec struct {
 	// AuxResources are the compute resources required by the cstor-pool pod
 	// side car containers.
 	AuxResources v1.ResourceRequirements `json:"auxResources"`
+	// Tolerations, if specified, are the pool pod's tolerations
+	// If tolerations at PoolConfig is empty, this is written to
+	// CSPI PoolConfig.
+	Tolerations []v1.Toleration `json:"tolerations"`
 }
 
 //PoolSpec is the spec for pool on node where it should be created.
@@ -113,6 +117,9 @@ type PoolConfig struct {
 	// Resources are the compute resources required by the cstor-pool
 	// container.
 	Resources *v1.ResourceRequirements `json:"resources"`
+
+	// Tolerations, if specified, the pool pod's tolerations.
+	Tolerations []v1.Toleration `json:"tolerations"`
 }
 
 // RaidGroup contains the details of a raid group for the pool

--- a/pkg/apis/openebs.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/openebs.io/v1alpha1/zz_generated.deepcopy.go
@@ -564,6 +564,13 @@ func (in *CStorPoolClusterSpec) DeepCopyInto(out *CStorPoolClusterSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.AuxResources.DeepCopyInto(&out.AuxResources)
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 
@@ -1454,6 +1461,13 @@ func (in *PoolConfig) DeepCopyInto(out *PoolConfig) {
 		in, out := &in.Resources, &out.Resources
 		*out = new(v1.ResourceRequirements)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	return
 }

--- a/pkg/kubernetes/podtemplatespec/v1alpha1/podtemplatespec.go
+++ b/pkg/kubernetes/podtemplatespec/v1alpha1/podtemplatespec.go
@@ -243,6 +243,22 @@ func (b *Builder) WithAffinity(affinity *corev1.Affinity) *Builder {
 	return b
 }
 
+// WithTolerationsByValue sets pod toleration.
+// If provided tolerations argument is empty it does not complain.
+func (b *Builder) WithTolerationsByValue(tolerations ...corev1.Toleration) *Builder {
+	if len(b.podtemplatespec.Object.Spec.Tolerations) == 0 {
+		b.podtemplatespec.Object.Spec.Tolerations = tolerations
+		return b
+	}
+
+	b.podtemplatespec.Object.Spec.Tolerations = append(
+		b.podtemplatespec.Object.Spec.Tolerations,
+		tolerations...,
+	)
+
+	return b
+}
+
 // WithTolerations merges the existing tolerations
 // with the provided arguments
 func (b *Builder) WithTolerations(tolerations ...corev1.Toleration) *Builder {


### PR DESCRIPTION
This PR adds the capability to pass tolerations via CSPC to the pool pods.
Following is an example CSPC YAML to pass tolerations: 

```yaml
apiVersion: openebs.io/v1alpha1
kind: CStorPoolCluster
metadata:
  name: cspc-mirror
  namespace: openebs
spec:
  # This toleration config will apply to all the pool config (pool pods) 
  # if there is no toleration config specified at pool config level.
  tolerations:
  - key: "key"
    operator: "Equal"
    value: "value"
    effect: "NoSchedule"
  pools:
  - nodeSelector:
      kubernetes.io/hostname: "gke-cstor-demo-default-pool-3385ab41-1r1n"
    raidGroups:
    - type: "mirror"
      isWriteCache: false
      isSpare: false
      isReadCache: false
      blockDevices:
      - blockDeviceName: "blockdevice-6380099a0365d2ebe45d4eb03e7a48df"
      - blockDeviceName: "blockdevice-c44d3872abc609182a80f74b66d23202"
    poolConfig:
      # For pool pod on this node -- this toleration config will be used and not the one 
      # specified at the top.
      tolerations:
      - key: "key1"
        operator: "Equal"
        value: "value1"
        effect: "NoSchedule"
  - nodeSelector:
      kubernetes.io/hostname: "gke-cstor-demo-default-pool-3385ab41-478j" 
    raidGroups:
    - type: "mirror"
      isWriteCache: false
      isSpare: false
      isReadCache: false
      blockDevices:
      - blockDeviceName: "blockdevice-27363f91861389d3669bea9d58465642"
      - blockDeviceName: "blockdevice-793e97d573ade7e0a7fd3a606d7283be"

  - nodeSelector:
      kubernetes.io/hostname: "gke-cstor-demo-default-pool-3385ab41-zbp0" 
    raidGroups:
    - type: "mirror"
      isWriteCache: false
      isSpare: false
      isReadCache: false
      blockDevices:
      - blockDeviceName: "blockdevice-24bba21020b7015c1532bfad120d6b75"
      - blockDeviceName: "blockdevice-3d02bad8bf6ea47e395ca6b757c84d17"

    poolConfig:
      cacheFile: ""
      defaultRaidGroupType: "mirror"
      overProvisioning: false
      compression: "off"
```
Signed-off-by: Ashutosh Kumar <ashutosh.kumar@openebs.io>