### PR TITLE
feat(build): enable arm64 auto build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ jobs:
       arch: amd64
       env:
         - RELEASE_TAG_DOWNSTREAM=1
+    - os: linux
+      arch: arm64
+      env:
+        - RELEASE_TAG_DOWNSTREAM=0
 
 services:
   - docker
@@ -44,39 +48,43 @@ install:
   - make format
 
 before_script:
+  # Install build/test dependencies for each platform
   # Download kubectl, which is a requirement for using minikube.
-  - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.13.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
   # Download minikube.
-  - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.35.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-  - mkdir -p $HOME/.kube $HOME/.minikube
-  - touch $KUBECONFIG
-  - sudo minikube start --vm-driver=none --kubernetes-version=v1.13.0
-  - "sudo chown -R travis: /home/travis/.minikube/"
   # Wait for Kubernetes to be up and ready.
-  - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
-  # Download and initialize helm.
-  #- ./ci/ubuntu-compile-nsenter.sh && sudo cp .tmp/util-linux-2.30.2/nsenter /usr/bin
-  #- curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
-  #- chmod 700 get_helm.sh
-  #- ./get_helm.sh
-  #- helm init
-
+  - if [ "$TRAVIS_CPU_ARCH" == "amd64" ]; then
+      curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.13.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/;
+      curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.35.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/;
+      mkdir -p $HOME/.kube $HOME/.minikube;
+      touch $KUBECONFIG;
+      sudo minikube start --vm-driver=none --kubernetes-version=v1.13.0;
+      sudo chown -R travis /home/travis/.minikube/;
+      JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done;
+    fi
+  # install zip package for arm64
+  - if [ "$TRAVIS_CPU_ARCH" == "arm64" ]; then
+      sudo apt-get install --yes zip;
+    fi
 script:
-  - kubectl cluster-info
-   # Verify kube-addon-manager.
-   # kube-addon-manager is responsible for managing other kubernetes components, such as kube-dns, dashboard, storage-provisioner..
-  - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lcomponent=kube-addon-manager -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-addon-manager to be available"; kubectl get pods --all-namespaces; done
-  - kubectl get deployment
+  # Verify kube-addon-manager.
+  # kube-addon-manager is responsible for managing other kubernetes components, such as kube-dns, dashboard, storage-provisioner.
+  - if [ "$TRAVIS_CPU_ARCH" == "amd64" ]; then
+      kubectl cluster-info;
+      JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lcomponent=kube-addon-manager -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-addon-manager to be available"; kubectl get pods --all-namespaces; done;
+      kubectl get deployment;
+    fi
   - ./buildscripts/travis-build.sh
-  - ./ci/travis-ci.sh
+  - if [ "$TRAVIS_CPU_ARCH" == "amd64" ]; then
+      ./ci/travis-ci.sh;
+    fi
   - make deploy-images
   # If this build is running due to travis release tag, and
   # this job indicates to push the release downstream, then
   # go ahead and tag the dependent repo.
   #
   # $TRAVIS_BRANCH contains the same value as $TRAVIS_TAG.
-  # Example: 1.9.0-RC1 tag and 1.9.0-RC1 branch. 
-  # OpenEBS release are done from branches named as v1.9.x. 
+  # Example: 1.9.0-RC1 tag and 1.9.0-RC1 branch.
+  # OpenEBS release are done from branches named as v1.9.x.
   # Convert the TRAVIS_TAG to the corresponding release branch.
   - if [ ! -z $TRAVIS_TAG ] && [ $RELEASE_TAG_DOWNSTREAM = 1 ] && [ "$TRAVIS_REPO_SLUG" == "openebs/maya" ]; then
       REL_BRANCH=$(echo v$(echo "$TRAVIS_TAG" | cut -d'-' -f1 | rev | cut -d'.' -f2- | rev).x) ;

--- a/buildscripts/admission-server/Makefile.mk
+++ b/buildscripts/admission-server/Makefile.mk
@@ -1,0 +1,37 @@
+
+# Specify the name for the binaries
+WEBHOOK=admission-server
+
+# Specify the name of the docker repo for amd64
+ADMISSION_SERVER_REPO_NAME?=admission-server
+
+# Specify the name of the docker repo for arm64
+ADMISSION_SERVER_REPO_NAME_ARM64?=admission-server-arm64
+
+.PHONY: admission-server
+admission-server:
+	@echo "----------------------------"
+	@echo -n "--> ${WEBHOOK} "
+	@echo "----------------------------"
+	@PNAME=${WEBHOOK} CTLNAME=${WEBHOOK} sh -c "'$(PWD)/buildscripts/build.sh'"
+
+.PHONY: admission-server-image
+admission-server-image: admission-server
+	@echo "----------------------------"
+	@echo -n "--> ${WEBHOOK} image"
+	@echo "${HUB_USER}/${ADMISSION_SERVER_REPO_NAME}:${IMAGE_TAG}"
+	@echo "----------------------------"
+	@cp bin/${WEBHOOK}/${WEBHOOK} buildscripts/admission-server/
+	@cd buildscripts/${WEBHOOK} && sudo docker build -t ${HUB_USER}/${ADMISSION_SERVER_REPO_NAME}:${IMAGE_TAG} --build-arg BUILD_DATE=${BUILD_DATE} .
+	@rm buildscripts/${WEBHOOK}/${WEBHOOK}
+
+.PHONY: admission-server-image.arm64
+admission-server-image.arm64: admission-server
+	@echo "----------------------------"
+	@echo -n "--> ${WEBHOOK} image"
+	@echo "${HUB_USER}/${ADMISSION_SERVER_REPO_NAME_ARM64}:${IMAGE_TAG}"
+	@echo "----------------------------"
+	@cp bin/${WEBHOOK}/${WEBHOOK} buildscripts/admission-server/
+	@cd buildscripts/${WEBHOOK} && sudo docker build -t ${HUB_USER}/${ADMISSION_SERVER_REPO_NAME_ARM64}:${IMAGE_TAG} --build-arg BUILD_DATE=${BUILD_DATE} .
+	@rm buildscripts/${WEBHOOK}/${WEBHOOK}
+

--- a/buildscripts/cspc-operator-debug/Makefile.mk
+++ b/buildscripts/cspc-operator-debug/Makefile.mk
@@ -1,0 +1,23 @@
+# Specify the name for the binaries
+CSPC_OPERATOR=cspc-operator
+CSPC_OPERATOR_DEBUG=cspc-operator-debug
+
+# Specify the name of the docker repo for amd64
+CSPC_OPERATOR_REPO_NAME?=cspc-operator
+
+.PHONY: cspc-operator-debug
+cspc-operator-debug:
+	@echo "----------------------------"
+	@echo -n "--> ${CSPC_OPERATOR} "
+	@echo "----------------------------"
+	@PNAME=${CSPC_OPERATOR_DEBUG} CTLNAME=${CSPC_OPERATOR} BUILD_TAG="-tags=debug" sh -c "'$(PWD)/buildscripts/build.sh'"
+
+.PHONY: cspc-operator-debug-image
+cspc-operator-debug-image: cspc-operator-debug
+	@echo "----------------------------"
+	@echo -n "--> ${CSPC_OPERATOR} image "
+	@echo "${HUB_USER}/${CSPC_OPERATOR_REPO_NAME}:${IMAGE_TAG}"
+	@echo "----------------------------"
+	@cp bin/${CSPC_OPERATOR_DEBUG}/${CSPC_OPERATOR} buildscripts/cspc-operator-debug/
+	@cd buildscripts/${CSPC_OPERATOR_DEBUG} && sudo docker build -t ${HUB_USER}/${CSPC_OPERATOR_REPO_NAME}:inject --build-arg BUILD_DATE=${BUILD_DATE} .
+	@rm buildscripts/${CSPC_OPERATOR_DEBUG}/${CSPC_OPERATOR}

--- a/buildscripts/cspc-operator/Dockerfile.arm64
+++ b/buildscripts/cspc-operator/Dockerfile.arm64
@@ -1,0 +1,26 @@
+#Make the base image configurable. If BASE IMAGES is not provided
+#docker command will fail
+ARG BASE_IMAGE=arm64v8/alpine
+FROM $BASE_IMAGE
+
+RUN apk add --no-cache \
+    iproute2 \
+    bash \
+    curl \
+    net-tools \
+    mii-tool \
+    procps \
+    libc6-compat \
+    ca-certificates
+
+COPY cspc-operator /usr/local/bin/cspc-operator
+
+ARG BUILD_DATE
+LABEL org.label-schema.name="cspc-operator"
+LABEL org.label-schema.description="CSPC Operator for OpenEBS cStor engine"
+LABEL org.label-schema.url="http://www.openebs.io/"
+LABEL org.label-schema.vcs-url="https://github.com/openebs/maya"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=$BUILD_DATE
+
+ENTRYPOINT ["/usr/local/bin/cspc-operator"]

--- a/buildscripts/cspc-operator/Makefile.mk
+++ b/buildscripts/cspc-operator/Makefile.mk
@@ -1,0 +1,36 @@
+
+# Specify the name for the binaries
+CSPC_OPERATOR=cspc-operator
+
+# Specify the name of the docker repo for amd64
+CSPC_OPERATOR_REPO_NAME?=cspc-operator
+
+# Specify the name of the docker repo for arm64
+CSPC_OPERATOR_REPO_NAME_ARM64?=cspc-operator-arm64
+
+.PHONY: cspc-operator
+cspc-operator:
+	@echo "----------------------------"
+	@echo -n "--> ${CSPC_OPERATOR} "
+	@echo "----------------------------"
+	@PNAME=${CSPC_OPERATOR} CTLNAME=${CSPC_OPERATOR} sh -c "'$(PWD)/buildscripts/build.sh'"
+
+.PHONY: cspc-operator-image
+cspc-operator-image: cspc-operator
+	@echo "----------------------------"
+	@echo -n "--> ${CSPC_OPERATOR} image "
+	@echo "${HUB_USER}/${CSPC_OPERATOR_REPO_NAME}:${IMAGE_TAG}"
+	@echo "----------------------------"
+	@cp bin/${CSPC_OPERATOR}/${CSPC_OPERATOR} buildscripts/cspc-operator/
+	@cd buildscripts/${CSPC_OPERATOR} && sudo docker build -t ${HUB_USER}/${CSPC_OPERATOR_REPO_NAME}:${IMAGE_TAG} --build-arg BUILD_DATE=${BUILD_DATE} .
+	@rm buildscripts/${CSPC_OPERATOR}/${CSPC_OPERATOR}
+
+.PHONY: cspc-operator-image.arm64
+cspc-operator-image.arm64: cspc-operator
+	@echo "----------------------------"
+	@echo -n "--> ${CSPC_OPERATOR} image "
+	@echo "${HUB_USER}/${CSPC_OPERATOR_REPO_NAME_ARM64}:${IMAGE_TAG}"
+	@echo "----------------------------"
+	@cp bin/${CSPC_OPERATOR}/${CSPC_OPERATOR} buildscripts/cspc-operator/
+	@cd buildscripts/${CSPC_OPERATOR} && sudo docker build -t ${HUB_USER}/${CSPC_OPERATOR_REPO_NAME_ARM64}:${IMAGE_TAG} -f Dockerfile.arm64 --build-arg BUILD_DATE=${BUILD_DATE} .
+	@rm buildscripts/${CSPC_OPERATOR}/${CSPC_OPERATOR}

--- a/buildscripts/cvc-operator/Makefile.mk
+++ b/buildscripts/cvc-operator/Makefile.mk
@@ -21,11 +21,11 @@ cvc-operator-image:
 cvc-operator-image.arm64:
 	@echo "----------------------------"
 	@echo -n "--> arm64 based cstor-volume-mgmt image "
-	@echo "${HUB_USER}/${CVC_OPERATOR_REPO_NAME}:${IMAGE_TAG}"
+	@echo "${HUB_USER}/${CVC_OPERATOR_REPO_NAME_ARM64}:${IMAGE_TAG}"
 	@echo "----------------------------"
 	@PNAME=${CVC_OPERATOR} CTLNAME=${CVC_OPERATOR} sh -c "'$(PWD)/buildscripts/build.sh'"
 	@cp bin/${CVC_OPERATOR}/${CVC_OPERATOR} buildscripts/cvc-operator/
-	@cd buildscripts/${CVC_OPERATOR} && sudo docker build -t ${HUB_USER}/${CSTOR_VOLUME_MGMT_REPO_NAME_ARM64}:${IMAGE_TAG} -f Dockerfile.arm64 --build-arg BUILD_DATE=${BUILD_DATE} .
+	@cd buildscripts/${CVC_OPERATOR} && sudo docker build -t ${HUB_USER}/${CVC_OPERATOR_REPO_NAME_ARM64}:${IMAGE_TAG} -f Dockerfile.arm64 --build-arg BUILD_DATE=${BUILD_DATE} .
 	@rm buildscripts/${CVC_OPERATOR}/${CVC_OPERATOR}
 
 

--- a/buildscripts/deploy.sh
+++ b/buildscripts/deploy.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Copyright 2020 The OpenEBS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Determine the arch/os we're building for
+ARCH=$(uname -m)
+
+if [ "${ARCH}" = "x86_64" ]; then
+  APISERVER_IMG="openebs/m-apiserver"
+  M_EXPORTER_IMG="openebs/m-exporter"
+  CSTOR_POOL_MGMT_IMG="openebs/cstor-pool-mgmt"
+  CSPI_MGMT_IMG="openebs/cspi-mgmt"
+  CSTOR_VOLUME_MGMT_IMG="openebs/cstor-volume-mgmt"
+  ADMISSION_SERVER_IMG="openebs/admission-server"
+  CSPC_OPERATOR_IMG="openebs/cspc-operator"
+  UPGRADE_IMG="openebs/m-upgrade"
+  PROVISIONER_LOCALPV="openebs/provisioner-localpv"
+  CVC_OPERATOR_IMG="openebs/cvc-operator"
+elif [ "${ARCH}" = "aarch64" ]; then
+  APISERVER_IMG="openebs/m-apiserver-arm64"
+  M_EXPORTER_IMG="openebs/m-exporter-arm64"
+  CSTOR_POOL_MGMT_IMG="openebs/cstor-pool-mgmt-arm64"
+  CSPI_MGMT_IMG="openebs/cspi-mgmt-arm64"
+  CSTOR_VOLUME_MGMT_IMG="openebs/cstor-volume-mgmt-arm64"
+  ADMISSION_SERVER_IMG="openebs/admission-server-arm64"
+  CSPC_OPERATOR_IMG="openebs/cspc-operator-arm64"
+  UPGRADE_IMG="openebs/m-upgrade-arm64"
+  PROVISIONER_LOCALPV="openebs/provisioner-localpv-arm64"
+  CVC_OPERATOR_IMG="openebs/cvc-operator-arm64"
+fi
+
+# tag and push all the images
+DIMAGE="${APISERVER_IMG}" ./buildscripts/push
+DIMAGE="${M_EXPORTER_IMG}" ./buildscripts/push
+DIMAGE="${CSTOR_POOL_MGMT_IMG}" ./buildscripts/push
+DIMAGE="${CSPI_MGMT_IMG}" ./buildscripts/push
+DIMAGE="${CSTOR_VOLUME_MGMT_IMG}" ./buildscripts/push
+DIMAGE="${ADMISSION_SERVER_IMG}" ./buildscripts/push
+DIMAGE="${CSPC_OPERATOR_IMG}" ./buildscripts/push
+DIMAGE="${UPGRADE_IMG}" ./buildscripts/push
+DIMAGE="${PROVISIONER_LOCALPV}" ./buildscripts/push
+DIMAGE="${CVC_OPERATOR_IMG}" ./buildscripts/push

--- a/buildscripts/travis-build.sh
+++ b/buildscripts/travis-build.sh
@@ -63,7 +63,11 @@ printf "\n"
 ./buildscripts/test-cov.sh
 rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 
-make all
+if [ "$TRAVIS_CPU_ARCH" == "arm64" ]; then
+  make all.arm64
+else
+  make all
+fi
 rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 
 if [ $SRC_REPO != $DST_REPO ];

--- a/buildscripts/travis-build.sh
+++ b/buildscripts/travis-build.sh
@@ -53,22 +53,24 @@ rc=$?; if [[ $rc != 0 ]]; then echo "dep check failed"; exit $rc; fi
 checkGitDiff "dep check"
 printf "\n"
 
+if [ "$TRAVIS_CPU_ARCH" == "amd64" ]; then
+  # kubegen and unit tests are executed only for amd64
+  echo "Running : make kubegen"
+  make kubegen
+  rc=$?; if [[ $rc != 0 ]]; then echo "make kubegen failed"; exit $rc; fi
+  checkGitDiff "make kubegen"
+  printf "\n"
 
-echo "Running : make kubegen"
-make kubegen
-rc=$?; if [[ $rc != 0 ]]; then echo "make kubegen failed"; exit $rc; fi
-checkGitDiff "make kubegen"
-printf "\n"
+  ./buildscripts/test-cov.sh
+  rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 
-./buildscripts/test-cov.sh
-rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
-
-if [ "$TRAVIS_CPU_ARCH" == "arm64" ]; then
-  make all.arm64
-else
   make all
+  rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+
+elif [ "$TRAVIS_CPU_ARCH" == "arm64" ]; then
+  make all.arm64
+  rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 fi
-rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 
 if [ $SRC_REPO != $DST_REPO ];
 then

--- a/buildscripts/upgrade-082090/Makefile.mk
+++ b/buildscripts/upgrade-082090/Makefile.mk
@@ -30,12 +30,12 @@ upgrade-082090:
 upgrade-image-082090: upgrade-082090
 	@echo "-----------------------------------------------------------------------"
 	@echo "--> ${UPGRADE-082090} image                                            "
-	@echo "${HUB_USER}/${M_UPGRADE_REPO_NAME}:${UPGRADE-082090-TAG}:${IMAGE_TAG}  "
+	@echo "${HUB_USER}/m-upgrade:${UPGRADE-082090-TAG}:${IMAGE_TAG}  "
 	@echo "-----------------------------------------------------------------------"
 	@# The binary is renamed as upgrade to keep it in sync with the upgrade image.
 	@cp bin/${UPGRADE-082090}/${UPGRADE-082090} buildscripts/${UPGRADE-082090}/upgrade
 	@cd buildscripts/${UPGRADE-082090} && \
-	 sudo docker build --tag "${HUB_USER}/${M_UPGRADE_REPO_NAME}:${UPGRADE-082090-TAG}" --build-arg BUILD_DATE=${BUILD_DATE} .
+	 sudo docker build --tag "${HUB_USER}/m-upgrade:${UPGRADE-082090-TAG}" --build-arg BUILD_DATE=${BUILD_DATE} .
 	@rm buildscripts/${UPGRADE-082090}/upgrade
 
 # cleanup upgrade build

--- a/buildscripts/upgrade/Makefile.mk
+++ b/buildscripts/upgrade/Makefile.mk
@@ -2,6 +2,12 @@
 # Specify the name for the binaries
 UPGRADE=upgrade
 
+# Specify the name of the docker repo for amd64
+UPGRADE_REPO_NAME="m-upgrade"
+
+# Specify the name of the docker repo for arm64
+UPGRADE_REPO_NAME_ARM64="m-upgrade-arm64"
+
 # build upgrade binary
 .PHONY: upgrade
 upgrade:
@@ -19,12 +25,26 @@ upgrade:
 upgrade-image: upgrade
 	@echo "-----------------------------------------------"
 	@echo "--> ${UPGRADE} image                           "
-	@echo "${HUB_USER}/${M_UPGRADE_REPO_NAME}:${IMAGE_TAG}"
+	@echo "${HUB_USER}/${UPGRADE_REPO_NAME}:${IMAGE_TAG}"
 	@echo "-----------------------------------------------"
 	@cp bin/${UPGRADE}/${UPGRADE} buildscripts/${UPGRADE}/
 	@cd buildscripts/${UPGRADE} && \
-	 sudo docker build -t "${HUB_USER}/${M_UPGRADE_REPO_NAME}:${IMAGE_TAG}" --build-arg BUILD_DATE=${BUILD_DATE} .
+	 sudo docker build -t "${HUB_USER}/${UPGRADE_REPO_NAME}:${IMAGE_TAG}" --build-arg BUILD_DATE=${BUILD_DATE} .
 	@rm buildscripts/${UPGRADE}/${UPGRADE}
+
+.PHONY: upgrade-image.arm64
+upgrade-image.arm64: upgrade
+	@echo "-----------------------------------------------"
+	@echo "--> ${UPGRADE} image                           "
+	@echo "${HUB_USER}/${UPGRADE_REPO_NAME_ARM64}:${IMAGE_TAG}"
+	@echo "-----------------------------------------------"
+	@cp bin/${UPGRADE}/${UPGRADE} buildscripts/${UPGRADE}/
+	@cd buildscripts/${UPGRADE} && \
+	 sudo docker build -t "${HUB_USER}/${UPGRADE_REPO_NAME_ARM64}:${IMAGE_TAG}" --build-arg BUILD_DATE=${BUILD_DATE} .
+	@rm buildscripts/${UPGRADE}/${UPGRADE}
+
+
+
 
 # cleanup upgrade build
 .PHONY: cleanup-upgrade

--- a/ci/travis-ci.sh
+++ b/ci/travis-ci.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 #./ci/helm_install_openebs.sh
 # global env vars to be used in test scripts
 export CI_BRANCH="master"


### PR DESCRIPTION
- add support for building arm64 images from travis ci
- enabled arm64 support for m-upgrade
- enabled arm64 support for cspc-operator
- enabled arm64 support for admission-server
- fixed bug in amr64 build of cvc-operator
- add support to push images of amd64 and arm64 from travis ci
- removed auto build of old m-upgrade binaries

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**What this PR does / why we need it**:
enable automatically building arm64 images from ci