### PR TITLE
chore(spc):introduce new field to control overprovisioning

### DIFF
--- a/pkg/algorithm/cstorpoolselect/v1alpha1/select.go
+++ b/pkg/algorithm/cstorpoolselect/v1alpha1/select.go
@@ -585,7 +585,7 @@ func CapacityAwareProvisioning(values ...string) buildOption {
 			if err != nil {
 				overProvisioningPolicy.err = append(overProvisioningPolicy.err, err)
 			} else {
-				if spc.Spec.PoolSpec.OverProvisioning {
+				if !spc.Spec.PoolSpec.ThickProvisioning {
 					overProvisioningPolicy.overProvisioning = true
 				}
 			}

--- a/pkg/apis/openebs.io/v1alpha1/cstor_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_pool.go
@@ -68,9 +68,12 @@ type BlockDeviceAttr struct {
 
 // CStorPoolAttr is to describe zpool related attributes.
 type CStorPoolAttr struct {
-	CacheFile        string `json:"cacheFile"`        //optional, faster if specified
-	PoolType         string `json:"poolType"`         //mirrored, striped
-	OverProvisioning bool   `json:"overProvisioning"` //true or false
+	CacheFile string `json:"cacheFile"` //optional, faster if specified
+	PoolType  string `json:"poolType"`  //mirrored, striped
+	// OverProvisioning field is deprecated and not honoured
+	OverProvisioning bool `json:"overProvisioning"` //true or false
+	// ThickProvisioning, If true disables OverProvisioning
+	ThickProvisioning bool `json:"thickProvisioning"` // true or false
 }
 
 // CStorPoolPhase is a typed string for phase field of CStorPool.


### PR DESCRIPTION
Following PR added support to restrict overprovisioning of volumes on a cStor pool. Please go through the following links to understand more.
https://github.com/openebs/maya/pull/1577
https://github.com/openebs/openebs/issues/2855

SPC has a field `overProvisioning` that was never used and the PR made use of that to decide on overprovisioning requirements.
Now every existing SPC might have SPC created with missing `overProvisioning` field(the missing field will have by default a false value as the field is of bool type) or value set to false.
Now, there can be failure in subsequent volume provisioning if a user intends to over-provision -- to fix this one would need to edit SPC yaml to turn `overProvisioning` to true.

This PR introduces a new field `thickProvisoning` to decide on over-provisioning requirements and the field `overProvisioning` in SPC is deprecated and will cause no impact.
1. If the field `thickProvisoning` is set to true -- overprovisioning is disabled.
2. If the field `thickProvisoning` is set to false -- overprovisioning is enabled.
3. If the field is not specified in the SPC -- overProvisioning is enabled.

Signed-off-by: chandan kumar <chandan.kr404@gmail.com>


**Special notes for your reviewer**:
Dependent PR: https://github.com/openebs/openebs/pull/2901
This PR needs to merge first in order to travis CI to pass for the PR.