### PR TITLE
feat(validation): add webhook validations for CVC replica scale 

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -241,3 +241,17 @@ func IsChangeInLists(listA, listB []string) bool {
 	}
 	return false
 }
+
+// IsUniqueList returns true if values in list are not repeated else return
+// false
+func IsUniqueList(list []string) bool {
+	listMap := map[string]bool{}
+
+	for _, str := range list {
+		if _, ok := listMap[str]; ok {
+			return false
+		}
+		listMap[str] = true
+	}
+	return true
+}

--- a/pkg/webhook/configuration.go
+++ b/pkg/webhook/configuration.go
@@ -73,6 +73,7 @@ var (
 	transformSvc    = []transformSvcFunc{}
 	transformConfig = []transformConfigFunc{
 		addCSPCDeleteRule,
+		addCVCWithUpdateRule,
 	}
 	cvcRuleWithOperations = v1beta1.RuleWithOperations{
 		Operations: []v1beta1.OperationType{

--- a/pkg/webhook/configuration.go
+++ b/pkg/webhook/configuration.go
@@ -74,6 +74,16 @@ var (
 	transformConfig = []transformConfigFunc{
 		addCSPCDeleteRule,
 	}
+	cvcRuleWithOperations = v1beta1.RuleWithOperations{
+		Operations: []v1beta1.OperationType{
+			v1beta1.Update,
+		},
+		Rule: v1beta1.Rule{
+			APIGroups:   []string{"*"},
+			APIVersions: []string{"*"},
+			Resources:   []string{"cstorvolumeclaims"},
+		},
+	}
 )
 
 // createWebhookService creates our webhook Service resource if it does not
@@ -133,9 +143,9 @@ func createWebhookService(
 	return err
 }
 
-// createAdmissionService creates our ValidatingWebhookConfiguration resource
+// createValidatingWebhookConfig creates our ValidatingWebhookConfiguration resource
 // if it does not exist.
-func createAdmissionService(
+func createValidatingWebhookConfig(
 	ownerReference metav1.OwnerReference,
 	validatorWebhook string,
 	namespace string,
@@ -160,17 +170,18 @@ func createAdmissionService(
 
 	webhookHandler := v1beta1.ValidatingWebhook{
 		Name: webhookHandlerName,
-		Rules: []v1beta1.RuleWithOperations{{
-			Operations: []v1beta1.OperationType{
-				v1beta1.Create,
-				v1beta1.Delete,
+		Rules: []v1beta1.RuleWithOperations{
+			{
+				Operations: []v1beta1.OperationType{
+					v1beta1.Create,
+					v1beta1.Delete,
+				},
+				Rule: v1beta1.Rule{
+					APIGroups:   []string{"*"},
+					APIVersions: []string{"*"},
+					Resources:   []string{"persistentvolumeclaims"},
+				},
 			},
-			Rule: v1beta1.Rule{
-				APIGroups:   []string{"*"},
-				APIVersions: []string{"*"},
-				Resources:   []string{"persistentvolumeclaims"},
-			},
-		},
 			{
 				Operations: []v1beta1.OperationType{
 					v1beta1.Create,
@@ -182,7 +193,9 @@ func createAdmissionService(
 					APIVersions: []string{"*"},
 					Resources:   []string{"cstorpoolclusters"},
 				},
-			}},
+			},
+			cvcRuleWithOperations,
+		},
 		ClientConfig: v1beta1.WebhookClientConfig{
 			Service: &v1beta1.ServiceReference{
 				Namespace: namespace,
@@ -356,7 +369,7 @@ func InitValidationServer(
 		)
 	}
 
-	validatorErr := createAdmissionService(
+	validatorErr := createValidatingWebhookConfig(
 		ownerReference,
 		validatorWebhook,
 		openebsNamespace,
@@ -455,6 +468,17 @@ func addCSPCDeleteRule(config *v1beta1.ValidatingWebhookConfiguration) {
 				v1beta1.Delete,
 			)
 		}
+	}
+}
+
+// addCVCWithUpdateRule adds the CVC webhook config with UPDATE operation if coming from
+// previous versions
+func addCVCWithUpdateRule(config *v1beta1.ValidatingWebhookConfiguration) {
+	if config.Labels[string(apis.OpenEBSVersionKey)] < "1.8.0" {
+		// Currenly we have only one webhook validation so CVC rule in under
+		// same webhook.
+		// https://github.com/openebs/maya/blob/9417d96abdaf41a2dbfcdbfb113fb73c83e6cf42/pkg/webhook/configuration.go#L212
+		config.Webhooks[0].Rules = append(config.Webhooks[0].Rules, cvcRuleWithOperations)
 	}
 }
 

--- a/pkg/webhook/cvc.go
+++ b/pkg/webhook/cvc.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2019 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"encoding/json"
+	"net/http"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	clientset "github.com/openebs/maya/pkg/client/generated/clientset/versioned"
+	cvc "github.com/openebs/maya/pkg/cstorvolumeclaim/v1alpha1"
+	util "github.com/openebs/maya/pkg/util"
+	"github.com/pkg/errors"
+	"k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+)
+
+type validateFunc func(cvcOldObj, cvcNewObj *apis.CStorVolumeClaim) error
+
+type getCVC func(name, namespace string, clientset clientset.Interface) (*apis.CStorVolumeClaim, error)
+
+func (wh *webhook) validateCVCUpdateRequest(req *v1beta1.AdmissionRequest, getCVC getCVC) *v1beta1.AdmissionResponse {
+	response := NewAdmissionResponse().
+		SetAllowed().
+		WithResultAsSuccess(http.StatusAccepted).AR
+	var cvcNewObj apis.CStorVolumeClaim
+	err := json.Unmarshal(req.Object.Raw, &cvcNewObj)
+	if err != nil {
+		klog.Errorf("Couldn't unmarshal raw object: %v to cvc error: %v", req.Object.Raw, err)
+		response = BuildForAPIObject(response).UnSetAllowed().WithResultAsFailure(err, http.StatusBadRequest).AR
+		return response
+	}
+
+	// Get old CVC object by making call to etcd
+	cvcOldObj, err := getCVC(cvcNewObj.Name, cvcNewObj.Namespace, wh.clientset)
+	if err != nil {
+		klog.Errorf("Failed to get CVC %s in namespace %s from etcd error: %v", cvcNewObj.Name, cvcNewObj.Namespace, err)
+		response = BuildForAPIObject(response).UnSetAllowed().WithResultAsFailure(err, http.StatusBadRequest).AR
+		return response
+	}
+	err = validateCVCSpecChanges(cvcOldObj, &cvcNewObj)
+	if err != nil {
+		klog.Errorf("invalid cvc changes: %s error: %s", cvcOldObj.Name, err.Error())
+		response = BuildForAPIObject(response).UnSetAllowed().WithResultAsFailure(err, http.StatusBadRequest).AR
+		return response
+	}
+	return response
+}
+
+func validateCVCSpecChanges(cvcOldObj, cvcNewObj *apis.CStorVolumeClaim) error {
+	validateFuncList := []validateFunc{validateReplicaCount,
+		validatePoolListChanges,
+		validateReplicaScaling,
+		validateScaleDown,
+		validateStatusPoolList}
+	for _, f := range validateFuncList {
+		err := f(cvcOldObj, cvcNewObj)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Below validations should be done only with new CVC object
+	err := validatePoolNames(cvcNewObj)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// TODO: isScalingInProgress(cvcObj *apis.CStorVolumeClaim) signature need to be
+// updated to cvcObj.IsScaleingInProgress()
+func isScalingInProgress(cvcObj *apis.CStorVolumeClaim) bool {
+	return len(cvcObj.Spec.Policy.ReplicaPoolInfo) != len(cvcObj.Status.PoolInfo)
+}
+
+// validateReplicaCount returns error if user modified the replica count after
+// provisioning the volume else return nil
+func validateReplicaCount(cvcOldObj, cvcNewObj *apis.CStorVolumeClaim) error {
+	if cvcOldObj.Spec.ReplicaCount != cvcNewObj.Spec.ReplicaCount {
+		return errors.Errorf(
+			"cvc %s replicaCount got modified from %d to %d",
+			cvcOldObj.Name,
+			cvcOldObj.Spec.ReplicaCount,
+			cvcNewObj.Spec.ReplicaCount,
+		)
+	}
+	return nil
+}
+
+// validatePoolListChanges returns error if user modified only the pool names
+func validatePoolListChanges(cvcOldObj, cvcNewObj *apis.CStorVolumeClaim) error {
+	if len(cvcNewObj.Spec.Policy.ReplicaPoolInfo) >= len(cvcOldObj.Spec.Policy.ReplicaPoolInfo) {
+		oldDesiredPoolNames := cvc.GetDesiredReplicaPoolNames(cvcOldObj)
+		newDesiredPoolNames := cvc.GetDesiredReplicaPoolNames(cvcNewObj)
+		modifiedPoolNames := util.ListDiff(oldDesiredPoolNames, newDesiredPoolNames)
+		if len(modifiedPoolNames) > 0 {
+			return errors.Errorf(
+				"volume replica migration directly by modifying pool names %v is not yet supported",
+				modifiedPoolNames,
+			)
+		}
+	}
+	return nil
+}
+
+// validateReplicaScaling returns error if user updated pool list when scaling is
+// already in progress
+func validateReplicaScaling(cvcOldObj, cvcNewObj *apis.CStorVolumeClaim) error {
+	if isScalingInProgress(cvcOldObj) {
+		// if old and new CVC has same count of pools then return true else
+		// return false
+		if len(cvcOldObj.Spec.Policy.ReplicaPoolInfo) != len(cvcNewObj.Spec.Policy.ReplicaPoolInfo) {
+			return errors.Errorf("scaling of CVC %s is already in progress", cvcOldObj.Name)
+		}
+	}
+	return nil
+}
+
+// validateScaleDown returns error if user performed more than one replica scale
+// down at a time
+func validateScaleDown(cvcOldObj, cvcNewObj *apis.CStorVolumeClaim) error {
+	oldDesiredPoolNames := cvc.GetDesiredReplicaPoolNames(cvcOldObj)
+	newDesiredPoolNames := cvc.GetDesiredReplicaPoolNames(cvcNewObj)
+	scaledDownPoolNames := util.ListDiff(oldDesiredPoolNames, newDesiredPoolNames)
+	if len(scaledDownPoolNames) > 1 {
+		return errors.Errorf(
+			"Can't perform more than one replica scale down requested scale down count %d",
+			len(scaledDownPoolNames),
+		)
+	}
+	return nil
+}
+
+// validateStatusPoolList return error if pools under status doesn't exist under
+// existing spec else return nil
+func validateStatusPoolList(cvcOldObj, cvcNewObj *apis.CStorVolumeClaim) error {
+	replicaPoolNames := []string{}
+	if len(cvcOldObj.Spec.Policy.ReplicaPoolInfo) == 0 &&
+		len(cvcOldObj.Status.PoolInfo) == 0 {
+		// Might be a case where controller updating Bound status along with
+		// spec and status pool names
+		replicaPoolNames = cvc.GetDesiredReplicaPoolNames(cvcNewObj)
+	} else {
+		replicaPoolNames = cvc.GetDesiredReplicaPoolNames(cvcOldObj)
+	}
+	// get pool names which are in status but not under spec
+	invalidStatusPoolNames := util.ListDiff(cvcNewObj.Status.PoolInfo, replicaPoolNames)
+	if len(invalidStatusPoolNames) > 0 {
+		return errors.Errorf(
+			"replica status pool names %v doesn't exist under spec pool list",
+			invalidStatusPoolNames,
+		)
+	}
+	return nil
+}
+
+// validatePoolNames returns error if there is repeatition of pool names either
+// under spec or status of cvc
+func validatePoolNames(cvcObj *apis.CStorVolumeClaim) error {
+	// TODO: Change cvcObj.GetDesiredReplicaPoolNames()
+	replicaPoolNames := cvc.GetDesiredReplicaPoolNames(cvcObj)
+	// Check repeatition of pool names under Spec of CVC Object
+	if !util.IsUniqueList(replicaPoolNames) {
+		return errors.Errorf(
+			"repeatition of pool names %v under spec of cvc %s",
+			replicaPoolNames,
+			cvcObj.Name,
+		)
+	}
+	// Check repeatition of pool names under Status of CVC Object
+	if !util.IsUniqueList(cvcObj.Status.PoolInfo) {
+		return errors.Errorf(
+			"repeatition of pool names %v under status of cvc %s",
+			cvcObj.Status.PoolInfo,
+			cvcObj.Name,
+		)
+	}
+	return nil
+}
+
+func getCVCObject(name, namespace string,
+	clientset clientset.Interface) (*apis.CStorVolumeClaim, error) {
+	return clientset.OpenebsV1alpha1().
+		CStorVolumeClaims(namespace).
+		Get(name, metav1.GetOptions{})
+}

--- a/pkg/webhook/cvc_test.go
+++ b/pkg/webhook/cvc_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The OpenEBS Authors.
+Copyright 2020 The OpenEBS Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/webhook/cvc_test.go
+++ b/pkg/webhook/cvc_test.go
@@ -340,7 +340,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 		"When Spec & Status Pool Names Was Updated By Controller With Invalid Pool Names Under Status": {
 			existingObj: &apis.CStorVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cvc8",
+					Name:      "cvc9",
 					Namespace: "openebs",
 				},
 				Spec: apis.CStorVolumeClaimSpec{
@@ -349,7 +349,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 			},
 			requestedObj: &apis.CStorVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cvc8",
+					Name:      "cvc9",
 					Namespace: "openebs",
 				},
 				Spec: apis.CStorVolumeClaimSpec{
@@ -372,7 +372,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 		"When Scale Up Alone Performed": {
 			existingObj: &apis.CStorVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cvc9",
+					Name:      "cvc10",
 					Namespace: "openebs",
 				},
 				Spec: apis.CStorVolumeClaimSpec{
@@ -389,7 +389,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 			},
 			requestedObj: &apis.CStorVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cvc9",
+					Name:      "cvc10",
 					Namespace: "openebs",
 				},
 				Spec: apis.CStorVolumeClaimSpec{
@@ -412,7 +412,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 		"When Scale Down Alone Performed": {
 			existingObj: &apis.CStorVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cvc10",
+					Name:      "cvc11",
 					Namespace: "openebs",
 				},
 				Spec: apis.CStorVolumeClaimSpec{
@@ -430,7 +430,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 			},
 			requestedObj: &apis.CStorVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cvc10",
+					Name:      "cvc11",
 					Namespace: "openebs",
 				},
 				Spec: apis.CStorVolumeClaimSpec{
@@ -451,7 +451,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 		"When Scale Up Status Was Updated Success": {
 			existingObj: &apis.CStorVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cvc11",
+					Name:      "cvc12",
 					Namespace: "openebs",
 				},
 				Spec: apis.CStorVolumeClaimSpec{
@@ -469,7 +469,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 			},
 			requestedObj: &apis.CStorVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cvc11",
+					Name:      "cvc12",
 					Namespace: "openebs",
 				},
 				Spec: apis.CStorVolumeClaimSpec{
@@ -491,7 +491,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 		"When Scale Down Status Was Updated Success": {
 			existingObj: &apis.CStorVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cvc12",
+					Name:      "cvc13",
 					Namespace: "openebs",
 				},
 				Spec: apis.CStorVolumeClaimSpec{
@@ -508,7 +508,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 			},
 			requestedObj: &apis.CStorVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cvc12",
+					Name:      "cvc13",
 					Namespace: "openebs",
 				},
 				Spec: apis.CStorVolumeClaimSpec{
@@ -529,7 +529,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 		"When CVC Spec Pool Names Were Repeated": {
 			existingObj: &apis.CStorVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cvc13",
+					Name:      "cvc14",
 					Namespace: "openebs",
 				},
 				Spec: apis.CStorVolumeClaimSpec{
@@ -547,7 +547,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 			},
 			requestedObj: &apis.CStorVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cvc13",
+					Name:      "cvc14",
 					Namespace: "openebs",
 				},
 				Spec: apis.CStorVolumeClaimSpec{
@@ -570,7 +570,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 		"When CVC Status Pool Names Were Repeated": {
 			existingObj: &apis.CStorVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cvc14",
+					Name:      "cvc15",
 					Namespace: "openebs",
 				},
 				Spec: apis.CStorVolumeClaimSpec{
@@ -589,7 +589,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 			},
 			requestedObj: &apis.CStorVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cvc14",
+					Name:      "cvc15",
 					Namespace: "openebs",
 				},
 				Spec: apis.CStorVolumeClaimSpec{
@@ -619,8 +619,19 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 					Raw: serialize(test.requestedObj),
 				},
 			}
-			fakeFixture := f.withOpenebsObjects(test.existingObj)
-			resp := fakeFixture.wh.validateCVCUpdateRequest(ar, test.getCVCObj)
+			// Create fake object in etcd
+			_, err := f.wh.clientset.OpenebsV1alpha1().
+				CStorVolumeClaims(test.existingObj.Namespace).
+				Create(test.existingObj)
+			if err != nil {
+				t.Fatalf(
+					"failed to create fake CVC %s Object in Namespace %s error: %v",
+					test.existingObj.Name,
+					test.existingObj.Namespace,
+					err,
+				)
+			}
+			resp := f.wh.validateCVCUpdateRequest(ar, test.getCVCObj)
 			if resp.Allowed != test.expectedRsp {
 				t.Errorf(
 					"%s test case failed expected response: %t but got %t error: %s",

--- a/pkg/webhook/cvc_test.go
+++ b/pkg/webhook/cvc_test.go
@@ -69,6 +69,9 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 					Name:      "cvc1",
 					Namespace: "openebs",
 				},
+				Status: apis.CStorVolumeClaimStatus{
+					Phase: apis.CStorVolumeClaimPhaseBound,
+				},
 			},
 			expectedRsp: false,
 			getCVCObj:   fakeGetCVCError,
@@ -82,6 +85,9 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 				Spec: apis.CStorVolumeClaimSpec{
 					ReplicaCount: 3,
 				},
+				Status: apis.CStorVolumeClaimStatus{
+					Phase: apis.CStorVolumeClaimPhaseBound,
+				},
 			},
 			requestedObj: &apis.CStorVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
@@ -90,6 +96,9 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 				},
 				Spec: apis.CStorVolumeClaimSpec{
 					ReplicaCount: 4,
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					Phase: apis.CStorVolumeClaimPhaseBound,
 				},
 			},
 			expectedRsp: false,
@@ -121,6 +130,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 					},
 				},
 				Status: apis.CStorVolumeClaimStatus{
+					Phase:    apis.CStorVolumeClaimPhaseBound,
 					PoolInfo: []string{"pool1", "pool2", "pool3"},
 				},
 			},
@@ -145,6 +155,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 				},
 				Status: apis.CStorVolumeClaimStatus{
 					PoolInfo: []string{"pool1", "pool2", "pool3"},
+					Phase:    apis.CStorVolumeClaimPhaseBound,
 				},
 			},
 			requestedObj: &apis.CStorVolumeClaim{
@@ -165,6 +176,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 				},
 				Status: apis.CStorVolumeClaimStatus{
 					PoolInfo: []string{"pool1", "pool2", "pool3"},
+					Phase:    apis.CStorVolumeClaimPhaseBound,
 				},
 			},
 			expectedRsp: false,
@@ -188,6 +200,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 				},
 				Status: apis.CStorVolumeClaimStatus{
 					PoolInfo: []string{"pool1", "pool2", "pool3"},
+					Phase:    apis.CStorVolumeClaimPhaseBound,
 				},
 			},
 			requestedObj: &apis.CStorVolumeClaim{
@@ -207,6 +220,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 				},
 				Status: apis.CStorVolumeClaimStatus{
 					PoolInfo: []string{"pool1", "pool2", "pool3"},
+					Phase:    apis.CStorVolumeClaimPhaseBound,
 				},
 			},
 			expectedRsp: false,
@@ -230,6 +244,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 				},
 				Status: apis.CStorVolumeClaimStatus{
 					PoolInfo: []string{"pool1", "pool2"},
+					Phase:    apis.CStorVolumeClaimPhaseBound,
 				},
 			},
 			requestedObj: &apis.CStorVolumeClaim{
@@ -250,6 +265,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 				},
 				Status: apis.CStorVolumeClaimStatus{
 					PoolInfo: []string{"pool1", "pool2"},
+					Phase:    apis.CStorVolumeClaimPhaseBound,
 				},
 			},
 			expectedRsp: false,
@@ -273,6 +289,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 				},
 				Status: apis.CStorVolumeClaimStatus{
 					PoolInfo: []string{"pool1", "pool2", "pool3"},
+					Phase:    apis.CStorVolumeClaimPhaseBound,
 				},
 			},
 			requestedObj: &apis.CStorVolumeClaim{
@@ -290,12 +307,13 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 				},
 				Status: apis.CStorVolumeClaimStatus{
 					PoolInfo: []string{"pool1", "pool2", "pool3"},
+					Phase:    apis.CStorVolumeClaimPhaseBound,
 				},
 			},
 			expectedRsp: false,
 			getCVCObj:   getCVCObject,
 		},
-		"When Status Was Updated With Non Spec Pool Names": {
+		"When ScaleUp was Performed Before CVC In Bound State": {
 			existingObj: &apis.CStorVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cvc8",
@@ -303,16 +321,6 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 				},
 				Spec: apis.CStorVolumeClaimSpec{
 					ReplicaCount: 3,
-					Policy: apis.CStorVolumePolicySpec{
-						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
-							apis.ReplicaPoolInfo{PoolName: "pool1"},
-							apis.ReplicaPoolInfo{PoolName: "pool2"},
-							apis.ReplicaPoolInfo{PoolName: "pool3"},
-						},
-					},
-				},
-				Status: apis.CStorVolumeClaimStatus{
-					PoolInfo: []string{"pool1", "pool2", "pool3"},
 				},
 			},
 			requestedObj: &apis.CStorVolumeClaim{
@@ -329,41 +337,6 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 							apis.ReplicaPoolInfo{PoolName: "pool3"},
 						},
 					},
-				},
-				Status: apis.CStorVolumeClaimStatus{
-					PoolInfo: []string{"pool1", "pool2", "pool3", "pool4"},
-				},
-			},
-			expectedRsp: false,
-			getCVCObj:   getCVCObject,
-		},
-		"When Spec & Status Pool Names Was Updated By Controller With Invalid Pool Names Under Status": {
-			existingObj: &apis.CStorVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cvc9",
-					Namespace: "openebs",
-				},
-				Spec: apis.CStorVolumeClaimSpec{
-					ReplicaCount: 3,
-				},
-			},
-			requestedObj: &apis.CStorVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cvc9",
-					Namespace: "openebs",
-				},
-				Spec: apis.CStorVolumeClaimSpec{
-					ReplicaCount: 3,
-					Policy: apis.CStorVolumePolicySpec{
-						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
-							apis.ReplicaPoolInfo{PoolName: "pool1"},
-							apis.ReplicaPoolInfo{PoolName: "pool2"},
-							apis.ReplicaPoolInfo{PoolName: "pool3"},
-						},
-					},
-				},
-				Status: apis.CStorVolumeClaimStatus{
-					PoolInfo: []string{"pool1", "pool2", "pool3", "pool4"},
 				},
 			},
 			expectedRsp: false,
@@ -385,6 +358,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 				},
 				Status: apis.CStorVolumeClaimStatus{
 					PoolInfo: []string{"pool1"},
+					Phase:    apis.CStorVolumeClaimPhaseBound,
 				},
 			},
 			requestedObj: &apis.CStorVolumeClaim{
@@ -404,6 +378,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 				},
 				Status: apis.CStorVolumeClaimStatus{
 					PoolInfo: []string{"pool1"},
+					Phase:    apis.CStorVolumeClaimPhaseBound,
 				},
 			},
 			expectedRsp: true,
@@ -426,6 +401,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 				},
 				Status: apis.CStorVolumeClaimStatus{
 					PoolInfo: []string{"pool1", "pool2"},
+					Phase:    apis.CStorVolumeClaimPhaseBound,
 				},
 			},
 			requestedObj: &apis.CStorVolumeClaim{
@@ -443,6 +419,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 				},
 				Status: apis.CStorVolumeClaimStatus{
 					PoolInfo: []string{"pool1", "pool2"},
+					Phase:    apis.CStorVolumeClaimPhaseBound,
 				},
 			},
 			expectedRsp: true,
@@ -465,6 +442,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 				},
 				Status: apis.CStorVolumeClaimStatus{
 					PoolInfo: []string{"pool1"},
+					Phase:    apis.CStorVolumeClaimPhaseBound,
 				},
 			},
 			requestedObj: &apis.CStorVolumeClaim{
@@ -483,6 +461,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 				},
 				Status: apis.CStorVolumeClaimStatus{
 					PoolInfo: []string{"pool1", "pool2"},
+					Phase:    apis.CStorVolumeClaimPhaseBound,
 				},
 			},
 			expectedRsp: true,
@@ -504,6 +483,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 				},
 				Status: apis.CStorVolumeClaimStatus{
 					PoolInfo: []string{"pool1", "pool2"},
+					Phase:    apis.CStorVolumeClaimPhaseBound,
 				},
 			},
 			requestedObj: &apis.CStorVolumeClaim{
@@ -521,6 +501,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 				},
 				Status: apis.CStorVolumeClaimStatus{
 					PoolInfo: []string{"pool1"},
+					Phase:    apis.CStorVolumeClaimPhaseBound,
 				},
 			},
 			expectedRsp: true,
@@ -543,6 +524,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 				},
 				Status: apis.CStorVolumeClaimStatus{
 					PoolInfo: []string{"pool1", "pool2"},
+					Phase:    apis.CStorVolumeClaimPhaseBound,
 				},
 			},
 			requestedObj: &apis.CStorVolumeClaim{
@@ -562,6 +544,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 				},
 				Status: apis.CStorVolumeClaimStatus{
 					PoolInfo: []string{"pool1", "pool2"},
+					Phase:    apis.CStorVolumeClaimPhaseBound,
 				},
 			},
 			expectedRsp: false,
@@ -585,6 +568,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 				},
 				Status: apis.CStorVolumeClaimStatus{
 					PoolInfo: []string{"pool1", "pool2"},
+					Phase:    apis.CStorVolumeClaimPhaseBound,
 				},
 			},
 			requestedObj: &apis.CStorVolumeClaim{
@@ -604,6 +588,7 @@ func TestValidateCVCUpdateRequest(t *testing.T) {
 				},
 				Status: apis.CStorVolumeClaimStatus{
 					PoolInfo: []string{"pool1", "pool2", "pool2"},
+					Phase:    apis.CStorVolumeClaimPhaseBound,
 				},
 			},
 			expectedRsp: false,

--- a/pkg/webhook/cvc_test.go
+++ b/pkg/webhook/cvc_test.go
@@ -1,0 +1,635 @@
+/*
+Copyright 2019 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package webhook
+
+import (
+	"testing"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	clientset "github.com/openebs/maya/pkg/client/generated/clientset/versioned"
+	openebsFakeClientset "github.com/openebs/maya/pkg/client/generated/clientset/versioned/fake"
+	"github.com/pkg/errors"
+	"k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type fixture struct {
+	wh             *webhook
+	openebsObjects []runtime.Object
+}
+
+func newFixture() *fixture {
+	return &fixture{
+		wh: &webhook{},
+	}
+}
+
+func (f *fixture) withOpenebsObjects(objects ...runtime.Object) *fixture {
+	f.openebsObjects = objects
+	f.wh.clientset = openebsFakeClientset.NewSimpleClientset(objects...)
+	return f
+}
+
+func fakeGetCVCError(name, namespace string, clientset clientset.Interface) (*apis.CStorVolumeClaim, error) {
+	return nil, errors.Errorf("fake error")
+}
+
+func TestValidateCVCUpdateRequest(t *testing.T) {
+	f := newFixture().withOpenebsObjects()
+	tests := map[string]struct {
+		// existingObj is object existing in etcd via fake client
+		existingObj  *apis.CStorVolumeClaim
+		requestedObj *apis.CStorVolumeClaim
+		expectedRsp  bool
+		getCVCObj    getCVC
+	}{
+		"When Failed to Get Object From etcd": {
+			existingObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc1",
+					Namespace: "openebs",
+				},
+			},
+			requestedObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc1",
+					Namespace: "openebs",
+				},
+			},
+			expectedRsp: false,
+			getCVCObj:   fakeGetCVCError,
+		},
+		"When ReplicaCount Updated": {
+			existingObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc2",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 3,
+				},
+			},
+			requestedObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc2",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 4,
+				},
+			},
+			expectedRsp: false,
+			getCVCObj:   getCVCObject,
+		},
+		"When Volume Boud Status Updated With Pool Info": {
+			existingObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc3",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 3,
+				},
+			},
+			requestedObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc3",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 3,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+							apis.ReplicaPoolInfo{PoolName: "pool2"},
+							apis.ReplicaPoolInfo{PoolName: "pool3"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1", "pool2", "pool3"},
+				},
+			},
+			expectedRsp: true,
+			getCVCObj:   getCVCObject,
+		},
+		"When Volume Replcias were Scaled by modifying exisitng pool names": {
+			existingObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc4",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 3,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+							apis.ReplicaPoolInfo{PoolName: "pool2"},
+							apis.ReplicaPoolInfo{PoolName: "pool3"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1", "pool2", "pool3"},
+				},
+			},
+			requestedObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc4",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 3,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+							apis.ReplicaPoolInfo{PoolName: "pool2"},
+							apis.ReplicaPoolInfo{PoolName: "pool5"},
+							apis.ReplicaPoolInfo{PoolName: "pool4"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1", "pool2", "pool3"},
+				},
+			},
+			expectedRsp: false,
+			getCVCObj:   getCVCObject,
+		},
+		"When Volume Replcias were migrated": {
+			existingObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc5",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 3,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+							apis.ReplicaPoolInfo{PoolName: "pool2"},
+							apis.ReplicaPoolInfo{PoolName: "pool3"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1", "pool2", "pool3"},
+				},
+			},
+			requestedObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc5",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 3,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool0"},
+							apis.ReplicaPoolInfo{PoolName: "pool2"},
+							apis.ReplicaPoolInfo{PoolName: "pool5"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1", "pool2", "pool3"},
+				},
+			},
+			expectedRsp: false,
+			getCVCObj:   getCVCObject,
+		},
+		"When CVC Scaling Up InProgress Performing Scaling Again": {
+			existingObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc6",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 3,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+							apis.ReplicaPoolInfo{PoolName: "pool2"},
+							apis.ReplicaPoolInfo{PoolName: "pool3"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1", "pool2"},
+				},
+			},
+			requestedObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc6",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 3,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+							apis.ReplicaPoolInfo{PoolName: "pool2"},
+							apis.ReplicaPoolInfo{PoolName: "pool3"},
+							apis.ReplicaPoolInfo{PoolName: "pool4"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1", "pool2"},
+				},
+			},
+			expectedRsp: false,
+			getCVCObj:   getCVCObject,
+		},
+		"When More Than One Replica Were Scale Down": {
+			existingObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc7",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 3,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+							apis.ReplicaPoolInfo{PoolName: "pool2"},
+							apis.ReplicaPoolInfo{PoolName: "pool3"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1", "pool2", "pool3"},
+				},
+			},
+			requestedObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc7",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 3,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1", "pool2", "pool3"},
+				},
+			},
+			expectedRsp: false,
+			getCVCObj:   getCVCObject,
+		},
+		"When Status Was Updated With Non Spec Pool Names": {
+			existingObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc8",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 3,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+							apis.ReplicaPoolInfo{PoolName: "pool2"},
+							apis.ReplicaPoolInfo{PoolName: "pool3"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1", "pool2", "pool3"},
+				},
+			},
+			requestedObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc8",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 3,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+							apis.ReplicaPoolInfo{PoolName: "pool2"},
+							apis.ReplicaPoolInfo{PoolName: "pool3"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1", "pool2", "pool3", "pool4"},
+				},
+			},
+			expectedRsp: false,
+			getCVCObj:   getCVCObject,
+		},
+		"When Spec & Status Pool Names Was Updated By Controller With Invalid Pool Names Under Status": {
+			existingObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc8",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 3,
+				},
+			},
+			requestedObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc8",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 3,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+							apis.ReplicaPoolInfo{PoolName: "pool2"},
+							apis.ReplicaPoolInfo{PoolName: "pool3"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1", "pool2", "pool3", "pool4"},
+				},
+			},
+			expectedRsp: false,
+			getCVCObj:   getCVCObject,
+		},
+		"When Scale Up Alone Performed": {
+			existingObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc9",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 1,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1"},
+				},
+			},
+			requestedObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc9",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 1,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+							apis.ReplicaPoolInfo{PoolName: "pool2"},
+							apis.ReplicaPoolInfo{PoolName: "pool3"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1"},
+				},
+			},
+			expectedRsp: true,
+			getCVCObj:   getCVCObject,
+		},
+		"When Scale Down Alone Performed": {
+			existingObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc10",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 1,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+							apis.ReplicaPoolInfo{PoolName: "pool2"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1", "pool2"},
+				},
+			},
+			requestedObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc10",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 1,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1", "pool2"},
+				},
+			},
+			expectedRsp: true,
+			getCVCObj:   getCVCObject,
+		},
+		"When Scale Up Status Was Updated Success": {
+			existingObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc11",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 1,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+							apis.ReplicaPoolInfo{PoolName: "pool2"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1"},
+				},
+			},
+			requestedObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc11",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 1,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+							apis.ReplicaPoolInfo{PoolName: "pool2"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1", "pool2"},
+				},
+			},
+			expectedRsp: true,
+			getCVCObj:   getCVCObject,
+		},
+		"When Scale Down Status Was Updated Success": {
+			existingObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc12",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 1,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1", "pool2"},
+				},
+			},
+			requestedObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc12",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 1,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1"},
+				},
+			},
+			expectedRsp: true,
+			getCVCObj:   getCVCObject,
+		},
+		"When CVC Spec Pool Names Were Repeated": {
+			existingObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc13",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 1,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+							apis.ReplicaPoolInfo{PoolName: "pool2"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1", "pool2"},
+				},
+			},
+			requestedObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc13",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 1,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+							apis.ReplicaPoolInfo{PoolName: "pool2"},
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1", "pool2"},
+				},
+			},
+			expectedRsp: false,
+			getCVCObj:   getCVCObject,
+		},
+		"When CVC Status Pool Names Were Repeated": {
+			existingObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc14",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 1,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+							apis.ReplicaPoolInfo{PoolName: "pool2"},
+							apis.ReplicaPoolInfo{PoolName: "pool3"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1", "pool2"},
+				},
+			},
+			requestedObj: &apis.CStorVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cvc14",
+					Namespace: "openebs",
+				},
+				Spec: apis.CStorVolumeClaimSpec{
+					ReplicaCount: 1,
+					Policy: apis.CStorVolumePolicySpec{
+						ReplicaPoolInfo: []apis.ReplicaPoolInfo{
+							apis.ReplicaPoolInfo{PoolName: "pool1"},
+							apis.ReplicaPoolInfo{PoolName: "pool2"},
+							apis.ReplicaPoolInfo{PoolName: "pool3"},
+						},
+					},
+				},
+				Status: apis.CStorVolumeClaimStatus{
+					PoolInfo: []string{"pool1", "pool2", "pool2"},
+				},
+			},
+			expectedRsp: false,
+			getCVCObj:   getCVCObject,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			ar := &v1beta1.AdmissionRequest{
+				Operation: v1beta1.Create,
+				Object: runtime.RawExtension{
+					Raw: serialize(test.requestedObj),
+				},
+			}
+			fakeFixture := f.withOpenebsObjects(test.existingObj)
+			resp := fakeFixture.wh.validateCVCUpdateRequest(ar, test.getCVCObj)
+			if resp.Allowed != test.expectedRsp {
+				t.Errorf(
+					"%s test case failed expected response: %t but got %t error: %s",
+					name,
+					test.expectedRsp,
+					resp.Allowed,
+					resp.Result.Message,
+				)
+			}
+		})
+	}
+}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -388,6 +388,8 @@ func (wh *webhook) validate(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespo
 	case "CStorPoolCluster":
 		klog.V(2).Infof("Admission webhook request for type %s", req.Kind.Kind)
 		return wh.validateCSPC(ar)
+	case "CStorVolumeClaim":
+		return wh.validateCVC(ar)
 	default:
 		klog.V(2).Infof("Admission webhook not configured for type %s", req.Kind.Kind)
 		return response
@@ -474,4 +476,17 @@ func (wh *webhook) Serve(w http.ResponseWriter, r *http.Request) {
 		klog.Errorf("Can't write response: %v", err)
 		http.Error(w, fmt.Sprintf("could not write response: %v", err), http.StatusInternalServerError)
 	}
+}
+
+func (wh *webhook) validateCVC(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
+	req := ar.Request
+	response := &v1beta1.AdmissionResponse{}
+	response.Allowed = true
+	// validates only if requested operation is UPDATE
+	if req.Operation == v1beta1.Update {
+		return wh.validateCVCUpdateRequest(req, getCVCObject)
+	}
+	klog.V(2).Info("Admission wehbook for CVC module not " +
+		"configured for operations other than UPDATE")
+	return response
 }

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -486,7 +486,7 @@ func (wh *webhook) validateCVC(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRe
 	if req.Operation == v1beta1.Update {
 		return wh.validateCVCUpdateRequest(req, getCVCObject)
 	}
-	klog.V(2).Info("Admission wehbook for CVC module not " +
+	klog.V(4).Info("Admission wehbook for CVC module not " +
 		"configured for operations other than UPDATE")
 	return response
 }


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds validations for CVC update requests and also handles upgrade changes for the admission server controller(CVC scaling feature PR https://github.com/openebs/maya/pull/1613).
**This PR Covers Below Validations and Test Cases For CVC Update:**
- Reject the request if  Replica Count was modified.
- Reject the request if the repetition of pool names either under the spec or status of CVC.
- Reject the request if the existing pool names were modified with new pool names.
- Reject the request if Scaling(Up/Down) was triggered when one other request is in progress. 
- Reject the request if more than one replica was scaled down that one replica at a time for scale down. 
- Reject the request if status pool names don't exist under spec of existing CVC(etcd) or new CVC(for the first time update by the controller).





**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests