### PR TITLE
fix(cStor, deployments): add OpenEBS base directory in deployments

### DIFF
--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -44,7 +44,7 @@ spec:
   # nothing exists at the given path i.e. an empty directory will be created.
   - name: HostPathType
     value: DirectoryOrCreate
-  # PersistentStoragePath is base directory to store lock, sock and cache and core files.
+  # PersistentStoragePath is base directory currently used to store core files.
   # PersistentStoragePath should be used only to mount inside a container.
   - name: PersistentStoragePath
     value: "/var/openebs"

--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -44,10 +44,6 @@ spec:
   # nothing exists at the given path i.e. an empty directory will be created.
   - name: HostPathType
     value: DirectoryOrCreate
-  # PersistentStoragePath is base directory currently used to store core files.
-  # PersistentStoragePath should be used only to mount inside a container.
-  - name: PersistentStoragePath
-    value: "/var/openebs"
   # OpenebsBaseDir is a hostPath directory to store process files on host machine
   - name: OpenebsBaseDir
     value: {{env "OPENEBS_IO_BASE_DIR" | default "/var/openebs"}}
@@ -285,7 +281,7 @@ spec:
             - name: device
               mountPath: /dev
             - name: storagepath
-              mountPath: {{ .Config.PersistentStoragePath.value }}
+              mountPath: /var/openebs
             - name: tmp
               mountPath: /tmp
             - name: sparse
@@ -325,7 +321,7 @@ spec:
             - name: tmp
               mountPath: /tmp
             - name: storagepath
-              mountPath: {{ .Config.PersistentStoragePath.value }}
+              mountPath: /var/openebs
             - name: sparse
               mountPath: {{ .Config.SparseDir.value }}
             - name: udev
@@ -374,7 +370,7 @@ spec:
             - name: tmp
               mountPath: /tmp
             - name: storagepath
-              mountPath: {{ .Config.PersistentStoragePath.value }}
+              mountPath: /var/openebs
             - mountPath: {{ .Config.SparseDir.value }}
               name: sparse
             - mountPath: /run/udev

--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -34,7 +34,7 @@ spec:
     value: {{env "OPENEBS_IO_VOLUME_MONITOR_IMAGE" | default "openebs/m-exporter:latest"}}
   - name: ReplicaCount
     value: "3"
-  # PersistentStoragePath is base directory to store core files.
+  # PersistentStoragePath is base directory currently used to store core files.
   # PersistentStoragePath should be used only to as mount in a container.
   - name: PersistentStoragePath
     value: "/var/openebs"

--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -588,6 +588,8 @@ spec:
               mountPath: /usr/local/etc/istgt
             - name: storagepath
               mountPath: {{ .Config.PersistentStoragePath.value }}
+            - name: tmp
+              mountPath: /tmp
               mountPropagation: Bidirectional
           {{- if eq $isMonitor "true" }}
           - image: {{ .Config.VolumeMonitorImage.value }}
@@ -657,6 +659,8 @@ spec:
               mountPath: /usr/local/etc/istgt
             - name: storagepath
               mountPath: {{ .Config.PersistentStoragePath.value }}
+            - name: tmp
+              mountPath: /tmp
               mountPropagation: Bidirectional
           volumes:
           - name: sockfile
@@ -666,6 +670,10 @@ spec:
           - name: storagepath
             hostPath:
               path: {{ .Config.OpenebsBaseDir.value }}/cstor-target/{{ .Volume.owner }}-target
+              type: DirectoryOrCreate
+          - name: tmp
+            hostPath:
+              path: {{ .Config.TargetDir.value }}/shared-{{ .Volume.owner }}-target
               type: DirectoryOrCreate
 ---
 # runTask to create cStorVolumeReplica/(s)

--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -34,10 +34,6 @@ spec:
     value: {{env "OPENEBS_IO_VOLUME_MONITOR_IMAGE" | default "openebs/m-exporter:latest"}}
   - name: ReplicaCount
     value: "3"
-  # PersistentStoragePath is base directory currently used to store core files.
-  # PersistentStoragePath should be used only to as mount in a container.
-  - name: PersistentStoragePath
-    value: "/var/openebs"
   # OpenebsBaseDir is a hostPath directory to store process files on host machine
   - name: OpenebsBaseDir
     value: {{env "OPENEBS_IO_BASE_DIR" | default "/var/openebs"}}
@@ -587,7 +583,7 @@ spec:
             - name: conf
               mountPath: /usr/local/etc/istgt
             - name: storagepath
-              mountPath: {{ .Config.PersistentStoragePath.value }}
+              mountPath: /var/openebs
             - name: tmp
               mountPath: /tmp
               mountPropagation: Bidirectional
@@ -658,7 +654,7 @@ spec:
             - name: conf
               mountPath: /usr/local/etc/istgt
             - name: storagepath
-              mountPath: {{ .Config.PersistentStoragePath.value }}
+              mountPath: /var/openebs
             - name: tmp
               mountPath: /tmp
               mountPropagation: Bidirectional


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR mounts the `/var/openebs` of the container into  OPENEBS_IO_BASE_DIR/<cstor_target/pool>/<resource_name> on the host path.
These changes are made to persist core files on the host path.

**How Users Can Configure**
Users can specify the value of OPENEBS_IO_BASE_DIR in Maya deployment.
While creating cStor pool/volume corresponding component will read the ENV value
and use base_dir for mounting. If ENV doesn't exist base_dir will mount `/var/openebs`.

Below are PR's to support dumping core in /var/openebs/core inside a container:
cStor: https://github.com/openebs/cstor/pull/284
istgt: https://github.com/openebs/istgt/pull/298




**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
These changes are for SPC type of provisioning subsequent PRs will be raised for CSPC.

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests