### PR TITLE
fix(BDD): fix SPC reconciliation BDD by adding extra filter

### DIFF
--- a/pkg/cstor/pool/v1alpha3/cstorpool.go
+++ b/pkg/cstor/pool/v1alpha3/cstorpool.go
@@ -68,6 +68,16 @@ func (l predicateList) all(c *CSP) bool {
 	return true
 }
 
+// IsNotDeleted returns true if deletion
+// timestamp was nil(which means
+// object is not deleted) else return false
+// i.e CSP is deleted
+func IsNotDeleted() Predicate {
+	return func(c *CSP) bool {
+		return c.Object.DeletionTimestamp.IsZero()
+	}
+}
+
 // IsNotUID returns true if provided csp
 // instance's UID does not match with any
 // of the provided UIDs

--- a/tests/operations.go
+++ b/tests/operations.go
@@ -717,7 +717,7 @@ func (ops *Operations) DeleteCSP(spcName string, deleteCount int) {
 	cspList := csp.
 		ListBuilderForAPIObject(cspAPIList).
 		List().
-		Filter(csp.HasLabel(string(apis.StoragePoolClaimCPK), spcName), csp.IsStatus("Healthy"))
+		Filter(csp.HasLabel(string(apis.StoragePoolClaimCPK), spcName), csp.IsStatus("Healthy"), csp.IsNotDeleted())
 	cspCount := cspList.Len()
 	Expect(deleteCount).Should(BeNumerically("<=", cspCount))
 
@@ -783,7 +783,7 @@ func (ops *Operations) GetHealthyCSPCount(spcName string, expectedCSPCount int) 
 		cspCount = csp.
 			ListBuilderForAPIObject(cspAPIList).
 			List().
-			Filter(csp.HasLabel(string(apis.StoragePoolClaimCPK), spcName), csp.IsStatus("Healthy")).
+			Filter(csp.HasLabel(string(apis.StoragePoolClaimCPK), spcName), csp.IsStatus("Healthy"), csp.IsNotDeleted()).
 			Len()
 		if cspCount == expectedCSPCount {
 			return cspCount


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This test fixes the CSP reconciliation BDD.

**Reason For Failure**:
When CSP deletion is triggered it takes a time(very small time)
to remove from etcd due to finalizer existence on it.
As this test is performing continuous deletion of CSP
and expecting them to be created. In this process of
deleting in nth deletion, it takes the deleted object to
perform the deletion. So when CSP is deleted from etcd
and deleting the same object causes the problem and
reporting object not found error.
```sh
STRIPED SPARSE SPC
/home/k8s/go_projects/src/github.com/openebs/maya/tests/cstor/pool/reconciliation/reconciliation_test.go:35
  when We we delete cstor sparse pool pod
  /home/k8s/go_projects/src/github.com/openebs/maya/tests/cstor/pool/reconciliation/reconciliation_test.go:84
    pool should be imported
    /home/k8s/go_projects/src/github.com/openebs/maya/tests/cstor/pool/reconciliation/reconciliation_test.go:85
------------------------------
STRIPED SPARSE SPC when We delete 1 pool out of 3 by deleting one of the csp 
  a new pool should come up again
  /home/k8s/go_projects/src/github.com/openebs/maya/tests/cstor/pool/reconciliation/reconciliation_test.go:150
Deleting sparse-pool-claim-1586196091882224979-7rxn error: <nil>
•
------------------------------
STRIPED SPARSE SPC when We delete 2 pool out of 3 by deleting 2 csps 
  2 new pool should come up again
  /home/k8s/go_projects/src/github.com/openebs/maya/tests/cstor/pool/reconciliation/reconciliation_test.go:165
Deleting sparse-pool-claim-1586196091882224979-7rxn error: <nil>
Deleting sparse-pool-claim-1586196091882224979-cgu4 error: <nil>
•
------------------------------
STRIPED SPARSE SPC when We delete 3 pool out of 3 by deleting 3 csps 
  3 new pool should come up again
  /home/k8s/go_projects/src/github.com/openebs/maya/tests/cstor/pool/reconciliation/reconciliation_test.go:180
Deleting sparse-pool-claim-1586196091882224979-7rxn error: cstorpools.openebs.io "sparse-pool-claim-1586196091882224979-7rxn" not found

• Failure [0.132 seconds]
STRIPED SPARSE SPC
/home/k8s/go_projects/src/github.com/openebs/maya/tests/cstor/pool/reconciliation/reconciliation_test.go:35
  when We delete 3 pool out of 3 by deleting 3 csps
  /home/k8s/go_projects/src/github.com/openebs/maya/tests/cstor/pool/reconciliation/reconciliation_test.go:179
    3 new pool should come up again [It]
    /home/k8s/go_projects/src/github.com/openebs/maya/tests/cstor/pool/reconciliation/reconciliation_test.go:180

    Expected
        <*errors.StatusError | 0xc0002ad4a0>: {
            ErrStatus: {
                TypeMeta: {Kind: "", APIVersion: ""},
                ListMeta: {
                    SelfLink: "",
                    ResourceVersion: "",
                    Continue: "",
                    RemainingItemCount: nil,
                },
                Status: "Failure",
                Message: "cstorpools.openebs.io \"sparse-pool-claim-1586196091882224979-7rxn\" not found",
                Reason: "NotFound",
                Details: {
                    Name: "sparse-pool-claim-1586196091882224979-7rxn",
                    Group: "openebs.io",
                    Kind: "cstorpools",
                    UID: "",
                    Causes: nil,
                    RetryAfterSeconds: 0,
                },
                Code: 404,
            },
        }
    to be nil
```


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests