### PR TITLE
fix(csp): add pool protection finalizer on CSP

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
@@ -78,6 +78,17 @@ func (c *CStorPoolController) syncHandler(key string, operation common.QueueOper
 		return err
 	}
 	klog.V(4).Infof("Lease acquired successfully on csp %s ", cspObject.Name)
+	newCSPObj, err := c.addPoolProtectionFinalizer(cspObject)
+	if err != nil {
+		c.recorder.Eventf(
+			cspObject,
+			corev1.EventTypeWarning,
+			"Failed to update",
+			"Error: %s", err.Error(),
+		)
+		return nil
+	}
+	cspObject = newCSPObj
 	cspObject, err = c.populateVersion(cspObject)
 	if err != nil {
 		klog.Errorf("failed to add versionDetails to csp %s:%s", cspObject.Name, err.Error())
@@ -434,15 +445,37 @@ func (c *CStorPoolController) getPoolResource(key string) (*apis.CStorPool, erro
 
 // removeFinalizer is to remove finalizer of cstorpool resource.
 func (c *CStorPoolController) removeFinalizer(cStorPoolGot *apis.CStorPool) error {
-	if len(cStorPoolGot.Finalizers) > 0 {
-		cStorPoolGot.Finalizers = []string{}
+	if !util.ContainsString(cStorPoolGot.Finalizers, apis.PoolProtectionFinalizer) {
+		return nil
 	}
+	cStorPoolGot.Finalizers = util.RemoveString(cStorPoolGot.Finalizers, apis.PoolProtectionFinalizer)
 	_, err := c.clientset.OpenebsV1alpha1().CStorPools().Update(cStorPoolGot)
 	if err != nil {
 		return err
 	}
 	klog.Infof("Removed Finalizer: %v, %v", cStorPoolGot.Name, string(cStorPoolGot.GetUID()))
 	return nil
+}
+
+// addPoolProtectionFinalizer will updates the CStorPool object
+// with poolProtectionFinalizer in etcd only if finalizer doesn't exist
+func (c *CStorPoolController) addPoolProtectionFinalizer(
+	cStorPool *apis.CStorPool) (*apis.CStorPool, error) {
+	if util.ContainsString(cStorPool.Finalizers, apis.PoolProtectionFinalizer) {
+		return cStorPool, nil
+	}
+	cStorPool.Finalizers = append(cStorPool.Finalizers, apis.PoolProtectionFinalizer)
+	cspObj, err := c.clientset.
+		OpenebsV1alpha1().
+		CStorPools().
+		Update(cStorPool)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err,
+			"failed to add %s finalizer on csp %s", apis.PoolProtectionFinalizer, cStorPool.Name)
+	}
+	klog.Infof("Added Finalizer: %v", cStorPool.Name)
+	return cspObj, nil
 }
 
 func (c *CStorPoolController) triggerImportPool(cStorPoolGot *apis.CStorPool, importOptions *pool.ImportOptions) (string, error) {

--- a/pkg/apis/openebs.io/v1alpha1/cas_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_pool.go
@@ -70,6 +70,10 @@ const (
 	PersistentVolumeCPK CasPoolKey = "openebs.io/persistent-volume"
 )
 
+const (
+	PoolProtectionFinalizer = "openebs.io/pool-protection"
+)
+
 // CasPool is a type which will be utilised by CAS engine to perform
 // storagepool related operation.
 // TODO: Restrucutre CasPool struct.

--- a/pkg/apis/openebs.io/v1alpha1/cas_pool.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_pool.go
@@ -71,6 +71,8 @@ const (
 )
 
 const (
+	// PoolProtectionFinalizer will make sure that pool will be destroyed
+	// on the disks before removing the CSP from etcd
 	PoolProtectionFinalizer = "openebs.io/pool-protection"
 )
 

--- a/pkg/upgrade/templates/v1/cstor_pool.go
+++ b/pkg/upgrade/templates/v1/cstor_pool.go
@@ -22,7 +22,10 @@ var (
     "metadata": {
         "labels": {
             "openebs.io/version": "{{.UpgradeVersion}}"
-        }
+        }{{if lt .CurrentVersion "1.9.0"}},
+        "finalizers": [
+            "openebs.io/pool-protection"
+        ]{{end}}
     },{{if lt .CurrentVersion "1.8.0"}}
     "spec": {
         "poolSpec": {

--- a/pkg/upgrade/upgrader/csp_upgrade.go
+++ b/pkg/upgrade/upgrader/csp_upgrade.go
@@ -138,6 +138,7 @@ func patchCSP(cspObj *apis.CStorPool) error {
 			return errors.Wrapf(err, "failed to populate template for csp patch")
 		}
 		cspPatch := buffer.String()
+		klog.V(6).Infof("Patching CSP %s with %s", cspObj.Name, cspPatch)
 		buffer.Reset()
 		_, err = cspClient.Patch(
 			cspObj.Name,


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds the Pool Protection finalizer(`openebs.io/pool-protection`) on CSP.
This finalizer will be added only if the CSP controller picks CSP object for reconciliation.

**Performed Upgrade Testing With Changes:**
```sh
kubectl logs -f cstor-spc-180190-cstor-sparse-pool-knrwl -n openebs
I0318 08:38:55.257364       1 cstor_spc.go:82] Upgrading to 1.9.0
I0318 08:38:55.582297       1 helper.go:68] Patching deployment cstor-sparse-pool-lqu8
I0318 08:39:56.064983       1 helper.go:95] Deployment cstor-sparse-pool-lqu8 rolled out successfully
I0318 08:39:56.065070       1 csp_upgrade.go:188] patched csp deployment cstor-sparse-pool-lqu8
I0318 08:39:56.078297       1 csp_upgrade.go:151] patched csp cstor-sparse-pool-lqu8
I0318 08:39:56.078343       1 csp_upgrade.go:274] Verifying the reconciliation of version for cstor-sparse-pool-lqu8 { phase:Healthy }
I0318 08:40:06.081530       1 csp_upgrade.go:274] Verifying the reconciliation of version for cstor-sparse-pool-lqu8 { phase:Healthy }
I0318 08:40:16.083315       1 csp_upgrade.go:274] Verifying the reconciliation of version for cstor-sparse-pool-lqu8 { phase:Healthy }
I0318 08:40:26.105873       1 csp_upgrade.go:377] Upgrade Successful for csp cstor-sparse-pool-lqu8
I0318 08:40:26.254153       1 spc_upgrade.go:148] Verifying the reconciliation of version for cstor-sparse-pool
I0318 08:40:36.262679       1 spc_upgrade.go:102] Upgrade Successful for spc cstor-sparse-pool
```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Test Case Related PR: https://github.com/openebs/openebs/pull/2970

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests