### PR TITLE
feat(upgrade): enable bulk upgrade for volumes and spc

### DIFF
--- a/cmd/upgrade/executor/jiva_volume.go
+++ b/cmd/upgrade/executor/jiva_volume.go
@@ -35,10 +35,13 @@ type JivaVolumeOptions struct {
 
 var (
 	jivaVolumeUpgradeCmdHelpText = `
-This command upgrades the Jiva Persistent Volume
-
-Usage: upgrade jiva-volume --volname <pv-name> --options...
+This command upgrades one or many Jiva Persistent Volume
 `
+	jivaVolumeUpgradeCmdExampleText = `  # Upgrade one volume at a time
+  upgrade jiva-volume --pv-name <pv-name> --options...
+
+  # Upgrade multiple volumes at a time
+  upgrade jiva-volume <pv-name>... --options...`
 )
 
 // NewUpgradeJivaVolumeJob upgrade a Jiva Volume
@@ -47,9 +50,9 @@ func NewUpgradeJivaVolumeJob() *cobra.Command {
 		Use:     "jiva-volume",
 		Short:   "Upgrade Jiva Volume",
 		Long:    jivaVolumeUpgradeCmdHelpText,
-		Example: `upgrade jiva-volume --pv-name <pv-name>`,
+		Example: jivaVolumeUpgradeCmdExampleText,
 		Run: func(cmd *cobra.Command, args []string) {
-			util.CheckErr(options.RunJivaVolumeUpgradeChecks(cmd, args), util.Fatal)
+			util.CheckErr(options.RunJivaVolumeUpgradeChecks(args), util.Fatal)
 			options.resourceKind = "jivaVolume"
 			if options.jivaVolume.pvName != "" {
 				singleJivaUpgrade(cmd)
@@ -82,7 +85,7 @@ func bulkJivaUpgrade(cmd *cobra.Command, args []string) {
 }
 
 // RunJivaVolumeUpgradeChecks will ensure the sanity of the jiva upgrade options
-func (u *UpgradeOptions) RunJivaVolumeUpgradeChecks(cmd *cobra.Command, args []string) error {
+func (u *UpgradeOptions) RunJivaVolumeUpgradeChecks(args []string) error {
 	if len(strings.TrimSpace(u.jivaVolume.pvName)) == 0 && len(args) == 0 {
 		return errors.Errorf("Cannot execute upgrade job:" +
 			" neither pv-name flag is set nor pv name list is provided")
@@ -117,6 +120,10 @@ func (u *UpgradeOptions) RunJivaVolumeUpgrade(cmd *cobra.Command) error {
 	} else {
 		return errors.Errorf("Invalid from version %s or to version %s", u.fromVersion, u.toVersion)
 	}
-	klog.Infof("Upgraded successfully")
+	klog.V(4).Infof("Successfully upgraded %s{%s} from %s to %s",
+		u.resourceKind,
+		u.jivaVolume.pvName,
+		u.fromVersion,
+		u.toVersion)
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR enables the bulk upgrade option for upgrade jobs where multiple volumes or spc can be upgraded in one job.

Updated job yaml:
```yaml
---
apiVersion: batch/v1
kind: Job
metadata:
  #VERIFY that you have provided a unique name for this upgrade job.
  #The name can be any valid K8s string for name. This example uses
  #the following convention: jiva-vol-<flattened-from-to-versions>
  name: jiva-vols-160190-busybox

  #VERIFY the value of namespace is same as the namespace where openebs components
  # are installed. You can verify using the command:
  # `kubectl get pods -n <openebs-namespace> -l openebs.io/component-name=maya-apiserver`
  # The above command should return status of the openebs-apiserver.
  namespace: openebs

spec:
  backoffLimit: 4
  template:
    spec:
      # VERIFY the value of serviceAccountName is pointing to service account
      # created within openebs namespace. Use the non-default account.
      # by running `kubectl get sa -n <openebs-namespace>`
      serviceAccountName: openebs-maya-operator
      containers:
      - name:  upgrade
        args:
        - "jiva-volume"

        # --from-version is the current version of the volume
        - "--from-version=1.6.0"

        # --to-version is the version desired upgrade version
        - "--to-version=1.9.0"

        #VERIFY that you have provided the correct list of jiva PV Name
        - "pvc-713e3bb6-afd2-11e9-8e79-42010a800065"
        - "pvc-02320288-22c8-44d4-b5a1-fc37acf2c597"
        
        #Following are optional parameters
        #Log Level
        - "--v=4"
        #DO NOT CHANGE BELOW PARAMETERS
        env:
        - name: OPENEBS_NAMESPACE
          valueFrom:
            fieldRef:
              fieldPath: metadata.namespace
        tty: true

        # the image version should be same as the --to-version mentioned above
        # in the args of the job
        image: quay.io/openebs/m-upgrade:1.9.0
        imagePullPolicy: Always
      restartPolicy: OnFailure
---
```

**Note: The old way of accepting pv name or spc name through the flags is still supported for upgrading one volume at a time.**
 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests