### PR TITLE
chore(CVR): enable REBUILD_ESTIMATES feature gate

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -650,7 +650,7 @@ func (c *CStorVolumeReplicaController) syncCVRStatus(cvr *apis.CStorVolumeReplic
 
 	err = volumereplica.GetAndUpdateSnapshotInfo(c.clientset, cvr)
 	if err != nil {
-		return errors.Wrapf(err, "Unable to update snapshot list details in CVR")
+		return errors.Wrapf(err, "unable to update snapshot list details in CVR")
 	}
 
 	return nil

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -648,12 +648,11 @@ func (c *CStorVolumeReplicaController) syncCVRStatus(cvr *apis.CStorVolumeReplic
 		cvr.Status.Capacity = *capacity
 	}
 
-	if os.Getenv(string(common.RebuildEstimates)) == "true" {
-		err = volumereplica.GetAndUpdateSnapshotInfo(c.clientset, cvr)
-		if err != nil {
-			return errors.Wrapf(err, "Unable to update snapshot list details in CVR")
-		}
+	err = volumereplica.GetAndUpdateSnapshotInfo(c.clientset, cvr)
+	if err != nil {
+		return errors.Wrapf(err, "Unable to update snapshot list details in CVR")
 	}
+
 	return nil
 }
 

--- a/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
+++ b/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
@@ -718,7 +718,7 @@ func GetAndUpdateSnapshotInfo(
 	//   as is to cover this corner case below check is required.
 	if cvr.Status.Phase == apis.CVRStatusOnline &&
 		len(cvr.Status.PendingSnapshots) != 0 {
-		klog.Infof("CVR: %s is marked as %s hence removing pending snapshots %v",
+		klog.V(2).Infof("CVR: %s is marked as %s hence removing pending snapshots %v",
 			cvr.Name,
 			cvr.Status.Phase,
 			getSnapshotNames(cvr.Status.PendingSnapshots),
@@ -766,7 +766,7 @@ func getAndAddPendingSnapshotList(
 		}
 	}
 
-	klog.Infof(
+	klog.V(2).Infof(
 		"Adding %v pending snapshots and deleting %v pending snapshots on CVR %s",
 		newSnapshots,
 		removedSnapshots,
@@ -871,7 +871,7 @@ func addOrDeleteSnapshotListInfo(
 			delete(cvr.Status.PendingSnapshots, snapName)
 		}
 	}
-	klog.Infof(
+	klog.V(2).Infof(
 		"Adding %v snapshots and deleting %v snapshots on CVR %s",
 		newSnapshots,
 		removedSnapshots,
@@ -900,39 +900,21 @@ func getSnapshotInfo(dsName, snapName string) (apis.CStorSnapshotInfo, error) {
 		WithScriptedMode(true).
 		WithParsableMode(true).
 		WithField("value").
-		WithProperty("referenced").
-		WithProperty("written").
 		WithProperty("logicalreferenced").
 		WithProperty("used").
-		WithProperty("compressratio").
 		WithDataset(dsName + "@" + snapName).
 		Execute()
 	if err != nil {
 		return apis.CStorSnapshotInfo{}, errors.Wrapf(err, "failed to get snapshot properties")
 	}
 	valueList := strings.Split(string(ret), "\n")
-	// Since we made zfs query in following order referenced, written,
-	// logicalreferenced, used and compressionratio output also will be
-	// in the same order
-
-	// referenced and written values are of type int64
-	var pInt64 []int64
-	var valI int64
-	for _, v := range []string{valueList[0], valueList[1]} {
-		valI, err = strconv.ParseInt(v, 10, 64)
-		if err != nil {
-			break
-		}
-		pInt64 = append(pInt64, valI)
-	}
-	if err != nil {
-		return apis.CStorSnapshotInfo{}, errors.Wrapf(err, "failed to parse the snapshot properties")
-	}
+	// Since we made zfs query in following order logicalreferenced,
+	// used output also will be in the same order
 
 	// logicalReferenced and Used values are of type uint64
 	var pUint64 []uint64
 	var valU uint64
-	for _, v := range []string{valueList[2], valueList[3]} {
+	for _, v := range []string{valueList[0], valueList[1]} {
 		valU, err = strconv.ParseUint(v, 10, 64)
 		if err != nil {
 			break
@@ -944,11 +926,8 @@ func getSnapshotInfo(dsName, snapName string) (apis.CStorSnapshotInfo, error) {
 	}
 
 	snapInfo := apis.CStorSnapshotInfo{
-		Referenced:        pInt64[0],
-		Written:           pInt64[1],
 		LogicalReferenced: pUint64[0],
 		Used:              pUint64[1],
-		CompressionRatio:  valueList[4],
 	}
 	return snapInfo, nil
 }

--- a/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
+++ b/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
@@ -718,7 +718,7 @@ func GetAndUpdateSnapshotInfo(
 	//   as is to cover this corner case below check is required.
 	if cvr.Status.Phase == apis.CVRStatusOnline &&
 		len(cvr.Status.PendingSnapshots) != 0 {
-		klog.V(2).Infof("CVR: %s is marked as %s hence removing pending snapshots %v",
+		klog.Infof("CVR: %s is marked as %s hence removing pending snapshots %v",
 			cvr.Name,
 			cvr.Status.Phase,
 			getSnapshotNames(cvr.Status.PendingSnapshots),

--- a/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
+++ b/cmd/cstor-pool-mgmt/volumereplica/volumereplica.go
@@ -927,7 +927,8 @@ func getSnapshotInfo(dsName, snapName string) (apis.CStorSnapshotInfo, error) {
 
 	snapInfo := apis.CStorSnapshotInfo{
 		LogicalReferenced: pUint64[0],
-		Used:              pUint64[1],
+		// TODO: Populate Used value when we are estimating time for rebuild
+		// Used:              pUint64[1],
 	}
 	return snapInfo, nil
 }

--- a/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
@@ -143,7 +143,7 @@ type CStorSnapshotInfo struct {
 	LogicalReferenced uint64 `json:"logicalReferenced"`
 
 	// Used is the used bytes for given snapshot
-	Used uint64 `json:"used"`
+	// Used uint64 `json:"used"`
 }
 
 // CStorVolumeCapacityAttr is for storing the volume capacity.

--- a/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
+++ b/pkg/apis/openebs.io/v1alpha1/cstor_volume_replica.go
@@ -142,16 +142,6 @@ type CStorSnapshotInfo struct {
 	// space consumed by metadata.
 	LogicalReferenced uint64 `json:"logicalReferenced"`
 
-	// Written describes the amount of referenced space written to this snapshot
-	Written int64 `json:"written"`
-
-	// CompressionRatio describes the compression factor of snapshot
-	CompressionRatio string `json:"compression"`
-
-	// Referenced describes the amount of data that is accessible
-	// by this snapshot
-	Referenced int64 `json:"referenced"`
-
 	// Used is the used bytes for given snapshot
 	Used uint64 `json:"used"`
 }


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Enables the feature gate REBUILD_ESTIMATES by default(previous PRs https://github.com/openebs/maya/pull/1639, https://github.com/openebs/maya/pull/1641). 
- Removes extra fields under CVR.Status.Snapshots, current it has only LogicalReferenced.
**LogicalReferenced**: Size in bytes of the volume when the snapshot was taken.

**Example CVR YAML**:
```yaml
apiVersion: openebs.io/v1alpha1
kind: CStorVolumeReplica
metadata:
  annotations:
    cstorpool.openebs.io/hostname: 127.0.0.1
    isRestoreVol: "false"
    openebs.io/storage-class-ref: |
      name: single-sc
      resourceVersion: 20797
  creationTimestamp: "2020-04-15T18:20:34Z"
  finalizers:
  - cstorvolumereplica.openebs.io/finalizer
  generation: 27
  labels:
    cstorpool.openebs.io/name: cstor-sparse-pool-g45t
    cstorpool.openebs.io/uid: fab7b50f-29ea-495b-bfc4-cd256ccb1d27
    cstorvolume.openebs.io/name: pvc-15ec16c1-49a6-43be-ad26-e1ce4229b7e7
    openebs.io/cas-template-name: cstor-volume-create-default-1.9.0
    openebs.io/persistent-volume: pvc-15ec16c1-49a6-43be-ad26-e1ce4229b7e7
    openebs.io/version: 1.9.0
  name: pvc-15ec16c1-49a6-43be-ad26-e1ce4229b7e7-cstor-sparse-pool-g45t
  namespace: openebs
  resourceVersion: "22857"
  selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/cstorvolumereplicas/pvc-15ec16c1-49a6-43be-ad26-e1ce4229b7e7-cstor-sparse-pool-g45t
  uid: 03f5be25-4ada-4dba-bb79-b5858f99e8d7
spec:
  capacity: 5G
  replicaid: 1733F78111FE8F998284A7DA13998CF5
  targetIP: 10.0.0.133
  zvolWorkers: ""
status:
  capacity:
    totalAllocated: 6K
    used: 6K
  lastTransitionTime: "2020-04-15T18:29:23Z"
  lastUpdateTime: "2020-04-15T18:38:48Z"
  phase: Healthy
  pendingSnapshots:
    vol1_snap3:
      logicalReferenced: 417277952
  snapshots:
    vol1_snap2:
      logicalReferenced: 6144
versionDetails:
  autoUpgrade: false
  desired: 1.9.0
  status:
    current: 1.9.0
    dependentsUpgraded: true
    lastUpdateTime: null
    state: ""
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
- As of now used value under the snapshot will not increase(need to fix it). 

**Release Note**:
- Enables `REBUILD_ESTIMATES` feature gate by default so that CVR status will have a list of snapshots and pending snapshots. The list under snapshots represents snapshots created for that volume and pendingSnapshots represents snapshots that are yet to rebuild from the peer replicas.

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests