### PR TITLE
 feat(pendingsnapshots): add pending snapshots on CVR by talking to peer replicas

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -629,27 +629,28 @@ func (c *CStorVolumeReplicaController) syncCvr(cvr *apis.CStorVolumeReplica) {
 	// Get the zfs volume name corresponding to this cvr.
 	volumeName, err := volumereplica.GetVolumeName(cvr)
 	if err != nil {
-		klog.Errorf("Unable to sync CVR capacity: %v", err)
 		c.recorder.Event(
 			cvr,
 			corev1.EventTypeWarning,
 			string(common.FailureCapacitySync),
 			string(common.MessageResourceFailCapacitySync),
 		)
+		return
 	}
 	// Get capacity of the volume.
 	capacity, err := volumereplica.Capacity(volumeName)
 	if err != nil {
-		klog.Errorf("Unable to sync CVR capacity: %v", err)
 		c.recorder.Event(
 			cvr,
 			corev1.EventTypeWarning,
 			string(common.FailureCapacitySync),
 			string(common.MessageResourceFailCapacitySync),
 		)
+		return
 	} else {
 		cvr.Status.Capacity = *capacity
 	}
+
 	if os.Getenv(string(common.RebuildEstimates)) == "true" {
 		err = volumereplica.GetAndUpdateSnapshotInfo(c.clientset, cvr)
 		if err != nil {
@@ -660,6 +661,7 @@ func (c *CStorVolumeReplicaController) syncCvr(cvr *apis.CStorVolumeReplica) {
 				fmt.Sprintf("Unable to update snapshot list ddetails in cvr status err: %v", err),
 			)
 		}
+
 	}
 }
 

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -651,7 +651,7 @@ func (c *CStorVolumeReplicaController) syncCvr(cvr *apis.CStorVolumeReplica) err
 	if os.Getenv(string(common.RebuildEstimates)) == "true" {
 		err = volumereplica.GetAndUpdateSnapshotInfo(c.clientset, cvr)
 		if err != nil {
-			return errors.Wrapf(err, "Unable to update snapshot list details in CVR status err: %v", err)
+			return errors.Wrapf(err, "Unable to update snapshot list details in CVR")
 		}
 	}
 	return nil

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -168,7 +168,16 @@ func (c *CStorVolumeReplicaController) syncHandler(
 	// Synchronize cstor volume total allocated and
 	// used capacity fields on CVR object.
 	// Any kind of sync activity should be done from here.
-	c.syncCvr(cvrGot)
+	err = c.syncCvr(cvrGot)
+	if err != nil {
+		c.recorder.Event(
+			cvrGot,
+			corev1.EventTypeWarning,
+			"SyncFailed",
+			fmt.Sprintf("failed to sync CVR error: %s", err.Error()),
+		)
+		return nil
+	}
 
 	_, err = c.clientset.
 		OpenebsV1alpha1().
@@ -625,28 +634,16 @@ func (c *CStorVolumeReplicaController) getCVRStatus(
 }
 
 // syncCvr updates field on CVR object after fetching the values from zfs utility.
-func (c *CStorVolumeReplicaController) syncCvr(cvr *apis.CStorVolumeReplica) {
+func (c *CStorVolumeReplicaController) syncCvr(cvr *apis.CStorVolumeReplica) error {
 	// Get the zfs volume name corresponding to this cvr.
 	volumeName, err := volumereplica.GetVolumeName(cvr)
 	if err != nil {
-		c.recorder.Event(
-			cvr,
-			corev1.EventTypeWarning,
-			string(common.FailureCapacitySync),
-			string(common.MessageResourceFailCapacitySync),
-		)
-		return
+		return err
 	}
 	// Get capacity of the volume.
 	capacity, err := volumereplica.Capacity(volumeName)
 	if err != nil {
-		c.recorder.Event(
-			cvr,
-			corev1.EventTypeWarning,
-			string(common.FailureCapacitySync),
-			string(common.MessageResourceFailCapacitySync),
-		)
-		return
+		return errors.Wrapf(err, "failed to get volume replica capacity")
 	} else {
 		cvr.Status.Capacity = *capacity
 	}
@@ -654,15 +651,10 @@ func (c *CStorVolumeReplicaController) syncCvr(cvr *apis.CStorVolumeReplica) {
 	if os.Getenv(string(common.RebuildEstimates)) == "true" {
 		err = volumereplica.GetAndUpdateSnapshotInfo(c.clientset, cvr)
 		if err != nil {
-			c.recorder.Event(
-				cvr,
-				corev1.EventTypeWarning,
-				"SnapshotList",
-				fmt.Sprintf("Unable to update snapshot list ddetails in cvr status err: %v", err),
-			)
+			return errors.Wrapf(err, "Unable to update snapshot list details in CVR status err: %v", err)
 		}
-
 	}
+	return nil
 }
 
 func (c *CStorVolumeReplicaController) reconcileVersion(cvr *apis.CStorVolumeReplica) (

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -168,7 +168,7 @@ func (c *CStorVolumeReplicaController) syncHandler(
 	// Synchronize cstor volume total allocated and
 	// used capacity fields on CVR object.
 	// Any kind of sync activity should be done from here.
-	err = c.syncCvr(cvrGot)
+	err = c.syncCVRStatus(cvrGot)
 	if err != nil {
 		c.recorder.Event(
 			cvrGot,
@@ -633,8 +633,8 @@ func (c *CStorVolumeReplicaController) getCVRStatus(
 	return replicaStatus, nil
 }
 
-// syncCvr updates field on CVR object after fetching the values from zfs utility.
-func (c *CStorVolumeReplicaController) syncCvr(cvr *apis.CStorVolumeReplica) error {
+// syncCVRStatus updates field on CVR status after fetching the values from zfs utility.
+func (c *CStorVolumeReplicaController) syncCVRStatus(cvr *apis.CStorVolumeReplica) error {
 	// Get the zfs volume name corresponding to this cvr.
 	volumeName, err := volumereplica.GetVolumeName(cvr)
 	if err != nil {

--- a/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
+++ b/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
@@ -785,41 +785,15 @@ func getPeerReplicas(
 func getPeerSnapshotInfoList(
 	peerCVRList *apis.CStorVolumeReplicaList) map[string]apis.CStorSnapshotInfo {
 
-	// TODO: Get Opinion From Review Comments
-	// NOTE: There are possibilites to have stale phase
-	healthyReplica := getHealthyReplicaFromPeerReplicas(peerCVRList)
-	if healthyReplica != nil {
-		// Since Updating the status of replica and snapshot list is atomic
-		// update safe to return status.snapshots
-		return healthyReplica.Status.Snapshots
-	}
-
 	snapshotInfoList := map[string]apis.CStorSnapshotInfo{}
 	for _, cvrObj := range peerCVRList.Items {
-		// No need to get snapshot information from Offline,
-		// NewReplicaDegraded and Recreate CVR becasue they might
-		// consist stale information
-		if cvrObj.Status.Phase == apis.CVRStatusDegraded {
-			for snapName, snapInfo := range cvrObj.Status.Snapshots {
-				if _, ok := snapshotInfoList[snapName]; !ok {
-					snapshotInfoList[snapName] = snapInfo
-				}
+		for snapName, snapInfo := range cvrObj.Status.Snapshots {
+			if _, ok := snapshotInfoList[snapName]; !ok {
+				snapshotInfoList[snapName] = snapInfo
 			}
 		}
 	}
 	return snapshotInfoList
-}
-
-// getHealthyReplicaFromPeerReplicas returns healthy replica from the
-// peer replica list if exists else it return nil
-func getHealthyReplicaFromPeerReplicas(
-	peerCVRList *apis.CStorVolumeReplicaList) *apis.CStorVolumeReplica {
-	for _, cvrObj := range peerCVRList.Items {
-		if cvrObj.Status.Phase == apis.CVRStatusOnline {
-			return &cvrObj
-		}
-	}
-	return nil
 }
 
 // addOrDeleteSnapshotListInfo adds/deletes the snapshots in CVR


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds the pending snapshots under CVR status.pendingsnapshots only if CVR underwent `Rebuilding`. This PR is continuation of PR https://github.com/openebs/maya/pull/1639.

**How Does It Gets Pending Snapshots**:
The replica which is undergoing rebuilding will get the list of pending snapshots from other peer CVR's Snapshot information.

**Sample YAML output when Rebuilding is in Progress**:
```yaml
apiVersion: openebs.io/v1alpha1
  kind: CStorVolumeReplica
  metadata:
    annotations:
      cstorpool.openebs.io/hostname: e2e1-node3
      isRestoreVol: "false"
      openebs.io/storage-class-ref: |
        name: single-sc
        resourceVersion: 41963
    creationTimestamp: "2020-04-01T09:47:53Z"
    finalizers:
    - cstorvolumereplica.openebs.io/finalizer
    generation: 9
    labels:
      cstorpool.openebs.io/name: cstor-sparse-pool-uw8i
      cstorpool.openebs.io/uid: ccc2be88-fa06-4cb6-9f64-ef5e6fd196c4
      cstorvolume.openebs.io/name: pvc-ffb6210a-dae5-4186-899f-f7f8333d24dd
      openebs.io/cas-template-name: cstor-volume-create-default-1.8.0
      openebs.io/persistent-volume: pvc-ffb6210a-dae5-4186-899f-f7f8333d24dd
      openebs.io/version: 1.8.0
    name: pvc-ffb6210a-dae5-4186-899f-f7f8333d24dd-cstor-sparse-pool-uw8i
    namespace: openebs
    resourceVersion: "78191"
    selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/cstorvolumereplicas/pvc-ffb6210a-dae5-4186-899f-f7f8333d24dd-cstor-sparse-pool-uw8i
    uid: 4131e38d-a31e-4c5d-beb1-d3ab255609d1
  spec:
    capacity: 5G
    replicaid: 9AB518DBF9730BDB258296E3D41178A8
    targetIP: 10.106.163.180
    zvolWorkers: ""
  status:
    capacity:
      totalAllocated: 192M
      used: 275M
    lastTransitionTime: "2020-04-01T09:59:42Z"
    lastUpdateTime: "2020-04-01T09:59:42Z"
    pendingSnapshots:
      istgt_snap2:
        compression: 1.30x
        logicalReferenced: 417277952
        referenced: 319405568
        used: 536576
        written: 173701632
    phase: Rebuilding
    snapshots:
      istgt_snap1:
        compression: 1.52x
        logicalReferenced: 232120832
        referenced: 152257024
        used: 1030656
        written: 152257024
  versionDetails:
    autoUpgrade: false
    desired: 1.8.0
    status:
      current: 1.8.0
      dependentsUpgraded: true
      lastUpdateTime: null
      state: ""
```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/openebs/openebs/issues/2936 (Part of the issue will be fixed).

**Special notes for your reviewer**:
- The test case will be covered in different PR.

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests