### PR TITLE
feat(PDB, cStor Pools): add a support to create PDB for cStor

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1117,6 +1117,7 @@
     "k8s.io/api/batch/v1",
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",
+    "k8s.io/api/policy/v1beta1",
     "k8s.io/api/storage/v1",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/resource",

--- a/cmd/cspc-operator/app/storagepool_create.go
+++ b/cmd/cspc-operator/app/storagepool_create.go
@@ -207,10 +207,10 @@ func getDeployOwnerReference(csp *apis.CStorPoolInstance) []metav1.OwnerReferenc
 // TODO: Use builder for labels and annotations
 func getDeployLabels(csp *apis.CStorPoolInstance) map[string]string {
 	return map[string]string{
-		string(apis.CStorPoolClusterCPK): csp.Labels[string(apis.CStorPoolClusterCPK)],
-		"app":                            "cstor-pool",
-		"openebs.io/cstor-pool-instance": csp.Name,
-		"openebs.io/version":             version.GetVersion(),
+		string(apis.CStorPoolClusterCPK):  csp.Labels[string(apis.CStorPoolClusterCPK)],
+		"app":                             "cstor-pool",
+		string(apis.CStorPoolInstanceCPK): csp.Name,
+		"openebs.io/version":              version.GetVersion(),
 	}
 }
 

--- a/cmd/cvc-operator/controller/cstorvolumeclaim.go
+++ b/cmd/cvc-operator/controller/cstorvolumeclaim.go
@@ -569,12 +569,11 @@ func getOrCreatePodDisruptionBudget(
 	if len(pdbList.Items) == 1 {
 		return &pdbList.Items[0], nil
 	}
-	return createPDB(cvObj, poolNames, cspcName)
+	return createPDB(poolNames, cspcName)
 }
 
 // createPDB creates PDB for cStorVolumes based on arguments
