### PR TITLE
fix(backup, cstor): fetching correct snap name in case of base backup failure

### DIFF
--- a/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
+++ b/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
@@ -396,7 +396,7 @@ func CreateVolumeRestore(rst *apis.CStorRestore) error {
 			"rname", rst.Spec.VolumeName,
 		)
 	} else {
-		alertlog.Logger.Errorw("",
+		alertlog.Logger.Infow("",
 			"eventcode", "cstor.volume.restore.success",
 			"msg", "Successfully restored CStor volume",
 			"rname", rst.Spec.VolumeName,

--- a/cmd/maya-apiserver/app/server/backup_endpoint_v1alpha1.go
+++ b/cmd/maya-apiserver/app/server/backup_endpoint_v1alpha1.go
@@ -231,6 +231,10 @@ func getLastBackupSnap(openebsClient *versioned.Clientset, bkp *v1alpha1.CStorBa
 		klog.Infof("LastBackup resource created for backup:%s volume:%s", bk.Spec.BackupName, bk.Spec.VolumeName)
 		return "", nil
 	}
+
+	if b.Spec.SnapName == "" {
+		return "", nil
+	}
 	return b.Spec.PrevSnapName, nil
 }
 

--- a/cmd/maya-apiserver/app/server/backup_endpoint_v1alpha1.go
+++ b/cmd/maya-apiserver/app/server/backup_endpoint_v1alpha1.go
@@ -217,9 +217,8 @@ func getLastBackupSnap(openebsClient *versioned.Clientset, bkp *v1alpha1.CStorBa
 				Labels:    bkp.Labels,
 			},
 			Spec: v1alpha1.CStorBackupSpec{
-				BackupName:   bkp.Spec.BackupName,
-				VolumeName:   bkp.Spec.VolumeName,
-				PrevSnapName: bkp.Spec.SnapName,
+				BackupName: bkp.Spec.BackupName,
+				VolumeName: bkp.Spec.VolumeName,
 			},
 		}
 
@@ -232,9 +231,6 @@ func getLastBackupSnap(openebsClient *versioned.Clientset, bkp *v1alpha1.CStorBa
 		return "", nil
 	}
 
-	if b.Spec.SnapName == "" {
-		return "", nil
-	}
 	return b.Spec.PrevSnapName, nil
 }
 


### PR DESCRIPTION
This change fix the logic to fetch the last snapshot name from `cstorcompletedbackups.openebs.io` for scheduled backup. If first backup for schedule fails then last snapshot name for next backup, for the same schedule, should be empty.

fixes https://github.com/openebs/openebs/issues/2926

