### PR TITLE
refact(jiva): create separate replica deployments and move all resources to openebsNamespace

### DIFF
--- a/ci/mayactl.sh
+++ b/ci/mayactl.sh
@@ -41,7 +41,7 @@ printf "\n\n"
 sleep 5
 
 echo "************** Running Jiva mayactl volume stats *************************"
-${MAYACTL} volume stats --volname  $JIVAVOL
+${MAYACTL} volume stats --volname  $JIVAVOL -n openebs
 rc=$?;
 if [[ $rc != 0 ]]; then
 	kubectl logs --tail=10 $MAPIPOD -n openebs

--- a/pkg/install/v1alpha1/jiva_volume.go
+++ b/pkg/install/v1alpha1/jiva_volume.go
@@ -263,8 +263,6 @@ spec:
   # should be cleared or retained.
   - name: RetainReplicaData
     enabled: "false"
-  - name: ReplicaCount
-    value: {{env "OPENEBS_IO_JIVA_REPLICA_COUNT" | default "3" | quote }}
   taskNamespace: {{env "OPENEBS_NAMESPACE"}}
   run:
     tasks:

--- a/pkg/templatefuncs/v1alpha1/runtask_functions.go
+++ b/pkg/templatefuncs/v1alpha1/runtask_functions.go
@@ -18,6 +18,7 @@ package templatefuncs
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -282,6 +283,15 @@ func runlog(resultpath, debugpath string, store map[string]interface{}, given *c
 	return
 }
 
+func mkNumberedSlice(n string) []string {
+	slice := []string{}
+	x, _ := strconv.Atoi(n)
+	for i := 1; i <= x; i++ {
+		slice = append(slice, strconv.Itoa(i))
+	}
+	return slice
+}
+
 // runCommandFuncs returns the set of runtask command based template functions
 func runCommandFuncs() template.FuncMap {
 	return template.FuncMap{
@@ -309,5 +319,6 @@ func runCommandFuncs() template.FuncMap {
 		"runas":           runas,
 		"runAlways":       runAlways,
 		"toJsonObj":       toJsonObj,
+		"mkNumberedSlice": mkNumberedSlice,
 	}
 }

--- a/pkg/templatefuncs/v1alpha1/runtask_functions.go
+++ b/pkg/templatefuncs/v1alpha1/runtask_functions.go
@@ -292,33 +292,41 @@ func mkNumberedSlice(n string) []string {
 	return slice
 }
 
+// removeFirstElement removes the first element from a space
+// separated string
+func removeFirstElement(s string) string {
+	i := strings.Index(s, " ") + 1
+	return s[i:]
+}
+
 // runCommandFuncs returns the set of runtask command based template functions
 func runCommandFuncs() template.FuncMap {
 	return template.FuncMap{
-		"delete":          delete,
-		"get":             get,
-		"lst":             list,
-		"create":          create,
-		"post":            post,
-		"patch":           patch,
-		"update":          update,
-		"put":             put,
-		"jiva":            jiva,
-		"cstor":           cstor,
-		"volume":          volume,
-		"http":            http,
-		"withOption":      withOption,
-		"withoption":      withOption,
-		"run":             run,
-		"runlog":          runlog,
-		"select":          slect,
-		"snapshot":        snapshot,
-		"storeAt":         storeAt,
-		"storeRunner":     storeRunner,
-		"storeRunnerCond": storeRunnerCond,
-		"runas":           runas,
-		"runAlways":       runAlways,
-		"toJsonObj":       toJsonObj,
-		"mkNumberedSlice": mkNumberedSlice,
+		"delete":             delete,
+		"get":                get,
+		"lst":                list,
+		"create":             create,
+		"post":               post,
+		"patch":              patch,
+		"update":             update,
+		"put":                put,
+		"jiva":               jiva,
+		"cstor":              cstor,
+		"volume":             volume,
+		"http":               http,
+		"withOption":         withOption,
+		"withoption":         withOption,
+		"run":                run,
+		"runlog":             runlog,
+		"select":             slect,
+		"snapshot":           snapshot,
+		"storeAt":            storeAt,
+		"storeRunner":        storeRunner,
+		"storeRunnerCond":    storeRunnerCond,
+		"runas":              runas,
+		"runAlways":          runAlways,
+		"toJsonObj":          toJsonObj,
+		"mkNumberedSlice":    mkNumberedSlice,
+		"removeFirstElement": removeFirstElement,
 	}
 }


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

This PR updates the runtasks
 -  to create, read and delete multiple replica deployments for jiva volumes.
 -  to create all the openebs resources for jiva volumes in openebs namespace.

**Local Test Results:**
```sh
mayadata:setup$ k get pods,svc,deploy
NAME                                                                  READY   STATUS    RESTARTS   AGE
pod/maya-apiserver-d9fccfdcc-p5d2h                                    1/1     Running   0          6m13s
pod/openebs-admission-server-695dbc8b74-sqrkn                         1/1     Running   0          8m19s
pod/openebs-localpv-provisioner-6f4d68b57f-ldjqv                      1/1     Running   0          8m18s
pod/openebs-ndm-lwsk6                                                 1/1     Running   0          8m21s
pod/openebs-ndm-mphbv                                                 1/1     Running   0          8m21s
pod/openebs-ndm-nw6pl                                                 1/1     Running   0          8m21s
pod/openebs-ndm-operator-77f88bc69-jgpgt                              1/1     Running   0          8m20s
pod/openebs-provisioner-6fc866b764-nlzqv                              1/1     Running   0          8m25s
pod/openebs-snapshot-operator-fd8f6494d-txrww                         2/2     Running   0          8m24s
pod/pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70-ctrl-747789569-5lqhq     2/2     Running   0          43s
pod/pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70-rep-1-5649857465-tx8ft   1/1     Running   0          36s
pod/pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70-rep-2-5649857465-nl2fw   1/1     Running   1          35s
pod/pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70-rep-3-5649857465-58tvv   1/1     Running   0          30s

NAME                                                        TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)                      AGE
service/admission-server-svc                                ClusterIP   10.76.13.104   <none>        443/TCP                      8m14s
service/maya-apiserver-service                              ClusterIP   10.76.11.62    <none>        5656/TCP                     8m27s
service/pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70-ctrl-svc   ClusterIP   10.76.14.202   <none>        3260/TCP,9501/TCP,9500/TCP   44s

NAME                                                                   READY   UP-TO-DATE   AVAILABLE   AGE
deployment.extensions/maya-apiserver                                   1/1     1            1           8m30s
deployment.extensions/openebs-admission-server                         1/1     1            1           8m21s
deployment.extensions/openebs-localpv-provisioner                      1/1     1            1           8m20s
deployment.extensions/openebs-ndm-operator                             1/1     1            1           8m22s
deployment.extensions/openebs-provisioner                              1/1     1            1           8m27s
deployment.extensions/openebs-snapshot-operator                        1/1     1            1           8m26s
deployment.extensions/pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70-ctrl    1/1     1            1           45s
deployment.extensions/pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70-rep-1   1/1     1            1           45s
deployment.extensions/pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70-rep-2   1/1     1            1           45s
deployment.extensions/pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70-rep-3   1/1     1            1           45s
mayadata:setup$ kubectl get pods
NAME                         READY   STATUS    RESTARTS   AGE
percona-2-6d769bf786-vx5jz   1/1     Running   0          55s


mayadata:setup$ k exec -it maya-apiserver-d9fccfdcc-p5d2h bash
bash-4.3# mayactl volume list
Namespace  Name                                      Status   Type  Capacity  StorageClass   Access Mode
---------  ----                                      ------   ----  --------  -------------  -----------
openebs    pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70  Running  jiva  5Gi       jiva-1r        ReadWriteOnce
bash-4.3# mayactl volume describe --volname pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70

Portal Details :
----------------
IQN               :   iqn.2016-09.com.openebs.jiva:pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70
Volume            :   pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70
Portal            :   10.76.14.202:3260
Size              :   5Gi
Controller Status :   running,running
Controller Node   :   gke-shubham-bajpai-test-default-pool-71c65463-hclh
Replica Count     :   3

Replica Details :
-----------------
NAME                                                                ACCESSMODE      STATUS      IP             NODE
-----                                                               -----------     -------     ---            ----- 
pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70-rep-1-5649857465-tx8ft     RW              running     10.12.1.7      gke-shubham-bajpai-test-default-pool-71c65463-hclh 
pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70-rep-2-5649857465-nl2fw     RW              running     10.12.0.7      gke-shubham-bajpai-test-default-pool-71c65463-j96l 
pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70-rep-3-5649857465-58tvv     RW              running     10.12.2.19     gke-shubham-bajpai-test-default-pool-71c65463-k7rd 
bash-4.3# mayactl volume stats --volname pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70 --namespace openebs
 
Portal Details :
---------------
Volume  :   pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70
Size    :   5.000000

Performance Stats :
--------------------
r/s      w/s      r(MB/s)      w(MB/s)      rLat(ms)      wLat(ms)
----     ----     --------     --------     ---------     ---------
0        48       0.000        0.566        0.000         2.674    

Capacity Stats :
---------------
LOGICAL(GB)      USED(GB)
------------     ---------
0.320            0.320    
bash-4.3# exit
exit
mayadata:setup$ kubectl -n openebs logs -f maya-apiserver-d9fccfdcc-p5d2h 
+ MAYA_API_SERVER_NETWORK=eth0
+ ip -4 addr show scope global dev eth0
+ awk {print $2}
+ cut -d / -f 1
+ grep inet
+ CONTAINER_IP_ADDR=10.12.1.4
+ exec /usr/local/bin/maya-apiserver start --bind=10.12.1.4
I0324 07:02:30.756442       6 start.go:148] Initializing maya-apiserver...
I0324 07:02:30.773644       6 start.go:279] Starting maya api server ...
I0324 07:02:32.405295       6 start.go:288] resources applied successfully by installer
I0324 07:02:33.098859       6 start.go:193] Maya api server configuration:
I0324 07:02:33.098886       6 start.go:195]          Log Level: INFO
I0324 07:02:33.098895       6 start.go:195]             Region: global (DC: dc1)
I0324 07:02:33.098966       6 start.go:195]            Version: 1.9.0-unreleased
I0324 07:02:33.098974       6 start.go:201] 
I0324 07:02:33.098981       6 start.go:204] Maya api server started! Log data will stream in below:
I0324 07:02:33.101316       6 runner.go:37] Starting SPC controller
I0324 07:02:33.101337       6 runner.go:40] Waiting for informer caches to sync
I0324 07:02:33.201499       6 runner.go:45] Checking for preupgrade tasks
I0324 07:02:33.206466       6 runner.go:51] Starting SPC workers
I0324 07:02:33.206495       6 runner.go:58] Started SPC workers
I0324 07:07:54.501027       6 volume_endpoint_v1alpha1.go:77] received cas volume request: http method {GET}
I0324 07:07:54.501085       6 volume_endpoint_v1alpha1.go:165] received volume read request: pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70
W0324 07:07:54.562206       6 task.go:433] notfound error at runtask {readlistsvc}: error {controller service not found}
W0324 07:07:54.563381       6 runner.go:166] nothing to rollback: no rollback tasks were found
2020/03/24 07:07:54.563620 [ERR] http: Request GET /latest/volumes/pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70
failed to read volume: volume {pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70} not found in namespace {default}
I0324 07:07:54.565740       6 volume_endpoint_v1alpha1.go:77] received cas volume request: http method {POST}
I0324 07:07:54.565759       6 volume_endpoint_v1alpha1.go:130] received volume create request
I0324 07:07:54.775858       6 volume_endpoint_v1alpha1.go:160] volume 'pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70' created successfully
I0324 07:07:54.778564       6 volume_endpoint_v1alpha1.go:77] received cas volume request: http method {GET}
I0324 07:07:54.778587       6 volume_endpoint_v1alpha1.go:165] received volume read request: pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70
I0324 07:07:57.815174       6 volume_endpoint_v1alpha1.go:220] volume 'pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70' read successfully
I0324 07:13:42.914843       6 volume_endpoint_v1alpha1.go:77] received cas volume request: http method {GET}
I0324 07:13:42.914874       6 volume_endpoint_v1alpha1.go:273] received volume list request
I0324 07:13:43.059408       6 volume_endpoint_v1alpha1.go:303] volumes listed successfully for namespace(s) {}
I0324 07:13:57.119743       6 volume_endpoint_v1alpha1.go:77] received cas volume request: http method {GET}
I0324 07:13:57.119794       6 volume_endpoint_v1alpha1.go:165] received volume read request: pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70
I0324 07:13:57.210970       6 volume_endpoint_v1alpha1.go:220] volume 'pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70' read successfully
I0324 07:14:21.302051       6 volume_endpoint_v1alpha1.go:77] received cas volume request: http method {GET}
I0324 07:14:21.302532       6 volume_endpoint_v1alpha1.go:308] received volume stats request
I0324 07:14:21.334237       6 volume_endpoint_v1alpha1.go:360] read volume stats was successful for 'pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70'
I0324 07:14:22.336011       6 volume_endpoint_v1alpha1.go:77] received cas volume request: http method {GET}
I0324 07:14:22.336037       6 volume_endpoint_v1alpha1.go:308] received volume stats request
I0324 07:14:22.366539       6 volume_endpoint_v1alpha1.go:360] read volume stats was successful for 'pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70'
I0324 07:17:00.554612       6 volume_endpoint_v1alpha1.go:77] received cas volume request: http method {DELETE}
I0324 07:17:00.554667       6 volume_endpoint_v1alpha1.go:225] received volume delete request
I0324 07:17:01.393240       6 volume_endpoint_v1alpha1.go:268] volume 'pvc-e5ebbd09-b523-4a5b-9fdc-0c9d44aedd70' deleted successfully

```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests