### PR TITLE
feat(BDD): add positive test cases for verifying waitforfirstconsumer With CStor Volume Provisioning

### DIFF
--- a/pkg/kubernetes/pod/v1alpha1/buildlist.go
+++ b/pkg/kubernetes/pod/v1alpha1/buildlist.go
@@ -24,7 +24,7 @@ import (
 // Podlist
 type ListBuilder struct {
 	list    *PodList
-	filters predicateList
+	filters PredicateList
 }
 
 // NewListBuilder returns a instance of ListBuilder

--- a/pkg/kubernetes/pod/v1alpha1/buildlist_test.go
+++ b/pkg/kubernetes/pod/v1alpha1/buildlist_test.go
@@ -126,33 +126,33 @@ func TestFilterList(t *testing.T) {
 	tests := map[string]struct {
 		availablePods map[string]string
 		filteredPods  []string
-		filters       predicateList
+		filters       PredicateList
 	}{
 		"Pods Set 1": {
 			availablePods: map[string]string{"Pod 1": "Running", "Pod 2": "CrashLoopBackOff"},
 			filteredPods:  []string{"Pod 1"},
-			filters:       predicateList{IsRunning()},
+			filters:       PredicateList{IsRunning()},
 		},
 		"Pods Set 2": {
 			availablePods: map[string]string{"Pod 1": "Running", "Pod 2": "Running"},
 			filteredPods:  []string{"Pod 1", "Pod 2"},
-			filters:       predicateList{IsRunning()},
+			filters:       PredicateList{IsRunning()},
 		},
 
 		"Pods Set 3": {
 			availablePods: map[string]string{"Pod 1": "CrashLoopBackOff", "Pod 2": "CrashLoopBackOff", "Pod 3": "CrashLoopBackOff"},
 			filteredPods:  []string{},
-			filters:       predicateList{IsRunning()},
+			filters:       PredicateList{IsRunning()},
 		},
 		"Pod Set 4": {
 			availablePods: map[string]string{"Pod 1": "Running", "Pod 2": "Running"},
 			filteredPods:  []string{},
-			filters:       predicateList{IsNil()},
+			filters:       PredicateList{IsNil()},
 		},
 		"Pod Set 5": {
 			availablePods: map[string]string{"Pod 1": "Running", "Pod 2": "Running"},
 			filteredPods:  []string{"Pod 1", "Pod 2"},
-			filters:       predicateList{},
+			filters:       PredicateList{},
 		},
 		"Pod Set 6": {
 			availablePods: map[string]string{"Pod 1": "Running", "Pod 2": "Running"},

--- a/pkg/kubernetes/pod/v1alpha1/pod.go
+++ b/pkg/kubernetes/pod/v1alpha1/pod.go
@@ -29,7 +29,7 @@ type PodList struct {
 }
 
 // PredicateList holds a list of predicate
-type predicateList []Predicate
+type PredicateList []Predicate
 
 // Predicate defines an abstraction
 // to determine conditional checks
@@ -64,7 +64,7 @@ func (pl *PodList) Len() int {
 // all returns true if all the predicates
 // succeed against the provided pod
 // instance
-func (l predicateList) all(p *Pod) bool {
+func (l PredicateList) all(p *Pod) bool {
 	for _, pred := range l {
 		if !pred(p) {
 			return false

--- a/pkg/kubernetes/storageclass/v1alpha1/build.go
+++ b/pkg/kubernetes/storageclass/v1alpha1/build.go
@@ -113,10 +113,6 @@ func (b *Builder) Build() (*storagev1.StorageClass, error) {
 // references the PeristentVolumeClaim.  The volume provisioning and
 // binding will occur during Pod scheduing.
 func (b *Builder) WithVolumeBindingMode(bindingMode storagev1.VolumeBindingMode) *Builder {
-	if bindingMode == "" {
-		b.errs = append(b.errs, errors.New("failed to build storageclass: missing volume binding mode"))
-		return b
-	}
 	b.sc.object.VolumeBindingMode = &bindingMode
 	return b
 }

--- a/pkg/kubernetes/storageclass/v1alpha1/build_test.go
+++ b/pkg/kubernetes/storageclass/v1alpha1/build_test.go
@@ -131,12 +131,6 @@ func TestBuilderWithVolumeBind(t *testing.T) {
 			builder:   &Builder{sc: &StorageClass{object: &storagev1.StorageClass{}}},
 			expectErr: false,
 		},
-
-		"Test SC with nil binding mode": {
-			bindmode:  "",
-			builder:   &Builder{sc: &StorageClass{object: &storagev1.StorageClass{}}},
-			expectErr: true,
-		},
 	}
 	for name, mock := range tests {
 		name, mock := name, mock

--- a/tests/cstor/volume/provision_test.go
+++ b/tests/cstor/volume/provision_test.go
@@ -29,6 +29,7 @@ import (
 	cvr "github.com/openebs/maya/pkg/cstor/volumereplica/v1alpha1"
 	pv "github.com/openebs/maya/pkg/kubernetes/persistentvolume/v1alpha1"
 	pvc "github.com/openebs/maya/pkg/kubernetes/persistentvolumeclaim/v1alpha1"
+	pod "github.com/openebs/maya/pkg/kubernetes/pod/v1alpha1"
 	sc "github.com/openebs/maya/pkg/kubernetes/storageclass/v1alpha1"
 	spc "github.com/openebs/maya/pkg/storagepoolclaim/v1alpha1"
 	"github.com/openebs/maya/tests/cstor"
@@ -212,7 +213,7 @@ var _ = Describe("[Cstor Volume Provisioning Positive] TEST VOLUME PROVISIONING"
 			Expect(err).To(BeNil(), "While fetching maya-apiserver address")
 			Expect(len(maddr)).To(Equal(1), "maya-apiserver address")
 
-			podList := ops.GetPodList(openebsNamespace, mayaAPIPodLabel)
+			podList := ops.GetPodList(openebsNamespace, mayaAPIPodLabel, pod.PredicateList{pod.IsRunning()})
 			Expect(err).To(BeNil(), "maya-apiserver pod fetch error")
 			mPodList := podList.ToAPIList()
 			Expect(len(mPodList.Items)).To(Equal(1), "maya-apiserver pod count")
@@ -284,7 +285,7 @@ var _ = Describe("[Cstor Volume Provisioning Positive] TEST VOLUME PROVISIONING"
 			Expect(err).To(BeNil(), "While fetching maya-apiserver address")
 			Expect(len(maddr)).To(Equal(1), "maya-apiserver address")
 
-			podList := ops.GetPodList(openebsNamespace, mayaAPIPodLabel)
+			podList := ops.GetPodList(openebsNamespace, mayaAPIPodLabel, pod.PredicateList{pod.IsRunning()})
 			Expect(err).To(BeNil(), "maya-apiserver pod fetch error")
 			mPodList := podList.ToAPIList()
 			Expect(len(mPodList.Items)).To(Equal(1), "maya-apiserver pod count")

--- a/tests/cstor/volume/suite_test.go
+++ b/tests/cstor/volume/suite_test.go
@@ -23,6 +23,7 @@ import (
 
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	ns "github.com/openebs/maya/pkg/kubernetes/namespace/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,6 +50,7 @@ var (
 	spcObj             *apis.StoragePoolClaim
 	pvcObj             *corev1.PersistentVolumeClaim
 	spcList            *apis.StoragePoolClaimList
+	appDeployment      *appsv1.Deployment
 	targetLabel        = "openebs.io/target=cstor-target"
 	pvLabel            = "openebs.io/persistent-volume="
 	pvcLabel           = "openebs.io/persistent-volume-claim="

--- a/tests/cstor/volume/waitforfirstconsumer_test.go
+++ b/tests/cstor/volume/waitforfirstconsumer_test.go
@@ -92,7 +92,7 @@ var _ = Describe("[WAITFORFIRSTCONSUMER] CStor Volume Provisioning", func() {
 		})
 	})
 
-	When("Deploying Percona Application", func() {
+	When("Deploying BusyBox Application", func() {
 		It("CStor Volume Related Resources Should Be Created and Become Healthy", func() {
 			var err error
 			// Deploying Application

--- a/tests/cstor/volume/waitforfirstconsumer_test.go
+++ b/tests/cstor/volume/waitforfirstconsumer_test.go
@@ -42,6 +42,9 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
+// This Test Can Be Run By Using Following Command
+// ginkgo -v -focus="\[WAITFORFIRSTCONSUMER\] " -- -kubeconfig=<path_to_kube_config> -cstor-maxpools=<no.of_pools> -cstor-replicas=<no.of_storagereplicas>
+
 var _ = Describe("[WAITFORFIRSTCONSUMER] CStor Volume Provisioning", func() {
 	When("SPC is created", func() {
 		It("cStor Pools Should be Provisioned ", func() {

--- a/tests/cstor/volume/waitforfirstconsumer_test.go
+++ b/tests/cstor/volume/waitforfirstconsumer_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	cv "github.com/openebs/maya/pkg/cstor/volume/v1alpha1"
+	cvr "github.com/openebs/maya/pkg/cstor/volumereplica/v1alpha1"
+	container "github.com/openebs/maya/pkg/kubernetes/container/v1alpha1"
+	deploy "github.com/openebs/maya/pkg/kubernetes/deployment/appsv1/v1alpha1"
+	pod "github.com/openebs/maya/pkg/kubernetes/pod/v1alpha1"
+	pts "github.com/openebs/maya/pkg/kubernetes/podtemplatespec/v1alpha1"
+	k8svolume "github.com/openebs/maya/pkg/kubernetes/volume/v1alpha1"
+	"github.com/openebs/maya/tests"
+	"github.com/openebs/maya/tests/cstor"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	// auth plugins
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+)
+
+var _ = Describe("[WAITFORFIRSTCONSUMER] CStor Volume Provisioning", func() {
+	When("SPC is created", func() {
+		It("cStor Pools Should be Provisioned ", func() {
+
+			By("Build And Create StoragePoolClaim object")
+			// Populate configurations and create
+			spcConfig := &tests.SPCConfig{
+				Name:                spcName,
+				DiskType:            "sparse",
+				PoolCount:           cstor.PoolCount,
+				IsThickProvisioning: true,
+				PoolType:            "striped",
+			}
+			ops.Config = spcConfig
+			spcObj = ops.BuildAndCreateSPC()
+			By("Creating SPC, Desired Number of CSP Should Be Created", func() {
+				ops.VerifyDesiredCSPCount(spcObj, cstor.PoolCount)
+			})
+		})
+	})
+
+	When("Apply Volume Related Artifacts", func() {
+		It("Volume Should be Created and Provisioned", func() {
+			By("Build And Create StorageClass")
+
+			casConfig := strings.Replace(
+				openebsCASConfigValue, "$spcName", spcObj.Name, 1)
+			casConfig = strings.Replace(
+				casConfig, "$count", strconv.Itoa(cstor.ReplicaCount), 1)
+			annotations[string(apis.CASTypeKey)] = string(apis.CstorVolume)
+			annotations[string(apis.CASConfigKey)] = casConfig
+			scConfig := &tests.SCConfig{
+				Name:              scName,
+				Annotations:       annotations,
+				Provisioner:       openebsProvisioner,
+				VolumeBindingMode: storagev1.VolumeBindingWaitForFirstConsumer,
+			}
+			ops.Config = scConfig
+			scObj = ops.CreateStorageClass()
+
+			pvcConfig := &tests.PVCConfig{
+				Name:        pvcName,
+				Namespace:   nsObj.Name,
+				SCName:      scObj.Name,
+				Capacity:    "5G",
+				AccessModes: accessModes,
+			}
+			ops.Config = pvcConfig
+			pvcObj = ops.BuildAndCreatePVC()
+		})
+	})
+
+	When("Deploying Percona Application", func() {
+		It("CStor Volume Related Resources Should Be Created and Become Healthy", func() {
+			var err error
+			// Deploying Application
+			createAndDeployAppPod()
+
+			By("Verifying pvc status as bound")
+
+			// Verify health of CStor Volume Related CR's
+			ops.VerifyVolumeStatus(pvcObj,
+				cstor.ReplicaCount,
+				cvr.PredicateList{cvr.IsHealthy()},
+				cv.PredicateList{cv.IsHealthy()},
+			)
+			pvcObj, err = ops.PVCClient.
+				WithNamespace(pvcObj.Namespace).
+				Get(pvcObj.Name, metav1.GetOptions{})
+			Expect(err).To(BeNil())
+		})
+	})
+
+	When("Deleting Application, PVC and SPC", func() {
+		It("Should Delete Volume and Pools Related to test", func() {
+			err := ops.DeployClient.WithNamespace(nsObj.Name).
+				Delete(appDeployment.Name, &metav1.DeleteOptions{})
+			Expect(err).ShouldNot(HaveOccurred(), "while deleting application pod")
+			cnt := ops.GetPodCountEventually(nsObj.Name, "app=busybox", pod.PredicateList{}, 0)
+			Expect(cnt).Should(BeNumerically("==", 0), fmt.Sprintf("While waiting for application pod to scale down"))
+
+			ops.DeletePersistentVolumeClaim(pvcObj.Name, pvcObj.Namespace)
+			ops.VerifyVolumeResources(pvcObj.Spec.VolumeName, openebsNamespace, cvr.PredicateList{}, cv.PredicateList{})
+			err = ops.SCClient.Delete(scObj.Name, &metav1.DeleteOptions{})
+			Expect(err).To(BeNil())
+
+			err = ops.SPCClient.Delete(
+				spcObj.Name, &metav1.DeleteOptions{})
+			Expect(err).To(BeNil(), "while deleting spc {%s}", spcObj.Name)
+		})
+	})
+})
+
+func createAndDeployAppPod() {
+	var err error
+	appName := "busybox-cstor"
+	By("Building a busybox app pod deployment using above csi cstor volume")
+	appDeployment, err = deploy.NewBuilder().
+		WithName(appName).
+		WithNamespace(nsObj.Name).
+		WithLabelsNew(
+			map[string]string{
+				"app": "busybox",
+			},
+		).
+		WithSelectorMatchLabelsNew(
+			map[string]string{
+				"app": "busybox",
+			},
+		).
+		WithPodTemplateSpecBuilder(
+			pts.NewBuilder().
+				WithLabelsNew(
+					map[string]string{
+						"app": "busybox",
+					},
+				).
+				WithContainerBuilders(
+					container.NewBuilder().
+						WithImage("busybox").
+						WithName("busybox").
+						WithImagePullPolicy(corev1.PullIfNotPresent).
+						WithCommandNew(
+							[]string{
+								"sh",
+								"-c",
+								"date > /mnt/cstore1/date.txt; sync; sleep 5; sync; tail -f /dev/null;",
+							},
+						).
+						WithVolumeMountsNew(
+							[]corev1.VolumeMount{
+								corev1.VolumeMount{
+									Name:      "datavol1",
+									MountPath: "/mnt/cstore1",
+								},
+							},
+						),
+				).
+				WithVolumeBuilders(
+					k8svolume.NewBuilder().
+						WithName("datavol1").
+						WithPVCSource(pvcObj.Name),
+				),
+		).
+		Build()
+
+	Expect(err).ShouldNot(HaveOccurred(), "while building app deployement {%s}", appName)
+
+	appDeployment, err = ops.DeployClient.WithNamespace(nsObj.Name).Create(appDeployment)
+	Expect(err).ShouldNot(
+		HaveOccurred(),
+		"while creating pod {%s} in namespace {%s}",
+		appName,
+		nsObj.Name,
+	)
+}

--- a/tests/operations.go
+++ b/tests/operations.go
@@ -34,15 +34,18 @@ import (
 	cvr "github.com/openebs/maya/pkg/cstor/volumereplica/v1alpha1"
 	cvc "github.com/openebs/maya/pkg/cstorvolumeclaim/v1alpha1"
 	kubeclient "github.com/openebs/maya/pkg/kubernetes/client/v1alpha1"
+	container "github.com/openebs/maya/pkg/kubernetes/container/v1alpha1"
 	deploy "github.com/openebs/maya/pkg/kubernetes/deployment/appsv1/v1alpha1"
 	ns "github.com/openebs/maya/pkg/kubernetes/namespace/v1alpha1"
 	node "github.com/openebs/maya/pkg/kubernetes/node/v1alpha1"
 	pv "github.com/openebs/maya/pkg/kubernetes/persistentvolume/v1alpha1"
 	pvc "github.com/openebs/maya/pkg/kubernetes/persistentvolumeclaim/v1alpha1"
 	pod "github.com/openebs/maya/pkg/kubernetes/pod/v1alpha1"
+	pts "github.com/openebs/maya/pkg/kubernetes/podtemplatespec/v1alpha1"
 	svc "github.com/openebs/maya/pkg/kubernetes/service/v1alpha1"
 	snap "github.com/openebs/maya/pkg/kubernetes/snapshot/v1alpha1"
 	sc "github.com/openebs/maya/pkg/kubernetes/storageclass/v1alpha1"
+	k8svolume "github.com/openebs/maya/pkg/kubernetes/volume/v1alpha1"
 	spc "github.com/openebs/maya/pkg/storagepoolclaim/v1alpha1"
 	templatefuncs "github.com/openebs/maya/pkg/templatefuncs/v1alpha1"
 	unstruct "github.com/openebs/maya/pkg/unstruct/v1alpha2"
@@ -50,6 +53,7 @@ import (
 	"github.com/openebs/maya/pkg/version"
 	"github.com/openebs/maya/tests/artifacts"
 	errors "github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1054,7 +1058,7 @@ func (ops *Operations) GetPodList(namespace, lselector string, predicateList pod
 		List()
 }
 
-// GetPodCountEventually reurns the no.of pods exists with specified labelselector
+// GetPodCountEventually returns the no.of pods exists with specified labelselector
 func (ops *Operations) GetPodCountEventually(
 	namespace, lselector string,
 	predicateList pod.PredicateList, expectedCount int) int {
@@ -1344,4 +1348,55 @@ func getCVRLabels(pool *apis.CStorPool, volumeName string) map[string]string {
 		"openebs.io/persistent-volume": volumeName,
 		"openebs.io/version":           version.GetVersion(),
 	}
+}
+
+func (ops *Operations) BuildAndDeployBusyBoxPod(
+	appName, pvcName, namespace string,
+	labels map[string]string) (*appsv1.Deployment, error) {
+	var err error
+	appDeployment, err := deploy.NewBuilder().
+		WithName(appName).
+		WithNamespace(namespace).
+		WithLabelsNew(labels).
+		WithSelectorMatchLabelsNew(labels).
+		WithPodTemplateSpecBuilder(
+			pts.NewBuilder().
+				WithLabelsNew(labels).
+				WithContainerBuilders(
+					container.NewBuilder().
+						WithImage("busybox").
+						WithName("busybox").
+						WithImagePullPolicy(corev1.PullIfNotPresent).
+						WithCommandNew(
+							[]string{
+								"sh",
+								"-c",
+								"date > /mnt/cstore1/date.txt; sync; sleep 5; sync; tail -f /dev/null;",
+							},
+						).
+						WithVolumeMountsNew(
+							[]corev1.VolumeMount{
+								corev1.VolumeMount{
+									Name:      "datavol1",
+									MountPath: "/mnt/cstore1",
+								},
+							},
+						),
+				).
+				WithVolumeBuilders(
+					k8svolume.NewBuilder().
+						WithName("datavol1").
+						WithPVCSource(pvcName),
+				),
+		).
+		Build()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to build busybox: %s deployment", appName)
+	}
+
+	appDeployment, err = ops.DeployClient.WithNamespace(namespace).Create(appDeployment)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create busybox %s deployment in namespace %s", appName, namespace)
+	}
+	return appDeployment, nil
 }


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR covers the test positive test case for PR https://github.com/openebs/maya/pull/1637.
This covers following TestCases:
- Provision CStor volume with single and multiple replicas with WaitForFirstConsumer Volume Binding mode. 

**Steps To Run BDD**:
Step1: cd into dir `tests/cstor/volume` after cloning Maya
Step2: Command to run the `WaitForFirstConsumer` test
```sh
ginkgo -v -focus="\[WAITFORFIRSTCONSUMER\] " -- -kubeconfig=<path_to_kube_config> -cstor-maxpools=<no.of_pools> -cstor-replicas=<no.of_replicas>
```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests