### PR TITLE
feat(localpv-device): allow local pv device on select devices

### DIFF
--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -37,12 +37,45 @@ const (
 	//KeyPVStorageType defines if the PV should be backed
 	// a hostpath ( sub directory or a storage device)
 	KeyPVStorageType = "StorageType"
+
 	//KeyPVBasePath defines base directory for hostpath volumes
 	// can be configured via the StorageClass annotations.
 	KeyPVBasePath = "BasePath"
+
 	//KeyPVFSType defines filesystem type to be used with devices
 	// and can be configured via the StorageClass annotations.
 	KeyPVFSType = "FSType"
+
+	//KeyBDPoolName defines the value for the Block Device Pool
+	//label selector configured via the StorageClass annotations.
+	//User can group block devices across nodes to form a block
+	//device pool, by setting the label on block devices as:
+	//  openebs.io/block-device-pool=<pool-name>
+	//
+	//The <pool-name> used above can be passsed to the
+	//Local PV device provisioner via the StorageClass
+	//CAS annotations.
+	//
+	//Example: Local PV device StorageClass for picking devices
+	//labeled as: openebs.io/block-device-pool=pool-x
+	//will be as follows
+	//
+	// kind: StorageClass
+	// metadata:
+	//   name: openebs-device-pool-x
+	//   annotations:
+	//     openebs.io/cas-type: local
+	//     cas.openebs.io/config: |
+	//       - name: StorageType
+	//         value: "device"
+	//       - name: BlockDevicePoolName
+	//         value: "pool-x"
+	// provisioner: openebs.io/local
+	// volumeBindingMode: WaitForFirstConsumer
+	// reclaimPolicy: Delete
+	//
+	KeyBDPoolName = "BlockDevicePoolName"
+
 	//KeyPVRelativePath defines the alternate folder name under the BasePath
 	// By default, the pv name will be used as the folder name.
 	// KeyPVBasePath can be useful for providing the same underlying folder
@@ -137,6 +170,20 @@ func (c *VolumeConfig) GetFSType() string {
 		return ""
 	}
 	return fsType
+}
+
+//GetBDPoolName returns the block device pool label
+//value configured in StorageClass.
+//
+//Default is "", no device pool will be set and all
+//the available block devices can be used for creating
+//Local PV.
+func (c *VolumeConfig) GetBDPoolName() string {
+	bdPoolName := c.getValue(KeyBDPoolName)
+	if len(strings.TrimSpace(bdPoolName)) == 0 {
+		return ""
+	}
+	return bdPoolName
 }
 
 //GetPath returns a valid PV path based on the configuration

--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -46,35 +46,37 @@ const (
 	// and can be configured via the StorageClass annotations.
 	KeyPVFSType = "FSType"
 
-	//KeyBDPoolName defines the value for the Block Device Pool
+	//KeyBDTag defines the value for the Block Device Tag
 	//label selector configured via the StorageClass annotations.
-	//User can group block devices across nodes to form a block
-	//device pool, by setting the label on block devices as:
-	//  openebs.io/block-device-pool=<pool-name>
+	//User can group block devices across nodes by setting the
+	//label on block devices as:
+	//  openebs.io/block-device-tag=<tag-value>
 	//
-	//The <pool-name> used above can be passsed to the
+	//The <tag-value> used above can be passsed to the
 	//Local PV device provisioner via the StorageClass
-	//CAS annotations.
+	//CAS annotations, to specify that Local PV (device)
+	//should only make use of those block devices that
+	//tagged with the given <tag-value>.
 	//
 	//Example: Local PV device StorageClass for picking devices
-	//labeled as: openebs.io/block-device-pool=pool-x
+	//labeled as: openebs.io/block-device-tag=tag-x
 	//will be as follows
 	//
 	// kind: StorageClass
 	// metadata:
-	//   name: openebs-device-pool-x
+	//   name: openebs-device-tag-x
 	//   annotations:
 	//     openebs.io/cas-type: local
 	//     cas.openebs.io/config: |
 	//       - name: StorageType
 	//         value: "device"
-	//       - name: BlockDevicePoolName
-	//         value: "pool-x"
+	//       - name: BlockDeviceTag
+	//         value: "tag-x"
 	// provisioner: openebs.io/local
 	// volumeBindingMode: WaitForFirstConsumer
 	// reclaimPolicy: Delete
 	//
-	KeyBDPoolName = "BlockDevicePoolName"
+	KeyBDTag = "BlockDeviceTag"
 
 	//KeyPVRelativePath defines the alternate folder name under the BasePath
 	// By default, the pv name will be used as the folder name.
@@ -172,18 +174,18 @@ func (c *VolumeConfig) GetFSType() string {
 	return fsType
 }
 
-//GetBDPoolName returns the block device pool label
+//GetBDTagValue returns the block device tag
 //value configured in StorageClass.
 //
-//Default is "", no device pool will be set and all
-//the available block devices can be used for creating
-//Local PV.
-func (c *VolumeConfig) GetBDPoolName() string {
-	bdPoolName := c.getValue(KeyBDPoolName)
-	if len(strings.TrimSpace(bdPoolName)) == 0 {
+//Default is "", no device tag will be set and any
+//available block device (without labelled with tag)
+//can be used for creating Local PV(device).
+func (c *VolumeConfig) GetBDTagValue() string {
+	bdTagValue := c.getValue(KeyBDTag)
+	if len(strings.TrimSpace(bdTagValue)) == 0 {
 		return ""
 	}
-	return bdPoolName
+	return bdTagValue
 }
 
 //GetPath returns a valid PV path based on the configuration

--- a/cmd/provisioner-localpv/app/helper_blockdevice.go
+++ b/cmd/provisioner-localpv/app/helper_blockdevice.go
@@ -65,6 +65,10 @@ type HelperBlockDeviceOptions struct {
 	bdcName string
 	//  volumeMode of PVC
 	volumeMode corev1.PersistentVolumeMode
+
+	//bdPoolName is the value passed for
+	// BlockDevicePoolName via StorageClass config
+	bdPoolName string
 }
 
 // validate checks that the required fields to create BDC
@@ -120,14 +124,20 @@ func (p *Provisioner) createBlockDeviceClaim(blkDevOpts *HelperBlockDeviceOption
 		return nil
 	}
 
-	bdcObj, err := blockdeviceclaim.NewBuilder().
+	bdcObjBuilder := blockdeviceclaim.NewBuilder().
 		WithNamespace(p.namespace).
 		WithName(bdcName).
 		WithHostName(blkDevOpts.nodeHostname).
 		WithCapacity(blkDevOpts.capacity).
 		WithFinalizer(LocalPVFinalizer).
-		WithBlockVolumeMode(blkDevOpts.volumeMode).
-		Build()
+		WithBlockVolumeMode(blkDevOpts.volumeMode)
+
+	// If bdPoolName is configure, set it on the BDC
+	if len(blkDevOpts.bdPoolName) > 0 {
+		bdcObjBuilder.WithBlockDevicePoolName(blkDevOpts.bdPoolName)
+	}
+
+	bdcObj, err := bdcObjBuilder.Build()
 
 	if err != nil {
 		//TODO : Need to relook at this error

--- a/cmd/provisioner-localpv/app/helper_blockdevice.go
+++ b/cmd/provisioner-localpv/app/helper_blockdevice.go
@@ -66,9 +66,9 @@ type HelperBlockDeviceOptions struct {
 	//  volumeMode of PVC
 	volumeMode corev1.PersistentVolumeMode
 
-	//bdPoolName is the value passed for
-	// BlockDevicePoolName via StorageClass config
-	bdPoolName string
+	//bdTagValue is the value passed for
+	// BlockDeviceTag via StorageClass config
+	bdTagValue string
 }
 
 // validate checks that the required fields to create BDC
@@ -132,9 +132,9 @@ func (p *Provisioner) createBlockDeviceClaim(blkDevOpts *HelperBlockDeviceOption
 		WithFinalizer(LocalPVFinalizer).
 		WithBlockVolumeMode(blkDevOpts.volumeMode)
 
-	// If bdPoolName is configure, set it on the BDC
-	if len(blkDevOpts.bdPoolName) > 0 {
-		bdcObjBuilder.WithBlockDevicePoolName(blkDevOpts.bdPoolName)
+	// If bdTagValue is configure, set it on the BDC
+	if len(blkDevOpts.bdTagValue) > 0 {
+		bdcObjBuilder.WithBlockDeviceTag(blkDevOpts.bdTagValue)
 	}
 
 	bdcObj, err := bdcObjBuilder.Build()

--- a/cmd/provisioner-localpv/app/provisioner_blockdevice.go
+++ b/cmd/provisioner-localpv/app/provisioner_blockdevice.go
@@ -45,6 +45,7 @@ func (p *Provisioner) ProvisionBlockDevice(opts pvController.VolumeOptions, volu
 		name:         name,
 		capacity:     capacity.String(),
 		volumeMode:   *opts.PVC.Spec.VolumeMode,
+		bdPoolName:   volumeConfig.GetBDPoolName(),
 	}
 
 	path, blkPath, err := p.getBlockDevicePath(blkDevOpts)

--- a/cmd/provisioner-localpv/app/provisioner_blockdevice.go
+++ b/cmd/provisioner-localpv/app/provisioner_blockdevice.go
@@ -45,7 +45,7 @@ func (p *Provisioner) ProvisionBlockDevice(opts pvController.VolumeOptions, volu
 		name:         name,
 		capacity:     capacity.String(),
 		volumeMode:   *opts.PVC.Spec.VolumeMode,
-		bdPoolName:   volumeConfig.GetBDPoolName(),
+		bdTagValue:   volumeConfig.GetBDTagValue(),
 	}
 
 	path, blkPath, err := p.getBlockDevicePath(blkDevOpts)

--- a/pkg/blockdeviceclaim/v1alpha1/build.go
+++ b/pkg/blockdeviceclaim/v1alpha1/build.go
@@ -35,9 +35,9 @@ const (
 	// APIVersion holds the value of OpenEBS version
 	APIVersion = "openebs.io/v1alpha1"
 
-	// bdPoolKey defines the label selector key
-	// used for grouping block devices on a given node
-	bdPoolKey = "openebs.io/block-device-pool"
+	// bdTagKey defines the label selector key
+	// used for grouping block devices using a tag.
+	bdTagKey = "openebs.io/block-device-tag"
 )
 
 // Builder is the builder object for BlockDeviceClaim
@@ -329,16 +329,16 @@ func (b *Builder) WithBlockVolumeMode(mode corev1.PersistentVolumeMode) *Builder
 	return b
 }
 
-// WithBlockDevicePoolName appends (or creates) the BDC Label Selector
+// WithBlockDeviceTag appends (or creates) the BDC Label Selector
 // by setting the provided value to the fixed key
-// openebs.io/block-device-pool
+// openebs.io/block-device-tag
 // This will enable the NDM to pick only devices that
-// match the node (hostname) and block device pool label.
-func (b *Builder) WithBlockDevicePoolName(bdPoolName string) *Builder {
-	if len(bdPoolName) == 0 {
+// match the node (hostname) and block device tag value.
+func (b *Builder) WithBlockDeviceTag(bdTagValue string) *Builder {
+	if len(bdTagValue) == 0 {
 		b.errs = append(
 			b.errs,
-			errors.New("failed to build BDC object: missing block device pool name"),
+			errors.New("failed to build BDC object: missing block device tag value"),
 		)
 		return b
 	}
@@ -350,6 +350,6 @@ func (b *Builder) WithBlockDevicePoolName(bdPoolName string) *Builder {
 		b.BDC.Object.Spec.Selector.MatchLabels = map[string]string{}
 	}
 
-	b.BDC.Object.Spec.Selector.MatchLabels[bdPoolKey] = bdPoolName
+	b.BDC.Object.Spec.Selector.MatchLabels[bdTagKey] = bdTagValue
 	return b
 }

--- a/pkg/blockdeviceclaim/v1alpha1/build.go
+++ b/pkg/blockdeviceclaim/v1alpha1/build.go
@@ -344,10 +344,10 @@ func (b *Builder) WithBlockDevicePoolName(bdPoolName string) *Builder {
 	}
 
 	if b.BDC.Object.Spec.Selector == nil {
-		newmatchlabels := map[string]string{}
-		b.BDC.Object.Spec.Selector = &metav1.LabelSelector{
-			MatchLabels: newmatchlabels,
-		}
+		b.BDC.Object.Spec.Selector = &metav1.LabelSelector{}
+	}
+	if b.BDC.Object.Spec.Selector.MatchLabels == nil {
+		b.BDC.Object.Spec.Selector.MatchLabels = map[string]string{}
 	}
 
 	b.BDC.Object.Spec.Selector.MatchLabels[bdPoolKey] = bdPoolName

--- a/pkg/blockdeviceclaim/v1alpha1/build_test.go
+++ b/pkg/blockdeviceclaim/v1alpha1/build_test.go
@@ -206,16 +206,46 @@ func TestBuildWithCapacity(t *testing.T) {
 	}
 }
 
+func TestBuilderWithBlockDevicePoolName(t *testing.T) {
+	tests := map[string]struct {
+		name      string
+		expectErr bool
+	}{
+		"Test Builder with pool name": {
+			name:      "test",
+			expectErr: false,
+		},
+		"Test Builder without pool name": {
+			name:      "",
+			expectErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			b := NewBuilder().WithBlockDevicePoolName(mock.name)
+			if mock.expectErr && len(b.errs) == 0 {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && len(b.errs) > 0 {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}
+
 func TestBuild(t *testing.T) {
 	tests := map[string]struct {
 		name        string
 		capacity    string
+		poolName    string
 		expectedBDC *apis.BlockDeviceClaim
 		expectedErr bool
 	}{
 		"BDC with correct details": {
 			name:     "BDC1",
 			capacity: "10Ti",
+			poolName: "",
 			expectedBDC: &apis.BlockDeviceClaim{
 				ObjectMeta: metav1.ObjectMeta{Name: "BDC1"},
 				Spec: apis.DeviceClaimSpec{
@@ -228,9 +258,31 @@ func TestBuild(t *testing.T) {
 			},
 			expectedErr: false,
 		},
+		"BDC with correct details, including device pool": {
+			name:     "BDC1",
+			capacity: "10Ti",
+			poolName: "test",
+			expectedBDC: &apis.BlockDeviceClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "BDC1"},
+				Spec: apis.DeviceClaimSpec{
+					Resources: apis.DeviceClaimResources{
+						Requests: corev1.ResourceList{
+							corev1.ResourceName(ndm.ResourceStorage): fakeCapacity("10Ti"),
+						},
+					},
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							bdPoolKey: "test",
+						},
+					},
+				},
+			},
+			expectedErr: false,
+		},
 		"BDC with error": {
 			name:        "",
 			capacity:    "500Gi",
+			poolName:    "test",
 			expectedBDC: nil,
 			expectedErr: true,
 		},
@@ -238,7 +290,16 @@ func TestBuild(t *testing.T) {
 	for name, mock := range tests {
 		name, mock := name, mock
 		t.Run(name, func(t *testing.T) {
-			bdcObj, err := NewBuilder().WithName(mock.name).WithCapacity(mock.capacity).Build()
+			bdcObjBuilder := NewBuilder().
+				WithName(mock.name).
+				WithCapacity(mock.capacity)
+
+			if len(mock.poolName) > 0 {
+				bdcObjBuilder.WithBlockDevicePoolName(mock.poolName)
+			}
+
+			bdcObj, err := bdcObjBuilder.Build()
+
 			if mock.expectedErr && err == nil {
 				t.Fatalf("Test %q failed: expected error not to be nil", name)
 			}

--- a/pkg/blockdeviceclaim/v1alpha1/build_test.go
+++ b/pkg/blockdeviceclaim/v1alpha1/build_test.go
@@ -206,24 +206,24 @@ func TestBuildWithCapacity(t *testing.T) {
 	}
 }
 
-func TestBuilderWithBlockDevicePoolName(t *testing.T) {
+func TestBuilderWithBlockDeviceTag(t *testing.T) {
 	tests := map[string]struct {
-		name      string
+		tag       string
 		expectErr bool
 	}{
-		"Test Builder with pool name": {
-			name:      "test",
+		"Test Builder with tag": {
+			tag:       "test",
 			expectErr: false,
 		},
-		"Test Builder without pool name": {
-			name:      "",
+		"Test Builder without tag": {
+			tag:       "",
 			expectErr: true,
 		},
 	}
 	for name, mock := range tests {
 		name, mock := name, mock
 		t.Run(name, func(t *testing.T) {
-			b := NewBuilder().WithBlockDevicePoolName(mock.name)
+			b := NewBuilder().WithBlockDeviceTag(mock.tag)
 			if mock.expectErr && len(b.errs) == 0 {
 				t.Fatalf("Test %q failed: expected error not to be nil", name)
 			}
@@ -238,14 +238,14 @@ func TestBuild(t *testing.T) {
 	tests := map[string]struct {
 		name        string
 		capacity    string
-		poolName    string
+		tagValue    string
 		expectedBDC *apis.BlockDeviceClaim
 		expectedErr bool
 	}{
 		"BDC with correct details": {
 			name:     "BDC1",
 			capacity: "10Ti",
-			poolName: "",
+			tagValue: "",
 			expectedBDC: &apis.BlockDeviceClaim{
 				ObjectMeta: metav1.ObjectMeta{Name: "BDC1"},
 				Spec: apis.DeviceClaimSpec{
@@ -261,7 +261,7 @@ func TestBuild(t *testing.T) {
 		"BDC with correct details, including device pool": {
 			name:     "BDC1",
 			capacity: "10Ti",
-			poolName: "test",
+			tagValue: "test",
 			expectedBDC: &apis.BlockDeviceClaim{
 				ObjectMeta: metav1.ObjectMeta{Name: "BDC1"},
 				Spec: apis.DeviceClaimSpec{
@@ -272,7 +272,7 @@ func TestBuild(t *testing.T) {
 					},
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							bdPoolKey: "test",
+							bdTagKey: "test",
 						},
 					},
 				},
@@ -282,7 +282,7 @@ func TestBuild(t *testing.T) {
 		"BDC with error": {
 			name:        "",
 			capacity:    "500Gi",
-			poolName:    "test",
+			tagValue:    "test",
 			expectedBDC: nil,
 			expectedErr: true,
 		},
@@ -294,8 +294,8 @@ func TestBuild(t *testing.T) {
 				WithName(mock.name).
 				WithCapacity(mock.capacity)
 
-			if len(mock.poolName) > 0 {
-				bdcObjBuilder.WithBlockDevicePoolName(mock.poolName)
+			if len(mock.tagValue) > 0 {
+				bdcObjBuilder.WithBlockDeviceTag(mock.tagValue)
 			}
 
 			bdcObj, err := bdcObjBuilder.Build()

--- a/tests/localpv/README.md
+++ b/tests/localpv/README.md
@@ -1,0 +1,40 @@
+# Local PV Provisioner BDD
+
+Local PV Provisioner BDD tests are developed using ginkgo & gomega libraries.
+
+## How to run the tests?
+
+### Pre-requisites
+
+- Install Ginkgo and Gomega on your development machine. 
+  ```
+  $ go get github.com/onsi/ginkgo/ginkgo
+  $ go get github.com/onsi/gomega/...
+  ```
+- Get your Kubernetes Cluster ready and make sure you can run 
+  kubectl from your development machine. 
+  Note down the path to the `kubeconfig` file used by kubectl 
+  to access your cluster.  Example: /home/<user>/.kube/config
+
+- (Optional) Set the KUBECONFIG environment variable on your 
+  development machine to point to the kubeconfig file. 
+  Example: KUBECONFIG=/home/<user>/.kube/config
+
+  If you do not set this ENV, you will have to pass the file 
+  to the ginkgo CLI
+
+- Some of the tests require block devices (that are not mounted)
+  to be available in the cluster.
+
+- Install required OpenEBS components. 
+  Example: `kubectl apply -f openebs-operator.yaml`
+
+### Run tests
+
+- Run the tests by being in the localpv tests folder. 
+  `$ cd $GOPATH/src/github.com/openebs/maya/tests/localpv/`
+  `$ ginkgo -v --`
+ 
+  In case the KUBECONFIG env is not configured, you can run:
+  `$ ginkgo -v -- -kubeconfig=/path/to/kubeconfig`
+

--- a/tests/localpv/suite_test.go
+++ b/tests/localpv/suite_test.go
@@ -16,6 +16,7 @@ package localpv
 import (
 	"flag"
 
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -45,7 +46,7 @@ func TestSource(t *testing.T) {
 }
 
 func init() {
-	flag.StringVar(&kubeConfigPath, "kubeconfig", "", "path to kubeconfig to invoke kubernetes API calls")
+	flag.StringVar(&kubeConfigPath, "kubeconfig", os.Getenv("KUBECONFIG"), "path to kubeconfig to invoke kubernetes API calls")
 }
 
 var ops *tests.Operations


### PR DESCRIPTION
**What this PR does / why we need it**:

Ref: https://github.com/openebs/openebs/issues/2916

This PR makes use of the Label Selector capability
added in the BDC. More details: https://github.com/openebs/openebs/issues/2921

The BDC Label Selector feature makes it possible for
administrators to `tag` a set of block devices and use
them for creating Local PV (device).

To use the Label Selector feature with Local PV (Devices)
the administrator is expected to `tag` a set of
block devices by assigning them the label:
` openebs.io/block-device-tag=< tag-value >`.

The `< tag-value >` can be passed to Local PV storage class
via cas annotations. If the value is present, then Local PV
device provisioner will set the following additional selector
on the BDC:
 `openebs.io/block-device-tag=< tag-value >`

Signed-off-by: kmova <kiran.mova@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**Special notes for your reviewer**:
BDDs will be pushed in another commit or PR. 

Executed the following tests:
- Existing BDDs execute without any issues, when the `block-device-tag` is not added to the storageclass. 
- Created a GKE cluster. Added label on only one device with `openebs.io/block-device-tag=mongo`. 
```
kiran_mova_mayadata_io@kmova-dev:maya$ kubectl get bd -n openebs --show-labels
NAME                                           NODENAME                                    SIZE           CLAIMSTATE   STATUS   AGE   LABELS
blockdevice-5a2e9602ff2bde719fa25a8b596ea64c   gke-kmova-helm-default-pool-f0c7b5f6-5ls5   402653184000   Unclaimed    Active   45m   kubernetes.io/hostname=gke-kmova-helm-default-pool-f0c7b5f6-5ls5,ndm.io/blockdevice-type=blockdevice,ndm.io/managed=true
blockdevice-8c90defa852a91fb7a85fd2b10691fe0   gke-kmova-helm-default-pool-f0c7b5f6-4x48   402653184000   Claimed      Active   45m   kubernetes.io/hostname=gke-kmova-helm-default-pool-f0c7b5f6-4x48,ndm.io/blockdevice-type=blockdevice,ndm.io/managed=true,openebs.io/block-device-tag=mongo
blockdevice-b542ca2d4a4afe7edb82b0635bcbb813   gke-kmova-helm-default-pool-f0c7b5f6-7q9j   402653184000   Unclaimed    Active   45m   kubernetes.io/hostname=gke-kmova-helm-default-pool-f0c7b5f6-7q9j,ndm.io/blockdevice-type=blockdevice,ndm.io/managed=true
blockdevice-bade4695f7101ea410dc45f941b4da92   gke-kmova-helm-default-pool-f0c7b5f6-4x48   402653184000   Unclaimed    Active   45m   kubernetes.io/hostname=gke-kmova-helm-default-pool-f0c7b5f6-4x48,ndm.io/blockdevice-type=blockdevice,ndm.io/managed=true
```
- Created a storage class with annotation for `BlockDeviceTag` as follows:
```
---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-device-mongo
  annotations:
    openebs.io/cas-type: local
    cas.openebs.io/config: |
      - name: StorageType
        value: "device"
      - name: BlockDeviceTag
        value: "mongo"
provisioner: openebs.io/local
volumeBindingMode: WaitForFirstConsumer
reclaimPolicy: Delete
---
```
- Created a Mongo statefulset by specifying storageclass as `openebs-device-mongo`
- Only the labeled block device was claimed and PV was created only for one PVC. 
```
kmova-dev:mongodb$ kubectl get bdc -n openebs
NAME                                           BLOCKDEVICENAME                                PHASE     AGE
bdc-pvc-cc31ced3-f686-4889-821c-1366790a2460   blockdevice8c90defa852a91fb7a85fd2b10691fe0   Bound     34m
bdc-pvc-f21fad99-1c5d-4591-b32a-014de39021fb                                                  Pending   34m

kmova-dev:mongodb$ kubectl get pvc
NAME                STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
mongo-pvc-mongo-0   Bound     pvc-cc31ced3-f686-4889-821c-1366790a2460   5G         RWO           openebs-device-mongo   35m
mongo-pvc-mongo-1   Pending                                                                        openebs-device-mongo   34m

```
- The BDC with label selector for device tag looks like this:
```
kmova-dev:mongodb$ kubectl describe bdc bdc-pvc-f21fad99-1c5d-4591-b32a-014de39021fb -n openebs
Name:         bdc-pvc-f21fad99-1c5d-4591-b32a-014de39021fb
Namespace:    openebs
Labels:       <none>
Annotations:  <none>
API Version:  openebs.io/v1alpha1
Kind:         BlockDeviceClaim
Metadata:
  Creation Timestamp:  2020-04-05T05:45:35Z
  Finalizers:
    local.openebs.io/finalizer
  Generation:        2
  Resource Version:  8199
  Self Link:         /apis/openebs.io/v1alpha1/namespaces/openebs/blockdeviceclaims/bdc-pvc-f21fad99-1c5d-4591-b32a-014de39021fb
  UID:               fc99366c-fd95-44dc-9dbb-427d87ad2fbd
Spec:
  Block Device Node Attributes:
    Host Name:  gke-kmova-helm-default-pool-f0c7b5f6-7q9j
  Device Claim Details:
  Device Type:  
  Host Name:    
  Resources:
    Requests:
      Storage:  5G
  Selector:
    Match Labels:
      openebs.io/block-device-tag:  mongo
Status:
  Phase:  Pending
Events:   <none>
```
- When other block devices were labelled, the BDC was bound and pods came to running state:
```
kmova-dev:mongodb$ kubectl get bd -n openebs -l openebs.io/block-device-tag=mongo
NAME                                           NODENAME                                    SIZE           CLAIMSTATE   STATUS   AGE
blockdevice-8c90defa852a91fb7a85fd2b10691fe0   gke-kmova-helm-default-pool-f0c7b5f6-4x48   402653184000   Claimed      Active   66m
blockdevice-b542ca2d4a4afe7edb82b0635bcbb813   gke-kmova-helm-default-pool-f0c7b5f6-7q9j   402653184000   Claimed      Active   66m
blockdevice-bade4695f7101ea410dc45f941b4da92   gke-kmova-helm-default-pool-f0c7b5f6-4x48   402653184000   Unclaimed    Active   66m
blockdevice-c9872f642d4ad75c26b4e8317fca9c26   gke-kmova-helm-default-pool-f0c7b5f6-5ls5   402653184000   Claimed      Active   66m
blockdevice-d05cb29fd2042111e6286b32ad880d10   gke-kmova-helm-default-pool-f0c7b5f6-7q9j   402653184000   Unclaimed    Active   66m

kmova-dev:mongodb$ kubectl get pods
NAME      READY   STATUS    RESTARTS   AGE
mongo-0   2/2     Running   0          50m
mongo-1   2/2     Running   0          4m7s
mongo-2   2/2     Running   0          3m57s
```
- Ran another test by tagging all the block devices and created a PVC without a tag. As expected no block device was attached. 

**Checklist:**
- [x] Fixes #<issue number>
- [x] Labelled this PR & related issue with `documentation` tag (if applicable)
- [x] PR messages has document related information (if applicable)
- [x] Labelled this PR & related issue with `breaking-changes` tag (if applicable)
- [x] PR messages has breaking changes related information (if applicable)
- [x] Labelled this PR & related issue with `requires-upgrade` tag (if applicable)
- [x] PR messages has upgrade related information (if applicable)
- [X] Commit has unit tests (if applicable)
- [ ] Commit has integration tests (if applicable)