### PR TITLE
fix(exporter): Handle pool sync time metrics collection gracefully

### DIFF
--- a/cmd/maya-exporter/app/collector/zvol/metrics.go
+++ b/cmd/maya-exporter/app/collector/zvol/metrics.go
@@ -68,7 +68,7 @@ type poolSyncMetrics struct {
 	zpoolLastSyncTime             *prometheus.GaugeVec
 	zpoolStateUnknown             *prometheus.GaugeVec
 	zpoolLastSyncTimeCommandError *prometheus.GaugeVec
-	zpoolListRequestRejectCounter prometheus.Gauge
+	cspiRequestRejectCounter      prometheus.Counter
 }
 
 // poolfields struct is for pool last sync time metric
@@ -438,15 +438,15 @@ func (p *poolSyncMetrics) withZpoolStateUnknown() *poolSyncMetrics {
 	return p
 }
 
-func (l *poolSyncMetrics) withRequestRejectCounter() *poolSyncMetrics {
-	l.zpoolListRequestRejectCounter = prometheus.NewGauge(
+func (p *poolSyncMetrics) withRequestRejectCounter() *poolSyncMetrics {
+	p.cspiRequestRejectCounter = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "openebs",
-			Name:      "zpool_list_request_reject_count",
-			Help:      "Total no of rejected requests of zpool list",
+			Name:      "zfs_get_livenesstimestamp_request_reject_count",
+			Help:      "Total no of rejected requests for pool liveness",
 		},
 	)
-	return l
+	return p
 }
 
 func (p *poolSyncMetrics) withzpoolLastSyncTimeCommandError() *poolSyncMetrics {

--- a/cmd/maya-exporter/app/collector/zvol/metrics.go
+++ b/cmd/maya-exporter/app/collector/zvol/metrics.go
@@ -68,6 +68,7 @@ type poolSyncMetrics struct {
 	zpoolLastSyncTime             *prometheus.GaugeVec
 	zpoolStateUnknown             *prometheus.GaugeVec
 	zpoolLastSyncTimeCommandError *prometheus.GaugeVec
+	zpoolListRequestRejectCounter prometheus.Gauge
 }
 
 // poolfields struct is for pool last sync time metric
@@ -435,6 +436,17 @@ func (p *poolSyncMetrics) withZpoolStateUnknown() *poolSyncMetrics {
 		[]string{"pool"},
 	)
 	return p
+}
+
+func (l *poolSyncMetrics) withRequestRejectCounter() *poolSyncMetrics {
+	l.zpoolListRequestRejectCounter = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "openebs",
+			Name:      "zpool_list_request_reject_count",
+			Help:      "Total no of rejected requests of zpool list",
+		},
+	)
+	return l
 }
 
 func (p *poolSyncMetrics) withzpoolLastSyncTimeCommandError() *poolSyncMetrics {

--- a/cmd/maya-exporter/app/collector/zvol/pool_synctime.go
+++ b/cmd/maya-exporter/app/collector/zvol/pool_synctime.go
@@ -116,9 +116,9 @@ func (p *poolMetrics) get() *poolfields {
 func (p *poolMetrics) Collect(ch chan<- prometheus.Metric) {
 	p.Lock()
 	if p.isRequestInProgress() {
-		p.zpoolListRequestRejectCounter.Inc()
+		p.cspiRequestRejectCounter.Inc()
 		p.Unlock()
-		p.zpoolListRequestRejectCounter.Collect(ch)
+		p.cspiRequestRejectCounter.Collect(ch)
 		return
 	}
 	p.request = true

--- a/cmd/maya-exporter/app/collector/zvol/pool_synctime.go
+++ b/cmd/maya-exporter/app/collector/zvol/pool_synctime.go
@@ -40,9 +40,14 @@ func NewPoolSyncMetric(runner types.Runner) col.Collector {
 		poolSyncMetrics: newPoolMetrics().
 			withZpoolLastSyncTime().
 			withZpoolStateUnknown().
+			withRequestRejectCounter().
 			withzpoolLastSyncTimeCommandError(),
 		runner: runner,
 	}
+}
+
+func (p *poolMetrics) isRequestInProgress() bool {
+	return p.request
 }
 
 func (p *poolMetrics) setRequestToFalse() {
@@ -110,6 +115,12 @@ func (p *poolMetrics) get() *poolfields {
 // Collect is implementation of prometheus's prometheus.Collector interface
 func (p *poolMetrics) Collect(ch chan<- prometheus.Metric) {
 	p.Lock()
+	if p.isRequestInProgress() {
+		p.zpoolListRequestRejectCounter.Inc()
+		p.Unlock()
+		p.zpoolListRequestRejectCounter.Collect(ch)
+		return
+	}
 	p.request = true
 	p.Unlock()
 


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR fixes a bug in the pool sync time metrics collector in Maya-exporter.
If the last request is in progress, don't queue the current request during pool
last Sync time metrics collection and increment the reject request counter.
**Note**
This PR is the address comments of #1615.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
UnitTest will be added once after understanding the flow.

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests