### PR TITLE
fix(upgrade): add support for images having more than one ":"

### DIFF
--- a/pkg/upgrade/upgrader/helper.go
+++ b/pkg/upgrade/upgrader/helper.go
@@ -112,6 +112,9 @@ func getBaseImage(deployObj *appsv1.Deployment, name string) (string, error) {
 	for _, con := range deployObj.Spec.Template.Spec.Containers {
 		if con.Name == name {
 			lastIndex := strings.LastIndex(con.Image, ":")
+			if lastIndex == -1 {
+				return "", errors.Errorf("no version tag found on image %s", con.Image)
+			}
 			baseImage := con.Image[:lastIndex]
 			if urlPrefix != "" {
 				// urlPrefix is the url to the directory where the images are present

--- a/pkg/upgrade/upgrader/helper.go
+++ b/pkg/upgrade/upgrader/helper.go
@@ -111,7 +111,8 @@ func getContainerName(d *appsv1.Deployment) (string, error) {
 func getBaseImage(deployObj *appsv1.Deployment, name string) (string, error) {
 	for _, con := range deployObj.Spec.Template.Spec.Containers {
 		if con.Name == name {
-			baseImage := strings.Split(con.Image, ":")[0]
+			lastIndex := strings.LastIndex(con.Image, ":")
+			baseImage := con.Image[:lastIndex]
 			if urlPrefix != "" {
 				// urlPrefix is the url to the directory where the images are present
 				// the below logic takes the image name from current baseImage and

--- a/pkg/upgrade/upgrader/helper_test.go
+++ b/pkg/upgrade/upgrader/helper_test.go
@@ -81,6 +81,7 @@ func Test_getBaseImage(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt // pin it
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := getBaseImage(tt.args.deployObj, tt.args.name)
 			if (err != nil) != tt.wantErr {

--- a/pkg/upgrade/upgrader/helper_test.go
+++ b/pkg/upgrade/upgrader/helper_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Test_getBaseImage(t *testing.T) {
+	type args struct {
+		deployObj *appsv1.Deployment
+		name      string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+		{
+			name:    "Without proxy",
+			want:    "quay.io/openebs/cstor-pool",
+			wantErr: false,
+			args: args{
+				deployObj: &appsv1.Deployment{
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									corev1.Container{
+										Name:  "cstor-pool",
+										Image: "quay.io/openebs/cstor-pool:1.4.0",
+									},
+								},
+							},
+						},
+					},
+				},
+				name: "cstor-pool",
+			},
+		},
+		{
+			name:    "With proxy",
+			want:    "fsdepot.evry.com:8085/openebs/cstor-pool",
+			wantErr: false,
+			args: args{
+				deployObj: &appsv1.Deployment{
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									corev1.Container{
+										Name:  "cstor-pool",
+										Image: "fsdepot.evry.com:8085/openebs/cstor-pool:1.4.0",
+									},
+								},
+							},
+						},
+					},
+				},
+				name: "cstor-pool",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getBaseImage(tt.args.deployObj, tt.args.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getBaseImage() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getBaseImage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/upgrade/upgrader/helper_test.go
+++ b/pkg/upgrade/upgrader/helper_test.go
@@ -79,6 +79,28 @@ func Test_getBaseImage(t *testing.T) {
 				name: "cstor-pool",
 			},
 		},
+		{
+			name:    "With no image tag",
+			want:    "",
+			wantErr: true,
+			args: args{
+				deployObj: &appsv1.Deployment{
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									corev1.Container{
+										Name:  "cstor-pool",
+										Image: "quay.io/openebs/cstor-pool",
+									},
+								},
+							},
+						},
+					},
+				},
+				name: "cstor-pool",
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt // pin it


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR fixes the `getBaseImage` function which only expected only one `:` to be present before the image tag. There can be cases where proxy image url can have more than one `:`. 
Refer: https://github.com/openebs/openebs/issues/2857

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests