### PR TITLE
fix(jiva-cleanup): allow cleanup jobs to run as previleged mode

### DIFF
--- a/pkg/install/v1alpha1/jiva_volume.go
+++ b/pkg/install/v1alpha1/jiva_volume.go
@@ -1390,6 +1390,8 @@ spec:
               type: ""
           containers:
           - name: sjr
+            securityContext:
+              privileged: true
             image: {{ .Config.ScrubImage.value }}
             command:
             - sh


### PR DESCRIPTION

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This commit fix the issue where scrub jobs were failing on openshift platform
or where non previleged pods are not allowed to access/modify hostpath.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # https://github.com/openebs/openebs/issues/2893

**Special notes for your reviewer**:
none
**Checklist:**
- [x] Fixes openebs/openebs#2893
- [ ] Labelled this PR & related issue with `documentation` tag
- [x] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [x] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests