### PR TITLE
fix(Makefile): update the expression to trim 'v' from tag

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -75,7 +75,7 @@ ifeq (${TRAVIS_TAG}, )
   BASE_TAG = ci
   export BASE_TAG
 else
-  BASE_TAG = ${TRAVIS_TAG#v}
+  BASE_TAG = $(TRAVIS_TAG:v%=%)
   export BASE_TAG
 endif
 


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

**Why is this PR required? What issue does it fix?**:
fixes Makefile trim logic to trim out the `v` from the cstor base tag image
Earlier logic only works in bash script but not in Makefiles

**What this PR does?**:
commit update the trim expression in Makefile which is failing
with the error unterminated variable reference due to error
in parsing expression

Similar logic works in bash script but not in Makefiles

**Does this PR require any upgrade changes?**:
NA

**If the changes in this PR are manually verified, list down the scenarios covered:**:
NA

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
