### PR TITLE
fix(cstor-restore): fixing restore api to return failure if cstorrestore is in invalid state

### DIFF
--- a/changelogs/unreleased/1682-mynktl
+++ b/changelogs/unreleased/1682-mynktl
@@ -1,0 +1,1 @@
+fix(cstor-restore): fixing restore api to return failure if cstorrestore is in invalid state

--- a/cmd/cstor-pool-mgmt/controller/restore/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/restore/handler.go
@@ -44,6 +44,10 @@ func (c *RestoreController) syncHandler(key string, operation common.QueueOperat
 		return fmt.Errorf("can not retrieve CStorRestore %q", key)
 	}
 
+	if IsDoneStatus(rst) || IsFailedStatus(rst) {
+		return nil
+	}
+
 	status, err := c.rstEventHandler(operation, rst)
 	if status == "" {
 		return nil

--- a/cmd/maya-apiserver/app/server/restore_endpoint_v1alpha1.go
+++ b/cmd/maya-apiserver/app/server/restore_endpoint_v1alpha1.go
@@ -230,7 +230,7 @@ func getRestoreStatus(rst *v1alpha1.CStorRestore) (v1alpha1.CStorRestoreStatus, 
 		switch rstStatus {
 		case v1alpha1.RSTCStorStatusInProgress:
 			rstStatus = v1alpha1.RSTCStorStatusInProgress
-		case v1alpha1.RSTCStorStatusFailed:
+		case v1alpha1.RSTCStorStatusFailed, v1alpha1.RSTCStorStatusInvalid:
 			if nr.Status != rstStatus {
 				// Restore for given CVR may failed due to node failure or pool failure
 				// Let's update status for given CVR's restore to failed


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
This PR is required to fix the issue https://github.com/openebs/maya/issues/1677.

**What this PR does?**:
This PR updates the REST api for cstore restore to report failure if cstorrestore resource is in invalid state.
There is one additional change in restore controller in cstor-pool-mgmt to ignore the update if cstorrestore CR is having state `Done` or `Failed`

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- Restart the cstor-pool pod when restore is in-progress state
          - outcome is restore failed
- Restart the cstor-pool pod before it process the cstorrestore CR
          - outcome is restore failed
- Restart the cstor-pool pod once it update the cstorrestore CR to init state
          - outcome is restore failed
- Restart the cstor-pool pod once the restore completes
          - outcome is cstorrestore status remains same

**Checklist:**
- [ ] Fixes #https://github.com/openebs/maya/issues/1677
- [ ] Has the change log section been updated?  yes
- [ ] Commit has unit tests: no
- [ ] Commit has integration tests: no

Signed-off-by: mayank <mayank.patel@mayadata.io>