### PR TITLE
fix(cStorvolumereplica): record the error while fetching the snapshot information

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -176,7 +176,6 @@ func (c *CStorVolumeReplicaController) syncHandler(
 			"SyncFailed",
 			fmt.Sprintf("failed to sync CVR error: %s", err.Error()),
 		)
-		return nil
 	}
 
 	_, err = c.clientset.
@@ -650,12 +649,7 @@ func (c *CStorVolumeReplicaController) syncCVRStatus(cvr *apis.CStorVolumeReplic
 
 	err = volumereplica.GetAndUpdateSnapshotInfo(c.clientset, cvr)
 	if err != nil {
-		c.recorder.Event(
-			cvr,
-			corev1.EventTypeWarning,
-			"List Snapshot",
-			fmt.Sprintf("unable to update snapshot list details in CVR error: %s", err.Error()),
-		)
+		return errors.Wrapf(err, "unable to update snapshot list details in CVR")
 	}
 
 	return nil

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/handler.go
@@ -650,7 +650,12 @@ func (c *CStorVolumeReplicaController) syncCVRStatus(cvr *apis.CStorVolumeReplic
 
 	err = volumereplica.GetAndUpdateSnapshotInfo(c.clientset, cvr)
 	if err != nil {
-		return errors.Wrapf(err, "unable to update snapshot list details in CVR")
+		c.recorder.Event(
+			cvr,
+			corev1.EventTypeWarning,
+			"List Snapshot",
+			fmt.Sprintf("unable to update snapshot list details in CVR error: %s", err.Error()),
+		)
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**:
This PR is required to update the status on CVR even though if an error occurred while fetching the snapshot info from ZFS instead of returning error(Returning error informs to not to update the CVR status). Since the Restore test in openebs/velero-plugin depends on the [status of CVR](https://github.com/openebs/velero-plugin/blob/837917c2bfa526ddc9a8ab492053fd3607cbe886/tests/sanity/backup_test.go#L171) it is essential to update the status irrespective of snapshot list.

**What this PR does?**:
This PR records the error if the error occurs while fetching the snapshot information from ZFS.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- Deployed the persistent volume claim and removed the targetIP by exec into the cStor pool pod. So error events are recorded on CVR instead of returning errors.

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_
- With this PR there might be chances of having pending snapshots in CVR Status even though CVR is `Healthy` but it will update the snapshot list in subsequent reconciliations.

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 