### PR TITLE
refact(log): remove cstor prefix from localPV log and alert messages

### DIFF
--- a/cmd/provisioner-localpv/app/provisioner.go
+++ b/cmd/provisioner-localpv/app/provisioner.go
@@ -132,7 +132,7 @@ func (p *Provisioner) Provision(opts pvController.VolumeOptions) (*v1.Persistent
 		return nil, fmt.Errorf("PV with BlockMode is not supported with StorageType %v", stgType)
 	}
 	alertlog.Logger.Errorw("",
-		"eventcode", "cstor.local.pv.provision.failure",
+		"eventcode", "local.pv.provision.failure",
 		"msg", "Failed to provision Local PV",
 		"rname", opts.PVName,
 		"reason", "StorageType not supported",
@@ -164,7 +164,7 @@ func (p *Provisioner) Delete(pv *v1.PersistentVolume) (err error) {
 			err := p.DeleteBlockDevice(pv)
 			if err != nil {
 				alertlog.Logger.Errorw("",
-					"eventcode", "cstor.local.pv.delete.failure",
+					"eventcode", "local.pv.delete.failure",
 					"msg", "Failed to delete Local PV",
 					"rname", pv.Name,
 					"reason", "failed to delete block device",
@@ -177,7 +177,7 @@ func (p *Provisioner) Delete(pv *v1.PersistentVolume) (err error) {
 		err = p.DeleteHostPath(pv)
 		if err != nil {
 			alertlog.Logger.Errorw("",
-				"eventcode", "cstor.local.pv.delete.failure",
+				"eventcode", "local.pv.delete.failure",
 				"msg", "Failed to delete Local PV",
 				"rname", pv.Name,
 				"reason", "failed to delete host path",
@@ -188,7 +188,7 @@ func (p *Provisioner) Delete(pv *v1.PersistentVolume) (err error) {
 	}
 	klog.Infof("Retained volume %v", pv.Name)
 	alertlog.Logger.Infow("",
-		"eventcode", "cstor.local.pv.delete.success",
+		"eventcode", "local.pv.delete.success",
 		"msg", "Successfully deleted Local PV",
 		"rname", pv.Name,
 	)

--- a/cmd/provisioner-localpv/app/provisioner.go
+++ b/cmd/provisioner-localpv/app/provisioner.go
@@ -133,7 +133,7 @@ func (p *Provisioner) Provision(opts pvController.VolumeOptions) (*v1.Persistent
 	}
 	alertlog.Logger.Errorw("",
 		"eventcode", "cstor.local.pv.provision.failure",
-		"msg", "Failed to provision CStor Local PV",
+		"msg", "Failed to provision Local PV",
 		"rname", opts.PVName,
 		"reason", "StorageType not supported",
 		"storagetype", stgType,
@@ -165,7 +165,7 @@ func (p *Provisioner) Delete(pv *v1.PersistentVolume) (err error) {
 			if err != nil {
 				alertlog.Logger.Errorw("",
 					"eventcode", "cstor.local.pv.delete.failure",
-					"msg", "Failed to delete CStor Local PV",
+					"msg", "Failed to delete Local PV",
 					"rname", pv.Name,
 					"reason", "failed to delete block device",
 					"storagetype", pvType,
@@ -178,7 +178,7 @@ func (p *Provisioner) Delete(pv *v1.PersistentVolume) (err error) {
 		if err != nil {
 			alertlog.Logger.Errorw("",
 				"eventcode", "cstor.local.pv.delete.failure",
-				"msg", "Failed to delete CStor Local PV",
+				"msg", "Failed to delete Local PV",
 				"rname", pv.Name,
 				"reason", "failed to delete host path",
 				"storagetype", pvType,
@@ -189,7 +189,7 @@ func (p *Provisioner) Delete(pv *v1.PersistentVolume) (err error) {
 	klog.Infof("Retained volume %v", pv.Name)
 	alertlog.Logger.Infow("",
 		"eventcode", "cstor.local.pv.delete.success",
-		"msg", "Successfully deleted CStor Local PV",
+		"msg", "Successfully deleted Local PV",
 		"rname", pv.Name,
 	)
 	return nil

--- a/cmd/provisioner-localpv/app/provisioner_blockdevice.go
+++ b/cmd/provisioner-localpv/app/provisioner_blockdevice.go
@@ -52,7 +52,7 @@ func (p *Provisioner) ProvisionBlockDevice(opts pvController.VolumeOptions, volu
 		klog.Infof("Initialize volume %v failed: %v", name, err)
 		alertlog.Logger.Errorw("",
 			"eventcode", "cstor.local.pv.provision.failure",
-			"msg", "Failed to provision CStor Local PV",
+			"msg", "Failed to provision Local PV",
 			"rname", opts.PVName,
 			"reason", "Block device initialization failed",
 			"storagetype", stgType,
@@ -103,7 +103,7 @@ func (p *Provisioner) ProvisionBlockDevice(opts pvController.VolumeOptions, volu
 	if err != nil {
 		alertlog.Logger.Errorw("",
 			"eventcode", "cstor.local.pv.provision.failure",
-			"msg", "Failed to provision CStor Local PV",
+			"msg", "Failed to provision Local PV",
 			"rname", opts.PVName,
 			"reason", "Building volume failed",
 			"storagetype", stgType,
@@ -112,7 +112,7 @@ func (p *Provisioner) ProvisionBlockDevice(opts pvController.VolumeOptions, volu
 	}
 	alertlog.Logger.Infow("",
 		"eventcode", "cstor.local.pv.provision.success",
-		"msg", "Successfully provisioned CStor Local PV",
+		"msg", "Successfully provisioned Local PV",
 		"rname", opts.PVName,
 		"storagetype", stgType,
 	)

--- a/cmd/provisioner-localpv/app/provisioner_blockdevice.go
+++ b/cmd/provisioner-localpv/app/provisioner_blockdevice.go
@@ -51,7 +51,7 @@ func (p *Provisioner) ProvisionBlockDevice(opts pvController.VolumeOptions, volu
 	if err != nil {
 		klog.Infof("Initialize volume %v failed: %v", name, err)
 		alertlog.Logger.Errorw("",
-			"eventcode", "cstor.local.pv.provision.failure",
+			"eventcode", "local.pv.provision.failure",
 			"msg", "Failed to provision Local PV",
 			"rname", opts.PVName,
 			"reason", "Block device initialization failed",
@@ -102,7 +102,7 @@ func (p *Provisioner) ProvisionBlockDevice(opts pvController.VolumeOptions, volu
 
 	if err != nil {
 		alertlog.Logger.Errorw("",
-			"eventcode", "cstor.local.pv.provision.failure",
+			"eventcode", "local.pv.provision.failure",
 			"msg", "Failed to provision Local PV",
 			"rname", opts.PVName,
 			"reason", "Building volume failed",
@@ -111,7 +111,7 @@ func (p *Provisioner) ProvisionBlockDevice(opts pvController.VolumeOptions, volu
 		return nil, err
 	}
 	alertlog.Logger.Infow("",
-		"eventcode", "cstor.local.pv.provision.success",
+		"eventcode", "local.pv.provision.success",
 		"msg", "Successfully provisioned Local PV",
 		"rname", opts.PVName,
 		"storagetype", stgType,

--- a/cmd/provisioner-localpv/app/provisioner_hostpath.go
+++ b/cmd/provisioner-localpv/app/provisioner_hostpath.go
@@ -43,7 +43,7 @@ func (p *Provisioner) ProvisionHostPath(opts pvController.VolumeOptions, volumeC
 	path, err := volumeConfig.GetPath()
 	if err != nil {
 		alertlog.Logger.Errorw("",
-			"eventcode", "cstor.local.pv.provision.failure",
+			"eventcode", "local.pv.provision.failure",
 			"msg", "Failed to provision Local PV",
 			"rname", opts.PVName,
 			"reason", "Unable to get volume config",
@@ -68,7 +68,7 @@ func (p *Provisioner) ProvisionHostPath(opts pvController.VolumeOptions, volumeC
 	if iErr != nil {
 		klog.Infof("Initialize volume %v failed: %v", name, iErr)
 		alertlog.Logger.Errorw("",
-			"eventcode", "cstor.local.pv.provision.failure",
+			"eventcode", "local.pv.provision.failure",
 			"msg", "Failed to provision Local PV",
 			"rname", opts.PVName,
 			"reason", "Volume initialization failed",
@@ -109,7 +109,7 @@ func (p *Provisioner) ProvisionHostPath(opts pvController.VolumeOptions, volumeC
 
 	if err != nil {
 		alertlog.Logger.Errorw("",
-			"eventcode", "cstor.local.pv.provision.failure",
+			"eventcode", "local.pv.provision.failure",
 			"msg", "Failed to provision Local PV",
 			"rname", opts.PVName,
 			"reason", "failed to build persistent volume",
@@ -118,7 +118,7 @@ func (p *Provisioner) ProvisionHostPath(opts pvController.VolumeOptions, volumeC
 		return nil, err
 	}
 	alertlog.Logger.Infow("",
-		"eventcode", "cstor.local.pv.provision.success",
+		"eventcode", "local.pv.provision.success",
 		"msg", "Successfully provisioned Local PV",
 		"rname", opts.PVName,
 		"storagetype", stgType,

--- a/cmd/provisioner-localpv/app/provisioner_hostpath.go
+++ b/cmd/provisioner-localpv/app/provisioner_hostpath.go
@@ -44,7 +44,7 @@ func (p *Provisioner) ProvisionHostPath(opts pvController.VolumeOptions, volumeC
 	if err != nil {
 		alertlog.Logger.Errorw("",
 			"eventcode", "cstor.local.pv.provision.failure",
-			"msg", "Failed to provision CStor Local PV",
+			"msg", "Failed to provision Local PV",
 			"rname", opts.PVName,
 			"reason", "Unable to get volume config",
 			"storagetype", stgType,
@@ -69,7 +69,7 @@ func (p *Provisioner) ProvisionHostPath(opts pvController.VolumeOptions, volumeC
 		klog.Infof("Initialize volume %v failed: %v", name, iErr)
 		alertlog.Logger.Errorw("",
 			"eventcode", "cstor.local.pv.provision.failure",
-			"msg", "Failed to provision CStor Local PV",
+			"msg", "Failed to provision Local PV",
 			"rname", opts.PVName,
 			"reason", "Volume initialization failed",
 			"storagetype", stgType,
@@ -110,7 +110,7 @@ func (p *Provisioner) ProvisionHostPath(opts pvController.VolumeOptions, volumeC
 	if err != nil {
 		alertlog.Logger.Errorw("",
 			"eventcode", "cstor.local.pv.provision.failure",
-			"msg", "Failed to provision CStor Local PV",
+			"msg", "Failed to provision Local PV",
 			"rname", opts.PVName,
 			"reason", "failed to build persistent volume",
 			"storagetype", stgType,
@@ -119,7 +119,7 @@ func (p *Provisioner) ProvisionHostPath(opts pvController.VolumeOptions, volumeC
 	}
 	alertlog.Logger.Infow("",
 		"eventcode", "cstor.local.pv.provision.success",
-		"msg", "Successfully provisioned CStor Local PV",
+		"msg", "Successfully provisioned Local PV",
 		"rname", opts.PVName,
 		"storagetype", stgType,
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:
- remove cstor prefix from localPV log messages
- remove cstor prefix from localPV alert messages.