### PR TITLE
feat(usage): include pvc name in volume events

### DIFF
--- a/changelogs/unreleased/1708-kmova
+++ b/changelogs/unreleased/1708-kmova
@@ -1,0 +1,1 @@
+feat(usage): include pvc name in the volume create events

--- a/pkg/install/v1alpha1/cstor_volume.go
+++ b/pkg/install/v1alpha1/cstor_volume.go
@@ -802,6 +802,7 @@ spec:
       labels:
         openebs.io/version: {{ .CAST.version }}
         openebs.io/cas-template-name: {{ .CAST.castName }}
+        openebs.io/persistent-volume-claim: {{ .Volume.pvc }}
     spec:
       capacity: {{ .Volume.capacity }}
       iqn: iqn.2016-09.com.openebs.cstor:{{ .Volume.owner }}

--- a/pkg/install/v1alpha1/jiva_volume.go
+++ b/pkg/install/v1alpha1/jiva_volume.go
@@ -1164,6 +1164,10 @@ spec:
       name: {{ .Volume.owner }}
       annotations:
         openebs.io/storageclass-version: {{ .TaskResult.creategetsc.storageClassVersion }}
+      labels:
+        openebs.io/version: {{ .CAST.version }}
+        openebs.io/cas-template-name: {{ .CAST.castName }}
+        openebs.io/persistent-volume-claim: {{ .Volume.pvc }}
     spec:
       capacity: {{ .Volume.capacity }}
       targetPortal: {{ .TaskResult.createputsvc.clusterIP }}:3260

--- a/pkg/usage/googleanalytics.go
+++ b/pkg/usage/googleanalytics.go
@@ -33,6 +33,7 @@ func (u *Usage) Send() {
 		}
 		gaClient.ClientID(u.clientID).
 			CampaignSource(u.campaignSource).
+			CampaignName(u.campaignName).
 			CampaignContent(u.clientID).
 			ApplicationID(u.appID).
 			ApplicationVersion(u.appVersion).

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -86,6 +86,9 @@ type Gclient struct {
 	// anonymous campaign source
 	campaignSource string
 
+	// anonymous campaign name
+	campaignName string
+
 	// https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#ds
 	// (usecase) node-detail
 	dataSource string
@@ -110,6 +113,12 @@ func (u *Usage) SetDataSource(dataSource string) *Usage {
 // SetTrackingID Sets the GA-code for the project
 func (u *Usage) SetTrackingID(track string) *Usage {
 	u.trackID = track
+	return u
+}
+
+// SetCampaignName : set the name of the PVC or will be empty.
+func (u *Usage) SetCampaignName(campaignName string) *Usage {
+	u.campaignName = campaignName
 	return u
 }
 


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:

From the usage analytics collected, it is hard
to know why a particular type of storage engine
is used over other.

**What this PR does?**:
As the PVC names typically correspond to the
application, this commit helps in adding PVC name
to the volume events.

The PVC name will be set as CampaignName property
in analytics.

**Does this PR require any upgrade changes?**:
Not applicable

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Verified by creating cstor, jiva and Local PV volumes. The PVC name was sent as part of the campaign. 

**Any additional information for your reviewer?** : 
The changes done in this PR needs to be made for ZFS Local PV and CSI volumes as well. 


**Checklist:**
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests

Signed-off-by: kmova <kiran.mova@mayadata.io>
