### PR TITLE
fix(new cStor deployments): add OpenEBS base directory in new CStor deployments

### DIFF
--- a/cmd/cspc-operator/app/storagepool_create.go
+++ b/cmd/cspc-operator/app/storagepool_create.go
@@ -21,6 +21,7 @@ import (
 
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	apiscsp "github.com/openebs/maya/pkg/cstor/poolinstance/v1alpha3"
+	env "github.com/openebs/maya/pkg/env/v1alpha1"
 	container "github.com/openebs/maya/pkg/kubernetes/container/v1alpha1"
 	deploy "github.com/openebs/maya/pkg/kubernetes/deployment/appsv1/v1alpha1"
 	pts "github.com/openebs/maya/pkg/kubernetes/podtemplatespec/v1alpha1"
@@ -62,6 +63,10 @@ var (
 		corev1.VolumeMount{
 			Name:      "udev",
 			MountPath: "/run/udev",
+		},
+		corev1.VolumeMount{
+			Name:      "storagepath",
+			MountPath: "/var/openebs/cstor-pool",
 		},
 	}
 	// hostpathType represents the hostpath type
@@ -174,13 +179,19 @@ func (pc *PoolConfig) GetPoolDeploySpec(cspi *apis.CStorPoolInstance) (*appsv1.D
 					volume.NewBuilder().
 						WithName("tmp").
 						WithHostPathAndType(
-							getSparseDirPath()+"/shared-"+pc.AlgorithmConfig.CSPC.Name,
+							env.GetOpenebsBaseDirPath()+"/cstor-pool/"+pc.AlgorithmConfig.CSPC.Name,
 							&hostpathTypeDirectoryOrCreate,
 						),
 					volume.NewBuilder().
 						WithName("sparse").
 						WithHostPathAndType(
 							getSparseDirPath(),
+							&hostpathTypeDirectoryOrCreate,
+						),
+					volume.NewBuilder().
+						WithName("storagepath").
+						WithHostPathAndType(
+							env.GetOpenebsBaseDirPath()+"/cstor-pool/"+pc.AlgorithmConfig.CSPC.Name,
 							&hostpathTypeDirectoryOrCreate,
 						),
 				),

--- a/pkg/env/v1alpha1/env.go
+++ b/pkg/env/v1alpha1/env.go
@@ -50,6 +50,10 @@ const (
 	// This environment variable is set via kubernetes downward API
 	Namespace ENVKey = "NAMESPACE"
 
+	// OpenEBSBaseDir is the environment variable to get base directory of
+	// openebs
+	OpenEBSBaseDir ENVKey = "OPENEBS_IO_BASE_DIR"
+
 	// OpenEBSMayaPodName is the environment variable to get maya-apiserver pod
 	// name
 	//
@@ -251,4 +255,14 @@ func lookupEnv(envKey string) (value string, present bool) {
 	value, present = os.LookupEnv(envKey)
 	value = strings.TrimSpace(value)
 	return
+}
+
+// GetOpenebsBaseDirPath returns the base path to store openebs related files on
+// host machine
+func GetOpenebsBaseDirPath() string {
+	baseDir, isPresent := lookupEnv(string(OpenEBSBaseDir))
+	if !isPresent {
+		return "/var/openebs"
+	}
+	return baseDir
 }

--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -616,6 +616,8 @@ spec:
               mountPath: /var/run
             - name: conf
               mountPath: /usr/local/etc/istgt
+            - name: storagepath
+              mountPath: /var/openebs/cstor-target
           {{- end }}
           - name: cstor-volume-mgmt
             image: {{ .Config.VolumeControllerImage.value }}

--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -669,7 +669,7 @@ spec:
             emptyDir: {}
           - name: storagepath
             hostPath:
-              path: {{ .Config.OpenebsBaseDir.value }}/cstor-target/{{ .Volume.owner }}-target
+              path: {{ .Config.OpenebsBaseDir.value }}/cstor-target/{{ .Volume.owner }}
               type: DirectoryOrCreate
           - name: tmp
             hostPath:


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR is a continuation of PR: https://github.com/openebs/maya/pull/1583 and new deployments strictly follow to store component related files in one path of the host machine and that path called OPENEBS_IO_BASE_DIR.
**How Users Can Configure:**
If users need to configure base directory he has to set on OPENEBS_IO_BASE_DIR Env in cspc-operator & CVC-operator.

What files stored in the host machine:
- When CSPC is deployed pool pod will generate lock file, sock file, core files, and pool cache file inside the container and the container path is mounted on  **BASE_DIR/cstor-pool/<cspc_name>** host path.
- When cStor volume is deployed target pod will store core files inside the container and the container path is mounted on **BASE_DIR/cstor-target/<volume_name>**  host path.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests