### PR TITLE
refactor(build): fix cstor base tag

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -75,7 +75,7 @@ ifeq (${TRAVIS_TAG}, )
   BASE_TAG = ci
   export BASE_TAG
 else
-  BASE_TAG = ${TRAVIS_TAG}
+  BASE_TAG = ${TRAVIS_TAG#v}
   export BASE_TAG
 endif
 


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:

The docker tags are created by removing the `v` from
prefix of TRAVIS_TAG (github tag). Using TRAVIS_TAG
to fetch cstor base image fails to build cstor related 
containers. 

**What this PR does?**:
While fetching the cstor base images, trim the leading `v` from the
TRAVIS_TAG

**Does this PR require any upgrade changes?**:
NA

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Need to test this in Travis with tags. 

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_

Ref: https://github.com/openebs/maya/pull/1684

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 

Signed-off-by: kmova <kiran.mova@mayadata.io>