### PR TITLE
feat(build): Automating localpv provisioner build for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ jobs:
       arch: arm64
       env:
         - RELEASE_TAG_DOWNSTREAM=0
+    - os: linux
+      arch: ppc64le
+      env:
+        - RELEASE_TAG_DOWNSTREAM=0
 
 services:
   - docker
@@ -62,7 +66,7 @@ before_script:
       JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done;
     fi
   # install zip package for arm64
-  - if [ "$TRAVIS_CPU_ARCH" == "arm64" ]; then
+  - if [[ "$TRAVIS_CPU_ARCH" == "arm64" || "$TRAVIS_CPU_ARCH" == "ppc64le" ]]; then
       sudo apt-get install --yes zip;
     fi
 script:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -163,6 +163,9 @@ all.arm64: apiserver-image.arm64 exporter-image.arm64 pool-mgmt-image.arm64 volu
            admission-server-image.arm64 cspc-operator-image.arm64 upgrade-image.arm64 \
            cvc-operator-image.arm64 cspi-mgmt-image.arm64 provisioner-localpv-image.arm64
 
+.PHONY: all.ppc64le
+all.ppc64le: provisioner-localpv-image.ppc64le
+
 .PHONY: initialize
 initialize: bootstrap
 

--- a/buildscripts/deploy.sh
+++ b/buildscripts/deploy.sh
@@ -40,16 +40,22 @@ elif [ "${ARCH}" = "aarch64" ]; then
   UPGRADE_IMG="${IMAGE_ORG}/m-upgrade-arm64"
   PROVISIONER_LOCALPV="${IMAGE_ORG}/provisioner-localpv-arm64"
   CVC_OPERATOR_IMG="${IMAGE_ORG}/cvc-operator-arm64"
+elif [ "${ARCH}" = "ppc64le" ]; then
+  PROVISIONER_LOCALPV="${IMAGE_ORG}/provisioner-localpv-ppc64le"
 fi
 
 # tag and push all the images
-DIMAGE="${APISERVER_IMG}" ./buildscripts/push
-DIMAGE="${M_EXPORTER_IMG}" ./buildscripts/push
-DIMAGE="${CSTOR_POOL_MGMT_IMG}" ./buildscripts/push
-DIMAGE="${CSPI_MGMT_IMG}" ./buildscripts/push
-DIMAGE="${CSTOR_VOLUME_MGMT_IMG}" ./buildscripts/push
-DIMAGE="${ADMISSION_SERVER_IMG}" ./buildscripts/push
-DIMAGE="${CSPC_OPERATOR_IMG}" ./buildscripts/push
-DIMAGE="${UPGRADE_IMG}" ./buildscripts/push
-DIMAGE="${PROVISIONER_LOCALPV}" ./buildscripts/push
-DIMAGE="${CVC_OPERATOR_IMG}" ./buildscripts/push
+if [ "${ARCH}" = "ppc64le" ]; then
+  DIMAGE="${PROVISIONER_LOCALPV}" ./buildscripts/push
+else
+  DIMAGE="${APISERVER_IMG}" ./buildscripts/push
+  DIMAGE="${M_EXPORTER_IMG}" ./buildscripts/push
+  DIMAGE="${CSTOR_POOL_MGMT_IMG}" ./buildscripts/push
+  DIMAGE="${CSPI_MGMT_IMG}" ./buildscripts/push
+  DIMAGE="${CSTOR_VOLUME_MGMT_IMG}" ./buildscripts/push
+  DIMAGE="${ADMISSION_SERVER_IMG}" ./buildscripts/push
+  DIMAGE="${CSPC_OPERATOR_IMG}" ./buildscripts/push
+  DIMAGE="${UPGRADE_IMG}" ./buildscripts/push
+  DIMAGE="${PROVISIONER_LOCALPV}" ./buildscripts/push
+  DIMAGE="${CVC_OPERATOR_IMG}" ./buildscripts/push
+fi

--- a/buildscripts/travis-build.sh
+++ b/buildscripts/travis-build.sh
@@ -70,6 +70,10 @@ if [ "$TRAVIS_CPU_ARCH" == "amd64" ]; then
 elif [ "$TRAVIS_CPU_ARCH" == "arm64" ]; then
   make all.arm64
   rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+
+elif [ "$TRAVIS_CPU_ARCH" == "ppc64le" ]; then
+  make all.ppc64le
+  rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 fi
 
 if [ $SRC_REPO != $DST_REPO ];


### PR DESCRIPTION

**Why is this PR required? What issue does it fix?**:

This PR adds automation for building ppc64le image for localpv provisioner. This is a follow up to: https://github.com/openebs/maya/pull/1632

**What this PR does?**:
Adds ppc64le build in travis file for localpv provisioner.

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
