### PR TITLE
feat(spc,csp): adding support for pool ReadOnly Threshold limit

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/common/common.go
+++ b/cmd/cstor-pool-mgmt/controller/common/common.go
@@ -97,6 +97,10 @@ const (
 	MessageResourceAlreadyPresent EventReason = "Resource already present"
 	// MessageImproperPoolStatus holds message for corresponding failed validate resource.
 	MessageImproperPoolStatus EventReason = "Improper pool status"
+	// PoolROThreshold holds status for pool read only state
+	PoolROThreshold EventReason = "PoolReadOnlyThreshold"
+	// MessagePoolROThreshold holds descriptive message for PoolROThreshold
+	MessagePoolROThreshold EventReason = "Pool storage limit reached to threshold. Pool expansion is required to make it's replica RW"
 )
 
 // Periodic interval duration.

--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
@@ -574,7 +574,7 @@ func (c *CStorPoolController) syncCsp(cStorPool *apis.CStorPool) {
 			return
 		}
 
-		total, free, used := qn[0], qn[1], qn[2]
+		total, _, used := qn[0], qn[1], qn[2]
 		usedCapacity := (used * 100) / total
 		if (int(usedCapacity) >= cStorPool.Spec.PoolSpec.ROThresholdLimit) &&
 			(cStorPool.Spec.PoolSpec.ROThresholdLimit != 0 &&

--- a/cmd/cstor-pool-mgmt/pool/pool.go
+++ b/cmd/cstor-pool-mgmt/pool/pool.go
@@ -439,14 +439,17 @@ func poolStatusOutputParser(output string) (bool, string) {
 	var poolStatus string
 	var readOnly bool
 
-	if strings.TrimSpace(string(output)) != "" {
-		outputStr = strings.Split(string(output), "\n")
-		if len(outputStr) <= 3 {
-			poolStatus = outputStr[0]
-			if outputStr[1] == "on" {
-				readOnly = true
-			}
-		}
+	output = strings.TrimSpace(string(output))
+	outputStr = strings.Split(string(output), "\n")
+
+	if len(outputStr) != 2 {
+		klog.Errorf("Invalid input='%s' for poolStatusOutputParser", output)
+		return readOnly, poolStatus
+	}
+
+	poolStatus = outputStr[0]
+	if outputStr[1] == "on" {
+		readOnly = true
 	}
 	return readOnly, poolStatus
 }

--- a/cmd/cstor-pool-mgmt/pool/pool.go
+++ b/cmd/cstor-pool-mgmt/pool/pool.go
@@ -439,15 +439,14 @@ func poolStatusOutputParser(output string) (bool, string) {
 	var poolStatus string
 	var readOnly bool
 
-	output = strings.TrimSpace(string(output))
 	outputStr = strings.Split(string(output), "\n")
 
-	if len(outputStr) != 2 {
+	if len(outputStr) != 3 {
 		klog.Errorf("Invalid input='%s' for poolStatusOutputParser", output)
 		return readOnly, poolStatus
 	}
 
-	poolStatus = outputStr[0]
+	poolStatus = strings.TrimSpace(string(outputStr[0]))
 	if outputStr[1] == "on" {
 		readOnly = true
 	}

--- a/cmd/cstor-pool-mgmt/pool/pool.go
+++ b/cmd/cstor-pool-mgmt/pool/pool.go
@@ -390,19 +390,12 @@ func Capacity(poolName string) (*apis.CStorPoolCapacityAttr, error) {
 }
 
 // PoolStatus finds the status of the pool.
-// The ouptut of command(`zpool status <pool-name>`) executed is as follows:
+// The ouptut of command(`zpool get -Hp  -ovalue health,io.openebs:readonly <pool-name>`) executed is as follows:
 
 /*
-		  pool: cstor-530c9c4f-e0df-11e8-94a8-42010a80013b
-	 state: ONLINE
-	  scan: none requested
-	config:
-
-		NAME                                        STATE     READ WRITE CKSUM
-		cstor-530c9c4f-e0df-11e8-94a8-42010a80013b  ONLINE       0     0     0
-		  scsi-0Google_PersistentDisk_ashu-disk2    ONLINE       0     0     0
-
-	errors: No known data errors
+root@cstor-pool-1dvj-854db8dc56-prblp:/# zpool get -Hp  -ovalue health,io.openebs:readonly  cstor-3cbec7b9-578d-11ea-b66e-42010a9a0080
+ONLINE
+off
 */
 // The output is then parsed by poolStatusOutputParser function to get the status of the pool
 func Status(poolName string) (string, bool, error) {

--- a/cmd/cstor-pool-mgmt/pool/pool_test.go
+++ b/cmd/cstor-pool-mgmt/pool/pool_test.go
@@ -80,6 +80,14 @@ func (r TestRunner) RunCombinedOutput(command string, args ...string) ([]byte, e
 			// Set env varibles for the 'TestCapacityHelperProcess' function which runs as a process.
 			env = []string{"GO_WANT_CAPACITY_HELPER_PROCESS=1"}
 		}
+	case "status":
+		if len(r.expectedError) != 0 {
+			return []byte(r.expectedError), nil
+		}
+		// Create command arguments
+		cs = []string{"-test.run=TestStatusHelperProcess", "--", command}
+		// Set env varibles for the 'TestStatusHelperProcess' function which runs as a process.
+		env = []string{"GO_WANT_STATUS_HELPER_PROCESS=1", "StatusType=" + os.Getenv("StatusType")}
 	case "set":
 		cs = []string{"-test.run=TestSetCachefileProcess", "--"}
 		env = []string{"SetErr=nil"}

--- a/cmd/maya-apiserver/cstor-operator/spc/handler.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/handler.go
@@ -339,6 +339,7 @@ var validateFuncList = []validateFunc{
 	validatePoolType,
 	validateDiskType,
 	validateAutoSpcMaxPool,
+	validateROThresholdLimit,
 }
 
 // validatePoolType validates pool type in spc.
@@ -371,6 +372,16 @@ func validateAutoSpcMaxPool(spc *apis.StoragePoolClaim) error {
 			return errors.Errorf("aborting storagepool create operation for %s as invalid maxPool value %d", spc.Name, maxPools)
 		}
 	}
+	return nil
+}
+
+// validateROThresholdLimit validated the RO threshold limit
+func validateROThresholdLimit(spc *apis.StoragePoolClaim) error {
+	if spc.Spec.PoolSpec.ROThresholdLimit < 0 ||
+		spc.Spec.PoolSpec.ROThresholdLimit > 100 {
+		return errors.Errorf("Invalid pool ROThreshold limit, it should be between 0 to 100")
+	}
+
 	return nil
 }
 

--- a/cmd/maya-apiserver/cstor-operator/spc/storagepool_create.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/storagepool_create.go
@@ -135,6 +135,7 @@ func (cb *CasPoolBuilder) withAnnotations(annotations map[string]string) *CasPoo
 	return cb
 }
 
+// WithPoolROThreshold set PoolROThreshold value
 func (cb *CasPoolBuilder) WithPoolROThreshold(poolROThreshold int) *CasPoolBuilder {
 	cb.CasPool.PoolROThreshold = poolROThreshold
 	return cb

--- a/cmd/maya-apiserver/cstor-operator/spc/storagepool_create.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/storagepool_create.go
@@ -72,6 +72,7 @@ func (pc *PoolCreateConfig) getCasPool(spc *apis.StoragePoolClaim) (*apis.CasPoo
 		withPoolCacheFile(spc.Spec.PoolSpec.CacheFile).
 		withAnnotations(spc.Annotations).
 		withMaxPool(spc).
+		WithPoolROThreshold(spc.Spec.PoolSpec.ROThresholdLimit).
 		Build()
 	casPoolWithDisks, err := pc.withDisks(casPool, spc)
 	if err != nil {
@@ -131,6 +132,11 @@ func (cb *CasPoolBuilder) withDiskType(diskType string) *CasPoolBuilder {
 
 func (cb *CasPoolBuilder) withAnnotations(annotations map[string]string) *CasPoolBuilder {
 	cb.CasPool.Annotations = annotations
+	return cb
+}
+
+func (cb *CasPoolBuilder) WithPoolROThreshold(poolROThreshold int) *CasPoolBuilder {
+	cb.CasPool.PoolROThreshold = poolROThreshold
 	return cb
 }
 

--- a/pkg/apis/openebs.io/v1alpha1/cas_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_pool.go
@@ -120,4 +120,7 @@ type CasPool struct {
 
 	DeviceID           []string
 	APIBlockDeviceList ndm.BlockDeviceList
+
+	// PoolROThreshold is threshold limit for pool read only mode
+	PoolROThreshold int
 }

--- a/pkg/apis/openebs.io/v1alpha1/cas_template_keys.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_template_keys.go
@@ -131,6 +131,8 @@ const (
 	InitPhaseCTP StoragePoolTLPProperty = "phase"
 	// PoolCacheFileCTP is the cache file used in case of imporitng pool
 	PoolCacheFileCTP StoragePoolTLPProperty = "poolCacheFile"
+	// PoolROThresholdLimitCTP is pool read only threshold limit
+	PoolROThresholdLimitCTP StoragePoolTLPProperty = "poolROThreshold"
 )
 
 // VolumeTLPProperty is used to define properties that comes

--- a/pkg/apis/openebs.io/v1alpha1/cstor_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_pool.go
@@ -74,6 +74,8 @@ type CStorPoolAttr struct {
 	OverProvisioning bool `json:"overProvisioning"` //true or false
 	// ThickProvisioning, If true disables OverProvisioning
 	ThickProvisioning bool `json:"thickProvisioning"` // true or false
+	// ROThresholdLimit is threshold(percentage base) limit for pool read only mode, if ROThresholdLimit(%) of pool storage is used then pool will become readonly, CVR also. (0 < ROThresholdLimit < 100, default:100)
+	ROThresholdLimit int `json:"roThresholdLimit"` //optional
 }
 
 // CStorPoolPhase is a typed string for phase field of CStorPool.
@@ -118,6 +120,7 @@ type CStorPoolStatus struct {
 	Phase    CStorPoolPhase        `json:"phase"`
 	Capacity CStorPoolCapacityAttr `json:"capacity"`
 	// LastTransitionTime refers to the time when the phase changes
+	ReadOnly           bool        `json:"readOnly"`
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
 	LastUpdateTime     metav1.Time `json:"lastUpdateTime,omitempty"`
 	Message            string      `json:"message,omitempty"`

--- a/pkg/apis/openebs.io/v1alpha1/cstor_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_pool.go
@@ -119,11 +119,15 @@ const (
 type CStorPoolStatus struct {
 	Phase    CStorPoolPhase        `json:"phase"`
 	Capacity CStorPoolCapacityAttr `json:"capacity"`
+
 	// LastTransitionTime refers to the time when the phase changes
-	ReadOnly           bool        `json:"readOnly"`
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
-	LastUpdateTime     metav1.Time `json:"lastUpdateTime,omitempty"`
-	Message            string      `json:"message,omitempty"`
+
+	//ReadOnly if pool is readOnly or not
+	ReadOnly bool `json:"readOnly"`
+
+	LastUpdateTime metav1.Time `json:"lastUpdateTime,omitempty"`
+	Message        string      `json:"message,omitempty"`
 }
 
 // CStorPoolCapacityAttr stores the pool capacity related attributes.

--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -127,14 +127,14 @@ spec:
     {{- jsonpath .JsonResult "{.metadata.uid}" | trim | addTo "putcstorpoolcr.objectUID" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.metadata.labels.kubernetes\\.io/hostname}" | trim | addTo "putcstorpoolcr.nodeName" .TaskResult | noop -}}
   task: |-
-    {{- $blockDeviceIdList:= toYaml .Storagepool | fromYaml -}}
+    {{- $storagePool:= toYaml .Storagepool | fromYaml -}}
     apiVersion: openebs.io/v1alpha1
     kind: CStorPool
     metadata:
-      name: {{$blockDeviceIdList.owner}}-{{randAlphaNum 4 |lower }}
+      name: {{$storagePool.owner}}-{{randAlphaNum 4 |lower }}
       labels:
-        openebs.io/storage-pool-claim: {{$blockDeviceIdList.owner}}
-        kubernetes.io/hostname: {{$blockDeviceIdList.nodeName}}
+        openebs.io/storage-pool-claim: {{$storagePool.owner}}
+        kubernetes.io/hostname: {{$storagePool.nodeName}}
         openebs.io/version: {{ .CAST.version }}
         openebs.io/cas-template-name: {{ .CAST.castName }}
         openebs.io/cas-type: cstor
@@ -143,11 +143,11 @@ spec:
         blockOwnerDeletion: true
         controller: true
         kind: StoragePoolClaim
-        name: {{$blockDeviceIdList.owner}}
+        name: {{$storagePool.owner}}
         uid: {{ .TaskResult.getspc.objectUID }}
     spec:
       group:
-        {{- range $k, $v := $blockDeviceIdList.blockDeviceList }}
+        {{- range $k, $v := $storagePool.blockDeviceList }}
         - blockDevice:
           {{- range $ki, $blockDevice := $v.blockDevice }}
           - name: {{$blockDevice.name}}
@@ -156,10 +156,10 @@ spec:
           {{- end }}
         {{- end }}
       poolSpec:
-        poolType: {{$blockDeviceIdList.poolType}}
-        cacheFile: {{$blockDeviceIdList.poolCacheFile}}
+        poolType: {{$storagePool.poolType}}
+        cacheFile: {{$storagePool.poolCacheFile}}
         overProvisioning: false
-        roThresholdLimit: {{$blockDeviceIdList.poolROThreshold}}
+        roThresholdLimit: {{$storagePool.poolROThreshold}}
     status:
       phase: Init
     versionDetails:

--- a/pkg/install/v1alpha1/cstor_pool.go
+++ b/pkg/install/v1alpha1/cstor_pool.go
@@ -159,6 +159,7 @@ spec:
         poolType: {{$blockDeviceIdList.poolType}}
         cacheFile: {{$blockDeviceIdList.poolCacheFile}}
         overProvisioning: false
+        roThresholdLimit: {{$blockDeviceIdList.poolROThreshold}}
     status:
       phase: Init
     versionDetails:

--- a/pkg/install/v1alpha1/openebs_crds.go
+++ b/pkg/install/v1alpha1/openebs_crds.go
@@ -199,6 +199,10 @@ spec:
     name: Status
     description: Identifies the current health of the pool
     type: string
+  - JSONPath: .status.readOnly
+    description: Identifies the pool read only mode
+    name: ReadOnly
+    type: boolean
   - JSONPath: .spec.poolSpec.poolType
     name: Type
     description: The type of the storage pool

--- a/pkg/storagepool/storagepool.go
+++ b/pkg/storagepool/storagepool.go
@@ -93,12 +93,13 @@ func (v *casPoolOperation) Create() (*v1alpha1.CasPool, error) {
 		openebsConfig,
 		string(v1alpha1.StoragePoolTLP),
 		map[string]interface{}{
-			string(v1alpha1.OwnerCTP):             v.pool.StoragePoolClaim,
-			string(v1alpha1.BlockDeviceListCTP):   v.pool.BlockDeviceList,
-			string(v1alpha1.NodeNameCTP):          v.pool.NodeName,
-			string(v1alpha1.PoolTypeCTP):          v.pool.PoolType,
-			string(v1alpha1.BlockDeviceIDListCTP): v.pool.DeviceID,
-			string(v1alpha1.PoolCacheFileCTP):     v.pool.PoolCacheFile,
+			string(v1alpha1.OwnerCTP):                v.pool.StoragePoolClaim,
+			string(v1alpha1.BlockDeviceListCTP):      v.pool.BlockDeviceList,
+			string(v1alpha1.NodeNameCTP):             v.pool.NodeName,
+			string(v1alpha1.PoolTypeCTP):             v.pool.PoolType,
+			string(v1alpha1.BlockDeviceIDListCTP):    v.pool.DeviceID,
+			string(v1alpha1.PoolCacheFileCTP):        v.pool.PoolCacheFile,
+			string(v1alpha1.PoolROThresholdLimitCTP): v.pool.PoolROThreshold,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Changes:
- Added support to set readOnly threshold for SPC/CSP.

Sample SPC spec
```
spec:
  name: cstor-pool
  type: sparse
  maxPools: 3
  poolSpec:
    poolType: striped
    roThresholdLimit: 80
```
Sample CSP spec:
```
spec:
  group:
  - blockDevice:
    - deviceID: /var/openebs/sparse/2-ndm-sparse.img
      inUseByPool: true
      name: sparse-362d689cfa30cf1ac2cd11ca6dcf9449
  poolSpec:
    cacheFile: /tmp/pool1.cache
    overProvisioning: false
    poolType: striped
    roThresholdLimit: 80
    thickProvisioning: false
```

Sample output :
```
kubectl get csp -n openebs
NAME              ALLOCATED   FREE    CAPACITY   STATUS    READONLY   TYPE      AGE
cstor-pool-1mns   117M        9.82G   9.94G      Healthy   true      striped   3h
```
```
Events:
  Type     Reason                 Age                  From       Message
  ----     ------                 ----                 ----       -------
  Normal   Synced                 12m                  CStorPool  Received Resource create event
  Normal   Synced                 12m (x2 over 12m)    CStorPool  Received Resource modify event
  Normal   Created                12m                  CStorPool  Resource created successfully
  Normal   Synced                 8m23s                CStorPool  Received Resource create event
  Normal   Imported               8m22s                CStorPool  Resource imported successfully
  Normal   Synced                 29s (x4 over 8m23s)  CStorPool  Received Resource modify event
  Warning  PoolReadOnlyThreshold  21s                  CStorPool  Pool storage limit reached to threshold. Pool expansion is required to make it's replica RW

```
Note:
1. Since SPC reconciliation is not supported, user can set `roThresholdLimit` on SPC during creation only. 
2. One can manually update the CSP's `roThresholdLimit`. 
3. By default `roThresholdLimit` is set to `0`.
4. If `roThresholdLimit` is set to `0` or `100`:
             -  Writes on the pool will be allowed until it runs out of space


Signed-off-by: mayank <mayank.patel@mayadata.io>

