### PR TITLE
feat(jiva): allow passing cleanup helper pod image as env

### DIFF
--- a/pkg/install/v1alpha1/jiva_volume.go
+++ b/pkg/install/v1alpha1/jiva_volume.go
@@ -259,7 +259,7 @@ spec:
   - name: OpenEBSNamespace
     value: {{env "OPENEBS_NAMESPACE"}}
   - name: ScrubImage
-    value: "quay.io/openebs/linux-utils:latest"
+    value: {{env "OPENEBS_IO_HELPER_IMAGE" | default "quay.io/openebs/linux-utils:latest"}}
   # RetainReplicaData specifies whether jiva replica data folder
   # should be cleared or retained.
   - name: RetainReplicaData


### PR DESCRIPTION
The default helper pod image used for cleaning data
after jiva PVs are deleted is hardcoded. The only way
to override is to provide via StorageClass SrubImage.

For supporting arm use cases or any custom image
repositories, all the jiva classes need to include
the above attribute.

This PR helps to pass the default image via the
env `OPENEBS_IO_HELPER_IMAGE`, similar to how it is
passed to Local Provisioner.

Refer:
https://github.com/openebs/openebs/issues/1295#issuecomment-562643605

Signed-off-by: kmova <kiran.mova@mayadata.io>
(cherry picked from commit 917532d9e2eb2c85daa5e4c5d20b2b2773a92d10)

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests