### PR TITLE
refact(upgrade): remove pod exec from jiva volume verification

### DIFF
--- a/pkg/upgrade/upgrader/jiva_upgrade.go
+++ b/pkg/upgrade/upgrader/jiva_upgrade.go
@@ -294,6 +294,7 @@ func getReplicationFactor(ctrlLabel, namespace string) (int, error) {
 		return 0, errors.Errorf("no deployments found for %s in %s", ctrlLabel, namespace)
 	}
 	ctrlPod := ctrlList.Items[0]
+	// the only env in jiva target pod is "REPLICATION_FACTOR"
 	return strconv.Atoi(ctrlPod.Spec.Containers[0].Env[0].Value)
 }
 
@@ -334,8 +335,8 @@ func validateSync(pvLabel, namespace string) error {
 		if err != nil {
 			return err
 		}
-		replicas := jivaClient.ReplicaCollection{}
 		defer resp.Body.Close()
+		replicas := jivaClient.ReplicaCollection{}
 		err = json.NewDecoder(resp.Body).Decode(&replicas)
 		if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR removes the pod exec from the jiva volume upgrade verification step to avoid failure of jobs when `pods/exec` permission is not provided or `DenyEscalatingExec` is used to configure the cluster.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests