### PR TITLE
feat(upgrade): add support to migrate jiva volumes resources to openebs namespace

### DIFF
--- a/pkg/upgrade/templates/v1/jiva_replica.go
+++ b/pkg/upgrade/templates/v1/jiva_replica.go
@@ -27,6 +27,7 @@ var (
 		   }
 		},
 		"spec": {
+			"replicas": 1,
 			"selector": {
 				"matchLabels":{
 					"openebs.io/persistent-volume": "{{.PVName}}",

--- a/pkg/upgrade/upgrader/helper.go
+++ b/pkg/upgrade/upgrader/helper.go
@@ -23,7 +23,6 @@ import (
 
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/upgrade/v1alpha1"
 	deploy "github.com/openebs/maya/pkg/kubernetes/deployment/appsv1/v1alpha1"
-	pod "github.com/openebs/maya/pkg/kubernetes/pod/v1alpha1"
 	templates "github.com/openebs/maya/pkg/upgrade/templates/v1"
 	utask "github.com/openebs/maya/pkg/upgrade/v1alpha2"
 	retry "github.com/openebs/maya/pkg/util/retry"
@@ -59,6 +58,23 @@ func getOpenEBSVersion(d *appsv1.Deployment) (string, error) {
 		return "", errors.Errorf("missing openebs version for %s", d.Name)
 	}
 	return d.Labels["openebs.io/version"], nil
+}
+
+func checkOpenEBSVersion(d *appsv1.Deployment) (string, error) {
+	version, err := getOpenEBSVersion(d)
+	if err != nil {
+		return "", err
+	}
+	if (version != currentVersion) && (version != upgradeVersion) {
+		return "", errors.Errorf(
+			"replica %s version %s is neither %s nor %s\n",
+			d.Name,
+			version,
+			currentVersion,
+			upgradeVersion,
+		)
+	}
+	return version, nil
 }
 
 func patchDelpoyment(
@@ -352,36 +368,6 @@ func scaleDeploy(name, namespace, label string, rc int) error {
 	// If number pods is not reached within 5 minutes return error.
 	if len(podList.Items) != rc {
 		return errors.Errorf("expected pods: %d, found: %d", rc, len(podList.Items))
-	}
-	return nil
-}
-
-func waitUntilPodsAreRunning(namespace, label string, rc int) error {
-	pods := &corev1.PodList{}
-	count := 0
-	var err error
-	// Wait for up to 5 minutes for deployment pods to reach desired replicaCount.
-	for i := 0; i < 60; i++ {
-		// GetPodRunningCount gives number of pods running currently
-		pods, err = podClient.
-			WithNamespace(namespace).
-			List(metav1.ListOptions{LabelSelector: label})
-		if err != nil {
-			return err
-		}
-		count = pod.
-			ListBuilderForAPIList(pods).
-			WithFilter(pod.IsRunning()).
-			List().
-			Len()
-		if count != rc {
-			time.Sleep(time.Second * 5)
-		} else {
-			break
-		}
-	}
-	if count != rc {
-		return errors.Errorf("expected running pods: %d, found: %d", rc, count)
 	}
 	return nil
 }

--- a/pkg/upgrade/upgrader/helper.go
+++ b/pkg/upgrade/upgrader/helper.go
@@ -60,23 +60,6 @@ func getOpenEBSVersion(d *appsv1.Deployment) (string, error) {
 	return d.Labels["openebs.io/version"], nil
 }
 
-func checkOpenEBSVersion(d *appsv1.Deployment) (string, error) {
-	version, err := getOpenEBSVersion(d)
-	if err != nil {
-		return "", err
-	}
-	if (version != currentVersion) && (version != upgradeVersion) {
-		return "", errors.Errorf(
-			"replica %s version %s is neither %s nor %s\n",
-			d.Name,
-			version,
-			currentVersion,
-			upgradeVersion,
-		)
-	}
-	return version, nil
-}
-
 func patchDelpoyment(
 	deployName,
 	namespace string,


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds support to migrate the old jiva volume resources to openebs namespace.

Test job logs:
```sh
mayadata:upgrade$ k logs -f jiva-vol-170180-pvc-fc34fbbd-6661-4f40-9-39a3-qjgtt
I0402 11:54:14.024428       1 jiva_volume.go:83] Started upgrading jivaVolume{pvc-be1d95bf-205d-49e2-8bc6-83f4c8ba42af} from 1.6.0 to 1.9.0-RC1
I0402 11:54:14.024504       1 jiva_volume.go:90] Upgrading to 1.9.0-RC1
I0402 11:54:14.117842       1 jiva_upgrade.go:413] Scaling down old deployments
I0402 11:54:14.117872       1 helper.go:325] Scaling deploy pvc-be1d95bf-205d-49e2-8bc6-83f4c8ba42af-ctrl in default namespace to 0
I0402 11:54:29.171796       1 helper.go:325] Scaling deploy pvc-be1d95bf-205d-49e2-8bc6-83f4c8ba42af-rep in default namespace to 0
I0402 11:54:44.241182       1 jiva_upgrade.go:695] splitting replica deployment
I0402 11:54:44.244362       1 jiva_upgrade.go:717] creating replica deployment pvc-be1d95bf-205d-49e2-8bc6-83f4c8ba42af-rep-1 in openebs namespace
I0402 11:54:49.270392       1 jiva_upgrade.go:717] creating replica deployment pvc-be1d95bf-205d-49e2-8bc6-83f4c8ba42af-rep-2 in openebs namespace
I0402 11:54:54.305663       1 jiva_upgrade.go:717] creating replica deployment pvc-be1d95bf-205d-49e2-8bc6-83f4c8ba42af-rep-3 in openebs namespace
I0402 11:54:59.352312       1 jiva_upgrade.go:762] creating controller deployment pvc-be1d95bf-205d-49e2-8bc6-83f4c8ba42af-ctrl in openebs namespace
I0402 11:55:04.389390       1 jiva_upgrade.go:781] removing controller service pvc-be1d95bf-205d-49e2-8bc6-83f4c8ba42af-ctrl-svc in default namespace
I0402 11:55:04.425101       1 jiva_upgrade.go:786] creating controller service pvc-be1d95bf-205d-49e2-8bc6-83f4c8ba42af-ctrl-svc in openebs namespace
I0402 11:55:09.522279       1 jiva_upgrade.go:318] Verifying replica sync
I0402 11:55:15.686415       1 jiva_upgrade.go:350] Synced replica quorum is reached
I0402 11:55:43.949692       1 jiva_upgrade.go:354] Replica syncing complete
I0402 11:55:43.991904       1 jiva_upgrade.go:654] Upgrade Successful forpvc-be1d95bf-205d-49e2-8bc6-83f4c8ba42af
I0402 11:55:44.002157       1 jiva_volume.go:106] Upgraded successfully
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests