### PR TITLE
fix(cspc, webhook): add validation for cspc deletion

### DIFF
--- a/pkg/kubernetes/secret/kubernetes.go
+++ b/pkg/kubernetes/secret/kubernetes.go
@@ -219,7 +219,7 @@ func (k *Kubeclient) Update(secret *corev1.Secret) (*corev1.Secret, error) {
 	}
 	cli, err := k.getClientsetOrCached()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to update secret")
+		return nil, errors.Wrapf(err, "failed to update secret %s", secret.Name)
 	}
 	return k.update(cli, k.namespace, secret)
 }

--- a/pkg/kubernetes/secret/kubernetes.go
+++ b/pkg/kubernetes/secret/kubernetes.go
@@ -40,6 +40,10 @@ type getFn func(cli *kubernetes.Clientset, namespace, name string, opts metav1.G
 // to create secret
 type createFn func(cli *kubernetes.Clientset, namespace string, secret *corev1.Secret) (*corev1.Secret, error)
 
+// updateFn is a typed function that abstracts
+// to update secret
+type updateFn func(cli *kubernetes.Clientset, namespace string, secret *corev1.Secret) (*corev1.Secret, error)
+
 // listFn is a typed function that abstracts listing of secret instances
 type listFn func(cli *kubernetes.Clientset, namespace string, opts metav1.ListOptions) (*corev1.SecretList, error)
 
@@ -68,6 +72,7 @@ type Kubeclient struct {
 	create              createFn
 	del                 deleteFn
 	list                listFn
+	update              updateFn
 }
 
 // KubeClientBuildOption defines the abstraction
@@ -100,7 +105,11 @@ func (k *Kubeclient) withDefaults() {
 			return cli.CoreV1().Secrets(namespace).List(opts)
 		}
 	}
-
+	if k.update == nil {
+		k.update = func(cli *kubernetes.Clientset, namespace string, secret *corev1.Secret) (*corev1.Secret, error) {
+			return cli.CoreV1().Secrets(namespace).Update(secret)
+		}
+	}
 	if k.del == nil {
 		k.del = func(cli *kubernetes.Clientset, namespace, name string, opts *metav1.DeleteOptions) error {
 			return cli.CoreV1().Secrets(namespace).Delete(name, opts)
@@ -201,4 +210,16 @@ func (k *Kubeclient) List(opts metav1.ListOptions) (*corev1.SecretList, error) {
 		return nil, errors.Wrapf(err, "failed to lists secret in namespace: {%s}", k.namespace)
 	}
 	return k.list(cli, k.namespace, opts)
+}
+
+// Update updates and returns updated secret instance
+func (k *Kubeclient) Update(secret *corev1.Secret) (*corev1.Secret, error) {
+	if secret == nil {
+		return nil, errors.New("failed to update secret: nil secret object")
+	}
+	cli, err := k.getClientsetOrCached()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to update secret")
+	}
+	return k.update(cli, k.namespace, secret)
 }

--- a/pkg/kubernetes/service/v1alpha1/kubernetes.go
+++ b/pkg/kubernetes/service/v1alpha1/kubernetes.go
@@ -65,6 +65,13 @@ type createFn func(
 	namespace string,
 ) (*corev1.Service, error)
 
+// updateFn is a typed function that abstracts delete of service instances
+type updateFn func(
+	cli *kubernetes.Clientset,
+	service *corev1.Service,
+	namespace string,
+) (*corev1.Service, error)
+
 // patchFn is a typed function that abstracts patch of service instances
 type patchFn func(
 	cli *kubernetes.Clientset,
@@ -92,6 +99,7 @@ type Kubeclient struct {
 	del                 delFn
 	create              createFn
 	patch               patchFn
+	update              updateFn
 }
 
 // KubeclientBuildOption defines the abstraction to build a kubeclient instance
@@ -170,6 +178,18 @@ func defaultCreate(
 		Create(service)
 }
 
+// defaultUpdate is the default implementation to update
+// a service instance in kubernetes cluster
+func defaultUpdate(
+	cli *kubernetes.Clientset,
+	service *corev1.Service,
+	namespace string,
+) (*corev1.Service, error) {
+	return cli.CoreV1().
+		Services(namespace).
+		Update(service)
+}
+
 // defaultPatch is the default implementation to patch
 // a service instance in kubernetes cluster
 func defaultPatch(
@@ -206,6 +226,9 @@ func (k *Kubeclient) withDefaults() {
 	}
 	if k.patch == nil {
 		k.patch = defaultPatch
+	}
+	if k.update == nil {
+		k.update = defaultUpdate
 	}
 }
 
@@ -334,6 +357,23 @@ func (k *Kubeclient) Create(service *corev1.Service) (*corev1.Service, error) {
 		)
 	}
 	return k.create(cli, service, k.namespace)
+}
+
+// Update updates a service in specified namespace in kubernetes cluster
+func (k *Kubeclient) Update(service *corev1.Service) (*corev1.Service, error) {
+	if service == nil {
+		return nil, errors.New("failed to create service: nil service object")
+	}
+	cli, err := k.getClientOrCached()
+	if err != nil {
+		return nil, errors.Wrapf(
+			err,
+			"failed to create service {%s} in namespace {%s}",
+			service.Name,
+			service.Namespace,
+		)
+	}
+	return k.update(cli, service, k.namespace)
 }
 
 // Patch patches service object for given name

--- a/pkg/kubernetes/service/v1alpha1/kubernetes.go
+++ b/pkg/kubernetes/service/v1alpha1/kubernetes.go
@@ -362,7 +362,7 @@ func (k *Kubeclient) Create(service *corev1.Service) (*corev1.Service, error) {
 // Update updates a service in specified namespace in kubernetes cluster
 func (k *Kubeclient) Update(service *corev1.Service) (*corev1.Service, error) {
 	if service == nil {
-		return nil, errors.New("failed to create service: nil service object")
+		return nil, errors.New("failed to update service: nil service object")
 	}
 	cli, err := k.getClientOrCached()
 	if err != nil {

--- a/pkg/kubernetes/service/v1alpha1/kubernetes.go
+++ b/pkg/kubernetes/service/v1alpha1/kubernetes.go
@@ -368,7 +368,7 @@ func (k *Kubeclient) Update(service *corev1.Service) (*corev1.Service, error) {
 	if err != nil {
 		return nil, errors.Wrapf(
 			err,
-			"failed to create service {%s} in namespace {%s}",
+			"failed to update service {%s} in namespace {%s}",
 			service.Name,
 			service.Namespace,
 		)

--- a/pkg/kubernetes/webhook/validate/v1alpha1/kubernetes.go
+++ b/pkg/kubernetes/webhook/validate/v1alpha1/kubernetes.go
@@ -52,6 +52,14 @@ type createFunc func(cli *kubernetes.Clientset,
 	error,
 )
 
+// updateFn is a typed function that abstracts
+// to update admissionwebhook configuration
+type updateFn func(cli *kubernetes.Clientset,
+	config *admission.ValidatingWebhookConfiguration) (
+	*admission.ValidatingWebhookConfiguration,
+	error,
+)
+
 // Kubeclient enables kubernetes API operations
 // on upgrade result instance
 type Kubeclient struct {
@@ -66,6 +74,7 @@ type Kubeclient struct {
 	create       createFunc
 	get          getFunc
 	del          delFunc
+	update       updateFn
 }
 
 // KubeclientBuildOption defines the abstraction
@@ -103,9 +112,12 @@ func (k *Kubeclient) withDefaults() {
 		k.del = func(cs *kubernetes.Clientset, name string, opts *metav1.DeleteOptions) error {
 			return cs.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Delete(name, opts)
 		}
-
 	}
-
+	if k.update == nil {
+		k.update = func(cs *kubernetes.Clientset, config *admission.ValidatingWebhookConfiguration) (*admission.ValidatingWebhookConfiguration, error) {
+			return cs.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Update(config)
+		}
+	}
 }
 
 // WithClientset sets the kubernetes clientset against
@@ -196,4 +208,17 @@ func (k *Kubeclient) Delete(name string, options *metav1.DeleteOptions) error {
 		return err
 	}
 	return k.del(cli, name, options)
+}
+
+// Update updates validatingWebhookConfiguration, and returns the updated
+// corresponding validatingWebhookConfiguration object, and an error if there is any.
+func (k *Kubeclient) Update(config *admission.ValidatingWebhookConfiguration) (*admission.ValidatingWebhookConfiguration, error) {
+	if config == nil {
+		return nil, errors.New("failed to create validating configuration: nil configuration")
+	}
+	cs, err := k.getClientOrCached()
+	if err != nil {
+		return nil, err
+	}
+	return k.update(cs, config)
 }

--- a/pkg/kubernetes/webhook/validate/v1alpha1/kubernetes.go
+++ b/pkg/kubernetes/webhook/validate/v1alpha1/kubernetes.go
@@ -214,7 +214,7 @@ func (k *Kubeclient) Delete(name string, options *metav1.DeleteOptions) error {
 // corresponding validatingWebhookConfiguration object, and an error if there is any.
 func (k *Kubeclient) Update(config *admission.ValidatingWebhookConfiguration) (*admission.ValidatingWebhookConfiguration, error) {
 	if config == nil {
-		return nil, errors.New("failed to create validating configuration: nil configuration")
+		return nil, errors.New("failed to update validating configuration: nil configuration")
 	}
 	cs, err := k.getClientOrCached()
 	if err != nil {

--- a/pkg/webhook/configuration.go
+++ b/pkg/webhook/configuration.go
@@ -468,12 +468,12 @@ func preUpgrade(openebsNamespace string) error {
 					return fmt.Errorf("failed to delete old secret %s: %s", scrt.Name, err.Error())
 				}
 			} else {
-				newScrt := &scrt
+				newScrt := scrt
 				for _, t := range transformSecret {
-					t(newScrt)
+					t(&newScrt)
 				}
 				newScrt.Labels["openebs.io/version"] = version.Current()
-				_, err = secret.NewKubeClient(secret.WithNamespace(openebsNamespace)).Update(newScrt)
+				_, err = secret.NewKubeClient(secret.WithNamespace(openebsNamespace)).Update(&newScrt)
 				if err != nil {
 					return fmt.Errorf("failed to update old secret %s: %s", scrt.Name, err.Error())
 				}
@@ -494,12 +494,12 @@ func preUpgrade(openebsNamespace string) error {
 					return fmt.Errorf("failed to delete old service %s: %s", service.Name, err.Error())
 				}
 			} else {
-				newSvc := &service
+				newSvc := service
 				for _, t := range transformSvc {
-					t(newSvc)
+					t(&newSvc)
 				}
 				newSvc.Labels["openebs.io/version"] = version.Current()
-				_, err = svc.NewKubeClient(svc.WithNamespace(openebsNamespace)).Update(newSvc)
+				_, err = svc.NewKubeClient(svc.WithNamespace(openebsNamespace)).Update(&newSvc)
 				if err != nil {
 					return fmt.Errorf("failed to update old service %s: %s", service.Name, err.Error())
 				}
@@ -519,12 +519,12 @@ func preUpgrade(openebsNamespace string) error {
 					return fmt.Errorf("failed to delete older webhook config %s: %s", config.Name, err.Error())
 				}
 			} else {
-				newConfig := &config
+				newConfig := config
 				for _, t := range transformConfig {
-					t(newConfig)
+					t(&newConfig)
 				}
 				newConfig.Labels["openebs.io/version"] = version.Current()
-				_, err = validate.KubeClient().Update(newConfig)
+				_, err = validate.KubeClient().Update(&newConfig)
 				if err != nil {
 					return fmt.Errorf("failed to update older webhook config %s: %s", config.Name, err.Error())
 				}

--- a/pkg/webhook/configuration.go
+++ b/pkg/webhook/configuration.go
@@ -163,6 +163,7 @@ func createAdmissionService(
 				Operations: []v1beta1.OperationType{
 					v1beta1.Create,
 					v1beta1.Update,
+					v1beta1.Delete,
 				},
 				Rule: v1beta1.Rule{
 					APIGroups:   []string{"*"},
@@ -447,7 +448,7 @@ func preUpgrade(openebsNamespace string) error {
 	}
 
 	for _, service := range svcList.Items {
-		if len(service.Labels["openebs.io/version"]) == 0 {
+		if service.Labels["openebs.io/version"] != version.Current() {
 			err = svc.NewKubeClient(svc.WithNamespace(openebsNamespace)).Delete(service.Name, &metav1.DeleteOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to delete old service %s: %s", service.Name, err.Error())
@@ -460,7 +461,7 @@ func preUpgrade(openebsNamespace string) error {
 	}
 
 	for _, config := range webhookConfigList.Items {
-		if len(config.Labels["openebs.io/version"]) == 0 {
+		if config.Labels["openebs.io/version"] != version.Current() {
 			err = validate.KubeClient().Delete(config.Name, &metav1.DeleteOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to delete older webhook config %s: %s", config.Name, err.Error())

--- a/pkg/webhook/cspc.go
+++ b/pkg/webhook/cspc.go
@@ -145,7 +145,8 @@ func (wh *webhook) validateCSPCDeleteRequest(req *v1beta1.AdmissionRequest) *v1b
 		return response
 	}
 	for _, cspiObj := range cspiList.Items {
-		cvrList, err := cvr.NewKubeclient().WithNamespace(cspiObj.Namespace).List(metav1.ListOptions{
+		// list cvrs in all namespaces
+		cvrList, err := cvr.NewKubeclient().WithNamespace("").List(metav1.ListOptions{
 			LabelSelector: "cstorpoolinstance.openebs.io/name=" + cspiObj.Name,
 		})
 		if err != nil {

--- a/pkg/webhook/cspc.go
+++ b/pkg/webhook/cspc.go
@@ -110,8 +110,6 @@ func (wh *webhook) validateCSPC(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionR
 		return wh.validateCSPCDeleteRequest(req)
 	}
 
-	klog.V(2).Info("Admission wehbook for CSPC not " +
-		"configured for operations other than UPDATE and CREATE")
 	return response
 }
 


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds validation for cspc deletion. When a volume is still present on the cspc pool the deletion of cspc should not be allowed.
```sh
mayadata:setup$ k delete cspc --all
Error from server (BadRequest): admission webhook "admission-webhook.openebs.io" denied the request: invalid cspc sparse-pool-1 deletion: volume still exists on pool sparse-pool-1-ff87
```
This PR also fixes the pre-upgrade cleanup or update of webhook secret, service, and validator.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests