### PR TITLE
fix(cstor-target): remove unnecessary mount paths for cstor target pod

### DIFF
--- a/cmd/cvc-operator/controller/cstorvolumedeployment.go
+++ b/cmd/cvc-operator/controller/cstorvolumedeployment.go
@@ -195,11 +195,6 @@ func getMonitorMounts() []corev1.VolumeMount {
 func getTargetMgmtMounts() []corev1.VolumeMount {
 	return append(
 		defaultMounts,
-		corev1.VolumeMount{
-			Name:             "tmp",
-			MountPath:        "/tmp",
-			MountPropagation: &mountPropagation,
-		},
 	)
 }
 
@@ -388,12 +383,6 @@ func getOrCreateCStorTargetDeployment(
 						volume.NewBuilder().
 							WithName("conf").
 							WithEmptyDir(&corev1.EmptyDirVolumeSource{}),
-						volume.NewBuilder().
-							WithName("tmp").
-							WithHostPathAndType(
-								getTargetDirPath(vol.Name),
-								&hostpathType,
-							),
 					),
 			).
 			Build()

--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -579,9 +579,6 @@ spec:
               mountPath: /var/run
             - name: conf
               mountPath: /usr/local/etc/istgt
-            - name: tmp
-              mountPath: /tmp
-              mountPropagation: Bidirectional
           {{- if eq $isMonitor "true" }}
           - image: {{ .Config.VolumeMonitorImage.value }}
             name: maya-volume-exporter
@@ -648,18 +645,11 @@ spec:
               mountPath: /var/run
             - name: conf
               mountPath: /usr/local/etc/istgt
-            - name: tmp
-              mountPath: /tmp
-              mountPropagation: Bidirectional
           volumes:
           - name: sockfile
             emptyDir: {}
           - name: conf
             emptyDir: {}
-          - name: tmp
-            hostPath:
-              path: {{ .Config.TargetDir.value }}/shared-{{ .Volume.owner }}-target
-              type: DirectoryOrCreate
 ---
 # runTask to create cStorVolumeReplica/(s)
 apiVersion: openebs.io/v1alpha1


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR removes the unnecessary mount path(/var/openebs/shared-pvc-ec03ed38-59a0-4025-a92f-81bd514dbd43-target) of the target pod.

Sample yaml of target pod without `/shared-pvc-47c.....`
```yaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    openebs.io/storage-class-ref: |
      name: single-sc
      resourceVersion: 2608
    prometheus.io/path: /metrics
    prometheus.io/port: "9500"
    prometheus.io/scrape: "true"
  creationTimestamp: "2020-01-07T12:47:19Z"
  generateName: pvc-ec03ed38-59a0-4025-a92f-81bd514dbd43-target-cc4884654-
  labels:
    app: cstor-volume-manager
    monitoring: volume_exporter_prometheus
    openebs.io/persistent-volume: pvc-ec03ed38-59a0-4025-a92f-81bd514dbd43
    openebs.io/persistent-volume-claim: demo-vol1-claim
    openebs.io/storage-class: single-sc
    openebs.io/target: cstor-target
    openebs.io/version: 1.6.0
    pod-template-hash: cc4884654
  name: pvc-ec03ed38-59a0-4025-a92f-81bd514dbd43-target-cc4884654-zdf4g
  namespace: test
  ownerReferences:
  - apiVersion: apps/v1
    blockOwnerDeletion: true
    controller: true
    kind: ReplicaSet
    name: pvc-ec03ed38-59a0-4025-a92f-81bd514dbd43-target-cc4884654
    uid: 62f22acd-144c-4b82-9e7c-8deccef1c9f6
  resourceVersion: "8592"
  selfLink: /api/v1/namespaces/test/pods/pvc-ec03ed38-59a0-4025-a92f-81bd514dbd43-target-cc4884654-zdf4g
  uid: 711ea063-7725-4330-a8db-3f3996d2717a
spec:
  containers:
  - image: openebs/cstor-istgt:ci
    imagePullPolicy: IfNotPresent
    name: cstor-istgt
    ports:
    - containerPort: 3260
      protocol: TCP
    resources: {}
    securityContext:
      privileged: true
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /var/run
      name: sockfile
    - mountPath: /usr/local/etc/istgt
      name: conf
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: openebs-maya-operator-token-jmd6j
      readOnly: true
  - args:
    - -e=cstor
    command:
    - maya-exporter
    image: quay.io/openebs/m-exporter:ci
    imagePullPolicy: IfNotPresent
    name: maya-volume-exporter
    ports:
    - containerPort: 9500
      protocol: TCP
    resources: {}
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /var/run
      name: sockfile
    - mountPath: /usr/local/etc/istgt
      name: conf
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: openebs-maya-operator-token-jmd6j
      readOnly: true
  - env:
    - name: OPENEBS_IO_CSTOR_VOLUME_ID
      value: 25ef3dd4-f5d8-4c0b-b089-9077403d1fc6
    - name: RESYNC_INTERVAL
      value: "30"
    - name: NODE_NAME
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: spec.nodeName
    - name: POD_NAME
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: metadata.name
    image: openebs/cstor-volume-mgmt:ci
    imagePullPolicy: IfNotPresent
    name: cstor-volume-mgmt
    ports:
    - containerPort: 80
      protocol: TCP
    resources: {}
    securityContext:
      privileged: true
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /var/run
      name: sockfile
    - mountPath: /usr/local/etc/istgt
      name: conf
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: openebs-maya-operator-token-jmd6j
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  nodeName: 127.0.0.1
  priority: 0
  restartPolicy: Always
  schedulerName: default-scheduler
  securityContext: {}
  serviceAccount: openebs-maya-operator
  serviceAccountName: openebs-maya-operator
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoExecute
    key: node.alpha.kubernetes.io/notReady
    operator: Exists
    tolerationSeconds: 30
  - effect: NoExecute
    key: node.alpha.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 30
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 30
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 30
  volumes:
  - emptyDir: {}
    name: sockfile
  - emptyDir: {}
    name: conf
  - name: openebs-maya-operator-token-jmd6j
    secret:
      defaultMode: 420
      secretName: openebs-maya-operator-token-jmd6j
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2020-01-07T12:47:20Z"
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2020-01-07T12:47:36Z"
    status: "True"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2020-01-07T12:47:36Z"
    status: "True"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2020-01-07T12:47:19Z"
    status: "True"
    type: PodScheduled
  containerStatuses:
  - containerID: docker://059acfa821b35e33362fb1a1c8be6c6ab6998e1adbf1ef9a90e8b63dfb8db43e
    image: openebs/cstor-istgt:ci
    imageID: docker-pullable://openebs/cstor-istgt@sha256:f9976ae3af3ddbf5976355424ba38d8bfc2a9918c7d5050c1f43a43191276d5e
    lastState: {}
    name: cstor-istgt
    ready: true
    restartCount: 0
    state:
      running:
        startedAt: "2020-01-07T12:47:29Z"
  - containerID: docker://38fa9c421593fb51cecd503b06be2e67f5e70c0ef7b17f3608559665a582165d
    image: openebs/cstor-volume-mgmt:ci
    imageID: docker://sha256:5298ac3f0a63ec5bba76d2cf59838f51f377ef9b3fdfc11cb801066d36a7036d
    lastState: {}
    name: cstor-volume-mgmt
    ready: true
    restartCount: 0
    state:
      running:
        startedAt: "2020-01-07T12:47:35Z"
  - containerID: docker://61a3a64c0df66abf3217a6c0429e1ba03213097f691f32b4b8a6a42e3c42e8c0
    image: quay.io/openebs/m-exporter:ci
    imageID: docker-pullable://quay.io/openebs/m-exporter@sha256:ecaacb24abf95aba20c9e2a8cc459617639bb843792b03ec3fa2967687db1fd3
    lastState: {}
    name: maya-volume-exporter
    ready: true
    restartCount: 0
    state:
      running:
        startedAt: "2020-01-07T12:47:32Z"
  hostIP: 127.0.0.1
  phase: Running
  podIP: 172.17.0.3
  qosClass: BestEffort
  startTime: "2020-01-07T12:47:20Z"
```
From the above pod yaml after removing the `/var/openebs/shared-pvc-ec03ed38-59a0-4025-a92f-81bd514dbd43-target` is running fine without any crashes or restarts.



**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests