### PR TITLE
chore(build): trigger downstream repo release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,10 +73,16 @@ script:
   # If this build is running due to travis release tag, and
   # this job indicates to push the release downstream, then
   # go ahead and tag the dependent repo.
+  #
+  # $TRAVIS_BRANCH contains the same value as $TRAVIS_TAG.
+  # Example: 1.9.0-RC1 tag and 1.9.0-RC1 branch. 
+  # OpenEBS release are done from branches named as v1.9.x. 
+  # Convert the TRAVIS_TAG to the corresponding release branch.
   - if [ ! -z $TRAVIS_TAG ] && [ $RELEASE_TAG_DOWNSTREAM = 1 ] && [ "$TRAVIS_REPO_SLUG" == "openebs/maya" ]; then
-      ./buildscripts/git-release "openebs/velero-plugin" "$TRAVIS_TAG" "$TRAVIS_BRANCH" || travis_terminate 1;
-      ./buildscripts/git-release "openebs/cstor-csi" "$TRAVIS_TAG" "$TRAVIS_BRANCH" || travis_terminate 1;
-      ./buildscripts/git-release "openebs/jiva-operator" "$TRAVIS_TAG" "$TRAVIS_BRANCH" || travis_terminate 1;
+      REL_BRANCH=$(echo v$(echo "$TRAVIS_TAG" | cut -d'-' -f1 | rev | cut -d'.' -f2- | rev).x) ;
+      ./buildscripts/git-release "openebs/velero-plugin" "$TRAVIS_TAG" "$REL_BRANCH" || travis_terminate 1;
+      ./buildscripts/git-release "openebs/cstor-csi" "$TRAVIS_TAG" "$REL_BRANCH" || travis_terminate 1;
+      ./buildscripts/git-release "openebs/jiva-operator" "$TRAVIS_TAG" "$REL_BRANCH" || travis_terminate 1;
     fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
+
 dist: xenial
+
 env:
   global:
     - CHANGE_MINIKUBE_NONE_USER=true
@@ -8,9 +10,19 @@ env:
     - MINIKUBE_HOME=$HOME
     - CHANGE_MINIKUBE_NONE_USER=true
     - KUBECONFIG=$HOME/.kube/config
+
+jobs:
+  include:
+    - os: linux
+      arch: amd64
+      env:
+        - RELEASE_TAG_DOWNSTREAM=1
+
 services:
   - docker
+
 language: go
+
 cache:
   directories:
     - $HOME/.cache/go-build
@@ -26,9 +38,11 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install --yes -qq gcc
   - sudo apt-get install --yes -qq libudev-dev
+
 install:
   - make bootstrap
   - make format
+
 before_script:
   # Download kubectl, which is a requirement for using minikube.
   - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.13.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
@@ -46,6 +60,7 @@ before_script:
   #- chmod 700 get_helm.sh
   #- ./get_helm.sh
   #- helm init
+
 script:
   - kubectl cluster-info
    # Verify kube-addon-manager.
@@ -54,14 +69,25 @@ script:
   - kubectl get deployment
   - ./buildscripts/travis-build.sh
   - ./ci/travis-ci.sh
-after_success:
   - make deploy-images
+  # If this build is running due to travis release tag, and
+  # this job indicates to push the release downstream, then
+  # go ahead and tag the dependent repo.
+  - if [ ! -z $TRAVIS_TAG ] && [ $RELEASE_TAG_DOWNSTREAM = 1 ] && [ "$TRAVIS_REPO_SLUG" == "openebs/maya" ]; then
+      ./buildscripts/git-release "openebs/velero-plugin" "$TRAVIS_TAG" "$TRAVIS_BRANCH" || travis_terminate 1;
+      ./buildscripts/git-release "openebs/cstor-csi" "$TRAVIS_TAG" "$TRAVIS_BRANCH" || travis_terminate 1;
+      ./buildscripts/git-release "openebs/jiva-operator" "$TRAVIS_TAG" "$TRAVIS_BRANCH" || travis_terminate 1;
+    fi
+
+after_success:
   - bash <(curl -s https://codecov.io/bash)
+
 notifications:
   email:
     recipients:
-    - kiran.mova@cloudbyte.com
+    - kiran.mova@mayadata.io
     - shubham.bajpai@mayadata.io
+
 deploy:
   provider: releases
   api_key:

--- a/buildscripts/git-release
+++ b/buildscripts/git-release
@@ -1,0 +1,92 @@
+#!/bin/bash
+set -e
+
+if [ "$#" -ne 3 ]; then
+    echo "Error: Unable to create a new release. Missing required input."
+    echo "Usage: $0 <github org/repo> <tag-name> <branch-name>"
+    echo "Example: $0 kmova/bootstrap v1.0.0 master"
+    exit 1
+fi
+
+C_GIT_URL=$(echo "https://api.github.com/repos/$1/releases")
+C_GIT_TAG_NAME=$2
+C_GIT_TAG_BRANCH=$3
+
+if [ -z ${GIT_NAME} ];
+then
+  echo "Error: Environment variable GIT_NAME not found. Please set it to proceed.";
+  echo "GIT_NAME should be a valid GitHub username.";
+  exit 1
+fi
+
+if [ -z ${GIT_TOKEN} ];
+then
+  echo "Error: Environment variable GIT_TOKEN not found. Please set it to proceed.";
+  echo "GIT_TOKEN should be a valid GitHub token associated with GitHub username.";
+  echo "GIT_TOKEN should be configured with required permissions to create new release.";
+  exit 1
+fi
+
+RELEASE_CREATE_JSON=$(echo \
+{ \
+ \"tag_name\":\"${C_GIT_TAG_NAME}\", \
+ \"target_commitish\":\"${C_GIT_TAG_BRANCH}\", \
+ \"name\":\"${C_GIT_TAG_NAME}\", \
+ \"body\":\"Release created via $0\", \
+ \"draft\":false, \
+ \"prerelease\":false \
+} \
+)
+
+#delete the temporary response file that might 
+#have been left around by previous run of the command
+#using a fixed name means that this script 
+#is not thread safe. only one execution is permitted 
+#at a time.
+TEMP_RESP_FILE=temp-curl-response.txt
+rm -rf ${TEMP_RESP_FILE}
+
+response_code=$(curl -u ${GIT_NAME}:${GIT_TOKEN} \
+ -w "%{http_code}" \
+ --silent \
+ --output ${TEMP_RESP_FILE} \
+ --url ${C_GIT_URL} \
+ --request POST --header 'content-type: application/json' \
+ --data "$RELEASE_CREATE_JSON")
+
+#When embedding this script in other scripts like travis, 
+#success responses like 200 can mean error. rc_code maps
+#the responses to either success (0) or error (1)
+rc_code=0
+
+#Github returns 201 Created on successfully creating a new release
+#201 means the request has been fulfilled and has resulted in one 
+#or more new resources being created.
+if [ $response_code != "201" ]; then
+    echo "Error: Unable to create release. See below response for more details"
+    #The GitHub error response is pretty well formatted.
+    #Printing the body gives all the details to fix the errors
+    #Sample response when the branch already exists looks like this:
+    #{
+    #  "message": "Validation Failed",
+    #  "errors": [
+    #    {
+    #      "resource": "Release",
+    #      "code": "already_exists",
+    #      "field": "tag_name"
+    #    }
+    #  ],
+    #  "documentation_url": "https://developer.github.com/v3/repos/releases/#create-a-release"
+    #}
+    rc_code=1
+else
+    #Note. In case of success, lots of details of returned, but just 
+    #knowing that creation worked is all that matters now.
+    echo "Successfully tagged $1 with release tag ${C_GIT_TAG_NAME} on branch ${C_GIT_TAG_BRANCH}"
+fi
+cat ${TEMP_RESP_FILE}
+
+#delete the temporary response file
+rm -rf ${TEMP_RESP_FILE}
+
+exit ${rc_code}


### PR DESCRIPTION
OpenEBS Control Plane code is split across multiple repos.

For releasing control plane code, multiple repo's need
to be tagged in a certain order.

This fix will help to trigger the release
on the downstream repo. In this case, after
releasing openebs/maya, the following repos should be
tagged:
  - openebs/velero-plugin
  - openebs/cstor-csi
  - openebs/jiva-operator

Note: Due to multiple jobs running in travis,
the release on the downstream should be done
only after the longest job that pushes the
containers is completed. This is manually
configured via ENV variable RELEASE_DOWNSTREAM.

Signed-off-by: kmova <kiran.mova@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests