### PR TITLE
refactor(build): fix hard coding of image org (#1703)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,19 +128,6 @@ notifications:
     - kiran.mova@mayadata.io
     - shubham.bajpai@mayadata.io
 
-deploy:
-  provider: releases
-  api_key:
-    secure: na/NPsgDHGGRaWxRSCo5gH3TPrEutNvhEK3q2k99bbW2INe0FZ+FIPeuL9rqV8eCQi8SWJGHNFjFyMRR798RRSn8bdiK0pxJXzYvphUEH2Azzoqr65TaJHpHNTkv1WTK9OtgahT71MbmIx777U6Vd6ylyJyWja+LPhY/z66XOYQmuXR2ds7FRBlAcWg8C0KIFTLYlms5C9RKwLS2jP5C8tlJBQXMDEk7ejR1mKn3R6KQyyHICGKPGhNE+d7iMs0qhhuGIhcDwXl1olChAAITOGyWEmjc2GeUbFALo8OXdQx9qBO7saw75IzyYV/itBjE0RpuM90jKuFzKGiotSyw7Fs0KgrjHC7keuaNMqBWgKl6qoAj2a5VVEBtx8k941hRLs/VpjQ+K8wJJpjlSR8vh906b8e+HL8BKJEifF09fKBTLd0AWy9I3x6TolmRqiamvIHEkup1fZqblhhe2ZLvwuuyfl3t1FTkkon5BASgSqFdBAhR3eAD/LOtrghjaRX7wCZCzKDEaS9QLeu9UbC+bmnaOo60Gaeyp/DN5FLc4cV/vZozroesu+UEtQIrC6VDlFNYfY0V1ETKpfEQ4I8yByDHx/KjMWDyUGd8e5tm0qsD1lW1yVekh5CjQRHpzShkmKvFieeVfqVy/aGB4GrTeWSxcKiN8W0ekcgCRYut6y0=
-  file_glob: true
-  file:
-    - bin/maya/maya-linux_*.zip
-    - bin/apiserver/maya-apiserver-linux_*.zip
-  skip_cleanup: true
-  overwrite: true
-  on:
-    repo: openebs/maya
-    tags: true
 branches:
   except:
     - /^*-v[0-9]/

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -79,27 +79,6 @@ else
   export BASE_TAG
 endif
 
-# Specify the name of cstor-base image
-CSTOR_BASE_IMAGE= openebs/cstor-base:${BASE_TAG}
-export CSTOR_BASE_IMAGE
-
-ifeq (${CSTOR_BASE_IMAGE_ARM64}, )
-  CSTOR_BASE_IMAGE_ARM64= openebs/cstor-base-arm64:${BASE_TAG}
-  export CSTOR_BASE_IMAGE_ARM64
-endif
-
-# Specify the name of base image for ARM64
-ifeq (${BASE_DOCKER_IMAGE_ARM64}, )
-  BASE_DOCKER_IMAGE_ARM64 = "arm64v8/ubuntu:18.04"
-  export BASE_DOCKER_IMAGE_ARM64
-endif
-
-# Specify the name of base image for PPC64LE
-ifeq (${BASE_DOCKER_IMAGE_PPC64LE}, )
-  BASE_DOCKER_IMAGE_PPC64LE = "ubuntu:18.04"
-  export BASE_DOCKER_IMAGE_PPC64LE
-endif
-
 # The images can be pushed to any docker/image registeries
 # like docker hub, quay. The registries are specified in 
 # the `build/push` script.
@@ -138,6 +117,27 @@ ifeq (${DBUILD_SITE_URL}, )
 endif
 
 export DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL} --build-arg ARCH=${ARCH}
+
+# Specify the name of cstor-base image
+CSTOR_BASE_IMAGE= ${IMAGE_ORG}/cstor-base:${BASE_TAG}
+export CSTOR_BASE_IMAGE
+
+ifeq (${CSTOR_BASE_IMAGE_ARM64}, )
+  CSTOR_BASE_IMAGE_ARM64= ${IMAGE_ORG}/cstor-base-arm64:${BASE_TAG}
+  export CSTOR_BASE_IMAGE_ARM64
+endif
+
+# Specify the name of base image for ARM64
+ifeq (${BASE_DOCKER_IMAGE_ARM64}, )
+  BASE_DOCKER_IMAGE_ARM64 = "arm64v8/ubuntu:18.04"
+  export BASE_DOCKER_IMAGE_ARM64
+endif
+
+# Specify the name of base image for PPC64LE
+ifeq (${BASE_DOCKER_IMAGE_PPC64LE}, )
+  BASE_DOCKER_IMAGE_PPC64LE = "ubuntu:18.04"
+  export BASE_DOCKER_IMAGE_PPC64LE
+endif
 
 
 include ./buildscripts/mayactl/Makefile.mk

--- a/buildscripts/travis-build.sh
+++ b/buildscripts/travis-build.sh
@@ -72,7 +72,7 @@ elif [ "$TRAVIS_CPU_ARCH" == "arm64" ]; then
   rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 fi
 
-if [ $SRC_REPO != $DST_REPO ];
+if [ $SRC_REPO != $DST_REPO ] && [ -f "coverage.txt" ];
 then
 	echo "Copying coverage.txt to $SRC_REPO"
 	cp coverage.txt $SRC_REPO/

--- a/ci/build-maya.sh
+++ b/ci/build-maya.sh
@@ -7,23 +7,27 @@ echo "*****************************Retagging images and setting up env**********
 # - during the release time, the image tags can be versioned like 0.7.0-RC..
 # - from a branch, the image tags can be the branch names like v0.7.x-ci
 
+IMAGE_ORG=${IMAGE_ORG:-openebs}
+
 set -e
 # If any of the images aren't present the script will exit returning
 # a non zero exit code, which will result in a build failure.
 if [ ${CI_TAG} != "ci" ]; then
-  sudo docker tag openebs/m-apiserver:ci openebs/m-apiserver:${CI_TAG}
-  sudo docker tag openebs/m-exporter:ci openebs/m-exporter:${CI_TAG}
-  sudo docker tag openebs/cstor-pool-mgmt:ci openebs/cstor-pool-mgmt:${CI_TAG}
-  sudo docker tag openebs/cstor-volume-mgmt:ci openebs/cstor-volume-mgmt:${CI_TAG}
-  sudo docker tag openebs/provisioner-localpv:ci openebs/provisioner-localpv:${CI_TAG}
+  sudo docker tag ${IMAGE_ORG}/m-apiserver:ci ${IMAGE_ORG}/m-apiserver:${CI_TAG}
+  sudo docker tag ${IMAGE_ORG}/m-exporter:ci ${IMAGE_ORG}/m-exporter:${CI_TAG}
+  sudo docker tag ${IMAGE_ORG}/cstor-pool-mgmt:ci ${IMAGE_ORG}/cstor-pool-mgmt:${CI_TAG}
+  sudo docker tag ${IMAGE_ORG}/cstor-volume-mgmt:ci ${IMAGE_ORG}/cstor-volume-mgmt:${CI_TAG}
+  sudo docker tag ${IMAGE_ORG}/provisioner-localpv:ci ${IMAGE_ORG}/provisioner-localpv:${CI_TAG}
 fi
 
 #Tag the images with quay.io, since the operator can either have quay or docker images
-sudo docker tag openebs/m-apiserver:ci quay.io/openebs/m-apiserver:${CI_TAG}
-sudo docker tag openebs/m-exporter:ci quay.io/openebs/m-exporter:${CI_TAG}
-sudo docker tag openebs/cstor-pool-mgmt:ci quay.io/openebs/cstor-pool-mgmt:${CI_TAG}
-sudo docker tag openebs/cstor-volume-mgmt:ci quay.io/openebs/cstor-volume-mgmt:${CI_TAG}
-sudo docker tag openebs/provisioner-localpv:ci quay.io/openebs/provisioner-localpv:${CI_TAG}
+#Note the quay tags are hard-coded to help with CI scripts that might use the quay.io/openebs prefix 
+# The quay images tagged here are not pushed.
+sudo docker tag ${IMAGE_ORG}/m-apiserver:ci quay.io/openebs/m-apiserver:${CI_TAG}
+sudo docker tag ${IMAGE_ORG}/m-exporter:ci quay.io/openebs/m-exporter:${CI_TAG}
+sudo docker tag ${IMAGE_ORG}/cstor-pool-mgmt:ci quay.io/openebs/cstor-pool-mgmt:${CI_TAG}
+sudo docker tag ${IMAGE_ORG}/cstor-volume-mgmt:ci quay.io/openebs/cstor-volume-mgmt:${CI_TAG}
+sudo docker tag ${IMAGE_ORG}/provisioner-localpv:ci quay.io/openebs/provisioner-localpv:${CI_TAG}
 
 ## install iscsi pkg
 echo "Installing iscsi packages"


### PR DESCRIPTION
There are a few places that had IMAGE_ORG
hardcoded to openebs, making the travis
builds on forked repos to fail.

Also included some minor fixes like:
- added check to copy coverage only if it exists
- removed the step to deploy binaries - which are not used

Signed-off-by: kmova <kiran.mova@mayadata.io>
(cherry picked from commit 0b208c2c0b010581bbc2f0d03f6ec0012dfd227d)

