### PR TITLE
[WIP] chore(cstor): add env to dump core in persistent storage path

### DIFF
--- a/cmd/cspc-operator/app/storagepool_create.go
+++ b/cmd/cspc-operator/app/storagepool_create.go
@@ -21,6 +21,7 @@ import (
 
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	apiscsp "github.com/openebs/maya/pkg/cstor/poolinstance/v1alpha3"
+	env "github.com/openebs/maya/pkg/env/v1alpha1"
 	container "github.com/openebs/maya/pkg/kubernetes/container/v1alpha1"
 	deploy "github.com/openebs/maya/pkg/kubernetes/deployment/appsv1/v1alpha1"
 	pts "github.com/openebs/maya/pkg/kubernetes/podtemplatespec/v1alpha1"
@@ -56,8 +57,8 @@ var (
 			MountPath: "/dev",
 		},
 		corev1.VolumeMount{
-			Name:      "tmp",
-			MountPath: "/tmp",
+			Name:      "storagepath",
+			MountPath: apis.PersistentStoragePath,
 		},
 		corev1.VolumeMount{
 			Name:      "udev",
@@ -172,9 +173,9 @@ func (pc *PoolConfig) GetPoolDeploySpec(cspi *apis.CStorPoolInstance) (*appsv1.D
 							&hostpathTypeDirectory,
 						),
 					volume.NewBuilder().
-						WithName("tmp").
+						WithName("storagepath").
 						WithHostPathAndType(
-							getSparseDirPath()+"/shared-"+pc.AlgorithmConfig.CSPC.Name,
+							env.GetOpenebsBaseDir()+"/cstor-pool/"+pc.AlgorithmConfig.CSPC.Name,
 							&hostpathTypeDirectoryOrCreate,
 						),
 					volume.NewBuilder().

--- a/cmd/cvc-operator/controller/cstorvolumedeployment.go
+++ b/cmd/cvc-operator/controller/cstorvolumedeployment.go
@@ -196,8 +196,8 @@ func getTargetMgmtMounts() []corev1.VolumeMount {
 	return append(
 		defaultMounts,
 		corev1.VolumeMount{
-			Name:             "tmp",
-			MountPath:        "/tmp",
+			Name:             "storagepath",
+			MountPath:        getPersistentStoragePath(),
 			MountPropagation: &mountPropagation,
 		},
 	)
@@ -267,15 +267,19 @@ func getVolumeMgmtImage() string {
 	return image
 }
 
-// getTargetDirPath returns cstor target volume directory for a
-// given volume, retrieves the value of the environment variable named
-// by the key.
-func getTargetDirPath(pvName string) string {
+func getPersistentStoragePath() string {
 	dir, present := os.LookupEnv("OPENEBS_IO_CSTOR_TARGET_DIR")
 	if !present {
 		dir = "/var/openebs"
 	}
-	return dir + "/shared-" + pvName + "-target"
+	return dir
+}
+
+// getTargetDirPath returns cstor target volume directory for a
+// given volume, retrieves the value of the environment variable named
+// by the key.
+func getTargetDirPath(pvName string) string {
+	return getPersistentStoragePath() + "/shared-" + pvName + "-target"
 }
 
 func getContainerPort(port int32) []corev1.ContainerPort {
@@ -389,7 +393,7 @@ func getOrCreateCStorTargetDeployment(
 							WithName("conf").
 							WithEmptyDir(&corev1.EmptyDirVolumeSource{}),
 						volume.NewBuilder().
-							WithName("tmp").
+							WithName("storagepath").
 							WithHostPathAndType(
 								getTargetDirPath(vol.Name),
 								&hostpathType,

--- a/cmd/cvc-operator/controller/cstorvolumedeployment.go
+++ b/cmd/cvc-operator/controller/cstorvolumedeployment.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	env "github.com/openebs/maya/pkg/env/v1alpha1"
 	container "github.com/openebs/maya/pkg/kubernetes/container/v1alpha1"
 	deploy "github.com/openebs/maya/pkg/kubernetes/deployment/appsv1/v1alpha1"
 	pts "github.com/openebs/maya/pkg/kubernetes/podtemplatespec/v1alpha1"
@@ -197,7 +198,7 @@ func getTargetMgmtMounts() []corev1.VolumeMount {
 		defaultMounts,
 		corev1.VolumeMount{
 			Name:             "storagepath",
-			MountPath:        getPersistentStoragePath(),
+			MountPath:        apis.PersistentStoragePath,
 			MountPropagation: &mountPropagation,
 		},
 	)
@@ -279,7 +280,7 @@ func getPersistentStoragePath() string {
 // given volume, retrieves the value of the environment variable named
 // by the key.
 func getTargetDirPath(pvName string) string {
-	return getPersistentStoragePath() + "/shared-" + pvName + "-target"
+	return env.GetOpenebsBaseDir() + "/cstor-target/" + pvName
 }
 
 func getContainerPort(port int32) []corev1.ContainerPort {

--- a/pkg/apis/openebs.io/v1alpha1/cas_keys.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_keys.go
@@ -85,6 +85,10 @@ const (
 	// PredecessorBDKey is the key to fetch the predecessor BD in case of
 	// block device replacement.
 	PredecessorBDKey = "openebs.io/bd-predecessor"
+
+	// PersistentStoragePath is the key to fetch the persistent storage path for
+	// cStor pool and target pods
+	PersistentStoragePath = "/var/openebs"
 )
 
 // CASPlainKey represents a openebs key used either in resource annotation

--- a/pkg/env/v1alpha1/env.go
+++ b/pkg/env/v1alpha1/env.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 )
 
 // ENVKey is a typed string to represent various environment keys used by this
@@ -68,6 +70,11 @@ const (
 	// This environment variable is set via kubernetes downward API
 	OpenEBSServiceAccount ENVKey = "OPENEBS_SERVICE_ACCOUNT"
 
+	// OpenEBSBaseDirectory is the environment variable to get openebs base
+	// directory on host machine
+	//
+	// This environment variable is set via users
+	OpenEBSBaseDirectory ENVKey = "OPENEBS_IO_BASE_DIR"
 	// TODO:
 	//
 	// The constants present here should be moved to respective/relevant packages
@@ -251,4 +258,13 @@ func lookupEnv(envKey string) (value string, present bool) {
 	value, present = os.LookupEnv(envKey)
 	value = strings.TrimSpace(value)
 	return
+}
+
+// GetOpenebsBaseDir returns the directory path to store necessary files
+func GetOpenebsBaseDir() string {
+	dir, present := lookupEnv(string(OpenEBSBaseDirectory))
+	if !present {
+		return apis.PersistentStoragePath
+	}
+	return dir
 }

--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -284,11 +284,11 @@ spec:
             - name: udev
               mountPath: /run/udev
             env:
-              ## PERSISTENT_STORAGE_PATH currently used to store
-              ## core dump of the process in specified path on host
-              ## machine
-            - name: PERSISTENT_STORAGE_PATH
-              value: {{ .Config.SparseDir.value }}
+            ## PERSISTENT_STORAGE_PATH currently used to store
+            ## core dump of the process in specified path on host
+            ## machine
+            ##- name: PERSISTENT_STORAGE_PATH
+            ##  value: {{ .Config.SparseDir.value }}
               # OPENEBS_IO_CSTOR_ID env has UID of cStorPool CR.
             - name: OPENEBS_IO_CSTOR_ID
               value: {{.TaskResult.putcstorpoolcr.objectUID}}

--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -284,6 +284,11 @@ spec:
             - name: udev
               mountPath: /run/udev
             env:
+              ## PERSISTENT_STORAGE_PATH currently used to store
+              ## core dump of the process in specified path on host
+              ## machine
+            - name: PERSISTENT_STORAGE_PATH
+              value: {{ .Config.SparseDir.value }}
               # OPENEBS_IO_CSTOR_ID env has UID of cStorPool CR.
             - name: OPENEBS_IO_CSTOR_ID
               value: {{.TaskResult.putcstorpoolcr.objectUID}}

--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -572,6 +572,11 @@ spec:
             - name: Luworkers
               value: {{ .Config.Luworkers.value }}
             {{- end }}
+              ## PERSISTENT_STORAGE_PATH currently used to store
+              ## core dump of the process in specified path on host
+              ## machine
+            - name: PERSISTENT_STORAGE_PATH
+              value: {{ .Config.TargetDir.value }}
             securityContext:
               privileged: true
             volumeMounts:
@@ -579,8 +584,8 @@ spec:
               mountPath: /var/run
             - name: conf
               mountPath: /usr/local/etc/istgt
-            - name: tmp
-              mountPath: /tmp
+            - name: storagePath
+              mountPath: {{ .Config.TargetDir.value }}
               mountPropagation: Bidirectional
           {{- if eq $isMonitor "true" }}
           - image: {{ .Config.VolumeMonitorImage.value }}
@@ -648,15 +653,15 @@ spec:
               mountPath: /var/run
             - name: conf
               mountPath: /usr/local/etc/istgt
-            - name: tmp
-              mountPath: /tmp
+            - name: storagePath
+              mountPath: {{ .Config.TargetDir.value }}
               mountPropagation: Bidirectional
           volumes:
           - name: sockfile
             emptyDir: {}
           - name: conf
             emptyDir: {}
-          - name: tmp
+          - name: storagePath
             hostPath:
               path: {{ .Config.TargetDir.value }}/shared-{{ .Volume.owner }}-target
               type: DirectoryOrCreate

--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -584,7 +584,7 @@ spec:
               mountPath: /var/run
             - name: conf
               mountPath: /usr/local/etc/istgt
-            - name: storagePath
+            - name: storagepath
               mountPath: {{ .Config.TargetDir.value }}
               mountPropagation: Bidirectional
           {{- if eq $isMonitor "true" }}
@@ -653,7 +653,7 @@ spec:
               mountPath: /var/run
             - name: conf
               mountPath: /usr/local/etc/istgt
-            - name: storagePath
+            - name: storagepath
               mountPath: {{ .Config.TargetDir.value }}
               mountPropagation: Bidirectional
           volumes:
@@ -661,7 +661,7 @@ spec:
             emptyDir: {}
           - name: conf
             emptyDir: {}
-          - name: storagePath
+          - name: storagepath
             hostPath:
               path: {{ .Config.TargetDir.value }}/shared-{{ .Volume.owner }}-target
               type: DirectoryOrCreate

--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -572,11 +572,11 @@ spec:
             - name: Luworkers
               value: {{ .Config.Luworkers.value }}
             {{- end }}
-              ## PERSISTENT_STORAGE_PATH currently used to store
-              ## core dump of the process in specified path on host
-              ## machine
-            - name: PERSISTENT_STORAGE_PATH
-              value: {{ .Config.TargetDir.value }}
+            ## PERSISTENT_STORAGE_PATH currently used to store
+            ## core dump of the process in specified path on host
+            ## machine
+            ##- name: PERSISTENT_STORAGE_PATH
+            ##  value: {{ .Config.TargetDir.value }}
             securityContext:
               privileged: true
             volumeMounts:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR fixes the mount path of cStor target pod to store
core dump of the process in a persistent location on the host machine.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests