### PR TITLE
fix(cspc): replace the spc label with cspc label

### DIFF
--- a/cmd/cspc-operator/app/handler.go
+++ b/cmd/cspc-operator/app/handler.go
@@ -332,7 +332,7 @@ func (pc *PoolConfig) removeCSPCFinalizer() error {
 	}
 
 	cspList, err := apiscsp.NewKubeClient().List(metav1.ListOptions{
-		LabelSelector: string(apis.StoragePoolClaimCPK) + "=" + pc.AlgorithmConfig.CSPC.Name,
+		LabelSelector: string(apis.CStorPoolClusterCPK) + "=" + pc.AlgorithmConfig.CSPC.Name,
 	})
 
 	if len(cspList.Items) > 0 {


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR replaces the spc label with cspc label in the cspc-operator. If the finalizers are removed from the cspi and for some unknown reason the deletion is stuck then in that case the cspc should not be deleted before cspi deletion.
