### PR TITLE
fix(webhook): cleanup old resources from 1.0.0 release

### DIFF
--- a/pkg/webhook/configuration.go
+++ b/pkg/webhook/configuration.go
@@ -491,7 +491,7 @@ func getOldService(openebsNamespace string) (*corev1.ServiceList, error) {
 	// fetch service 1.1.0 onwards based on label
 	svcList, err := svc.NewKubeClient(svc.WithNamespace(openebsNamespace)).List(metav1.ListOptions{LabelSelector: webhooksvcLabel})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list old service: %s", err.Error())
+		return nil, err
 	}
 	// for 1.0.0 fetch service based on old name
 	oldSVC, err := svc.NewKubeClient(svc.WithNamespace(openebsNamespace)).Get(v100SVCName, metav1.GetOptions{})
@@ -512,7 +512,7 @@ func getOldSecret(openebsNamespace string) (*corev1.SecretList, error) {
 	secretList, err := secret.NewKubeClient(secret.WithNamespace(openebsNamespace)).
 		List(metav1.ListOptions{LabelSelector: webhookLabel})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list old secret: %s", err.Error())
+		return nil, err
 	}
 	// for 1.0.0 fetch secret based on old name
 	oldSecret, err := secret.NewKubeClient(secret.WithNamespace(openebsNamespace)).
@@ -533,7 +533,7 @@ func getOldConfig() (*v1beta1.ValidatingWebhookConfigurationList, error) {
 	// fetch config 1.1.0 onwards based on label
 	webhookConfigList, err := validate.KubeClient().List(metav1.ListOptions{LabelSelector: webhookLabel})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list older webhook config: %s", err.Error())
+		return nil, err
 	}
 
 	// for 1.0.0 fetch config based on name

--- a/pkg/webhook/configuration.go
+++ b/pkg/webhook/configuration.go
@@ -486,10 +486,79 @@ func addCVCWithUpdateRule(config *v1beta1.ValidatingWebhookConfiguration) {
 	}
 }
 
+func getOldService(openebsNamespace string) (*corev1.ServiceList, error) {
+	v100SVCName := "admission-server-svc"
+	// fetch service 1.1.0 onwards based on label
+	svcList, err := svc.NewKubeClient(svc.WithNamespace(openebsNamespace)).List(metav1.ListOptions{LabelSelector: webhooksvcLabel})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list old service: %s", err.Error())
+	}
+	// for 1.0.0 fetch service based on old name
+	oldSVC, err := svc.NewKubeClient(svc.WithNamespace(openebsNamespace)).Get(v100SVCName, metav1.GetOptions{})
+	if err != nil && !k8serror.IsNotFound(err) {
+		return nil, err
+	}
+
+	if err == nil {
+		svcList.Items = append(svcList.Items, *oldSVC)
+	}
+
+	return svcList, nil
+}
+
+func getOldSecret(openebsNamespace string) (*corev1.SecretList, error) {
+	v100SecretName := "admission-server-certs"
+	// fetch secret 1.1.0 onwards based on label
+	secretList, err := secret.NewKubeClient(secret.WithNamespace(openebsNamespace)).
+		List(metav1.ListOptions{LabelSelector: webhookLabel})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list old secret: %s", err.Error())
+	}
+	// for 1.0.0 fetch secret based on old name
+	oldSecret, err := secret.NewKubeClient(secret.WithNamespace(openebsNamespace)).
+		Get(v100SecretName, metav1.GetOptions{})
+	if err != nil && !k8serror.IsNotFound(err) {
+		return nil, err
+	}
+	if err == nil {
+		secretList.Items = append(secretList.Items, *oldSecret)
+	}
+	return secretList, nil
+
+}
+
+func getOldConfig() (*v1beta1.ValidatingWebhookConfigurationList, error) {
+	v100HelmConfig := "openebs-validation-webhook-cfg"
+	v100OperatorConfig := "validation-webhook-cfg"
+	// fetch config 1.1.0 onwards based on label
+	webhookConfigList, err := validate.KubeClient().List(metav1.ListOptions{LabelSelector: webhookLabel})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list older webhook config: %s", err.Error())
+	}
+
+	// for 1.0.0 fetch config based on name
+	oldHelmConfig, err := validate.KubeClient().Get(v100HelmConfig, metav1.GetOptions{})
+	if err != nil && !k8serror.IsNotFound(err) {
+		return nil, err
+	}
+	if err == nil {
+		webhookConfigList.Items = append(webhookConfigList.Items, *oldHelmConfig)
+	}
+	oldOperatorConfig, err := validate.KubeClient().Get(v100OperatorConfig, metav1.GetOptions{})
+	if err != nil && !k8serror.IsNotFound(err) {
+		return nil, err
+	}
+	if err == nil {
+		webhookConfigList.Items = append(webhookConfigList.Items, *oldOperatorConfig)
+	}
+
+	return webhookConfigList, nil
+}
+
 // preUpgrade checks for the required older webhook configs,older
 // then 1.4.0 if exists delete them.
 func preUpgrade(openebsNamespace string) error {
-	secretlist, err := secret.NewKubeClient(secret.WithNamespace(openebsNamespace)).List(metav1.ListOptions{LabelSelector: webhookLabel})
+	secretlist, err := getOldSecret(openebsNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to list old secret: %s", err.Error())
 	}
@@ -515,7 +584,7 @@ func preUpgrade(openebsNamespace string) error {
 		}
 	}
 
-	svcList, err := svc.NewKubeClient(svc.WithNamespace(openebsNamespace)).List(metav1.ListOptions{LabelSelector: webhooksvcLabel})
+	svcList, err := getOldService(openebsNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to list old service: %s", err.Error())
 	}
@@ -540,7 +609,7 @@ func preUpgrade(openebsNamespace string) error {
 			}
 		}
 	}
-	webhookConfigList, err := validate.KubeClient().List(metav1.ListOptions{LabelSelector: webhookLabel})
+	webhookConfigList, err := getOldConfig()
 	if err != nil {
 		return fmt.Errorf("failed to list older webhook config: %s", err.Error())
 	}


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

**Why is this PR required? What issue does it fix?**:

This PR handles the successful cleanup of old service, secret and webhookconfig for admission webhook in case of operator and helm due to non-uniform labels across different installations in v1.0.0 once they upgrade v1.10.0 version.

Above issue has been seen, when we install openebs v1.0.0 version using openebs-operator yaml 
and  upgrading the v1.0.0 version to the any greater version ( v1.1.0 onwards) using openebs-operator yaml (not with helm as helm maintain there set of labels in each resources, which take cares of upgrading/patching the resources).

Since we have changed the Webhook `FailurePolicy: Fail` , this causes failure for any configuration mistakes in webhook in older version v1.0.0.

Other version since v1.1.0 onwards doesn't have similar upgrade issue due to matching similar labels in subsequent versions and upgrade is taken care by the webhook itself internally as a preupgrade step.


**Does this PR require any upgrade changes?**:
 No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- Tested Upgrade using Helm (although helm doesn't have stale resource issue)
   - from 1.0.0-->1.5.0-->1.10.0 ( via using helm upgrade)
   - Provisioned cstor and jiva volumes
- Tested Upgrade using Operator yaml ( via just applying openebs-operator.yaml)
  - from 1.0.0-->1.5.0-->1.10.0
  - Provisioned cstor and jiva volumes
