### PR TITLE
fix(maya-exporter): fix duplicate metrics for openebs_zpool_last_sync_time

### DIFF
--- a/changelogs/unreleased/1678-slalwani97
+++ b/changelogs/unreleased/1678-slalwani97
@@ -1,0 +1,1 @@
+fix(maya-exporter): fix duplicate metrics generation after pool pod restart or any error.

--- a/changelogs/unreleased/1678-slalwani97
+++ b/changelogs/unreleased/1678-slalwani97
@@ -1,1 +1,1 @@
-fix(maya-exporter): fix duplicate metrics generation after pool pod restart or any error.
+fix(maya-exporter): duplicate metrics generation after pool pod restart or any error.

--- a/cmd/maya-exporter/app/collector/zvol/metrics.go
+++ b/cmd/maya-exporter/app/collector/zvol/metrics.go
@@ -524,7 +524,7 @@ func poolMetricParser(stdout []byte) *poolfields {
 	}
 
 	pool := poolfields{
-		name:                          f[0],
+		name:                          os.Getenv("HOSTNAME"),
 		zpoolLastSyncTime:             poolSyncTimeParseFloat64(f[2]),
 		zpoolStateUnknown:             zpool.ZpoolLastSyncCommandErrorOrUnknownUnset,
 		zpoolLastSyncTimeCommandError: zpool.ZpoolLastSyncCommandErrorOrUnknownUnset,

--- a/cmd/maya-exporter/app/collector/zvol/pool_synctime.go
+++ b/cmd/maya-exporter/app/collector/zvol/pool_synctime.go
@@ -30,8 +30,8 @@ import (
 type poolMetrics struct {
 	sync.Mutex
 	*poolSyncMetrics
-	request               bool
-	runner                types.Runner
+	request bool
+	runner  types.Runner
 	// setLastSyncTimeAsZero is a boolean which tells to set the last_sync_time as zero
 	// in case of an error for the first time.
 	setLastSyncTimeAsZero bool

--- a/cmd/maya-exporter/app/collector/zvol/pool_synctime.go
+++ b/cmd/maya-exporter/app/collector/zvol/pool_synctime.go
@@ -26,6 +26,10 @@ import (
 	"k8s.io/klog"
 )
 
+// setLastSyncTimeAsZero is a boolean which tells to set the last_sync_time as zero
+// in case of an error for the first time.
+var setLastSyncTimeAsZero = true
+
 // poolMetrics implements prometheus.Collector interface
 type poolMetrics struct {
 	sync.Mutex
@@ -141,7 +145,12 @@ func (p *poolMetrics) Collect(ch chan<- prometheus.Metric) {
 }
 
 func (p *poolMetrics) setPoolStats(poolSyncTime *poolfields) {
-	p.zpoolLastSyncTime.WithLabelValues(poolSyncTime.name).Set(poolSyncTime.zpoolLastSyncTime)
+	// Do not set the last_sync_time if there is any error, it will retain the previous metric value.
+	// setLastSyncTimeAsZero will set the first metric as zero if it is not set in case of an error.
+	if (poolSyncTime.zpoolStateUnknown != 1 && poolSyncTime.zpoolLastSyncTimeCommandError != 1) || setLastSyncTimeAsZero {
+		p.zpoolLastSyncTime.WithLabelValues(poolSyncTime.name).Set(poolSyncTime.zpoolLastSyncTime)
+		setLastSyncTimeAsZero = false
+	}
 	p.zpoolLastSyncTimeCommandError.WithLabelValues(poolSyncTime.name).Set(poolSyncTime.zpoolLastSyncTimeCommandError)
 	p.zpoolStateUnknown.WithLabelValues(poolSyncTime.name).Set(poolSyncTime.zpoolStateUnknown)
 

--- a/cmd/maya-exporter/app/collector/zvol/pool_synctime_test.go
+++ b/cmd/maya-exporter/app/collector/zvol/pool_synctime_test.go
@@ -112,8 +112,9 @@ func TestPoolSyncTimeMetricCollector(t *testing.T) {
 			regex := mockServer.BuildRegex(out)
 			vol := NewPoolSyncMetric(tt.runner)
 			stop := make(chan struct{})
+			hostname := os.Getenv("HOSTNAME")
 			os.Setenv("HOSTNAME", tt.hostname)
-			defer os.Unsetenv("HOSTNAME")
+			defer os.Setenv("HOSTNAME", hostname)
 			buf := mockServer.PrometheusService(vol, stop)
 			// expectedOutput the regex after parsing the expected output of zfs list command into prometheus's format.
 			for _, re := range regex {


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
This PR fixes the generation of duplicate metrics of openebs_zpool_last_sync_time metric.

**What this PR does?**:
This PR makes the labeled `pool` value as a pod name, which means the label will be the same in case of error and non-error. So that it does not lead to two different metrics. It also does not set the last_sync_time value in case of error so as to retain the previous metric value.

Signed-off-by: Sumit Lalwani <sumit.lalwani97@gmail.com>