### PR TITLE
fix(pool-mgmt): Removing stale CVR/CSP when dataset/pool does not exist

### DIFF
--- a/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
+++ b/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
@@ -448,7 +448,7 @@ func DeleteVolume(fullVolName string) error {
 	stdoutStderr, err := RunnerVar.RunCombinedOutput(VolumeReplicaOperator, deleteVolStr...)
 	if err != nil {
 		// If volume is missing then do not return error
-		if strings.Contains(err.Error(), "dataset does not exist") {
+		if strings.Contains(string(stdoutStderr), "dataset does not exist") {
 			klog.Infof("Assuming volume deletion successful for error: %v", string(stdoutStderr))
 			return nil
 		}
@@ -458,7 +458,7 @@ func DeleteVolume(fullVolName string) error {
 			"msg", "Failed to delete CStor volume",
 			"rname", fullVolName,
 		)
-		return err
+		return errors.Wrapf(err, "failed to delete volume.. %s", string(stdoutStderr))
 	}
 	alertlog.Logger.Infow("",
 		"eventcode", "cstor.volume.delete.success",

--- a/tests/admission/admission_test.go
+++ b/tests/admission/admission_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	cvr "github.com/openebs/maya/pkg/cstor/volumereplica/v1alpha1"
 	pvc "github.com/openebs/maya/pkg/kubernetes/persistentvolumeclaim/v1alpha1"
 	snap "github.com/openebs/maya/pkg/kubernetes/snapshot/v1alpha1"
 	sc "github.com/openebs/maya/pkg/kubernetes/storageclass/v1alpha1"
@@ -131,7 +132,7 @@ var _ = Describe("[cstor] TEST ADMISSION SERVER VALIDATION", func() {
 				nsName,
 			)
 			cvrLabel := pvLabel + pvcObj.Spec.VolumeName
-			cvrCount := ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, cvrLabel, cstor.ReplicaCount)
+			cvrCount := ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, cvrLabel, cstor.ReplicaCount, cvr.IsHealthy())
 			Expect(cvrCount).To(Equal(true), "while checking cstorvolume replica count")
 
 			By("verifying pvc status as bound")

--- a/tests/csi/cstor/volume/utils.go
+++ b/tests/csi/cstor/volume/utils.go
@@ -27,6 +27,7 @@ import (
 	cspc "github.com/openebs/maya/pkg/cstor/poolcluster/v1alpha1"
 	poolspec "github.com/openebs/maya/pkg/cstor/poolcluster/v1alpha1/cstorpoolspecs"
 	rgrp "github.com/openebs/maya/pkg/cstor/poolcluster/v1alpha1/raidgroups"
+	cvr "github.com/openebs/maya/pkg/cstor/volumereplica/v1alpha1"
 	container "github.com/openebs/maya/pkg/kubernetes/container/v1alpha1"
 	deploy "github.com/openebs/maya/pkg/kubernetes/deployment/appsv1/v1alpha1"
 	pvc "github.com/openebs/maya/pkg/kubernetes/persistentvolumeclaim/v1alpha1"
@@ -295,7 +296,7 @@ func verifyTargetPodCount(count int) {
 
 func verifyCstorVolumeReplicaCount(count int) {
 	targetVolumeLabel := pvLabel + pvcObj.Spec.VolumeName
-	isReqCVRCount := ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, targetVolumeLabel, count)
+	isReqCVRCount := ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, targetVolumeLabel, count, cvr.IsHealthy())
 	Expect(isReqCVRCount).To(Equal(true), "while checking cstorvolume replica count")
 }
 

--- a/tests/cstor/clone/clone_test.go
+++ b/tests/cstor/clone/clone_test.go
@@ -31,6 +31,7 @@ import (
 	spc "github.com/openebs/maya/pkg/storagepoolclaim/v1alpha1"
 	"github.com/openebs/maya/tests/cstor"
 
+	cvr "github.com/openebs/maya/pkg/cstor/volumereplica/v1alpha1"
 	container "github.com/openebs/maya/pkg/kubernetes/container/v1alpha1"
 	volume "github.com/openebs/maya/pkg/kubernetes/volume/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -138,7 +139,7 @@ var _ = Describe("[cstor] TEST VOLUME CLONE PROVISIONING", func() {
 				nsObj.Name,
 			)
 			cvrLabel := pvLabel + pvcObj.Spec.VolumeName
-			cvrCount := ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, cvrLabel, cstor.ReplicaCount)
+			cvrCount := ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, cvrLabel, cstor.ReplicaCount, cvr.IsHealthy())
 			Expect(cvrCount).To(Equal(true), "while checking cstorvolume replica count")
 
 			By("verifying pvc status as bound")

--- a/tests/cstor/node-selector/volume_selector_test.go
+++ b/tests/cstor/node-selector/volume_selector_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	cvr "github.com/openebs/maya/pkg/cstor/volumereplica/v1alpha1"
 	pvc "github.com/openebs/maya/pkg/kubernetes/persistentvolumeclaim/v1alpha1"
 	sc "github.com/openebs/maya/pkg/kubernetes/storageclass/v1alpha1"
 	spc "github.com/openebs/maya/pkg/storagepoolclaim/v1alpha1"
@@ -132,7 +133,7 @@ var _ = Describe("[cstor] TEST VOLUME PROVISIONING USING TARGET AND REPLICA SELE
 
 				By("verifying cstorvolume replica count")
 				cvrLabel := pvLabel + pvcObj.Spec.VolumeName
-				cvrCount := ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, cvrLabel, cstor.ReplicaCount)
+				cvrCount := ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, cvrLabel, cstor.ReplicaCount, cvr.IsHealthy())
 				Expect(cvrCount).To(Equal(true), "while checking cstorvolume replica count")
 
 				By("verifying pvc status as bound")

--- a/tests/cstor/pool/negative/provision_without_pool.go
+++ b/tests/cstor/pool/negative/provision_without_pool.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package negative
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openebs/maya/cmd/cstor-pool-mgmt/pool"
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	"github.com/openebs/maya/tests"
+	"github.com/openebs/maya/tests/cstor"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("[cstor] [-ve] TEST PROVISION WITHOUT POOL", func() {
+	var (
+		err error
+	)
+
+	BeforeEach(func() {
+		By("creating storagepoolclaim")
+		spcConfig := &tests.SPCConfig{
+			Name:               spcName,
+			DiskType:           "sparse",
+			PoolCount:          cstor.PoolCount,
+			IsOverProvisioning: false,
+			PoolType:           "striped",
+		}
+		ops.Config = spcConfig
+		spcObj = ops.BuildAndCreateSPC()
+		By("Creating SPC, Desired Number of CSP Should Be Created", func() {
+			ops.VerifyDesiredCSPCount(spcObj, cstor.PoolCount)
+		})
+	})
+
+	AfterEach(func() {
+		By("deleting storagepoolclaim")
+
+		err = ops.SPCClient.Delete(spcObj.Name, &metav1.DeleteOptions{})
+		Expect(err).To(BeNil(), "while deleting the storagepoolclaim {%s}", spcObj.Name)
+
+		cspCount := ops.GetCSPCount(getLabelSelector(spcObj))
+		Expect(cspCount).To(Equal(0), "stale CSP")
+	})
+
+	When("creating storagepoolclaim without", func() {
+		It("Testing SPC deletion if pool does not exist", func() {
+			spcLabel := getLabelSelector(spcObj)
+			poolPodList, err := ops.PodClient.
+				WithNamespace(openebsNamespace).
+				List(metav1.ListOptions{LabelSelector: spcLabel})
+			Expect(err).To(BeNil())
+			Expect(len(poolPodList.Items)).Should(BeNumerically(">=", 1))
+
+			tPod := poolPodList.Items[0]
+			var puid string
+			for _, e := range tPod.Spec.Containers[0].Env {
+				if e.Name == "OPENEBS_IO_CSTOR_ID" {
+					puid = e.Value
+				}
+			}
+			Expect(len(puid)).Should(BeNumerically(">=", 1))
+
+			cspList, err := ops.CSPClient.List(metav1.ListOptions{LabelSelector: string(apis.StoragePoolClaimCPK) + "=" + spcObj.Name})
+			Expect(len(cspList.Items)).Should(BeNumerically(">=", 1))
+			var cspObj apis.CStorPool
+			for _, l := range cspList.Items {
+				if l.GetUID() == types.UID(puid) {
+					cspObj = l
+					break
+				}
+			}
+
+			poolName := string(pool.PoolPrefix) + string(cspObj.ObjectMeta.UID)
+			zfsCmd := "zpool destroy -f " + poolName
+			cmd := []string{"/bin/bash", "-c", zfsCmd}
+
+			opts := tests.NewOptions().
+				WithPodName(tPod.Name).
+				WithNamespace(openebsNamespace).
+				WithContainer("cstor-pool").
+				WithCommand(cmd...)
+
+			out, err := ops.ExecPod(opts)
+			Expect(err).To(BeNil())
+			Expect(len(out)).Should(BeNumerically("==", 0))
+		})
+	})
+})
+
+func getLabelSelector(spc *apis.StoragePoolClaim) string {
+	return string(apis.StoragePoolClaimCPK) + "=" + spc.Name
+}

--- a/tests/cstor/pool/negative/provision_without_pool.go
+++ b/tests/cstor/pool/negative/provision_without_pool.go
@@ -59,13 +59,14 @@ var _ = Describe("[cstor] [-ve] TEST PROVISION WITHOUT POOL", func() {
 		Expect(cspCount).To(Equal(0), "stale CSP")
 	})
 
-	When("creating storagepoolclaim without", func() {
-		It("Testing SPC deletion if pool does not exist", func() {
+	When("Deleting SPC if the pool does not exist", func() {
+		It("Should delete the SPC", func() {
 			spcLabel := getLabelSelector(spcObj)
 			poolPodList, err := ops.PodClient.
 				WithNamespace(openebsNamespace).
 				List(metav1.ListOptions{LabelSelector: spcLabel})
 			Expect(err).To(BeNil())
+			// Since spc is created successfully, pool pod count should be >= 1
 			Expect(len(poolPodList.Items)).Should(BeNumerically(">=", 1))
 
 			tPod := poolPodList.Items[0]

--- a/tests/cstor/pool/negative/provision_without_pool.go
+++ b/tests/cstor/pool/negative/provision_without_pool.go
@@ -78,6 +78,7 @@ var _ = Describe("[cstor] [-ve] TEST PROVISION WITHOUT POOL", func() {
 			Expect(len(puid)).Should(BeNumerically(">=", 1))
 
 			cspList, err := ops.CSPClient.List(metav1.ListOptions{LabelSelector: string(apis.StoragePoolClaimCPK) + "=" + spcObj.Name})
+			Expect(err).To(BeNil())
 			Expect(len(cspList.Items)).Should(BeNumerically(">=", 1))
 			var cspObj apis.CStorPool
 			for _, l := range cspList.Items {

--- a/tests/cstor/snapshot/snapshot_test.go
+++ b/tests/cstor/snapshot/snapshot_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	cvr "github.com/openebs/maya/pkg/cstor/volumereplica/v1alpha1"
 	pvc "github.com/openebs/maya/pkg/kubernetes/persistentvolumeclaim/v1alpha1"
 	snap "github.com/openebs/maya/pkg/kubernetes/snapshot/v1alpha1"
 	sc "github.com/openebs/maya/pkg/kubernetes/storageclass/v1alpha1"
@@ -131,7 +132,7 @@ var _ = Describe("[cstor] TEST SNAPSHOT PROVISIONING", func() {
 				nsObj.Name,
 			)
 			cvrLabel := pvLabel + pvcObj.Spec.VolumeName
-			cvrCount := ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, cvrLabel, cstor.ReplicaCount)
+			cvrCount := ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, cvrLabel, cstor.ReplicaCount, cvr.IsHealthy())
 			Expect(cvrCount).To(Equal(true), "while checking cstorvolume replica count")
 
 			By("verifying pvc status as bound")

--- a/tests/cstor/volume/provision_negative_test.go
+++ b/tests/cstor/volume/provision_negative_test.go
@@ -104,7 +104,7 @@ var _ = Describe("[Cstor Volume Provisioning Negative] Volume Provisioning", fun
 
 	When("Volume provisioning with create/update error injection", func() {
 		cvrPred, cvPred := cvr.PredicateList{}, cv.PredicateList{}
-		if cstor.ReplicaCount > 1 {
+		if cstor.ReplicaCount > 2 {
 			cvrPred = append(cvrPred, cvr.IsHealthy())
 			cvPred = append(cvPred, cv.IsHealthy())
 		}
@@ -190,6 +190,8 @@ var _ = Describe("[Cstor Volume Provisioning Negative] Volume Provisioning", fun
 				debug.NewErrorInjection().
 					WithCVRUpdateError(debug.Eject))
 			Expect(err).To(BeNil())
+			cvrPred = append(cvrPred, cvr.IsHealthy())
+			cvPred = append(cvPred, cv.IsHealthy())
 
 			By("Checking replica count after error ejection")
 			ops.VerifyVolumeStatus(pvcObj, cstor.ReplicaCount, cvrPred, cvPred)

--- a/tests/cstor/volume/provision_test.go
+++ b/tests/cstor/volume/provision_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	cvr "github.com/openebs/maya/pkg/cstor/volumereplica/v1alpha1"
 	pvc "github.com/openebs/maya/pkg/kubernetes/persistentvolumeclaim/v1alpha1"
 	sc "github.com/openebs/maya/pkg/kubernetes/storageclass/v1alpha1"
 	spc "github.com/openebs/maya/pkg/storagepoolclaim/v1alpha1"
@@ -131,7 +132,7 @@ var _ = Describe("[Cstor Volume Provisioning Positive] TEST VOLUME PROVISIONING"
 
 			By("verifying cstorvolume replica count")
 			cvrLabel := pvLabel + pvcObj.Spec.VolumeName
-			cvrCount := ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, cvrLabel, cstor.ReplicaCount)
+			cvrCount := ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, cvrLabel, cstor.ReplicaCount, cvr.IsHealthy())
 			Expect(cvrCount).To(Equal(true), "while checking cstorvolume replica count")
 
 			By("verifying pvc status as bound")

--- a/tests/cstor/volume/replica_replace/replica_replace_test.go
+++ b/tests/cstor/volume/replica_replace/replica_replace_test.go
@@ -20,6 +20,8 @@ package replicareplace
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	cv "github.com/openebs/maya/pkg/cstor/volume/v1alpha1"
+	cvr "github.com/openebs/maya/pkg/cstor/volumereplica/v1alpha1"
 	"github.com/openebs/maya/tests"
 	"github.com/openebs/maya/tests/cstor"
 
@@ -61,7 +63,11 @@ var _ = Describe("[REPLICA REPLACE] CSTOR REPLICA REPLACE", func() {
 			ops.Config = pvcConfig
 			pvcObj = ops.BuildAndCreatePVC()
 			By("Creating PVC, Desired Number of CVR Should Be Created", func() {
-				ops.VerifyVolumeStatus(pvcObj, cstor.ReplicaCount)
+				ops.VerifyVolumeStatus(pvcObj,
+					cstor.ReplicaCount,
+					cvr.PredicateList{cvr.IsHealthy()},
+					cv.PredicateList{cv.IsHealthy()},
+				)
 			})
 			// GetLatest PVC object
 			var err error
@@ -77,7 +83,11 @@ var _ = Describe("[REPLICA REPLACE] CSTOR REPLICA REPLACE", func() {
 			By("Update CStorVolume Configurations to Start Rebuild", updateCVConfigurationsAndVerifyStatus)
 			By("Restart CStor-Pool-Mgmt Container Pods Doesn't Have Volume DataSets", restartPoolPods)
 			By("Verify Volume Status after Performing Replica Replace", func() {
-				ops.VerifyVolumeStatus(pvcObj, cstor.ReplicaCount)
+				ops.VerifyVolumeStatus(pvcObj,
+					cstor.ReplicaCount,
+					cvr.PredicateList{cvr.IsHealthy()},
+					cv.PredicateList{cv.IsHealthy()},
+				)
 			})
 			By("Verify Volume configurations from cstor volume", verifyCVConfigForReplicaReplaceEventually)
 		})
@@ -88,7 +98,11 @@ var _ = Describe("[REPLICA REPLACE] CSTOR REPLICA REPLACE", func() {
 			By("Build And Create CstorVolumeReplica then Delete Which Has To Migrate Replica", migrateReplica)
 			By("Verify Volume configurations from cstorvolume", verifyCVConfigForReplicaMigrationEventually)
 			By("Verify Volume Status after Performing Replica Movement", func() {
-				ops.VerifyVolumeStatus(pvcObj, cstor.ReplicaCount)
+				ops.VerifyVolumeStatus(pvcObj,
+					cstor.ReplicaCount,
+					cvr.PredicateList{cvr.IsHealthy()},
+					cv.PredicateList{cv.IsHealthy()},
+				)
 			})
 		})
 	})

--- a/tests/cstor/volume/replica_replace/replica_replace_utils_test.go
+++ b/tests/cstor/volume/replica_replace/replica_replace_utils_test.go
@@ -109,7 +109,7 @@ func deleteZFSDataSets() {
 
 	// Make Sure data sets are deleted ( we can get it by checking the phase of
 	// cvr)
-	isExpectedCVRCount := ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, volumeLabel, ReplicaCount-FailureReplicaCount)
+	isExpectedCVRCount := ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, volumeLabel, ReplicaCount-FailureReplicaCount, cvr.IsHealthy())
 	Expect(isExpectedCVRCount).To(Equal(true), "while checking cstorvolume replica count after deleting volume datasets")
 }
 

--- a/tests/cstor/volume/scaleup_replica/scaleup_replica_test.go
+++ b/tests/cstor/volume/scaleup_replica/scaleup_replica_test.go
@@ -19,6 +19,8 @@ package replicascaleup
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	cv "github.com/openebs/maya/pkg/cstor/volume/v1alpha1"
+	cvr "github.com/openebs/maya/pkg/cstor/volumereplica/v1alpha1"
 	"github.com/openebs/maya/tests"
 	"github.com/openebs/maya/tests/cstor"
 
@@ -61,7 +63,11 @@ var _ = Describe("[REPLICA SCALEUP/SCALEDOWN] CSTOR REPLICA SCALEUP And SCALEDOW
 			pvcObj = ops.BuildAndCreatePVC()
 			By("Creating PVC, Desired Number of CVR Should Be Created", func() {
 				// ReplicaCount is initilized as 1
-				ops.VerifyVolumeStatus(pvcObj, ReplicaCount)
+				ops.VerifyVolumeStatus(pvcObj,
+					ReplicaCount,
+					cvr.PredicateList{cvr.IsHealthy()},
+					cv.PredicateList{cv.IsHealthy()},
+				)
 			})
 			// GetLatest PVC object
 			var err error
@@ -77,7 +83,11 @@ var _ = Describe("[REPLICA SCALEUP/SCALEDOWN] CSTOR REPLICA SCALEUP And SCALEDOW
 			By("Build and Create CStorVolumeReplica", buildAndCreateCVR)
 			ReplicaCount = ReplicaCount + 1
 			By("Verify Volume Status after ScaleUp Replica", func() {
-				ops.VerifyVolumeStatus(pvcObj, ReplicaCount)
+				ops.VerifyVolumeStatus(pvcObj,
+					ReplicaCount,
+					cvr.PredicateList{cvr.IsHealthy()},
+					cv.PredicateList{cv.IsHealthy()},
+				)
 			})
 			By("Verify Volume configurations from cstor volume", verifyVolumeConfigurationEventually)
 		})
@@ -93,7 +103,11 @@ var _ = Describe("[REPLICA SCALEUP/SCALEDOWN] CSTOR REPLICA SCALEUP And SCALEDOW
 				verifyCVConfigForReplicaScaleDownEventually(ReplicaCount)
 			})
 			By("Verify Volume Status after ScaleDown Replica", func() {
-				ops.VerifyVolumeStatus(pvcObj, ReplicaCount)
+				ops.VerifyVolumeStatus(pvcObj,
+					ReplicaCount,
+					cvr.PredicateList{cvr.IsHealthy()},
+					cv.PredicateList{cv.IsHealthy()},
+				)
 			})
 		})
 	})

--- a/tests/operations.go
+++ b/tests/operations.go
@@ -1000,7 +1000,7 @@ func (ops *Operations) ExecPod(opts *Options) ([]byte, error) {
 		Tty:    false,
 	})
 	Expect(err).To(BeNil(), "while streaming the command in pod ", opts.podName, execOut.String(), execErr.String())
-	Expect(execOut.Len()).Should(BeNumerically(">", 0), "while streaming the command in pod ", opts.podName, execErr.String(), execOut.String())
+	Expect(execOut.Len()).Should(BeNumerically(">=", 0), "while streaming the command in pod ", opts.podName, execErr.String(), execOut.String())
 	return execOut.Bytes(), nil
 }
 

--- a/tests/operations.go
+++ b/tests/operations.go
@@ -310,10 +310,10 @@ func (ops *Operations) GetPodRunningCountEventually(namespace, lselector string,
 
 // GetCstorVolumeCount gives the count of cstorvolume based on
 // selecter
-func (ops *Operations) GetCstorVolumeCount(namespace, lselector string, expectedCVCount int) int {
+func (ops *Operations) GetCstorVolumeCount(namespace, lselector string, expectedCVCount int, preds ...cv.Predicate) int {
 	var cvCount int
 	for i := 0; i < maxRetry; i++ {
-		cvCount = ops.GetCVCount(namespace, lselector)
+		cvCount = ops.GetCVCount(namespace, lselector, preds...)
 		if cvCount == expectedCVCount {
 			return cvCount
 		}
@@ -326,7 +326,7 @@ func (ops *Operations) GetCstorVolumeCount(namespace, lselector string, expected
 // selecter eventually
 func (ops *Operations) GetCstorVolumeCountEventually(namespace, lselector string, expectedCVCount int) bool {
 	return Eventually(func() int {
-		cvCount := ops.GetCVCount(namespace, lselector)
+		cvCount := ops.GetCVCount(namespace, lselector, cv.IsHealthy())
 		return cvCount
 	},
 		120, 10).Should(Equal(expectedCVCount))
@@ -334,9 +334,9 @@ func (ops *Operations) GetCstorVolumeCountEventually(namespace, lselector string
 
 // GetCstorVolumeReplicaCountEventually gives the count of cstorvolume based on
 // selecter eventually
-func (ops *Operations) GetCstorVolumeReplicaCountEventually(namespace, lselector string, expectedCVRCount int) bool {
+func (ops *Operations) GetCstorVolumeReplicaCountEventually(namespace, lselector string, expectedCVRCount int, pred ...cvr.Predicate) bool {
 	return Eventually(func() int {
-		cvCount := ops.GetCstorVolumeReplicaCount(namespace, lselector)
+		cvCount := ops.GetCstorVolumeReplicaCount(namespace, lselector, pred...)
 		return cvCount
 	},
 		120, 10).Should(Equal(expectedCVRCount))
@@ -365,7 +365,7 @@ func (ops *Operations) GetPodRunningCount(namespace, lselector string) int {
 }
 
 // GetCVCount gives cstorvolume healthy count currently based on selecter
-func (ops *Operations) GetCVCount(namespace, lselector string) int {
+func (ops *Operations) GetCVCount(namespace, lselector string, pred ...cv.Predicate) int {
 	cvs, err := ops.CVClient.
 		WithNamespace(namespace).
 		List(metav1.ListOptions{LabelSelector: lselector})
@@ -373,13 +373,13 @@ func (ops *Operations) GetCVCount(namespace, lselector string) int {
 	return cv.
 		NewListBuilder().
 		WithAPIList(cvs).
-		WithFilter(cv.IsHealthy()).
+		WithFilter(pred...).
 		List().
 		Len()
 }
 
 // GetCstorVolumeReplicaCount gives cstorvolumereplica healthy count currently based on selecter
-func (ops *Operations) GetCstorVolumeReplicaCount(namespace, lselector string) int {
+func (ops *Operations) GetCstorVolumeReplicaCount(namespace, lselector string, pred ...cvr.Predicate) int {
 	cvrs, err := ops.CVRClient.
 		WithNamespace(namespace).
 		List(metav1.ListOptions{LabelSelector: lselector})
@@ -387,7 +387,7 @@ func (ops *Operations) GetCstorVolumeReplicaCount(namespace, lselector string) i
 	return cvr.
 		NewListBuilder().
 		WithAPIList(cvrs).
-		WithFilter(cvr.IsHealthy()).
+		WithFilter(pred...).
 		List().
 		Len()
 }
@@ -1177,15 +1177,15 @@ func (ops *Operations) DeletePersistentVolumeClaim(name, namespace string) {
 }
 
 // VerifyVolumeResources verifies whether volume resource exist or not
-func (ops *Operations) VerifyVolumeResources(pvName, namespace string) {
+func (ops *Operations) VerifyVolumeResources(pvName, namespace string, cvrPred cvr.PredicateList, cvPred cv.PredicateList) {
 	volumeLabel := pvLabel + pvName
 	targetPodCount := ops.GetPodRunningCountEventually(namespace, volumeLabel, 0)
 	Expect(targetPodCount).To(Equal(0), "when pvc is deleted target pod should be deleted")
 
-	cvCount := ops.GetCstorVolumeCount(openebsNamespace, volumeLabel, 0)
+	cvCount := ops.GetCstorVolumeCount(openebsNamespace, volumeLabel, 0, cvPred...)
 	Expect(cvCount).To(Equal(0), "when pvc is deleted cstorvolume should be deleted")
 
-	IsCVRDeleted := ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, volumeLabel, 0)
+	IsCVRDeleted := ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, volumeLabel, 0, cvrPred...)
 	Expect(IsCVRDeleted).To(Equal(true), "when pvc is deleted cstorvolumereplica should be deleted")
 }
 
@@ -1207,7 +1207,7 @@ func (ops *Operations) VerifyPoolResources(spcName string) {
 // 2. Verifies whether CStorVolume is in Healthy or not
 // 3. Verifies whether specified number of CVR's are healthy or not
 func (ops *Operations) VerifyVolumeStatus(
-	pvcObj *corev1.PersistentVolumeClaim, replicaCount int) {
+	pvcObj *corev1.PersistentVolumeClaim, replicaCount int, cvrPred cvr.PredicateList, cvPred cv.PredicateList) {
 	status := ops.IsPVCBoundEventually(pvcObj.Name)
 	Expect(status).To(Equal(true), "while checking status equal to bound")
 
@@ -1218,10 +1218,10 @@ func (ops *Operations) VerifyVolumeStatus(
 	Expect(err).To(BeNil())
 
 	volumeLabel := pvLabel + updatedPVCObj.Spec.VolumeName
-	cvCount := ops.GetCstorVolumeCount(openebsNamespace, volumeLabel, 1)
+	cvCount := ops.GetCstorVolumeCount(openebsNamespace, volumeLabel, 1, cvPred...)
 	Expect(cvCount).To(Equal(1), "while checking cstorvolume count")
 
-	cvrCount := ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, volumeLabel, replicaCount)
+	cvrCount := ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, volumeLabel, replicaCount, cvrPred...)
 	Expect(cvrCount).To(Equal(true), "while checking cstorvolume replica count")
 }
 
@@ -1230,7 +1230,7 @@ func (ops *Operations) DeleteVolumeResources(
 	pvcObj *corev1.PersistentVolumeClaim,
 	scObj *storagev1.StorageClass) {
 	ops.DeletePersistentVolumeClaim(pvcObj.Name, pvcObj.Namespace)
-	ops.VerifyVolumeResources(pvcObj.Spec.VolumeName, openebsNamespace)
+	ops.VerifyVolumeResources(pvcObj.Spec.VolumeName, openebsNamespace, cvr.PredicateList{}, cv.PredicateList{})
 	err := ops.SCClient.Delete(scObj.Name, &metav1.DeleteOptions{})
 	Expect(err).To(BeNil())
 }


### PR DESCRIPTION
Changes:
- When dataset or pool doesn't exist on zfs, cvr/csp controller should return success in case of dataset/pool deletion.

Signed-off-by: mayank <mayank.patel@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests