### PR TITLE
feat(localpv-hostpath): support provisioning on nodes with taints

### DIFF
--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -227,3 +227,10 @@ func GetNodeHostname(n *v1.Node) string {
 	}
 	return hostname
 }
+
+// GetTaints extracts the Taints from the Spec on the node
+// If Taints are empty, it just returns empty structure of corev1.Taints
+func GetTaints(n *v1.Node) []v1.Taint {
+	//var taints []v1.Taint
+	return n.Spec.Taints
+}

--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -231,6 +231,5 @@ func GetNodeHostname(n *v1.Node) string {
 // GetTaints extracts the Taints from the Spec on the node
 // If Taints are empty, it just returns empty structure of corev1.Taints
 func GetTaints(n *v1.Node) []v1.Taint {
-	//var taints []v1.Taint
 	return n.Spec.Taints
 }

--- a/cmd/provisioner-localpv/app/helper_hostpath.go
+++ b/cmd/provisioner-localpv/app/helper_hostpath.go
@@ -38,6 +38,7 @@ import (
 type podConfig struct {
 	pOpts                         *HelperPodOptions
 	parentDir, volumeDir, podName string
+	tolerations                   []corev1.Toleration
 }
 
 var (
@@ -66,6 +67,8 @@ type HelperPodOptions struct {
 
 	// serviceAccountName is the service account with which the pod should be launched
 	serviceAccountName string
+
+	selectedNodeTaints []corev1.Taint
 }
 
 // validate checks that the required fields to launch
@@ -93,6 +96,7 @@ func (p *Provisioner) createInitPod(pOpts *HelperPodOptions) error {
 		return err
 	}
 
+	config.tolerations = pOpts.getTolerations()
 	// Initialize HostPath builder and validate that
 	// volume directory is not directly under root.
 	// Extract the base path and the volume unique path.
@@ -129,6 +133,7 @@ func (p *Provisioner) createCleanupPod(pOpts *HelperPodOptions) error {
 		return err
 	}
 
+	config.tolerations = pOpts.getTolerations()
 	// Initialize HostPath builder and validate that
 	// volume directory is not directly under root.
 	// Extract the base path and the volume unique path.
@@ -157,11 +162,12 @@ func (p *Provisioner) launchPod(config podConfig) (*corev1.Pod, error) {
 	// Helper pods need to create and delete directories on the host.
 	privileged := true
 
-	helperPod, _ := pod.NewBuilder().
+	helperPod, err := pod.NewBuilder().
 		WithName(config.podName + "-" + config.pOpts.name).
 		WithRestartPolicy(corev1.RestartPolicyNever).
 		WithNodeSelectorHostnameNew(config.pOpts.nodeHostname).
 		WithServiceAccountName(config.pOpts.serviceAccountName).
+		WithTolerations(config.tolerations...).
 		WithContainerBuilder(
 			container.NewBuilder().
 				WithName("local-path-" + config.podName).
@@ -212,4 +218,25 @@ func (p *Provisioner) exitPod(hPod *corev1.Pod) error {
 		return errors.Errorf("create process timeout after %v seconds", CmdTimeoutCounts)
 	}
 	return nil
+}
+
+// getToleration() returns the tolerations, for the respective taints.
+func (pOpts *HelperPodOptions) getTolerations() []corev1.Toleration {
+	// Convert the taints into pod tolerations
+	// to be passed to pod builder to set appropriate toleration
+	var tolerations []corev1.Toleration
+	nodeTaints := pOpts.selectedNodeTaints
+	for i := range nodeTaints {
+		var toleration corev1.Toleration
+		toleration.Key = nodeTaints[i].Key
+		toleration.Effect = nodeTaints[i].Effect
+		if len(nodeTaints[i].Value) == 0 {
+			toleration.Operator = corev1.TolerationOpExists
+		} else {
+			toleration.Value = nodeTaints[i].Value
+			toleration.Operator = corev1.TolerationOpEqual
+		}
+		tolerations = append(tolerations, toleration)
+	}
+	return tolerations
 }

--- a/cmd/provisioner-localpv/app/provisioner_hostpath.go
+++ b/cmd/provisioner-localpv/app/provisioner_hostpath.go
@@ -126,7 +126,7 @@ func (p *Provisioner) ProvisionHostPath(opts pvController.VolumeOptions, volumeC
 	return pvObj, nil
 }
 
-// GetNodeObjectFromHostName returns the Node Object with matching NodeHostName
+// GetNodeObjectFromHostName returns the Node Object with matching NodeHostName.
 func (p *Provisioner) GetNodeObjectFromHostName(hostName string) (*v1.Node, error) {
 	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{persistentvolume.KeyNode: hostName}}
 	listOptions := metav1.ListOptions{
@@ -163,6 +163,8 @@ func (p *Provisioner) DeleteHostPath(pv *v1.PersistentVolume) (err error) {
 		return errors.Errorf("cannot find affinited node hostname")
 	}
 	alertlog.Logger.Infof("Get the Node Object from hostName: %v", hostname)
+
+	//Get the node Object once again to get updated Taints.
 	nodeObject, err := p.GetNodeObjectFromHostName(hostname)
 	if err != nil {
 		return err

--- a/cmd/provisioner-localpv/app/provisioner_hostpath.go
+++ b/cmd/provisioner-localpv/app/provisioner_hostpath.go
@@ -20,6 +20,8 @@ import (
 	"github.com/openebs/maya/pkg/alertlog"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog"
 
 	pvController "sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
@@ -33,6 +35,7 @@ import (
 func (p *Provisioner) ProvisionHostPath(opts pvController.VolumeOptions, volumeConfig *VolumeConfig) (*v1.PersistentVolume, error) {
 	pvc := opts.PVC
 	nodeHostname := GetNodeHostname(opts.SelectedNode)
+	taints := GetTaints(opts.SelectedNode)
 	name := opts.PVName
 	stgType := volumeConfig.GetStorageType()
 	saName := getOpenEBSServiceAccountName()
@@ -59,8 +62,8 @@ func (p *Provisioner) ProvisionHostPath(opts pvController.VolumeOptions, volumeC
 		path:               path,
 		nodeHostname:       nodeHostname,
 		serviceAccountName: saName,
+		selectedNodeTaints: taints,
 	}
-
 	iErr := p.createInitPod(podOpts)
 	if iErr != nil {
 		klog.Infof("Initialize volume %v failed: %v", name, iErr)
@@ -123,6 +126,21 @@ func (p *Provisioner) ProvisionHostPath(opts pvController.VolumeOptions, volumeC
 	return pvObj, nil
 }
 
+// GetNodeObjectFromHostName returns the Node Object with matching NodeHostName
+func (p *Provisioner) GetNodeObjectFromHostName(hostName string) (*v1.Node, error) {
+	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{persistentvolume.KeyNode: hostName}}
+	listOptions := metav1.ListOptions{
+		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
+		Limit:         1,
+	}
+	nodeList, err := p.kubeClient.CoreV1().Nodes().List(listOptions)
+	if err != nil {
+		return nil, errors.Errorf("Unable to get the Node with the NodeHostName")
+	}
+	return &nodeList.Items[0], nil
+
+}
+
 // DeleteHostPath is invoked by the PVC controller to perform clean-up
 //  activities before deleteing the PV object. If reclaim policy is
 //  set to not-retain, then this function will create a helper pod
@@ -133,7 +151,6 @@ func (p *Provisioner) DeleteHostPath(pv *v1.PersistentVolume) (err error) {
 	}()
 
 	saName := getOpenEBSServiceAccountName()
-
 	//Determine the path and node of the Local PV.
 	pvObj := persistentvolume.NewForAPIObject(pv)
 	path := pvObj.GetPath()
@@ -145,7 +162,12 @@ func (p *Provisioner) DeleteHostPath(pv *v1.PersistentVolume) (err error) {
 	if hostname == "" {
 		return errors.Errorf("cannot find affinited node hostname")
 	}
-
+	alertlog.Logger.Infof("Get the Node Object from hostName: %v", hostname)
+	nodeObject, err := p.GetNodeObjectFromHostName(hostname)
+	if err != nil {
+		return err
+	}
+	taints := GetTaints(nodeObject)
 	//Initiate clean up only when reclaim policy is not retain.
 	klog.Infof("Deleting volume %v at %v:%v", pv.Name, hostname, path)
 	cleanupCmdsForPath := []string{"rm", "-rf"}
@@ -155,6 +177,7 @@ func (p *Provisioner) DeleteHostPath(pv *v1.PersistentVolume) (err error) {
 		path:               path,
 		nodeHostname:       hostname,
 		serviceAccountName: saName,
+		selectedNodeTaints: taints,
 	}
 
 	if err := p.createCleanupPod(podOpts); err != nil {

--- a/pkg/kubernetes/pod/v1alpha1/build.go
+++ b/pkg/kubernetes/pod/v1alpha1/build.go
@@ -40,8 +40,22 @@ func NewBuilder() *Builder {
 	return &Builder{pod: &Pod{object: &corev1.Pod{}}}
 }
 
-// WithTolerations sets the Spec.Tolerations withh provided value.
-func (b *Builder) WithTolerations(tolerations ...corev1.Toleration) *Builder {
+// WithTolerationsForTaints sets the Spec.Tolerations with provided taints.
+func (b *Builder) WithTolerationsForTaints(taints ...corev1.Taint) *Builder {
+
+	tolerations := []corev1.Toleration{}
+	for i := range taints {
+		var toleration corev1.Toleration
+		toleration.Key = taints[i].Key
+		toleration.Effect = taints[i].Effect
+		if len(taints[i].Value) == 0 {
+			toleration.Operator = corev1.TolerationOpExists
+		} else {
+			toleration.Value = taints[i].Value
+			toleration.Operator = corev1.TolerationOpEqual
+		}
+		tolerations = append(tolerations, toleration)
+	}
 
 	b.pod.object.Spec.Tolerations = append(
 		b.pod.object.Spec.Tolerations,

--- a/pkg/kubernetes/pod/v1alpha1/build.go
+++ b/pkg/kubernetes/pod/v1alpha1/build.go
@@ -40,6 +40,19 @@ func NewBuilder() *Builder {
 	return &Builder{pod: &Pod{object: &corev1.Pod{}}}
 }
 
+// WithTolerations sets the Spec.Tolerations withh provided value.
+func (b *Builder) WithTolerations(tolerations ...corev1.Toleration) *Builder {
+	/*if len(tolerations) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build Pod object: missing Tolerations"),
+		)
+		return b
+	}*/
+	b.pod.object.Spec.Tolerations = tolerations
+	return b
+}
+
 // WithName sets the Name field of Pod with provided value.
 func (b *Builder) WithName(name string) *Builder {
 	if len(name) == 0 {

--- a/pkg/kubernetes/pod/v1alpha1/build.go
+++ b/pkg/kubernetes/pod/v1alpha1/build.go
@@ -49,7 +49,10 @@ func (b *Builder) WithTolerations(tolerations ...corev1.Toleration) *Builder {
 		)
 		return b
 	}*/
-	b.pod.object.Spec.Tolerations = tolerations
+	b.pod.object.Spec.Tolerations = append(
+		b.pod.object.Spec.Tolerations,
+		tolerations...,
+	)
 	return b
 }
 

--- a/pkg/kubernetes/pod/v1alpha1/build.go
+++ b/pkg/kubernetes/pod/v1alpha1/build.go
@@ -42,13 +42,7 @@ func NewBuilder() *Builder {
 
 // WithTolerations sets the Spec.Tolerations withh provided value.
 func (b *Builder) WithTolerations(tolerations ...corev1.Toleration) *Builder {
-	/*if len(tolerations) == 0 {
-		b.errs = append(
-			b.errs,
-			errors.New("failed to build Pod object: missing Tolerations"),
-		)
-		return b
-	}*/
+
 	b.pod.object.Spec.Tolerations = append(
 		b.pod.object.Spec.Tolerations,
 		tolerations...,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- This PR is fixing the deploying of the helperPod used by localPV-provisioner (`openebs-hostpath`), when the nodes are tainted, by adding the respective tolerations to the pod.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
- With reference to PR: https://github.com/openebs/openebs/issues/2860

**Special notes for your reviewer**:
- In this PR, I have added a more struct of `corev1.Tolerations`, in helperPod Config.
- Added a struct of `corev1.Taints` in the node related details.
- Added helper to get the appropriate details.
- For testing purposes, added taints to the nodes, on which the PV was claimed, then commented out the exit for helperPod, and then just described the pod yaml, to check if tolerations was added to them.

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests