### PR TITLE
fix(exporter): Handle pool sync time metrics collection gracefully

### DIFF
--- a/cmd/maya-exporter/app/collector/zvol/pool_synctime.go
+++ b/cmd/maya-exporter/app/collector/zvol/pool_synctime.go
@@ -51,6 +51,10 @@ func (p *poolMetrics) setRequestToFalse() {
 	p.Unlock()
 }
 
+func (p *poolMetrics) isRequestInProgress() bool {
+	return p.request
+}
+
 // collectors returns the list of the collectors
 func (p *poolMetrics) collectors() []prometheus.Collector {
 	return []prometheus.Collector{
@@ -110,6 +114,10 @@ func (p *poolMetrics) get() *poolfields {
 // Collect is implementation of prometheus's prometheus.Collector interface
 func (p *poolMetrics) Collect(ch chan<- prometheus.Metric) {
 	p.Lock()
+	if p.isRequestInProgress() {
+		p.Unlock()
+		return
+	}
 	p.request = true
 	p.Unlock()
 


### PR DESCRIPTION
Signed-off-by: Meghna Singh <singhmegna79@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR fixes a bug in pool sync time metrics collector in maya exporter. If last request is in progress, don't queue the current request during pool last Sync time metrics collection.