### PR TITLE
chore(gitignore): add .idea to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ nohup.out
 .DS_Store
 .testfiles/
 openebs-operator-autogen.yaml
+.idea/*


### PR DESCRIPTION
Signed-off-by: Saurav Tiwary <srv.twry@gmail.com>

**Why is this PR required? What issue does it fix?**:
When using Goland, the IDE creates a `.idea` directory which shouldn't be tracked in the version control. 

**What this PR does?**:
Adds it in the `.gitignore`.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Not necessary

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 