### PR TITLE
fix(restore,pvc): handling of pvc's annotation for existing velero-plugin's restore 

### DIFF
--- a/cmd/maya-exporter/app/collector/cstor.go
+++ b/cmd/maya-exporter/app/collector/cstor.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	v1 "github.com/openebs/maya/pkg/stats/v1alpha1"
+	"github.com/openebs/maya/pkg/util"
 	"github.com/pkg/errors"
 	"k8s.io/klog"
 )
@@ -158,16 +159,6 @@ func (c *cstor) readHeader() error {
 	return nil
 }
 
-// removeItem removes the string passed as argument from the slice
-func (c *cstor) removeItem(slice []string, str string) []string {
-	for index, value := range slice {
-		if value == str {
-			slice = append(slice[:index], slice[index+1:]...)
-		}
-	}
-	return slice
-}
-
 // unmarshal the result into VolumeStats instances.
 func (c *cstor) unmarshal(result string) (v1.VolumeStats, error) {
 	metrics := v1.VolumeStats{}
@@ -185,7 +176,7 @@ func (c *cstor) unmarshal(result string) (v1.VolumeStats, error) {
 func (c *cstor) splitter(resp string) string {
 	var result []string
 	result = strings.Split(resp, EOF)
-	result = c.removeItem(result, Footer)
+	result = util.RemoveItemFromSlice(result, Footer)
 	if len(result[0]) == 0 {
 		return ""
 	}

--- a/pkg/apis/openebs.io/v1alpha1/cas_keys.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_keys.go
@@ -90,7 +90,7 @@ const (
 	// CStor pool. This key is present on CVR labels
 	CStorPoolKey CASKey = "cstorpool.openebs.io/name"
 
-	// cstorVolumeKey is the key to getch CStorVolume CR of a
+	// CStorVolumeKey is the key to getch CStorVolume CR of a
 	// CVR. This key is present on CVR label.
 	CStorVolumeKey CASKey = "cstorvolume.openebs.io/name"
 
@@ -99,6 +99,9 @@ const (
 
 	// CStorpoolInstanceLabel is the key used on pool dependent resources
 	CStorpoolInstanceLabel = "cstorpoolinstance.openebs.io/name"
+
+	// PVCreatedByKey is key to fetch the details of pv creation in case of restore
+	PVCreatedByKey = "openebs.io/created-through"
 )
 
 // CASPlainKey represents a openebs key used either in resource annotation

--- a/pkg/cstor/volumereplica/v1alpha1/cstorvolumereplica.go
+++ b/pkg/cstor/volumereplica/v1alpha1/cstorvolumereplica.go
@@ -152,6 +152,12 @@ func (p *CVR) IsHealthy() bool {
 	return p.object.Status.Phase == "Healthy"
 }
 
+// IsErrored returns true if the CVR is in
+// Error state
+func (p *CVR) IsErrored() bool {
+	return p.object.Status.Phase == "Error"
+}
+
 // HasLabel returns true only if label key value matched to provided
 // value.
 func (p *CVR) HasLabel(key, value string) bool {
@@ -171,6 +177,14 @@ func HasLabel(key, value string) Predicate {
 func IsHealthy() Predicate {
 	return func(p *CVR) bool {
 		return p.IsHealthy()
+	}
+}
+
+// IsErrored is a Predicate to filter out cvrs
+// which is in errored state
+func IsErrored() Predicate {
+	return func(p *CVR) bool {
+		return p.IsErrored()
 	}
 }
 

--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -430,7 +430,7 @@ spec:
     {{- $auxResourceRequestsVal := fromYaml .Config.AuxResourceRequests.value -}}
     {{- $setAuxResourceLimits := .Config.AuxResourceLimits.value | default "none" -}}
     {{- $auxResourceLimitsVal := fromYaml .Config.AuxResourceLimits.value -}}
-    {{- $targetAffinityVal := .TaskResult.creategetpvc.targetAffinity -}}
+    {{- $targetAffinityVal := .TaskResult.creategetpvc.targetAffinity | default "none" -}}
     {{- $hasNodeSelector := .Config.TargetNodeSelector.value | default "none" -}}
     {{- $nodeSelectorVal := fromYaml .Config.TargetNodeSelector.value -}}
     {{- $hasTargetToleration := .Config.TargetTolerations.value | default "none" -}}
@@ -693,11 +693,11 @@ spec:
     Calculate the replica count
     Add as many poolUid to resources as there is replica count
     */}}
-    {{- $hostName := .TaskResult.creategetpvc.hostName -}}
+    {{- $hostName := .TaskResult.creategetpvc.hostName | default "" -}}
     {{- $capacity := .Volume.capacity -}}
     {{- $spc := .Config.StoragePoolClaim.value }}
-    {{- $replicaAntiAffinity := .TaskResult.creategetpvc.replicaAntiAffinity }}
-    {{- $preferredReplicaAntiAffinity := .TaskResult.creategetpvc.preferredReplicaAntiAffinity }}
+    {{- $replicaAntiAffinity := .TaskResult.creategetpvc.replicaAntiAffinity  | default "" -}}
+    {{- $preferredReplicaAntiAffinity := .TaskResult.creategetpvc.preferredReplicaAntiAffinity | default "" -}}
     {{- $antiAffinityLabelSelector := printf "openebs.io/replica-anti-affinity=%s" $replicaAntiAffinity | IfNotNil $replicaAntiAffinity }}
     {{- $preferredAntiAffinityLabelSelector := printf "openebs.io/preferred-replica-anti-affinity=%s" $preferredReplicaAntiAffinity | IfNotNil $preferredReplicaAntiAffinity }}
     {{- $preferedScheduleOnHostAnnotationSelector := printf "volume.kubernetes.io/selected-node=%s" $hostName | IfNotNil $hostName }}
@@ -718,8 +718,8 @@ spec:
       {{- end }}
       {{- end }}
   task: |
-    {{- $replicaAntiAffinity := .TaskResult.creategetpvc.replicaAntiAffinity -}}
-    {{- $preferredReplicaAntiAffinity := .TaskResult.creategetpvc.preferredReplicaAntiAffinity }}
+    {{- $replicaAntiAffinity := .TaskResult.creategetpvc.replicaAntiAffinity | default "" -}}
+    {{- $preferredReplicaAntiAffinity := .TaskResult.creategetpvc.preferredReplicaAntiAffinity | default "" -}}
     {{- $isClone := .Volume.isCloneEnable | default "false" -}}
     {{- $zvolWorkers := .Config.ZvolWorkers.value | default "" -}}
     kind: CStorVolumeReplica

--- a/pkg/kubernetes/persistentvolume/v1alpha1/build.go
+++ b/pkg/kubernetes/persistentvolume/v1alpha1/build.go
@@ -129,6 +129,16 @@ func (b *Builder) WithLocalHostPathFormat(path, fstype string) *Builder {
 	return b
 }
 
+// WithPersistentVolumeSource sets the volume source field of PV with provided source
+func (b *Builder) WithPersistentVolumeSource(source *corev1.PersistentVolumeSource) *Builder {
+	if source == nil {
+		b.errs = append(b.errs, errors.New("failed to build PV object: missing PV source"))
+		return b
+	}
+	b.pv.object.Spec.PersistentVolumeSource = *source
+	return b
+}
+
 // WithNodeAffinity sets the NodeAffinity field of PV with provided node name
 func (b *Builder) WithNodeAffinity(nodeName string) *Builder {
 	if len(nodeName) == 0 {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -242,6 +242,16 @@ func IsChangeInLists(listA, listB []string) bool {
 	return false
 }
 
+// RemoveItemFromSlice removes the string passed as argument from the slice
+func RemoveItemFromSlice(slice []string, str string) []string {
+	for index, value := range slice {
+		if value == str {
+			slice = append(slice[:index], slice[index+1:]...)
+		}
+	}
+	return slice
+}
+
 // IsUniqueList returns true if values in list are not repeated else return
 // false
 func IsUniqueList(list []string) bool {

--- a/tests/cstor/clone/clone_test.go
+++ b/tests/cstor/clone/clone_test.go
@@ -367,6 +367,17 @@ var _ = Describe("[cstor] TEST VOLUME CLONE PROVISIONING", func() {
 			By("veryfing data consistency")
 			Expect(podOutput).To(Equal(clonePodOutput), "while checking data consistency")
 
+			// try to delete source PVC
+			By("try deleting source persistentvolumeclaim")
+			err = ops.PVCClient.Delete(pvcName, &metav1.DeleteOptions{})
+			Expect(err).NotTo(BeNil())
+			Expect(strings.Contains(err.Error(), "admission webhook \"admission-webhook.openebs.io\" denied the request")).
+				To(Equal(true),
+					"while deleting source pvc {%s} in namespace {%s} without deleting clone",
+					pvcName,
+					nsObj.Name,
+				)
+
 			By("deleting application pod")
 			err = ops.PodClient.WithNamespace(nsObj.Name).
 				Delete(podObj.Name, &metav1.DeleteOptions{})

--- a/tests/cstor/volume/provision_test.go
+++ b/tests/cstor/volume/provision_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package volume
 
 import (
+	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -25,11 +27,21 @@ import (
 
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	cvr "github.com/openebs/maya/pkg/cstor/volumereplica/v1alpha1"
+	pv "github.com/openebs/maya/pkg/kubernetes/persistentvolume/v1alpha1"
 	pvc "github.com/openebs/maya/pkg/kubernetes/persistentvolumeclaim/v1alpha1"
 	sc "github.com/openebs/maya/pkg/kubernetes/storageclass/v1alpha1"
 	spc "github.com/openebs/maya/pkg/storagepoolclaim/v1alpha1"
 	"github.com/openebs/maya/tests/cstor"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// mayaAPIServiceLabel is label for Maya-API server Service
+	mayaAPIServiceLabel = "openebs.io/component-name=maya-apiserver-svc"
+
+	// mayaAPIPodLabel is label for Maya-API server Pod
+	mayaAPIPodLabel = "openebs.io/component-name=maya-apiserver"
 )
 
 var _ = Describe("[Cstor Volume Provisioning Positive] TEST VOLUME PROVISIONING", func() {
@@ -73,7 +85,6 @@ var _ = Describe("[Cstor Volume Provisioning Positive] TEST VOLUME PROVISIONING"
 			By("creating storageclass")
 			scObj, err = ops.SCClient.Create(scObj)
 			Expect(err).To(BeNil(), "while creating storageclass", scName)
-
 		})
 	})
 
@@ -190,4 +201,207 @@ var _ = Describe("[Cstor Volume Provisioning Positive] TEST VOLUME PROVISIONING"
 			Expect(cvCount).To(Equal(true), "while checking cstorvolume count")
 		})
 	})
+
+	When("cstor PV with replicacount n is created without PVC", func() {
+		It("should create cstor volume target pod", func() {
+			_ = pvcName
+			_ = err
+			volname := "pv-created-without-pvc"
+
+			maddr, err := ops.GetSVCClusterIP(openebsNamespace, mayaAPIServiceLabel)
+			Expect(err).To(BeNil(), "While fetching maya-apiserver address")
+			Expect(len(maddr)).To(Equal(1), "maya-apiserver address")
+
+			podList := ops.GetPodList(openebsNamespace, mayaAPIPodLabel)
+			Expect(err).To(BeNil(), "maya-apiserver pod fetch error")
+			mPodList := podList.ToAPIList()
+			Expect(len(mPodList.Items)).To(Equal(1), "maya-apiserver pod count")
+
+			mpod := mPodList.Items[0]
+			capacity := "200M"
+			vol := newCASVolumeWithoutPVC(volname, capacity, scObj.Name, false)
+
+			volData, err := json.Marshal(vol)
+			Expect(err).To(BeNil())
+
+			command := "curl -XPOST -d '" + string(volData) + "'" + " http://" + maddr[0] + "/latest/volumes/"
+			res := ops.ExecuteCMDEventually(&mpod, "", command, true)
+			Expect(res).NotTo(BeEmpty())
+			Expect(strings.Contains(res, "failed to create volume")).To(Equal(false), fmt.Sprintf("volume creation error=%s", res))
+
+			var rvol apis.CASVolume
+			err = json.Unmarshal([]byte(res), &rvol)
+			Expect(err).To(BeNil())
+			Expect(rvol.Spec.TargetPortal).NotTo(BeEmpty())
+			Expect(rvol.Spec.TargetIP).NotTo(BeEmpty())
+			Expect(rvol.Spec.TargetPort).NotTo(BeEmpty())
+
+			// create pv object
+			pvobj, err := createPVObj(volname, scObj.Name, capacity, rvol)
+			Expect(err).To(BeNil())
+			pvobj, err = ops.PVClient.Create(pvobj)
+			Expect(err).To(BeNil())
+
+			By("verifying target pod count as 1")
+			targetVolumeLabel := pvLabel + volname
+			controllerPodCount := ops.GetPodRunningCountEventually(openebsNamespace, targetVolumeLabel, 1)
+			Expect(controllerPodCount).To(Equal(1), "while checking controller pod count")
+
+			By("verifying cstorvolume replica count")
+			cvrLabel := pvLabel + volname
+			cvrCount := ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, cvrLabel, cstor.ReplicaCount, cvr.IsHealthy())
+			Expect(cvrCount).To(Equal(true), "while checking cstorvolume replica count")
+
+			// delete the volume
+			command = "curl -XDELETE " + " http://" + maddr[0] + "/latest/volumes/" + volname
+			res = ops.ExecuteCMDEventually(&mpod, "", command, true)
+			Expect(res).NotTo(BeEmpty())
+			Expect(strings.Contains(res, "failed to delete volume")).To(Equal(false), fmt.Sprintf("volume deletion error=%s", res))
+
+			// delete pv object
+			err = ops.PVClient.Delete(pvobj.Name, &metav1.DeleteOptions{})
+			Expect(err).To(BeNil())
+
+			By("verifying target pod count as 0")
+			targetVolumeLabel = pvLabel + volname
+			controllerPodCount = ops.GetPodRunningCountEventually(openebsNamespace, targetVolumeLabel, 1)
+			Expect(controllerPodCount).To(Equal(1), "while checking controller pod count")
+
+			By("verifying cstorvolume replica count")
+			cvrLabel = pvLabel + volname
+			cvrCount = ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, cvrLabel, 0, cvr.IsErrored())
+			Expect(cvrCount).To(Equal(true), "while checking cstorvolume replica count")
+		})
+	})
+
+	When("cstor PV with replicacount n is created without PVC and restore label", func() {
+		It("should create cstor volume target pod", func() {
+			_ = pvcName
+			_ = err
+			volname := "restore-pv-created-without-pvc"
+
+			maddr, err := ops.GetSVCClusterIP(openebsNamespace, mayaAPIServiceLabel)
+			Expect(err).To(BeNil(), "While fetching maya-apiserver address")
+			Expect(len(maddr)).To(Equal(1), "maya-apiserver address")
+
+			podList := ops.GetPodList(openebsNamespace, mayaAPIPodLabel)
+			Expect(err).To(BeNil(), "maya-apiserver pod fetch error")
+			mPodList := podList.ToAPIList()
+			Expect(len(mPodList.Items)).To(Equal(1), "maya-apiserver pod count")
+
+			mpod := mPodList.Items[0]
+			capacity := "200M"
+			vol := newCASVolumeWithoutPVC(volname, capacity, scObj.Name, true)
+
+			volData, err := json.Marshal(vol)
+			Expect(err).To(BeNil())
+
+			command := "curl -XPOST -d '" + string(volData) + "'" + " http://" + maddr[0] + "/latest/volumes/"
+			res := ops.ExecuteCMDEventually(&mpod, "", command, true)
+			Expect(res).NotTo(BeEmpty())
+			Expect(strings.Contains(res, "failed to create volume")).To(Equal(false), fmt.Sprintf("volume creation error=%s", res))
+
+			var rvol apis.CASVolume
+			err = json.Unmarshal([]byte(res), &rvol)
+			Expect(err).To(BeNil())
+			Expect(rvol.Spec.TargetPortal).NotTo(BeEmpty())
+			Expect(rvol.Spec.TargetIP).NotTo(BeEmpty())
+			Expect(rvol.Spec.TargetPort).NotTo(BeEmpty())
+
+			// create pv object
+			pvobj, err := createPVObj(volname, scObj.Name, capacity, rvol)
+			Expect(err).To(BeNil())
+			pvobj, err = ops.PVClient.Create(pvobj)
+			Expect(err).To(BeNil())
+
+			By("verifying target pod count as 1")
+			targetVolumeLabel := pvLabel + volname
+			controllerPodCount := ops.GetPodRunningCountEventually(openebsNamespace, targetVolumeLabel, 1)
+			Expect(controllerPodCount).To(Equal(1), "while checking controller pod count")
+
+			By("verifying cstorvolume replica count")
+			cvrLabel := pvLabel + volname
+			cvrCount := ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, cvrLabel, cstor.ReplicaCount, cvr.IsErrored())
+			Expect(cvrCount).To(Equal(true), "while checking cstorvolume replica count")
+
+			// delete the volume
+			command = "curl -XDELETE " + " http://" + maddr[0] + "/latest/volumes/" + volname
+			res = ops.ExecuteCMDEventually(&mpod, "", command, true)
+			Expect(res).NotTo(BeEmpty())
+			Expect(strings.Contains(res, "failed to delete volume")).To(Equal(false), fmt.Sprintf("volume deletion error=%s", res))
+
+			// delete pv object
+			err = ops.PVClient.Delete(pvobj.Name, &metav1.DeleteOptions{})
+			Expect(err).To(BeNil())
+
+			By("verifying target pod count as 0")
+			targetVolumeLabel = pvLabel + volname
+			controllerPodCount = ops.GetPodRunningCountEventually(openebsNamespace, targetVolumeLabel, 1)
+			Expect(controllerPodCount).To(Equal(1), "while checking controller pod count")
+
+			By("verifying cstorvolume replica count")
+			cvrLabel = pvLabel + volname
+			cvrCount = ops.GetCstorVolumeReplicaCountEventually(openebsNamespace, cvrLabel, 0, cvr.IsErrored())
+			Expect(cvrCount).To(Equal(true), "while checking cstorvolume replica count")
+		})
+
+	})
 })
+
+func createPVObj(pvname, scname, size string, cas apis.CASVolume) (*v1.PersistentVolume, error) {
+	iscsiVolSource := &v1.PersistentVolumeSource{
+		ISCSI: &v1.ISCSIPersistentVolumeSource{
+			TargetPortal: cas.Spec.TargetPortal,
+			IQN:          cas.Spec.Iqn,
+			Lun:          cas.Spec.Lun,
+			FSType:       cas.Spec.FSType,
+			ReadOnly:     false,
+		},
+	}
+
+	pvObj, err := pv.NewBuilder().
+		WithName(pvname).
+		WithAnnotations(
+			map[string]string{
+				"openebs.io/cas-type":             "cstor",
+				"pv.kubernetes.io/provisioned-by": "openebs.io/provisioner-iscsi",
+			},
+		).
+		WithLabels(
+			map[string]string{
+				"openebs.io/cas-type":     "cstor",
+				"openebs.io/storageclass": scname,
+			},
+		).
+		WithReclaimPolicy(v1.PersistentVolumeReclaimDelete).
+		WithVolumeMode(v1.PersistentVolumeFilesystem).
+		WithCapacity(size).
+		WithPersistentVolumeSource(iscsiVolSource).
+		WithAccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	return pvObj, nil
+}
+
+func newCASVolumeWithoutPVC(name, capacity, sc string, isRestore bool) *apis.CASVolume {
+	casAnn := map[string]string{}
+
+	if isRestore {
+		casAnn[apis.PVCreatedByKey] = "restore"
+	}
+	return &apis.CASVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				string(apis.StorageClassKey): sc,
+			},
+			Annotations: casAnn,
+			Name:        name,
+		},
+		Spec: apis.CASVolumeSpec{
+			Capacity: capacity,
+		},
+	}
+}


### PR DESCRIPTION
Changes:
- CStor backup/restore plugin `openebs/velero-plugin` creates PVC using restore annotation `openebs.io/created-through` to disable connection between CStor replica and target. Recently we removed this annotation and moved it to CASVolume for local snapshot support, but since cloud-snapshot of velero-plugin is already using this feature, we need to handle this until all the changes mentioned in https://github.com/openebs/velero-plugin/pull/47 and https://github.com/openebs/velero-plugin/pull/46 gets merged.