-func createPDB(cvObj *apis.CStorVolume,
-	poolNames []string, cspcName string) (*policy.PodDisruptionBudget, error) {
+func createPDB(poolNames []string, cspcName string) (*policy.PodDisruptionBudget, error) {
 	// To store sorted poolNames
 	var copyPoolNames []string
 	// Calculate minAvailable value from cStorVolume replica count
@@ -584,7 +583,7 @@ func createPDB(cvObj *apis.CStorVolume,
 	sort.Strings(copyPoolNames)
 	hash, err := hash.Hash(copyPoolNames)
 	if err != nil {
-		errors.Wrapf(err, "failed to get hash of pools to populate PDB name")
+		return nil, errors.Wrapf(err, "failed to get hash of pools to populate PDB name")
 	}
 	// If two threads tries to create PDB for same pools at same then one who
 	// created first will succeed other will be errored saying PDB already

--- a/cmd/cvc-operator/controller/cstorvolumeclaim.go
+++ b/cmd/cvc-operator/controller/cstorvolumeclaim.go
@@ -569,8 +569,8 @@ func getOrCreatePodDisruptionBudget(
 func createPDB(cvObj *apis.CStorVolume,
 	poolNames []string, cspcName string) (*policy.PodDisruptionBudget, error) {
 	// Calculate minAvailable value from cStorVolume replica count
-	minAvailable := (cvObj.Spec.ReplicationFactor >> 1) + 1
-	minAvailableIntStr := intstr.FromInt(minAvailable)
+	//minAvailable := (cvObj.Spec.ReplicationFactor >> 1) + 1
+	maxUnavailableIntStr := intstr.FromInt(1)
 
 	//build podDisruptionBudget for volume
 	pdbObj := policy.PodDisruptionBudget{
@@ -579,8 +579,8 @@ func createPDB(cvObj *apis.CStorVolume,
 			Labels:       cvclaim.GetPDBLabels(poolNames, cspcName),
 		},
 		Spec: policy.PodDisruptionBudgetSpec{
-			MinAvailable: &minAvailableIntStr,
-			Selector:     getPDBSelector(poolNames),
+			MaxUnavailable: &maxUnavailableIntStr,
+			Selector:       getPDBSelector(poolNames),
 		},
 	}
 	// Create podDisruptionBudget

--- a/cmd/cvc-operator/controller/cstorvolumeclaim.go
+++ b/cmd/cvc-operator/controller/cstorvolumeclaim.go
@@ -589,7 +589,7 @@ func createPDB(cvObj *apis.CStorVolume,
 	// If two threads tries to create PDB for same pools at same then one who
 	// created first will succeed other will be errored saying PDB already
 	// exists with that name
-	pdbName := cspcName + hash
+	pdbName := cspcName + "-" + hash
 
 	//build podDisruptionBudget for volume
 	pdbObj := policy.PodDisruptionBudget{

--- a/cmd/cvc-operator/controller/cvc_controller.go
+++ b/cmd/cvc-operator/controller/cvc_controller.go
@@ -628,6 +628,8 @@ func (c *CVCController) resizeCV(cv *apis.CStorVolume, newCapacity resource.Quan
 // deletePDBIfNotInUse deletes the PDB if no volume is refering to the
 // cStorvolumeclaim PDB
 func (c *CVCController) deletePDBIfNotInUse(cvc *apis.CStorVolumeClaim) error {
+	//TODO: If HALease is enabled active-active then below code needs to be
+	//revist
 	pdbName := getPDBName(cvc)
 	cvcLabelSelector := string(apis.PodDisruptionBudgetKey) + "=" + pdbName
 	cvcList, err := c.clientset.

--- a/cmd/cvc-operator/controller/cvc_controller.go
+++ b/cmd/cvc-operator/controller/cvc_controller.go
@@ -275,6 +275,8 @@ func (c *CVCController) createVolumeOperation(cvc *apis.CStorVolumeClaim) (*apis
 	}
 
 	if isHAVolume(cvc) {
+		// TODO: When multiple threads or multiple CVC controllers are set then
+		// we have to revist entier PDB code path
 		var pdbObj *policy.PodDisruptionBudget
 		pdbObj, err = getOrCreatePodDisruptionBudget(cvObj, getCSPC(cvc))
 		if err != nil {

--- a/cmd/cvc-operator/controller/cvc_controller.go
+++ b/cmd/cvc-operator/controller/cvc_controller.go
@@ -26,6 +26,7 @@ import (
 	errors "github.com/pkg/errors"
 	"k8s.io/klog"
 
+	cvclaim "github.com/openebs/maya/pkg/cstorvolumeclaim/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1beta1"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
@@ -274,7 +275,7 @@ func (c *CVCController) createVolumeOperation(cvc *apis.CStorVolumeClaim) (*apis
 		return nil, err
 	}
 
-	if isHAVolume(cvc) {
+	if cvclaim.IsHAVolume(cvc) {
 		var pdbObj *policy.PodDisruptionBudget
 		pdbObj, err = getOrCreatePodDisruptionBudget(cvObj, getCSPC(cvc))
 		if err != nil {
@@ -355,7 +356,7 @@ func (c *CVCController) isClaimDeletionCandidate(cvc *apis.CStorVolumeClaim) boo
 func (c *CVCController) removeClaimFinalizer(
 	cvc *apis.CStorVolumeClaim,
 ) error {
-	if isHAVolume(cvc) {
+	if cvclaim.IsHAVolume(cvc) {
 		err := c.deletePDBIfNotInUse(cvc)
 		if err != nil {
 			return errors.Wrapf(err,

--- a/cmd/cvc-operator/controller/cvc_controller.go
+++ b/cmd/cvc-operator/controller/cvc_controller.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	apispdb "github.com/openebs/maya/pkg/kubernetes/poddisruptionbudget"
 	errors "github.com/pkg/errors"
 	"k8s.io/klog"
 
@@ -31,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -63,6 +65,9 @@ const (
 	// CStorVolumeClaimFinalizer name of finalizer on CStorVolumeClaim that
 	// are bound by CStorVolume
 	CStorVolumeClaimFinalizer = "cvc.openebs.io/finalizer"
+	// DeProvisioning is used as part of the event 'reason' during
+	// cstorvolumeclaim deprovisioning stage
+	DeProvisioning = "DeProvisioning"
 )
 
 var knownResizeConditions = map[apis.CStorVolumeClaimConditionType]bool{
@@ -144,7 +149,11 @@ func (c *CVCController) syncCVC(cvc *apis.CStorVolumeClaim) error {
 	// and remove finalizer.
 	if c.isClaimDeletionCandidate(cvc) {
 		klog.Infof("syncClaim: remove finalizer for CStorVolumeClaimVolume [%s]", cvc.Name)
-		return c.removeClaimFinalizer(cvc)
+		err := c.removeClaimFinalizer(cvc)
+		if err != nil {
+			c.recorder.Eventf(cvc, corev1.EventTypeWarning, DeProvisioning, err.Error())
+		}
+		return nil
 	}
 
 	volName := cvc.Name
@@ -193,7 +202,6 @@ func (c *CVCController) syncCVC(cvc *apis.CStorVolumeClaim) error {
 	if err != nil {
 		return err
 	}
-
 	return nil
 }
 
@@ -230,7 +238,9 @@ func (c *CVCController) updateCVCObj(
 // 2. Create cstorvolume resource with required iscsi information.
 // 3. Create target deployment.
 // 4. Create cstorvolumeclaim resource.
-// 5. Update the cstorvolumeclaim with claimRef info and bound with cstorvolume.
+// 5. Create PDB provisioning volume is HA volume.
+// 5. Update the cstorvolumeclaim with claimRef info, PDB label(only for HA
+//    volumes) and bound with cstorvolume.
 func (c *CVCController) createVolumeOperation(cvc *apis.CStorVolumeClaim) (*apis.CStorVolumeClaim, error) {
 
 	policyName := cvc.Annotations[string(apis.VolumePolicyKey)]
@@ -261,6 +271,15 @@ func (c *CVCController) createVolumeOperation(cvc *apis.CStorVolumeClaim) (*apis
 	err = c.distributePendingCVRs(cvc, cvObj, svcObj)
 	if err != nil {
 		return nil, err
+	}
+
+	if isHAVolume(cvc) {
+		pdbObj, err := getOrCreatePodDisruptionBudget(cvObj, getCSPC(cvc))
+		if err != nil {
+			return nil, errors.Wrapf(err,
+				"failed to create PDB for volume: %s", cvc.Name)
+		}
+		cvc = addPDBLabelOnCVC(cvc, pdbObj)
 	}
 
 	volumeRef, err := ref.GetReference(scheme.Scheme, cvObj)
@@ -334,6 +353,15 @@ func (c *CVCController) isClaimDeletionCandidate(cvc *apis.CStorVolumeClaim) boo
 func (c *CVCController) removeClaimFinalizer(
 	cvc *apis.CStorVolumeClaim,
 ) error {
+	if isHAVolume(cvc) {
+		err := c.deletePDBIfNotInUse(cvc)
+		if err != nil {
+			return errors.Wrapf(err,
+				"failed to verify whether PDB %s is in use by other volumes",
+				getPDBName(cvc),
+			)
+		}
+	}
 	cvcPatch := []Patch{
 		Patch{
 			Op:   "remove",
@@ -591,6 +619,28 @@ func (c *CVCController) resizeCV(cv *apis.CStorVolume, newCapacity resource.Quan
 		Patch(cv.Name, types.MergePatchType, patchBytes)
 	if updateErr != nil {
 		return updateErr
+	}
+	return nil
+}
+
+func (c *CVCController) deletePDBIfNotInUse(cvc *apis.CStorVolumeClaim) error {
+	pdbName := getPDBName(cvc)
+	cvcLabelSelector := string(apis.PodDisruptionBudgetKey) + "=" + pdbName
+	cvcList, err := c.clientset.
+		OpenebsV1alpha1().
+		CStorVolumeClaims(cvc.Namespace).
+		List(metav1.ListOptions{LabelSelector: cvcLabelSelector})
+	if err != nil {
+		return errors.Wrapf(err,
+			"failed to list volumes refering to PDB %s", pdbName)
+	}
+	if len(cvcList.Items) == 1 {
+		err = apispdb.KubeClient().
+			WithNamespace(cvc.Namespace).
+			Delete(pdbName, &metav1.DeleteOptions{})
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/cmd/cvc-operator/controller/start.go
+++ b/cmd/cvc-operator/controller/start.go
@@ -84,6 +84,12 @@ func Start() error {
 		return errors.Wrap(err, "error building ndm clientset")
 	}
 
+	// openebsNamespace will hold where the OpenEBS is installed
+	openebsNamespace = getNamespace()
+	if openebsNamespace == "" {
+		return errors.Errorf("failed to get openebs namespace got empty")
+	}
+
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, time.Second*30)
 	cvcInformerFactory := informers.NewSharedInformerFactory(openebsClient, time.Second*30)
 

--- a/pkg/apis/openebs.io/v1alpha1/cas_keys.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_keys.go
@@ -93,6 +93,9 @@ const (
 	// cstorVolumeKey is the key to getch CStorVolume CR of a
 	// CVR. This key is present on CVR label.
 	CStorVolumeKey CASKey = "cstorvolume.openebs.io/name"
+
+	//PodDisruptionBudgetKey is the key used to identify the PDB
+	PodDisruptionBudgetKey = "openebs.io/pod-disruption-budget"
 )
 
 // CASPlainKey represents a openebs key used either in resource annotation

--- a/pkg/apis/openebs.io/v1alpha1/cas_keys.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_keys.go
@@ -97,8 +97,8 @@ const (
 	//PodDisruptionBudgetKey is the key used to identify the PDB
 	PodDisruptionBudgetKey = "openebs.io/pod-disruption-budget"
 
-	// CstorpoolInstanceLabel is the key used on pool dependent resources
-	CstorpoolInstanceLabel = "cstorpoolinstance.openebs.io/name"
+	// CStorpoolInstanceLabel is the key used on pool dependent resources
+	CStorpoolInstanceLabel = "cstorpoolinstance.openebs.io/name"
 )
 
 // CASPlainKey represents a openebs key used either in resource annotation

--- a/pkg/apis/openebs.io/v1alpha1/cas_keys.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_keys.go
@@ -96,6 +96,9 @@ const (
 
 	//PodDisruptionBudgetKey is the key used to identify the PDB
 	PodDisruptionBudgetKey = "openebs.io/pod-disruption-budget"
+
+	// CstorpoolInstanceLabel is the key used on pool dependent resources
+	CstorpoolInstanceLabel = "cstorpoolinstance.openebs.io/name"
 )
 
 // CASPlainKey represents a openebs key used either in resource annotation

--- a/pkg/apis/openebs.io/v1alpha1/cas_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_pool.go
@@ -37,6 +37,11 @@ const (
 	StoragePoolClaimCPK CasPoolKey = "openebs.io/storage-pool-claim"
 	// CStorPoolClusterCPK is the CStorPoolcluster label
 	CStorPoolClusterCPK CasPoolKey = "openebs.io/cstor-pool-cluster"
+	// CStorPoolInstanceCPK is the CStorPoolInstance label
+	CStorPoolInstanceCPK CasPoolKey = "openebs.io/cstor-pool-instance"
+	// PredecessorBlockDeviceCPK is the annotation on the block device claim
+	// holding previous block device name
+	PredecessorBlockDeviceCPK CasPoolKey = "openebs.io/bd-predecessor"
 	// NdmDiskTypeCPK is the node-disk-manager disk type e.g. 'sparse' or 'disk'
 	NdmDiskTypeCPK CasPoolKey = "ndm.io/disk-type"
 	// NdmBlockDeviceTypeCPK is the node-disk-manager blockdevice type e.g. // 'blockdevice'
@@ -63,6 +68,9 @@ const (
 	RaidzBlockDeviceCountCPV CasPoolValInt = 3
 	// Raidz2BlockDeviceCountCPV is the count for raidz2 type pool
 	Raidz2BlockDeviceCountCPV CasPoolValInt = 6
+	// PersistentVolumeCPK is a key on the various resources to identify it belongs
+	// to particular volume
+	PersistentVolumeCPK CasPoolKey = "openebs.io/persistent-volume"
 )
 
 // CasPool is a type which will be utilised by CAS engine to perform

--- a/pkg/apis/openebs.io/v1alpha1/cas_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_pool.go
@@ -39,9 +39,6 @@ const (
 	CStorPoolClusterCPK CasPoolKey = "openebs.io/cstor-pool-cluster"
 	// CStorPoolInstanceCPK is the CStorPoolInstance label
 	CStorPoolInstanceCPK CasPoolKey = "openebs.io/cstor-pool-instance"
-	// PredecessorBlockDeviceCPK is the annotation on the block device claim
-	// holding previous block device name
-	PredecessorBlockDeviceCPK CasPoolKey = "openebs.io/bd-predecessor"
 	// NdmDiskTypeCPK is the node-disk-manager disk type e.g. 'sparse' or 'disk'
 	NdmDiskTypeCPK CasPoolKey = "ndm.io/disk-type"
 	// NdmBlockDeviceTypeCPK is the node-disk-manager blockdevice type e.g. // 'blockdevice'

--- a/pkg/apis/openebs.io/v1alpha1/cstor_volume_claim.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_volume_claim.go
@@ -59,12 +59,6 @@ type CStorVolumeClaimSpec struct {
 	// CstorVolumeSource contains the source volumeName@snapShotname
 	// combaination.  This will be filled only if it is a clone creation.
 	CstorVolumeSource string `json:"cstorVolumeSource,omitempty"`
-	// PodDisruptionBudget will handle the podDisruptionBudget of volume
-	// 1. If podDisruptionBudget is set true then CVC controller will create PDB with
-	//    minAvailable value as 51% of replica count.
-	// 2. If podDisruptionBudget is set false then CVC controller will delete if there
-	//    is any existing PDB.
-	PodDisruptionBudget bool `json:"podDisruptionBudget,omitempty"`
 }
 
 // CStorVolumeClaimPublish contains info related to attachment of a volume to a node.

--- a/pkg/apis/openebs.io/v1alpha1/cstor_volume_claim.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_volume_claim.go
@@ -59,6 +59,12 @@ type CStorVolumeClaimSpec struct {
 	// CstorVolumeSource contains the source volumeName@snapShotname
 	// combaination.  This will be filled only if it is a clone creation.
 	CstorVolumeSource string `json:"cstorVolumeSource,omitempty"`
+	// PodDisruptionBudget will handle the podDisruptionBudget of volume
+	// 1. If podDisruptionBudget is set true then CVC controller will create PDB with
+	//    minAvailable value as 51% of replica count.
+	// 2. If podDisruptionBudget is set false then CVC controller will delete if there
+	//    is any existing PDB.
+	PodDisruptionBudget bool `json:"podDisruptionBudget,omitempty"`
 }
 
 // CStorVolumeClaimPublish contains info related to attachment of a volume to a node.

--- a/pkg/cstor/volumereplica/v1alpha1/utils.go
+++ b/pkg/cstor/volumereplica/v1alpha1/utils.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	errors "github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// getCVRList returns list of volume replicas related to provided volume
+func getCVRList(cvObj *apis.CStorVolume) (*apis.CStorVolumeReplicaList, error) {
+	pvName := cvObj.Labels[string(apis.PersistentVolumeCPK)]
+	pvLabel := string(apis.PersistentVolumeCPK) + "=" + pvName
+	return NewKubeclient(WithNamespace(cvObj.Namespace)).
+		List(metav1.ListOptions{
+			LabelSelector: pvLabel,
+		})
+}
+
+// getPoolNames returns list of pool names from cStor volume replcia list
+func getPoolNames(cvrList *apis.CStorVolumeReplicaList) []string {
+	poolNames := []string{}
+	for _, cvrObj := range cvrList.Items {
+		poolNames = append(poolNames, cvrObj.Labels[string(apis.CstorpoolInstanceLabel)])
+	}
+	return poolNames
+}
+
+// GetReplicaPoolNames return list of replicas pool names by taking cStor
+// volume claim as a argument and return error(if any error occured)
+func GetReplicaPoolNames(cvObj *apis.CStorVolume) ([]string, error) {
+	pvName := cvObj.Labels[string(apis.PersistentVolumeCPK)]
+	cvrList, err := getCVRList(cvObj)
+	if err != nil {
+		return []string{}, errors.Wrapf(err,
+			"failed to list cStorVolumeReplicas related to volume %s",
+			pvName)
+	}
+	return getPoolNames(cvrList), nil
+}

--- a/pkg/cstorvolumeclaim/v1alpha1/utils.go
+++ b/pkg/cstorvolumeclaim/v1alpha1/utils.go
@@ -61,7 +61,7 @@ func GetPDBPoolLabels(poolNames []string) map[string]string {
 	pdbLabels := map[string]string{}
 	for _, poolName := range poolNames {
 		key := fmt.Sprintf("openebs.io/%s", poolName)
-		pdbLabels[key] = ""
+		pdbLabels[key] = "true"
 	}
 	return pdbLabels
 }

--- a/pkg/cstorvolumeclaim/v1alpha1/utils.go
+++ b/pkg/cstorvolumeclaim/v1alpha1/utils.go
@@ -24,12 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 )
 
-const (
-	// minHAReplicaCount is minimum no.of replicas are required to decide
-	// HighAvailable volume
-	minHAReplicaCount = 3
-)
-
 // CVCKey returns an unique key of a CVC object,
 func CVCKey(cvc *apis.CStorVolumeClaim) string {
 	return fmt.Sprintf("%s/%s", cvc.Namespace, cvc.Name)
@@ -49,11 +43,6 @@ func getPatchData(oldObj, newObj interface{}) ([]byte, error) {
 		return nil, fmt.Errorf("CreateTwoWayMergePatch failed: %v", err)
 	}
 	return patchBytes, nil
-}
-
-// IsHAVolume returns true if replica count is greater than or equal to 3
-func IsHAVolume(cvcObj *apis.CStorVolumeClaim) bool {
-	return cvcObj.Spec.ReplicaCount >= minHAReplicaCount
 }
 
 // GetPDBPoolLabels returns the pool labels from poolNames

--- a/pkg/hash/hash_test.go
+++ b/pkg/hash/hash_test.go
@@ -15,6 +15,7 @@
 package hash
 
 import (
+	"sort"
 	"testing"
 )
 
@@ -103,5 +104,23 @@ func TestHashInnerStruct(t *testing.T) {
 	fakeHash, err := Hash(fakeComplexStruct)
 	if err != nil {
 		t.Errorf("Failed to calculate the hash expected string but got: '%s' Error: '%v'", fakeHash, err)
+	}
+}
+
+func TestHashOutput(t *testing.T) {
+	list1 := []string{"one", "three", "two", "four"}
+	list2 := []string{"four", "one", "three", "two"}
+	sort.Strings(list1)
+	sort.Strings(list2)
+	hash1, err := Hash(list1)
+	if err != nil {
+		t.Errorf("Failed to calculate the hash expected string but got: '%s' Error: '%v'", hash1, err)
+	}
+	hash2, err := Hash(list2)
+	if err != nil {
+		t.Errorf("Failed to calculate the hash expected string but got: '%s' Error: '%v'", hash2, err)
+	}
+	if hash1 != hash2 {
+		t.Errorf("hash value didn't matched for the same list")
 	}
 }

--- a/pkg/kubernetes/poddisruptionbudget/kubernetes.go
+++ b/pkg/kubernetes/poddisruptionbudget/kubernetes.go
@@ -34,9 +34,6 @@ import (
 var (
 	kubeClientInst *kubernetes.Clientset
 	once           sync.Once
-	// pdbMutex will helpful if multiple threads are simultaneously accessing PDB
-	// NOTE: Take a lock only for write operations
-	pdbMutex *sync.Mutex = &sync.Mutex{}
 )
 
 // delFunc is a typed function that abstracts deleting poddisruptionbudget
@@ -181,8 +178,6 @@ func (k *Kubeclient) Delete(name string, options *metav1.DeleteOptions) error {
 	if err != nil {
 		return err
 	}
-	pdbMutex.Lock()
-	defer pdbMutex.Unlock()
 	return k.del(cli, name, k.namespace, options)
 }
 
@@ -193,8 +188,6 @@ func (k *Kubeclient) List(opts metav1.ListOptions) (*policy.PodDisruptionBudgetL
 	if err != nil {
 		return nil, err
 	}
-	pdbMutex.Lock()
-	defer pdbMutex.Unlock()
 	return k.list(cs, k.namespace, opts)
 }
 
@@ -208,8 +201,6 @@ func (k *Kubeclient) Create(pdb *policy.PodDisruptionBudget) (*policy.PodDisrupt
 	if err != nil {
 		return nil, err
 	}
-	pdbMutex.Lock()
-	defer pdbMutex.Unlock()
 	return k.create(cs, k.namespace, pdb)
 }
 
@@ -223,7 +214,5 @@ func (k *Kubeclient) Get(name string, opts metav1.GetOptions) (*policy.PodDisrup
 	if err != nil {
 		return nil, err
 	}
-	pdbMutex.Lock()
-	defer pdbMutex.Unlock()
 	return k.get(cs, name, k.namespace, opts)
 }

--- a/pkg/kubernetes/poddisruptionbudget/kubernetes.go
+++ b/pkg/kubernetes/poddisruptionbudget/kubernetes.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/pkg/errors"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	client "github.com/openebs/maya/pkg/kubernetes/client/v1alpha1"
+	policy "k8s.io/api/policy/v1beta1"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+// make kubernetes clientset as singleton
+var (
+	kubeClientInst *kubernetes.Clientset
+	once           sync.Once
+)
+
+// delFunc is a typed function that abstracts deleting poddisruptionbudget
+type delFunc func(cs *kubernetes.Clientset, name, namespace string, opts *metav1.DeleteOptions) error
+
+// getFunc is a typed function that abstracts
+// getting poddisruptionbudget instances
+type getFunc func(cs *kubernetes.Clientset, name, namespace string, opts metav1.GetOptions) (*policy.PodDisruptionBudget, error)
+
+// createFn is a typed function that abstracts
+// deleting poddisruptionbudget
+type createFunc func(cli *kubernetes.Clientset, namespace string,
+	pdb *policy.PodDisruptionBudget) (
+	*policy.PodDisruptionBudget,
+	error,
+)
+
+// listFunc is a typed function that abstracts
+// listing poddisruptionbudget instances
+type listFunc func(cs *kubernetes.Clientset, namespace string, opts metav1.ListOptions) (*policy.PodDisruptionBudgetList, error)
+
+// getClientsetFunc is a typed function that
+// abstracts fetching internal clientset
+type getClientsetFunc func() (cs *kubernetes.Clientset, err error)
+
+// KubeclientBuildOption defines the abstraction
+// to build a kubeclient instance
+type KubeclientBuildOption func(*Kubeclient)
+
+// Kubeclient enables kubernetes API operations
+// on upgrade result instance
+type Kubeclient struct {
+	// clientset refers to upgrade's
+	// clientset that will be responsible to
+	// make kubernetes API calls
+	clientset *kubernetes.Clientset
+	namespace string
+	// functions useful during mocking
+	getClientset getClientsetFunc
+	list         listFunc
+	create       createFunc
+	get          getFunc
+	del          delFunc
+}
+
+// withDefaults sets the default options
+// of kubeclient instance
+func (k *Kubeclient) withDefaults() {
+	if k.getClientset == nil {
+		k.getClientset = func() (cs *kubernetes.Clientset, err error) {
+			if kubeClientInst != nil {
+				return kubeClientInst, nil
+			}
+			config, err := client.GetConfig(client.New())
+			if err != nil {
+				return nil, err
+			}
+			kubeCS, err := kubernetes.NewForConfig(config)
+			if err != nil {
+				return nil, err
+			}
+			once.Do(func() {
+				kubeClientInst = kubeCS
+			})
+			return kubeCS, nil
+		}
+	}
+	if k.del == nil {
+		k.del = func(cs *kubernetes.Clientset, name, namesapce string, opts *metav1.DeleteOptions) error {
+			return cs.PolicyV1beta1().PodDisruptionBudgets(namesapce).Delete(name, opts)
+		}
+	}
+	if k.create == nil {
+		k.create = func(cs *kubernetes.Clientset,
+			namesapce string, pdb *policy.PodDisruptionBudget) (*policy.PodDisruptionBudget, error) {
+			return cs.PolicyV1beta1().PodDisruptionBudgets(namesapce).Create(pdb)
+		}
+	}
+	if k.list == nil {
+		k.list = func(cs *kubernetes.Clientset,
+			namespace string, opts metav1.ListOptions) (*policy.PodDisruptionBudgetList, error) {
+			return cs.PolicyV1beta1().PodDisruptionBudgets(namespace).List(opts)
+		}
+	}
+	if k.get == nil {
+		k.get = func(
+			cs *kubernetes.Clientset,
+			name, namespace string, opts metav1.GetOptions) (*policy.PodDisruptionBudget, error) {
+			return cs.PolicyV1beta1().PodDisruptionBudgets(namespace).Get(name, opts)
+		}
+	}
+}
+
+// WithClientset sets the kubernetes clientset against
+// the kubeclient instance
+func WithClientset(c *kubernetes.Clientset) KubeclientBuildOption {
+	return func(k *Kubeclient) {
+		k.clientset = c
+	}
+}
+
+// KubeClient returns a new instance of kubeclient meant for
+// admission webhook related operations
+func KubeClient(opts ...KubeclientBuildOption) *Kubeclient {
+	k := &Kubeclient{}
+	for _, o := range opts {
+		o(k)
+	}
+	k.withDefaults()
+	return k
+}
+
+// WithNamespace sets namespace that should be used during
+// kuberenets API calls against namespaced resource
+func (k *Kubeclient) WithNamespace(namespace string) *Kubeclient {
+	k.namespace = namespace
+	return k
+}
+
+// getClientOrCached returns either a new instance
+// of kubernetes client or its cached copy
+func (k *Kubeclient) getClientOrCached() (*kubernetes.Clientset, error) {
+	if k.clientset != nil {
+		return k.clientset, nil
+	}
+	c, err := k.getClientset()
+	if err != nil {
+		return nil, err
+	}
+	k.clientset = c
+	return k.clientset, nil
+}
+
+// Delete deletes poddisruptionbudget object for given name in corresponding
+// namespace
+func (k *Kubeclient) Delete(name string, options *metav1.DeleteOptions) error {
+	if strings.TrimSpace(name) == "" {
+		return errors.New("failed to delete poddisruptionbudget: missing name")
+	}
+
+	cli, err := k.getClientOrCached()
+	if err != nil {
+		return err
+	}
+	return k.del(cli, name, k.namespace, options)
+}
+
+// List takes label and field selectors, and returns the list of
+// PodDisruptionBudget instances that match those selectors.
+func (k *Kubeclient) List(opts metav1.ListOptions) (*policy.PodDisruptionBudgetList, error) {
+	cs, err := k.getClientOrCached()
+	if err != nil {
+		return nil, err
+	}
+	return k.list(cs, k.namespace, opts)
+}
+
+// Create create poddisruptionbudget, and returns the
+// corresponding poddisruptionbudget object, and an error if there is any.
+func (k *Kubeclient) Create(pdb *policy.PodDisruptionBudget) (*policy.PodDisruptionBudget, error) {
+	if pdb == nil {
+		return nil, errors.New("failed to create poddisruptionbudget: nil pdb")
+	}
+	cs, err := k.getClientOrCached()
+	if err != nil {
+		return nil, err
+	}
+	return k.create(cs, k.namespace, pdb)
+}
+
+// Get takes name of the poddisruptionbudget, and returns the
+// corresponding poddisruptionbudget object, and an error if there is any.
+func (k *Kubeclient) Get(name string, opts metav1.GetOptions) (*policy.PodDisruptionBudget, error) {
+	if strings.TrimSpace(name) == "" {
+		return nil, errors.New("failed to get PodDisruptionBudget: missing poddisruptionbudget name")
+	}
+	cs, err := k.getClientOrCached()
+	if err != nil {
+		return nil, err
+	}
+	return k.get(cs, name, k.namespace, opts)
+}

--- a/pkg/kubernetes/poddisruptionbudget/poddisruptionbudget.go
+++ b/pkg/kubernetes/poddisruptionbudget/poddisruptionbudget.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+// GetPDBLabelSelector returns the labelSelector to list the PDB
+func GetPDBLabelSelector(pdbLabels map[string]string) string {
+	var labelSelector string
+	for key, value := range pdbLabels {
+		labelSelector = labelSelector + key + "=" + value + ","
+	}
+	return labelSelector[:len(labelSelector)-1]
+}


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does**:
This PR adds support to create PodDisruptionBudget only for cStor Pool pods
which contains HA volume replicas(volume provisioned with >= 3 replicas) in cStor pools.

 **why we need it**:
Valid voluntary disruptions will be disallowed on cStor pool pods if eviction of cStor pool pod affects the volume quorum factor.
- Draining a node for repair or upgrade.
- Draining a node from a cluster to scale the cluster down.

**Example for PDB creation:**
Provisioned a CSPC with five pool specs that intern creates 5 cStor pools. Now hundreds of HA volumes are provisioned with 3 replicas and volume replicas can be scheduled in any random order across CSPC cStor pools, no.of PDBs’ will be combination among the cStor pools. In this case, at most 5C3 PDBs will be created i.e 10 PDBs will be created[what if my storage replica count is 4? **5C3 + 5C4** PDB will be created].

**Sample PDB YAML:**
```yaml
apiVersion: policy/v1beta1
kind: PodDisruptionBudget
metadata:
  creationTimestamp: "2020-01-03T07:21:28Z"
  generateName: cstor-sparse-cspc
  generation: 1
  labels:
    openebs.io/cstor-pool-cluster: cstor-sparse-cspc
    openebs.io/cstor-sparse-cspc-jdgt: true
    openebs.io/cstor-sparse-cspc-klx6: true
    openebs.io/cstor-sparse-cspc-tblc: true
  name: cstor-sparse-cspcvlhqs
  namespace: openebs
  resourceVersion: "358868"
  selfLink: /apis/policy/v1beta1/namespaces/openebs/poddisruptionbudgets/cstor-sparse-cspcvlhqs
  uid: 7037b472-87b1-4dc3-ae1b-808b5265c043
spec:
  minAvailable: 2
  selector:
    matchExpressions:
    - key: openebs.io/cstor-pool-instance
      operator: In
      values:
      - cstor-sparse-cspc-jdgt
      - cstor-sparse-cspc-klx6
      - cstor-sparse-cspc-tblc
    matchLabels:
      app: cstor-pool
status:
  currentHealthy: 3
  desiredHealthy: 2
  disruptionsAllowed: 1
  expectedPods: 3
  observedGeneration: 1
```
**Sample CVC yaml after refering to PDB:**
```yaml
apiVersion: openebs.io/v1alpha1
kind: CStorVolumeClaim
metadata:
  annotations:
    openebs.io/volumeID: pvc-40dbc220-f1f3-45a2-b054-4d2add1450b0
  creationTimestamp: "2020-01-03T07:30:32Z"
  finalizers:
  - cvc.openebs.io/finalizer
  generation: 3
  labels:
    openebs.io/cstor-pool-cluster: cstor-sparse-cspc
    openebs.io/pod-disruption-budget: cstor-sparse-cspcq65jf 
  name: pvc-40dbc220-f1f3-45a2-b054-4d2add1450b0
  namespace: openebs
  resourceVersion: "362110"
  selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/cstorvolumeclaims/pvc-40dbc220-f1f3-45a2-b054-4d2add1450b0
  uid: 706aeac8-789d-4084-b5db-c82c353ff4ec
publish:
  nodeId: gke-shubham-test-default-pool-205971c3-122z
spec:
  capacity:
    storage: 5Gi
  cstorVolumeRef:
    apiVersion: openebs.io/v1alpha1
    kind: CStorVolume
    name: pvc-40dbc220-f1f3-45a2-b054-4d2add1450b0
    namespace: openebs
    resourceVersion: "362087"
    uid: 67171169-4b30-4167-bcc4-9e0fbcab159b
  replicaCount: 3
```
In above CVC `openebs.io/pod-disruption-budget: cstor-sparse-cspcq65jf`
label is added.

**Design Doc:**
https://docs.google.com/document/d/1Pq2ZDE7K1ttmqdJl4LgZW1B6JImxzJsLGrydOpjV7rs/edit?usp=sharing
OEP for PDB:
https://github.com/openebs/openebs/pull/2887

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests