### PR TITLE
fix(cspc): cleanup bdcs after deletion or scaledown of cspi

### DIFF
--- a/cmd/cspc-operator/app/cleanup.go
+++ b/cmd/cspc-operator/app/cleanup.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2020 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	bdc "github.com/openebs/maya/pkg/blockdeviceclaim/v1alpha1"
+	apiscspc "github.com/openebs/maya/pkg/cstor/poolcluster/v1alpha1"
+	cspi "github.com/openebs/maya/pkg/cstor/poolinstance/v1alpha3"
+	util "github.com/openebs/maya/pkg/util"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func cleanupCSPIResources(cspcObj *apis.CStorPoolCluster) error {
+	cspiList, err := cspi.NewKubeClient().WithNamespace(cspcObj.Namespace).List(
+		metav1.ListOptions{
+			LabelSelector: string(apis.CStorPoolClusterCPK) + "=" + cspcObj.Name,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	opts := []cspiCleanupOptions{cleanupBDC}
+	for _, cspiObj := range cspiList.Items {
+		cspiObj := cspiObj // pin it
+		if cspiObj.DeletionTimestamp != nil && len(cspiObj.Finalizers) == 1 {
+			for _, o := range opts {
+				err = o(cspiObj)
+				if err != nil {
+					return errors.Wrap(err, "failed to cleanup cspi resources")
+				}
+			}
+			cspiItem := &cspiObj
+			cspiItem.Finalizers = []string{}
+			_, err = cspi.NewKubeClient().WithNamespace(cspiObj.Namespace).Update(cspiItem)
+			if err != nil {
+				return errors.Wrap(err, "failed to remove finalizer from cspi")
+			}
+		}
+	}
+	return nil
+}
+
+type cspiCleanupOptions func(apis.CStorPoolInstance) error
+
+func cleanupBDC(cspiObj apis.CStorPoolInstance) error {
+	bdcList, err := bdc.NewKubeClient().WithNamespace(cspiObj.Namespace).List(
+		metav1.ListOptions{},
+	)
+	if err != nil {
+		return err
+	}
+	for _, bdcItem := range bdcList.Items {
+		bdcItem := bdcItem // pin it
+		if isBDCForCSPI(bdcItem.Spec.BlockDeviceName, cspiObj) {
+			bdcObj := &bdcItem
+			bdcObj.Finalizers = util.RemoveString(bdcObj.Finalizers, apiscspc.CSPCFinalizer)
+			bdcObj, err = bdc.NewKubeClient().WithNamespace(cspiObj.Namespace).Update(bdcObj)
+			if err != nil {
+				return errors.Wrap(err, "failed to remove finalizers from bdc")
+			}
+			err = bdc.NewKubeClient().WithNamespace(cspiObj.Namespace).Delete(bdcObj.Name, &metav1.DeleteOptions{})
+			if err != nil {
+				return errors.Wrap(err, "failed to delete bdc")
+			}
+		}
+	}
+	return err
+}
+
+func isBDCForCSPI(bdName string, cspiObj apis.CStorPoolInstance) bool {
+	for _, raidGroup := range cspiObj.Spec.RaidGroups {
+		for _, bdcObj := range raidGroup.BlockDevices {
+			if bdcObj.BlockDeviceName == bdName {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/cmd/cspc-operator/app/cleanup.go
+++ b/cmd/cspc-operator/app/cleanup.go
@@ -43,6 +43,8 @@ func cleanupCSPIResources(cspcObj *apis.CStorPoolCluster) error {
 		cspiItem := cspiItem // pin it
 		cspiObj := &cspiItem
 		if cspiObj.DeletionTimestamp != nil {
+			// if PoolProtectionFinalizer is not removed wait for the next reconcile
+			// attempt to perform cleanup
 			if canPerformCSPICleanup(cspiObj) {
 				for _, o := range opts {
 					err = o(cspiObj)
@@ -57,6 +59,8 @@ func cleanupCSPIResources(cspcObj *apis.CStorPoolCluster) error {
 				}
 				klog.Infof("cleanup for cspi %s was successful", cspiItem.Name)
 			} else {
+				// returning error helps prevent removal of finalizer on cspc object
+				// cspc object should not get deleted before all cspi are deleted successfully
 				return errors.Errorf("failed to cleanup cspi %s for cspc %s : waiting for pool to get destroyed",
 					cspiItem.Name, cspcObj.Name)
 			}

--- a/cmd/cspc-operator/app/cleanup.go
+++ b/cmd/cspc-operator/app/cleanup.go
@@ -34,7 +34,7 @@ func cleanupCSPIResources(cspcObj *apis.CStorPoolCluster) error {
 		},
 	)
 	if err != nil {
-		klog.Errorf("failed to cleanup resources for cspc %s: %s", cspcObj.Name, err.Error())
+		klog.Errorf("failed to list cspi for cspc %s to perform cleanup: %s", cspcObj.Name, err.Error())
 		return nil
 	}
 	opts := []cspiCleanupOptions{cleanupBDC}

--- a/cmd/cspc-operator/app/cleanup.go
+++ b/cmd/cspc-operator/app/cleanup.go
@@ -45,13 +45,13 @@ func cleanupCSPIResources(cspcObj *apis.CStorPoolCluster) error {
 			for _, o := range opts {
 				err = o(cspiObj)
 				if err != nil {
-					return errors.Wrapf(err, "failed to cleanup cspi %s for cspc %s", cspiObj.Name, cspcObj.Name)
+					return errors.Wrapf(err, "failed to cleanup cspi %s for cspc %s", cspiItem.Name, cspcObj.Name)
 				}
 			}
 			cspiObj.Finalizers = util.RemoveString(cspiObj.Finalizers, apiscspc.CSPCFinalizer)
-			_, err = cspi.NewKubeClient().WithNamespace(cspiObj.Namespace).Update(cspiObj)
+			_, err = cspi.NewKubeClient().WithNamespace(cspiItem.Namespace).Update(cspiObj)
 			if err != nil {
-				return errors.Wrapf(err, "failed to remove finalizer from cspi %s", cspiObj.Name)
+				return errors.Wrapf(err, "failed to remove finalizer from cspi %s", cspiItem.Name)
 			}
 		}
 	}
@@ -105,7 +105,7 @@ func cleanupBDC(cspiObj *apis.CStorPoolInstance) error {
 			bdcObj.Finalizers = util.RemoveString(bdcObj.Finalizers, apiscspc.CSPCFinalizer)
 			bdcObj, err = bdc.NewKubeClient().WithNamespace(cspiObj.Namespace).Update(bdcObj)
 			if err != nil {
-				return errors.Wrapf(err, "failed to remove finalizers from bdc %s", bdcObj.Name)
+				return errors.Wrapf(err, "failed to remove finalizers from bdc %s", bdcItem.Name)
 			}
 			err = bdc.NewKubeClient().WithNamespace(cspiObj.Namespace).Delete(bdcObj.Name, &metav1.DeleteOptions{})
 			if err != nil {

--- a/cmd/cspc-operator/app/cleanup.go
+++ b/cmd/cspc-operator/app/cleanup.go
@@ -63,7 +63,7 @@ func cleanupCSPIResources(cspcObj *apis.CStorPoolCluster) error {
 				// if cspi has DeletionTimestamp but the PoolProtectionFinalizer is present
 				// returning error helps prevent removal of finalizer on cspc object
 				// cspc object should not get deleted before all cspi are deleted successfully
-				return errors.Errorf("failed to cleanup cspi %s for cspc %s : waiting for pool to get destroyed",
+				return errors.Errorf("failed to cleanup cspi %s for cspc %s: waiting for pool to get destroyed or there is no CSPC label on CSPI",
 					cspiItem.Name, cspcObj.Name)
 			}
 		}

--- a/cmd/cspc-operator/app/handler.go
+++ b/cmd/cspc-operator/app/handler.go
@@ -95,6 +95,10 @@ func (c *Controller) syncHandler(key string) error {
 	// TODO: Deep-copy only when needed.
 	cspcGot := cspc.DeepCopy()
 	err = c.syncCSPC(cspcGot)
+	if err != nil {
+		return err
+	}
+	err = cleanupCSPIResources(cspcGot)
 	return err
 }
 

--- a/cmd/cspc-operator/app/handler.go
+++ b/cmd/cspc-operator/app/handler.go
@@ -319,6 +319,7 @@ func (pc *PoolConfig) deleteAssociatedCSPI() error {
 // BDC and CSPI resources in correct order and CSPC object itself.
 func (pc *PoolConfig) removeCSPCFinalizer() error {
 
+	// clean up all cspi related resources for given cspc
 	err := cleanupCSPIResources(pc.AlgorithmConfig.CSPC)
 	if err != nil {
 		klog.Errorf("Failed to cleanup CSPC api object %s: %s", pc.AlgorithmConfig.CSPC.Name, err.Error())

--- a/cmd/cspi-mgmt/app/handler.go
+++ b/cmd/cspi-mgmt/app/handler.go
@@ -272,7 +272,7 @@ func (c *CStorPoolInstanceController) removeFinalizer(cspi *apis.CStorPoolInstan
 
 // addPoolProtectionFinalizer is to add PoolProtectionFinalizer finalizer of cstorpoolinstance resource.
 func (c *CStorPoolInstanceController) addPoolProtectionFinalizer(cspi *apis.CStorPoolInstance) error {
-	// is CSPI is deleted or the finalizer is already present skip this step
+	// if PoolProtectionFinalizer is already present return
 	if util.ContainsString(cspi.Finalizers, apiscspc.PoolProtectionFinalizer) {
 		return nil
 	}

--- a/cmd/cspi-mgmt/app/handler.go
+++ b/cmd/cspi-mgmt/app/handler.go
@@ -129,6 +129,10 @@ func (c *CStorPoolInstanceController) reconcile(key string) error {
 func (c *CStorPoolInstanceController) destroy(cspi *apis.CStorPoolInstance) error {
 	var phase apis.CStorPoolPhase
 
+	if !util.ContainsString(cspi.Finalizers, apiscspc.PoolProtectionFinalizer) {
+		return nil
+	}
+
 	// DeletePool is to delete cstor zpool.
 	// It will also clear the label for relevant disk
 	err := zpool.Delete(cspi)

--- a/cmd/cspi-mgmt/app/handler.go
+++ b/cmd/cspi-mgmt/app/handler.go
@@ -25,6 +25,8 @@ import (
 
 	zpool "github.com/openebs/maya/cmd/cstor-pool-mgmt/pool/v1alpha2"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	apiscspc "github.com/openebs/maya/pkg/cstor/poolcluster/v1alpha1"
+	"github.com/openebs/maya/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -241,7 +243,7 @@ func (c *CStorPoolInstanceController) removeFinalizer(cspi *apis.CStorPoolInstan
 	if len(cspi.Finalizers) == 0 {
 		return nil
 	}
-	cspi.Finalizers = []string{}
+	cspi.Finalizers = util.RemoveString(cspi.Finalizers, apiscspc.PoolProtectionFinalizer)
 	_, err := c.clientset.
 		OpenebsV1alpha1().
 		CStorPoolInstances(cspi.Namespace).

--- a/pkg/algorithm/nodeselect/v1alpha2/build_csp.go
+++ b/pkg/algorithm/nodeselect/v1alpha2/build_csp.go
@@ -54,7 +54,7 @@ func (ac *Config) GetCSPSpec() (*apis.CStorPoolInstance, error) {
 
 	csplabels := ac.buildLabelsForCSPI(nodeName)
 	cspObj, err := apiscsp.NewBuilder().
-		WithName(ac.CSPC.Name+"-"+rand.String(4)).
+		WithName(ac.CSPC.Name + "-" + rand.String(4)).
 		WithNamespace(ac.Namespace).
 		WithNodeSelectorByReference(poolSpec.NodeSelector).
 		WithNodeName(nodeName).
@@ -62,7 +62,7 @@ func (ac *Config) GetCSPSpec() (*apis.CStorPoolInstance, error) {
 		WithRaidGroups(poolSpec.RaidGroups).
 		WithCSPCOwnerReference(ac.CSPC).
 		WithLabelsNew(csplabels).
-		WithFinalizer(apicspsc.CSPCFinalizer, apicspsc.PoolProtectionFinalizer).
+		WithFinalizer(apicspsc.CSPCFinalizer).
 		WithNewVersion(version.GetVersion()).
 		WithDependentsUpgraded().
 		Build()

--- a/pkg/algorithm/nodeselect/v1alpha2/build_csp.go
+++ b/pkg/algorithm/nodeselect/v1alpha2/build_csp.go
@@ -54,7 +54,7 @@ func (ac *Config) GetCSPSpec() (*apis.CStorPoolInstance, error) {
 
 	csplabels := ac.buildLabelsForCSPI(nodeName)
 	cspObj, err := apiscsp.NewBuilder().
-		WithName(ac.CSPC.Name + "-" + rand.String(4)).
+		WithName(ac.CSPC.Name+"-"+rand.String(4)).
 		WithNamespace(ac.Namespace).
 		WithNodeSelectorByReference(poolSpec.NodeSelector).
 		WithNodeName(nodeName).
@@ -62,7 +62,7 @@ func (ac *Config) GetCSPSpec() (*apis.CStorPoolInstance, error) {
 		WithRaidGroups(poolSpec.RaidGroups).
 		WithCSPCOwnerReference(ac.CSPC).
 		WithLabelsNew(csplabels).
-		WithFinalizer(apicspsc.CSPCFinalizer).
+		WithFinalizer(apicspsc.CSPCFinalizer, apicspsc.PoolProtectionFinalizer).
 		WithNewVersion(version.GetVersion()).
 		WithDependentsUpgraded().
 		Build()

--- a/pkg/cstor/poolcluster/v1alpha1/cstorpoolcluster.go
+++ b/pkg/cstor/poolcluster/v1alpha1/cstorpoolcluster.go
@@ -24,6 +24,9 @@ import (
 const (
 	// CSPCFinalizer represents finalizer value used by cspc
 	CSPCFinalizer = "cstorpoolcluster.openebs.io/finalizer"
+	// PoolProtectionFinalizer is used to make sure cspi and it's bdcs
+	// are not deleted before destroying the zpool
+	PoolProtectionFinalizer = "openebs.io/pool-protection"
 )
 
 // CSPC is a wrapper over cstorpoolcluster api

--- a/tests/cstor/cspc/provisioning/cspc_provisioning_utils_test.go
+++ b/tests/cstor/cspc/provisioning/cspc_provisioning_utils_test.go
@@ -14,11 +14,13 @@ limitations under the License.
 package provisioning
 
 import (
+	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	cspc_v1alpha1 "github.com/openebs/maya/pkg/cstor/poolcluster/v1alpha1"
 	cspcspecs_v1alpha1 "github.com/openebs/maya/pkg/cstor/poolcluster/v1alpha1/cstorpoolspecs"
 	cspcrg_v1alpha1 "github.com/openebs/maya/pkg/cstor/poolcluster/v1alpha1/raidgroups"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func createCSPCObjectForStripe() {
@@ -103,4 +105,30 @@ func verifyDesiredCSPIResourceCountTo(count int) {
 // This function is local to this package
 func getLabelSelector(cspc *apis.CStorPoolCluster) string {
 	return string(apis.CStorPoolClusterCPK) + "=" + cspc.Name
+}
+
+func downScaleCSPCObject() {
+	// getting the object to avoid update failure
+	cspcObj, err := ops.CSPCClient.WithNamespace(cspcObj.Namespace).
+		Get(cspcObj.Name, metav1.GetOptions{})
+	Expect(err).To(BeNil())
+	// downsclaing cspc by 1
+	cspcObj.Spec.Pools = cspcObj.Spec.Pools[:2]
+	_, err = ops.CSPCClient.WithNamespace(ops.NameSpace).Update(cspcObj)
+	Expect(err).To(BeNil())
+	cspiCount := ops.GetCSPIResourceCountEventually(getLabelSelector(cspcObj), 2)
+	Expect(cspiCount).To(Equal(2))
+}
+
+func cleanCSPCObject() {
+	When("Cleaning up cspc", func() {
+		It("should delete the cspc", func() {
+			SkipTest(skipPositiveCaseIfRequired)
+			err := ops.CSPCClient.Delete(cspcObj.Name, &metav1.DeleteOptions{})
+			Expect(err).To(BeNil())
+			cspiCount := ops.GetCSPIResourceCountEventually(getLabelSelector(cspcObj), 0)
+			Expect(cspiCount).To(BeZero())
+			Expect(ops.IsCSPCNotExists(cspcObj.Name)).To(BeTrue())
+		})
+	})
 }

--- a/tests/cstor/cspc/provisioning/cspc_provisioning_utils_test.go
+++ b/tests/cstor/cspc/provisioning/cspc_provisioning_utils_test.go
@@ -109,7 +109,8 @@ func getLabelSelector(cspc *apis.CStorPoolCluster) string {
 
 func downScaleCSPCObject() {
 	// getting the object to avoid update failure
-	cspcObj, err := ops.CSPCClient.WithNamespace(cspcObj.Namespace).
+	var err error
+	cspcObj, err = ops.CSPCClient.WithNamespace(cspcObj.Namespace).
 		Get(cspcObj.Name, metav1.GetOptions{})
 	Expect(err).To(BeNil())
 	// downsclaing cspc by 1

--- a/tests/operations.go
+++ b/tests/operations.go
@@ -794,7 +794,9 @@ func (ops *Operations) GetCSPIResourceCountEventually(labelSelector string, expe
 // GetHealthyCSPICount gets healthy csp based on spcName
 func (ops *Operations) GetHealthyCSPICount(cspcName string, expectedCSPICount int) int {
 	var cspiCount int
-	for i := 0; i < maxRetry; i++ {
+	// as cspi deletion takes more time now for cleanup of its resources
+	// for reconciled cspi to come up it can take additional time.
+	for i := 0; i < (maxRetry + 60); i++ {
 		cspiAPIList, err := ops.CSPIClient.WithNamespace(ops.NameSpace).List(metav1.ListOptions{})
 		time.Sleep(5 * time.Second)
 		Expect(err).To(BeNil())
@@ -806,7 +808,7 @@ func (ops *Operations) GetHealthyCSPICount(cspcName string, expectedCSPICount in
 		if cspiCount == expectedCSPICount {
 			return cspiCount
 		}
-		time.Sleep(5 * time.Second)
+		time.Sleep(3 * time.Second)
 	}
 	return cspiCount
 }


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
When a cspi is deleted or the cspc is scaled down by removing a poolSpec the bdcs for the cspi are not cleaned up. This results in stale resource and unwanted claims on bd which can be used by other resources. This PR adds the cleanup of bdcs in such cases.

Sample BDD output:
```sh
mayadata:provisioning$ ginkgo --focus=STRIPE  -v -- -kubeconfig=/var/run/kubernetes/admin.kubeconfig 
Running Suite: Test cstor invalid config
========================================
Random Seed: 1579607994
Will run 20 of 38 specs

STEP: waiting for maya-apiserver pod to come into running state
STEP: waiting for openebs-provisioner pod to come into running state
STEP: Verifying 'admission-server' pod status as running
[CSPC] CSTOR STRIPE POOL PROVISIONING AND DownScaling With BDC cleanup  when A CSPC Is Created 
  cStor Pools Should be Provisioned 
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:82
STEP: Preparing A CSPC Object, No Error Should Occur
STEP: Creating A CSPC Object, Desired Number of CSPIs Should Be Created

• [SLOW TEST:13.531 seconds]
[CSPC] CSTOR STRIPE POOL PROVISIONING AND DownScaling With BDC cleanup 
/home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:39
  when A CSPC Is Created
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:81
    cStor Pools Should be Provisioned 
    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:82
------------------------------
[CSPC] CSTOR STRIPE POOL PROVISIONING AND DownScaling With BDC cleanup  when The CSPC Is DownScaled  
  Extra BDCs Should Be Removed
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:91

• [SLOW TEST:5.476 seconds]
[CSPC] CSTOR STRIPE POOL PROVISIONING AND DownScaling With BDC cleanup 
/home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:39
  when The CSPC Is DownScaled 
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:90
    Extra BDCs Should Be Removed
    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:91
------------------------------
[CSPC] CSTOR STRIPE POOL PROVISIONING AND DownScaling With BDC cleanup  when Cleaning up cspc 
  should delete the cspc
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/cspc_provisioning_utils_test.go:125

• [SLOW TEST:15.433 seconds]
[CSPC] CSTOR STRIPE POOL PROVISIONING AND DownScaling With BDC cleanup 
/home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:39
  when Cleaning up cspc
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/cspc_provisioning_utils_test.go:124
    should delete the cspc
    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/cspc_provisioning_utils_test.go:125
------------------------------
SSSSSS
------------------------------
[CSPC] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION  when A CSPC Is Created 
  cStor Pools Should be Provisioned 
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:45
STEP: Preparing A CSPC Object, No Error Should Occur
STEP: Creating A CSPC Object, Desired Number of CSPIs Should Be Created

• [SLOW TEST:13.505 seconds]
[CSPC] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION 
/home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:27
  when A CSPC Is Created
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:44
    cStor Pools Should be Provisioned 
    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:45
------------------------------
[CSPC] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION  when The CSPC Finalizer Is Removed From CSPC 
  The Finalizer Should Come Back As Part Of Reconcilation
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:54
•
------------------------------
[CSPC] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION  when 1 CSPI Is Deleted 
  1 New CSPI Should Come Up Again
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:67

• [SLOW TEST:5.210 seconds]
[CSPC] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION 
/home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:27
  when 1 CSPI Is Deleted
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:64
    1 New CSPI Should Come Up Again
    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:67
------------------------------
[CSPC] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION  when 2 CSPI Is Deleted 
  2 New CSPI Should Come Up Again
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:67

• [SLOW TEST:5.254 seconds]
[CSPC] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION 
/home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:27
  when 2 CSPI Is Deleted
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:64
    2 New CSPI Should Come Up Again
    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:67
------------------------------
[CSPC] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION  when 3 CSPI Is Deleted 
  3 New CSPI Should Come Up Again
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:67

• [SLOW TEST:5.599 seconds]
[CSPC] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION 
/home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:27
  when 3 CSPI Is Deleted
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:64
    3 New CSPI Should Come Up Again
    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_test.go:67
------------------------------
[CSPC] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION  when Cleaning up cspc 
  should delete the cspc
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/cspc_provisioning_utils_test.go:125
•
------------------------------
[CSPC-NEGATIVE] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION  when A CSPC Is Created with CSPC Update error 
  No pool resource will be created  
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:43

S [SKIPPING] [0.001 seconds]
[CSPC-NEGATIVE] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION 
/home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:30
  when A CSPC Is Created with CSPC Update error
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:42
    No pool resource will be created   [It]
    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:43

    Skipping negative cases

    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:37
------------------------------
[CSPC-NEGATIVE] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION  when CSPC update error is removed 
  cStor Pools Should be Provisioned 
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:59

S [SKIPPING] [0.001 seconds]
[CSPC-NEGATIVE] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION 
/home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:30
  when CSPC update error is removed
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:58
    cStor Pools Should be Provisioned  [It]
    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:59

    Skipping negative cases

    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:37
------------------------------
[CSPC-NEGATIVE] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION  when Cleaning up cspc 
  should delete the cspc
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:165

S [SKIPPING] [0.001 seconds]
[CSPC-NEGATIVE] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION 
/home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:30
  when Cleaning up cspc
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:164
    should delete the cspc [It]
    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:165

    Skipping negative cases

    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:37
------------------------------
[CSPC-NEGATIVE] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION  when A CSPC Is Created with CSPI create error 
  No cStor Pools Should be Provisioned 
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:75

S [SKIPPING] [0.001 seconds]
[CSPC-NEGATIVE] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION 
/home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:30
  when A CSPC Is Created with CSPI create error
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:74
    No cStor Pools Should be Provisioned  [It]
    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:75

    Skipping negative cases

    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:37
------------------------------
[CSPC-NEGATIVE] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION  when CSPI create error is removed 
  cStor Pools Should be Provisioned 
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:91

S [SKIPPING] [0.001 seconds]
[CSPC-NEGATIVE] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION 
/home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:30
  when CSPI create error is removed
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:90
    cStor Pools Should be Provisioned  [It]
    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:91

    Skipping negative cases

    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:37
------------------------------
[CSPC-NEGATIVE] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION  when Cleaning up cspc 
  should delete the cspc
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:165

S [SKIPPING] [0.001 seconds]
[CSPC-NEGATIVE] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION 
/home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:30
  when Cleaning up cspc
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:164
    should delete the cspc [It]
    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:165

    Skipping negative cases

    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:37
------------------------------
[CSPC-NEGATIVE] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION  when A CSPC Is Created with deployment create error 
  CSPI should get created but not the corresponding pool deployments
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:107

S [SKIPPING] [0.001 seconds]
[CSPC-NEGATIVE] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION 
/home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:30
  when A CSPC Is Created with deployment create error
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:106
    CSPI should get created but not the corresponding pool deployments [It]
    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:107

    Skipping negative cases

    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:37
------------------------------
[CSPC-NEGATIVE] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION  when Deployment create error is removed 
  Pool deployments should come up and corresponding CSPIs should become healthy 
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:123

S [SKIPPING] [0.001 seconds]
[CSPC-NEGATIVE] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION 
/home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:30
  when Deployment create error is removed
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:122
    Pool deployments should come up and corresponding CSPIs should become healthy  [It]
    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:123

    Skipping negative cases

    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:37
------------------------------
[CSPC-NEGATIVE] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION  when Cleaning up cspc 
  should delete the cspc
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:165

S [SKIPPING] [0.001 seconds]
[CSPC-NEGATIVE] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION 
/home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:30
  when Cleaning up cspc
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:164
    should delete the cspc [It]
    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:165

    Skipping negative cases

    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:37
------------------------------
[CSPC-NEGATIVE] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION  when A CSPC Is Created with 30 % random error injection threshold  
  Pools should get provisioned eventually after all the errors has been ejected
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:137

S [SKIPPING] [0.001 seconds]
[CSPC-NEGATIVE] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION 
/home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:30
  when A CSPC Is Created with 30 % random error injection threshold 
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:136
    Pools should get provisioned eventually after all the errors has been ejected [It]
    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:137

    Skipping negative cases

    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:37
------------------------------
[CSPC-NEGATIVE] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION  when Cleaning up cspc 
  should delete the cspc
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:165

S [SKIPPING] [0.001 seconds]
[CSPC-NEGATIVE] CSTOR STRIPE POOL PROVISIONING AND RECONCILIATION 
/home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:30
  when Cleaning up cspc
  /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:164
    should delete the cspc [It]
    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:165

    Skipping negative cases

    /home/mayadata/work/src/github.com/openebs/maya/tests/cstor/cspc/provisioning/provisioning_negative_test.go:37
------------------------------
SSSSSSSSSSSS
Ran 9 of 38 Specs in 65.107 seconds
SUCCESS! -- 9 Passed | 0 Failed | 0 Pending | 29 Skipped
PASS

Ginkgo ran 1 suite in 1m9.083259009s
Test Suite Passed

```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests