### PR TITLE
[WIP] (feat) localPV-hostpath-provisioner : Support for SharedMount, and AllowedTopology in localPV Provisioner

### DIFF
--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -54,6 +54,7 @@ const (
 	// is specified with PVC and is useful for granting shared access
 	// to underlying hostpaths across multiple pods.
 	//KeyPVAbsolutePath = "AbsolutePath"
+	KeyShared = "Shared"
 )
 
 const (
@@ -116,6 +117,17 @@ func (p *Provisioner) GetVolumeConfig(pvName string, pvc *v1.PersistentVolumeCla
 		options: pvConfigMap,
 	}
 	return c, nil
+}
+
+//GetSharedMountValue return the value of KeyShared value configured
+// in StorageClass. Default is false.
+func (c *VolumeConfig) GetSharedMountValue() bool {
+	sharedMountValue := c.getValue(KeyShared)
+	if strings.TrimSpace(sharedMountValue) == "true" {
+		return true
+	} else {
+		return false
+	}
 }
 
 //GetStorageType returns the StorageType value configured

--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -54,6 +54,7 @@ const (
 	// is specified with PVC and is useful for granting shared access
 	// to underlying hostpaths across multiple pods.
 	//KeyPVAbsolutePath = "AbsolutePath"
+	//KeyShared defines the usage of sharedMount
 	KeyShared = "Shared"
 )
 
@@ -122,12 +123,7 @@ func (p *Provisioner) GetVolumeConfig(pvName string, pvc *v1.PersistentVolumeCla
 //GetSharedMountValue return the value of KeyShared value configured
 // in StorageClass. Default is false.
 func (c *VolumeConfig) GetSharedMountValue() bool {
-	sharedMountValue := c.getValue(KeyShared)
-	if strings.TrimSpace(sharedMountValue) == "true" {
-		return true
-	} else {
-		return false
-	}
+	return util.CheckTruthy(c.getValue(KeyShared))
 }
 
 //GetStorageType returns the StorageType value configured

--- a/cmd/provisioner-localpv/app/provisioner_hostpath.go
+++ b/cmd/provisioner-localpv/app/provisioner_hostpath.go
@@ -104,10 +104,12 @@ func (p *Provisioner) ProvisionHostPath(opts pvController.VolumeOptions, volumeC
 		WithAccessModes(pvc.Spec.AccessModes).
 		WithVolumeMode(fs).
 		WithCapacityQty(pvc.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]).
-		WithLocalHostDirectory(path).
-		WithNodeAffinity(nodeHostname)
+		WithLocalHostDirectory(path)
+		//WithNodeAffinity(nodeHostname).
 
-	if isShared == true {
+	if isShared == false {
+		pvBuilder.WithNodeAffinity(nodeHostname)
+	} else if isShared == true && opts.AllowedTopologies != nil {
 		pvBuilder.WithAllowedTopologies(opts.AllowedTopologies)
 	}
 

--- a/cmd/provisioner-localpv/app/provisioner_hostpath.go
+++ b/cmd/provisioner-localpv/app/provisioner_hostpath.go
@@ -39,7 +39,7 @@ func (p *Provisioner) ProvisionHostPath(opts pvController.VolumeOptions, volumeC
 	name := opts.PVName
 	stgType := volumeConfig.GetStorageType()
 	saName := getOpenEBSServiceAccountName()
-	shared := volumeConfig.GetSharedMountValue()
+	isShared := volumeConfig.GetSharedMountValue()
 
 	path, err := volumeConfig.GetPath()
 	if err != nil {
@@ -107,7 +107,7 @@ func (p *Provisioner) ProvisionHostPath(opts pvController.VolumeOptions, volumeC
 		WithLocalHostDirectory(path).
 		WithNodeAffinity(nodeHostname)
 
-	if shared == true {
+	if isShared == true {
 		pvBuilder.WithAllowedTopologies(opts.AllowedTopologies)
 	}
 


### PR DESCRIPTION
Ref: https://github.com/openebs/openebs/issues/2861


    - Added function to create VolumeNodeAffinity using AllowedTopologies
    - Added function to get the Value of Shared(true/false) from the CAS Config of openebs-hostpath StorageClass
     - If shared == true, then use the allowedTopologies, else dont.


Signed-off-by: Rahul M Chheda <rahul.chheda@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests