### PR TITLE
fix(spc): validate SPC deletion request

### DIFF
--- a/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
+++ b/cmd/cstor-pool-mgmt/controller/pool-controller/handler.go
@@ -260,7 +260,7 @@ func (c *CStorPoolController) cStorPoolCreate(cStorPoolGot *apis.CStorPool) (str
 	err = pool.CreatePool(cStorPoolGot, devIDList)
 	if err != nil {
 		klog.Errorf("Pool creation failure: %v", string(cStorPoolGot.GetUID()))
-		c.recorder.Event(cStorPoolGot, corev1.EventTypeWarning, string(common.FailureCreate), string(common.MessageResourceFailCreate))
+		c.recorder.Eventf(cStorPoolGot, corev1.EventTypeWarning, string(common.FailureCreate), "Pool creation failed %s", err.Error())
 		return string(apis.CStorPoolStatusCreateFailed), err
 	}
 	klog.Infof("Pool creation successful: %v", string(cStorPoolGot.GetUID()))

--- a/pkg/webhook/configuration.go
+++ b/pkg/webhook/configuration.go
@@ -77,6 +77,7 @@ var (
 	transformConfig = []transformConfigFunc{
 		addCSPCDeleteRule,
 		addCVCWithUpdateRule,
+		addSPCWithDeleteRule,
 	}
 	cvcRuleWithOperations = v1beta1.RuleWithOperations{
 		Operations: []v1beta1.OperationType{
@@ -86,6 +87,16 @@ var (
 			APIGroups:   []string{"*"},
 			APIVersions: []string{"*"},
 			Resources:   []string{"cstorvolumeclaims"},
+		},
+	}
+	spcRuleWithOperations = v1beta1.RuleWithOperations{
+		Operations: []v1beta1.OperationType{
+			v1beta1.Delete,
+		},
+		Rule: v1beta1.Rule{
+			APIGroups:   []string{"*"},
+			APIVersions: []string{"*"},
+			Resources:   []string{"storagepoolclaims"},
 		},
 	}
 )
@@ -199,6 +210,7 @@ func createValidatingWebhookConfig(
 				},
 			},
 			cvcRuleWithOperations,
+			spcRuleWithOperations,
 		},
 		ClientConfig: v1beta1.WebhookClientConfig{
 			Service: &v1beta1.ServiceReference{
@@ -483,6 +495,12 @@ func addCVCWithUpdateRule(config *v1beta1.ValidatingWebhookConfiguration) {
 		// same webhook.
 		// https://github.com/openebs/maya/blob/9417d96abdaf41a2dbfcdbfb113fb73c83e6cf42/pkg/webhook/configuration.go#L212
 		config.Webhooks[0].Rules = append(config.Webhooks[0].Rules, cvcRuleWithOperations)
+	}
+}
+
+func addSPCWithDeleteRule(config *v1beta1.ValidatingWebhookConfiguration) {
+	if util.IsCurrentLessThanNewVersion(config.Labels[string(apis.OpenEBSVersionKey)], "1.11.0") {
+		config.Webhooks[0].Rules = append(config.Webhooks[0].Rules, spcRuleWithOperations)
 	}
 }
 

--- a/pkg/webhook/spc.go
+++ b/pkg/webhook/spc.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2020 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"fmt"
+	"net/http"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	"github.com/pkg/errors"
+	"k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+)
+
+func (wh *webhook) validateSPCDeleteRequest(req *v1beta1.AdmissionRequest) *v1beta1.AdmissionResponse {
+	response := NewAdmissionResponse().
+		SetAllowed().
+		WithResultAsSuccess(http.StatusAccepted).AR
+
+	cspList, err := wh.clientset.OpenebsV1alpha1().CStorPools().List(
+		metav1.ListOptions{
+			LabelSelector: string(apis.StoragePoolClaimCPK) + "=" + req.Name,
+		})
+	if err != nil {
+		err = errors.Wrapf(err, "could not list csp for spc %s", req.Name)
+		klog.Error(err)
+		response = BuildForAPIObject(response).UnSetAllowed().WithResultAsFailure(err, http.StatusBadRequest).AR
+		return response
+	}
+	fmt.Printf("%+v", cspList.Items)
+	for _, cspObj := range cspList.Items {
+		// list cvrs in all namespaces
+		cvrList, err := wh.clientset.OpenebsV1alpha1().CStorVolumeReplicas("").List(metav1.ListOptions{
+			LabelSelector: string(apis.CStorPoolKey) + "=" + cspObj.Name,
+		})
+		if err != nil {
+			err = errors.Wrapf(err, "Could not list cvr for csp %s", cspObj.Name)
+			response = BuildForAPIObject(response).UnSetAllowed().WithResultAsFailure(err, http.StatusBadRequest).AR
+			return response
+		}
+		if len(cvrList.Items) != 0 {
+			err := errors.Errorf("invalid spc %s deletion: volumereplicas still exists on pool %s", req.Name, cspObj.Name)
+			response = BuildForAPIObject(response).UnSetAllowed().WithResultAsFailure(err, http.StatusUnprocessableEntity).AR
+			return response
+		}
+	}
+
+	return response
+}

--- a/pkg/webhook/spc_test.go
+++ b/pkg/webhook/spc_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2020 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"testing"
+
+	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	"k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func (f *fixture) createCVRsFromCVRList(cvrList *apis.CStorVolumeReplicaList) error {
+	for _, cvrObj := range cvrList.Items {
+		_, err := f.wh.clientset.OpenebsV1alpha1().CStorVolumeReplicas(cvrObj.Namespace).Create(&cvrObj)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *fixture) createCSPsFromCSPList(cspList *apis.CStorPoolList) error {
+	for _, cspObj := range cspList.Items {
+		_, err := f.wh.clientset.OpenebsV1alpha1().CStorPools().Create(&cspObj)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestValidateSPCDeleteRequest(t *testing.T) {
+	f := newFixture().withOpenebsObjects()
+	tests := map[string]struct {
+		spcObj      *apis.StoragePoolClaim
+		cspList     *apis.CStorPoolList
+		cvrList     *apis.CStorVolumeReplicaList
+		expectedRsp bool
+	}{
+		"When CVR exists for given SPC": {
+			spcObj: &apis.StoragePoolClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "spc1",
+				},
+			},
+			cspList: &apis.CStorPoolList{
+				Items: []apis.CStorPool{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "spc1-csp1",
+							Labels: map[string]string{
+								string(apis.StoragePoolClaimCPK): "spc1",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "spc1-csp2",
+							Labels: map[string]string{
+								string(apis.StoragePoolClaimCPK): "spc1",
+							},
+						},
+					},
+				},
+			},
+			cvrList: &apis.CStorVolumeReplicaList{
+				Items: []apis.CStorVolumeReplica{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "spc1-csp2-cvr1",
+							Namespace: "openebs",
+							Labels: map[string]string{
+								string(apis.CStorPoolKey): "spc1-csp2",
+							},
+						},
+					},
+				},
+			},
+			expectedRsp: false,
+		},
+		"When CSP alone exist for deleting SPC": {
+			spcObj: &apis.StoragePoolClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "spc2",
+				},
+			},
+			cspList: &apis.CStorPoolList{
+				Items: []apis.CStorPool{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "spc2-csp1",
+							Labels: map[string]string{
+								string(apis.StoragePoolClaimCPK): "spc2",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "spc2-csp2",
+							Labels: map[string]string{
+								string(apis.StoragePoolClaimCPK): "spc2",
+							},
+						},
+					},
+				},
+			},
+			expectedRsp: true,
+		},
+		"When CSP doesn't exist for deleting SPC": {
+			spcObj: &apis.StoragePoolClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "spc3",
+				},
+			},
+			expectedRsp: true,
+		},
+		"When other CSP and CVR exists in cluster": {
+			spcObj: &apis.StoragePoolClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "spc4",
+				},
+			},
+			cspList: &apis.CStorPoolList{
+				Items: []apis.CStorPool{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "unknown-spc4-csp1",
+							Labels: map[string]string{
+								string(apis.StoragePoolClaimCPK): "unknown-spc4",
+							},
+						},
+					},
+				},
+			},
+			cvrList: &apis.CStorVolumeReplicaList{
+				Items: []apis.CStorVolumeReplica{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "spc4-csp1-cvr1",
+							Namespace: "openebs",
+							Labels: map[string]string{
+								string(apis.CStorPoolKey): "unknown-spc4-csp1",
+							},
+						},
+					},
+				},
+			},
+			expectedRsp: true,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			ar := &v1beta1.AdmissionRequest{
+				Operation: v1beta1.Delete,
+				Name:      test.spcObj.Name,
+				Object: runtime.RawExtension{
+					Raw: serialize(test.spcObj),
+				},
+			}
+			// Create fake object in etcd
+			if test.cspList != nil {
+				err := f.createCSPsFromCSPList(test.cspList)
+				if err != nil {
+					t.Errorf("failed to create csp error: %s", err.Error())
+				}
+			}
+			if test.cvrList != nil {
+				err := f.createCVRsFromCVRList(test.cvrList)
+				if err != nil {
+					t.Errorf("failed to create cvr error: %s", err.Error())
+				}
+			}
+			resp := f.wh.validateSPCDeleteRequest(ar)
+			if resp.Allowed != test.expectedRsp {
+				t.Errorf(
+					"%s test case failed expected response: %t but got %t error: %s",
+					name,
+					test.expectedRsp,
+					resp.Allowed,
+					resp.Result.Message,
+				)
+			}
+		})
+	}
+}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -53,6 +53,7 @@ var (
 
 const (
 	snapshotMetadataPVName = "SnapshotMetadata-PVName"
+	skipValidation         = "openebs.io/skip-validations"
 )
 
 // Skip validation in special namespaces, i.e. in kube-system and kube-public

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -510,6 +510,8 @@ func (wh *webhook) validateSPC(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRe
 	if req.Operation == v1beta1.Delete {
 		return wh.validateSPCDeleteRequest(req)
 	}
+	klog.V(4).Info("Admission wehbook for SPC module not "+
+		"configured for operations other than DELETE requested operation %s", req.Operation)
 	return response
 }
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -406,6 +406,9 @@ func (wh *webhook) validate(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespo
 	case "PersistentVolumeClaim":
 		klog.V(2).Infof("Admission webhook request for type %s", req.Kind.Kind)
 		return wh.validatePVC(ar)
+	case "StoragePoolClaim":
+		klog.V(2).Infof("Admission webhook request for type %s", req.Kind.Kind)
+		return wh.validateSPC(ar)
 	case "CStorPoolCluster":
 		klog.V(2).Infof("Admission webhook request for type %s", req.Kind.Kind)
 		return wh.validateCSPC(ar)
@@ -497,6 +500,17 @@ func (wh *webhook) Serve(w http.ResponseWriter, r *http.Request) {
 		klog.Errorf("Can't write response: %v", err)
 		http.Error(w, fmt.Sprintf("could not write response: %v", err), http.StatusInternalServerError)
 	}
+}
+
+func (wh *webhook) validateSPC(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
+	req := ar.Request
+	response := &v1beta1.AdmissionResponse{}
+	response.Allowed = true
+	// validates only if requested operation is DELETE
+	if req.Operation == v1beta1.Delete {
+		return wh.validateSPCDeleteRequest(req)
+	}
+	return response
 }
 
 func (wh *webhook) validateCVC(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**:
This PR is required to avoid the SPC deletion when
CStorVolumeReplicas exist in the pool and also it
avoids overwriting the pool on the disk during creation
if other pool traces  exist on the disk.

**What this PR does?**:
This PR does the following changes
- Validates the SPC deletion request and rejects
the SPC deletion request if it has CVRs that exist
SPC pools(i.e CSP).
- It avoids the force creation of CStorPools i.e pool
creation will fail if there are any pool traces on the disk.
  

**Does this PR require any upgrade changes?**:
Yes, and upgrade related changes are already handled in PR.

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Yes, verified in the single node cluster.
- Deleting the pool when CVR exists and deletion request
got rejected by OpenEBS admission server.
```sh
sai@sai:~/gocode/src/github.com/openebs/cstor-operators$ kubectl delete spc cstor-sparse-pool
Error from server (BadRequest): admission webhook "admission-webhook.openebs.io" denied the request: invalid spc cstor-sparse-pool deletion: volumereplicas still exists on pool cstor-sparse-pool-u9pm
``` 
- Verified by creating a pool if pool already exists and describe of CSP will show the reason for pool creation failure.
```sh
Events:
  Type     Reason      Age                From       Message
  ----     ------      ----               ----       -------
  Normal   Synced      10s                CStorPool  Received Resource create event
  Normal   Synced      10s (x2 over 10s)  CStorPool  Received Resource modify event
  Warning  FailCreate  9s                 CStorPool  Pool creation failed zpool create command failed error: invalid vdev specification
use '-f' to override the following errors:
/var/openebs/sparse/6-ndm-sparse.img is part of potentially active pool 'cstor-9acb70ad-23c5-4201-afd1-d8ca08368c31'
: exit status 1
```
- Upgraded admission server  from 1.10.0 version to ci 
 and verified SPC rule on calidatingwebhookconfiguration.
 
**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [x] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
