### PR TITLE
feat(apis): add new fields into BlockDevice

### DIFF
--- a/pkg/apis/openebs.io/ndm/v1alpha1/blockdevice_types.go
+++ b/pkg/apis/openebs.io/ndm/v1alpha1/blockdevice_types.go
@@ -121,8 +121,23 @@ type DeviceCapacity struct {
 
 // DeviceDetails represent certain hardware/static attributes of the block device
 type DeviceDetails struct {
-	// DeviceType represents the type of drive like SSD, HDD etc.,
+	// DeviceType represents the type of device like
+	// sparse, disk, partition, lvm, raid
 	DeviceType string `json:"deviceType"`
+
+	// DriveType is the type of backing drive, HDD/SSD
+	DriveType string `json:"driveType"`
+
+	// LogicalBlockSize is the logical block size in bytes
+	// reported by /sys/class/block/sda/queue/logical_block_size
+	LogicalBlockSize uint32 `json:"logicalBlockSize"`
+
+	// PhysicalBlockSize is the physical block size in bytes
+	// reported by /sys/class/block/sda/queue/physical_block_size
+	PhysicalBlockSize uint32 `json:"physicalBlockSize"`
+
+	// HardwareSectorSize is the hardware sector size in bytes
+	HardwareSectorSize uint32 `json:"hardwareSectorSize"`
 
 	// Model is model of disk
 	Model string `json:"model"`
@@ -164,8 +179,8 @@ type DeviceStatus struct {
 	// claim state of the block device
 	ClaimState DeviceClaimState `json:"claimState"`
 
-	// current state of the blockdevice (Active/Inactive)
-	State string `json:"state"`
+	// State is the current state of the blockdevice (Active/Inactive)
+	State BlockDeviceState `json:"state"`
 }
 
 // DeviceClaimState defines the observed state of BlockDevice
@@ -182,6 +197,21 @@ const (
 
 	// BlockDeviceClaimed represents that the block device is bound to a BDC
 	BlockDeviceClaimed DeviceClaimState = "Claimed"
+)
+
+// BlockDeviceState defines the observed state of the disk
+type BlockDeviceState string
+
+const (
+	// BlockDeviceActive is the state for a block device that is connected to the node
+	BlockDeviceActive BlockDeviceState = "Active"
+
+	// BlockDeviceInactive is the state for a block device that is disconnected from a node
+	BlockDeviceInactive BlockDeviceState = "Inactive"
+
+	// BlockDeviceUnknown is the state for a block device whose state (attached/detached) cannot
+	// be determined at this time.
+	BlockDeviceUnknown BlockDeviceState = "Unknown"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/blockdevice/v1alpha1/blockdevice.go
+++ b/pkg/blockdevice/v1alpha1/blockdevice.go
@@ -172,7 +172,7 @@ func (bd *BlockDevice) WithState(state string) *BlockDevice {
 // build predicated to the New constructor.
 func WithState(state string) BuildOptionFunc {
 	return func(bd *BlockDevice) {
-		bd.BlockDevice.Status.State = state
+		bd.BlockDevice.Status.State = ndm.BlockDeviceState(state)
 	}
 }
 

--- a/pkg/blockdevice/v1alpha2/blockdevice.go
+++ b/pkg/blockdevice/v1alpha2/blockdevice.go
@@ -25,14 +25,6 @@ import (
 //TODO: While using these packages UnitTest
 //must be written to corresponding function
 
-// BlockDeviceState is label for block device states
-type BlockDeviceState string
-
-const (
-	// BlockDeviceStateActive is active state of the block device
-	BlockDeviceStateActive BlockDeviceState = "Active"
-)
-
 // DefaultBlockDeviceCount is a map containing the
 // default block device count of various raid types.
 var DefaultBlockDeviceCount = map[string]int{
@@ -116,7 +108,7 @@ func IsActive() Predicate {
 
 // IsActive returns true if the block device is active.
 func (bd *BlockDevice) IsActive() bool {
-	return bd.Object.Status.State == string(BlockDeviceStateActive)
+	return bd.Object.Status.State == ndm.BlockDeviceActive
 }
 
 // IsUnclaimed filters the block device based on unclaimed status


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**What this PR does / why we need it**:
- add DriveType and BlockSize fields into BlockDevice spec


**Special notes for your reviewer**:
- These are the same changes as in PR [#33](https://github.com/openebs/api/pull/33)