### PR TITLE
refact(exporter): handle concurrent scrape requests

### DIFF
--- a/changelogs/unreleased/1698-utkarshmani1997
+++ b/changelogs/unreleased/1698-utkarshmani1997
@@ -1,1 +1,1 @@
-refact(exporter): handle concurrent GET http requests
+refact(exporter): handle concurrent scrape requests

--- a/changelogs/unreleased/1698-utkarshmani1997
+++ b/changelogs/unreleased/1698-utkarshmani1997
@@ -1,0 +1,1 @@
+refact(exporter): handle concurrent GET http requests

--- a/cmd/maya-exporter/app/collector/collector.go
+++ b/cmd/maya-exporter/app/collector/collector.go
@@ -151,7 +151,6 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 	klog.V(2).Info("Get metrics")
 	metrics := &c.metrics
 	if volumeStats, err = c.get(); err != nil {
-		c.setRequestToFalse()
 		klog.Errorln(err)
 		c.setError(err)
 	}

--- a/cmd/maya-exporter/app/collector/cstor.go
+++ b/cmd/maya-exporter/app/collector/cstor.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"net"
 	"strings"
-	"sync"
 	"time"
 
 	v1 "github.com/openebs/maya/pkg/stats/v1alpha1"
@@ -55,7 +54,6 @@ var (
 // cstor implements the Exporter interface. It exposes
 // the metrics of a OpenEBS (cstor) volume.
 type cstor struct {
-	sync.Mutex
 	// conn is used as unix network connection
 	conn       net.Conn
 	socketPath string
@@ -188,12 +186,6 @@ func (c *cstor) splitter(resp string) string {
 // if the connection is available else retry to initiate
 // connection again.
 func (c *cstor) get() (v1.VolumeStats, error) {
-	// locking ensures only one request is being processed
-	// at a time and hence ensure that there is no fd leak.
-	// because if we create a new connection for each request
-	// there will be fd leak.
-	c.Lock()
-	defer c.Unlock()
 	var (
 		err   error
 		stats v1.VolumeStats

--- a/cmd/maya-exporter/app/collector/cstor_test.go
+++ b/cmd/maya-exporter/app/collector/cstor_test.go
@@ -183,7 +183,6 @@ func TestCstorCollector(t *testing.T) {
 			defer resp.Body.Close()
 
 			buf, err := ioutil.ReadAll(resp.Body)
-			fmt.Println(string(buf))
 			if err != nil {
 				t.Fatalf("failed reading server response: %s", err)
 			}

--- a/cmd/maya-exporter/app/collector/cstor_test.go
+++ b/cmd/maya-exporter/app/collector/cstor_test.go
@@ -113,6 +113,7 @@ func TestCstorCollector(t *testing.T) {
 				regexp.MustCompile(`openebs_write_block_count 15`),
 				regexp.MustCompile(`openebs_read_time 13`),
 				regexp.MustCompile(`openebs_write_time 132`),
+				regexp.MustCompile(`openebs_target_reject_request_counter 0`),
 			},
 			// unmatch is used for negative test, but this use case is for
 			// positive test, so passing default value.
@@ -131,6 +132,7 @@ func TestCstorCollector(t *testing.T) {
 				regexp.MustCompile(`openebs_write_block_count 0`),
 				regexp.MustCompile(`openebs_read_time 0`),
 				regexp.MustCompile(`openebs_write_time 0`),
+				regexp.MustCompile(`openebs_target_reject_request_counter 0`),
 			},
 			// unmatch is used for negative test, but this use case is for
 			// positive test, so passing default value.
@@ -151,6 +153,7 @@ func TestCstorCollector(t *testing.T) {
 				regexp.MustCompile(`openebs_write_block_count `),
 				regexp.MustCompile(`openebs_read_time `),
 				regexp.MustCompile(`openebs_write_time `),
+				regexp.MustCompile(`openebs_target_reject_request_counter `),
 			},
 		},
 	}
@@ -180,6 +183,7 @@ func TestCstorCollector(t *testing.T) {
 			defer resp.Body.Close()
 
 			buf, err := ioutil.ReadAll(resp.Body)
+			fmt.Println(string(buf))
 			if err != nil {
 				t.Fatalf("failed reading server response: %s", err)
 			}

--- a/cmd/maya-exporter/app/collector/metrics.go
+++ b/cmd/maya-exporter/app/collector/metrics.go
@@ -47,27 +47,28 @@ import (
 
 // metrics keeps all the volume related stats values into the respective fields.
 type metrics struct {
-	actualUsed             prometheus.Gauge
-	logicalSize            prometheus.Gauge
-	sectorSize             prometheus.Gauge
-	reads                  prometheus.Gauge
-	totalReadTime          prometheus.Gauge
-	totalReadBlockCount    prometheus.Gauge
-	totalReadBytes         prometheus.Gauge
-	writes                 prometheus.Gauge
-	totalWriteTime         prometheus.Gauge
-	totalWriteBlockCount   prometheus.Gauge
-	totalWriteBytes        prometheus.Gauge
-	sizeOfVolume           prometheus.Gauge
-	volumeStatus           prometheus.Gauge
-	parseErrorCounter      prometheus.Gauge
-	connectionRetryCounter prometheus.Gauge
-	connectionErrorCounter prometheus.Gauge
-	healthyReplicaCounter  prometheus.Gauge
-	degradedReplicaCounter prometheus.Gauge
-	totalReplicaCounter    prometheus.Gauge
-	isClientConnected      prometheus.Gauge
-	volumeUpTime           *prometheus.GaugeVec
+	actualUsed                 prometheus.Gauge
+	logicalSize                prometheus.Gauge
+	sectorSize                 prometheus.Gauge
+	reads                      prometheus.Gauge
+	totalReadTime              prometheus.Gauge
+	totalReadBlockCount        prometheus.Gauge
+	totalReadBytes             prometheus.Gauge
+	writes                     prometheus.Gauge
+	totalWriteTime             prometheus.Gauge
+	totalWriteBlockCount       prometheus.Gauge
+	totalWriteBytes            prometheus.Gauge
+	sizeOfVolume               prometheus.Gauge
+	volumeStatus               prometheus.Gauge
+	parseErrorCounter          prometheus.Gauge
+	connectionRetryCounter     prometheus.Gauge
+	connectionErrorCounter     prometheus.Gauge
+	healthyReplicaCounter      prometheus.Gauge
+	degradedReplicaCounter     prometheus.Gauge
+	totalReplicaCounter        prometheus.Gauge
+	isClientConnected          prometheus.Gauge
+	volumeUpTime               *prometheus.GaugeVec
+	targetRejectRequestCounter prometheus.Counter
 }
 
 // stats keep the values of read/write I/O's and
@@ -258,6 +259,14 @@ func Metrics(cas string) metrics {
 				Namespace: "openebs",
 				Name:      "iscsi_initiator_login_status",
 				Help:      "iSCSI Initiator to jiva target login status: (0, 1): {Not Logged In, Logged In}",
+			},
+		),
+
+		targetRejectRequestCounter: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace: "openebs",
+				Name:      "target_reject_request_counter",
+				Help:      "Total no of rejected GET http requests if a request is already in progress",
 			},
 		),
 	}

--- a/cmd/maya-exporter/app/collector/metrics.go
+++ b/cmd/maya-exporter/app/collector/metrics.go
@@ -266,7 +266,7 @@ func Metrics(cas string) metrics {
 			prometheus.CounterOpts{
 				Namespace: "openebs",
 				Name:      "target_reject_request_counter",
-				Help:      "Total no of rejected GET http requests if a request is already in progress",
+				Help:      "Total no of rejected scrape requests if a previous request is in progress",
 			},
 		),
 	}


### PR DESCRIPTION
Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>



**Why is this PR required? What issue does it fix?**:
This commit fixes an issue where it handles the concurrent http
requests and rejects it if a request is already in progress.

**What this PR does?**:
It adds a new metrics "openebs_target_reject_request_counter" to increase the count
of rejected requests, which can be helpful in debugging and improves mutex locking.

**Does this PR require any upgrade changes?**:
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:
- Introduce delay in fake server written in cstor_test.go and send multiple concurrent get requests to
  the exporter, it will only process 1 request at a time and rest other requests will be rejected and new metrics openebs_target_reject_request_counter will be incremented.

**Any additional information for your reviewer?** : 
No

**Checklist:**
- [x] Fixes https://mdap.zendesk.com/agent/tickets/1073
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [x] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
