### PR TITLE
fix(Makefile): update the expression to trim 'v' from tag

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -75,7 +75,7 @@ ifeq (${TRAVIS_TAG}, )
   BASE_TAG = ci
   export BASE_TAG
 else
-  BASE_TAG = ${TRAVIS_TAG#v}
+  BASE_TAG = $(TRAVIS_TAG:v%=%)
   export BASE_TAG
 endif
 


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>


**Why is this PR required? What issue does it fix?**:
fixes Makefile trim logic to trim out the `v` from the cstor base tag image
Earlier logic only works in bash script but not in Makefiles

**What this PR does?**:
commit update the trim expression in Makefile which is failing
with the error unterminated variable reference due to error
in parsing expression

Similar logic works in bash script but not in Makefiles

**Does this PR require any upgrade changes?**:
NA

**If the changes in this PR are manually verified, list down the scenarios covered:**:
NA

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 


**PLEASE REMOVE BELOW INFORMATION BEFORE SUBMITTING**

The PR title message must follow convention:
   `<type>(<scope>): <subject>`.

Where: <br />
- `type` is defining if release will be triggering after merging submitted changes, details in [CONTRIBUTING.md](../CONTRIBUTING.md).
    Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit. 
  Most common scopes are like:
    - data engine (`localpv`, `jiva`, `cstor`)
    - feature (`provisioning`, `backup`, `restore`, `exporter`)
    - code component (`api`, `webhook`, `cast`, `upgrade`)
    - test (`tests`, `bdd`)
    - chores (`version`, `build`, `log`, `travis`)

- `subject` is a single line brief description of the changes made in the pull request.