### PR TITLE
skip validations checks and handle snapshot deletion once migrated to CSI

### DIFF
--- a/pkg/apis/openebs.io/v1alpha1/cas_keys.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_keys.go
@@ -102,6 +102,9 @@ const (
 
 	// PVCreatedByKey is key to fetch the details of pv creation in case of restore
 	PVCreatedByKey = "openebs.io/created-through"
+
+	// Name of the CSI driver
+	CSIDriverName = "cstor.csi.openebs.io"
 )
 
 // CASPlainKey represents a openebs key used either in resource annotation

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -195,7 +195,8 @@ func admissionRequired(ignoredList []string, metadata *metav1.ObjectMeta) bool {
 	switch strings.ToLower(annotations[skipValidation]) {
 	default:
 		required = true
-	case "n", "no", "false", "off":
+	case "y", "yes", "true":
+		klog.Infof("Skipping validations for %s/%s due to PVC has skip validation", metadata.Namespace, metadata.Name)
 		required = false
 	}
 	return required
@@ -245,18 +246,14 @@ func (wh *webhook) validatePVCDeleteRequest(req *v1beta1.AdmissionRequest) *v1be
 		return response
 	}
 
-	// skip pvc validation if skip-validations annotation has been set
-	if _, ok := pvc.GetAnnotations()[skipValidation]; ok {
-		klog.Infof("Skipping validations for %s/%s due to PVC has skip validation", pvc.Namespace, pvc.Name)
-		return response
-	}
-
 	// If PVC is not yet bound to PV then don't even perform any checks
 	if pvc.Spec.VolumeName == "" {
 		klog.Infof("Skipping validations for %s/%s due to PVC is not yet bound", pvc.Namespace, pvc.Name)
 		return response
 	}
 
+	// skip pvc validation if skip-validations annotation has been set to true
+	// "openebs.io/skip-validations: true"
 	if !validationRequired(ignoredNamespaces, &pvc.ObjectMeta) {
 		klog.V(4).Infof("Skipping validation for %s/%s due to policy check", pvc.Namespace, pvc.Name)
 		return response

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -282,6 +282,51 @@ func TestValidatePVCDeleteRequest(t *testing.T) {
 			isRequiresPVCCreation: true,
 			expectedResponse:      true,
 		},
+		"Skip PVC validations if skip-validaions annotations set even snapshotData exists": {
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "PVC7",
+					Namespace:   "test",
+					Annotations: map[string]string{skipValidation: "true"},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					VolumeName: "PV1",
+				},
+			},
+			snapshotData: &snapshotapi.VolumeSnapshotData{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "SnapData1",
+				},
+				Spec: snapshotapi.VolumeSnapshotDataSpec{
+					PersistentVolumeRef: &corev1.ObjectReference{
+						Name: "PV1",
+					},
+				},
+			},
+			isRequiresPVCCreation: true,
+			expectedResponse:      true,
+		},
+		"Skip pvc validaion if skipValidation annotations set even snapshot exists": {
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "PVC8",
+					Namespace:   "test",
+					Annotations: map[string]string{skipValidation: "true"},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					VolumeName: "PV1",
+				},
+			},
+			snapshot: &snapshotapi.VolumeSnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "Snap1",
+					Namespace: "test",
+					Labels:    map[string]string{snapshotMetadataPVName: "PV1"},
+				},
+			},
+			isRequiresPVCCreation: true,
+			expectedResponse:      true,
+		},
 	}
 	for name, test := range tests {
 		name, test := name, test

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -306,12 +306,12 @@ func TestValidatePVCDeleteRequest(t *testing.T) {
 			isRequiresPVCCreation: true,
 			expectedResponse:      true,
 		},
-		"Skip pvc validaion if skipValidation annotations set even snapshot exists": {
+		"validate pvc if skipValidation annotations set to false": {
 			pvc: &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "PVC8",
 					Namespace:   "test",
-					Annotations: map[string]string{skipValidation: "true"},
+					Annotations: map[string]string{skipValidation: ""},
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{
 					VolumeName: "PV1",
@@ -325,7 +325,29 @@ func TestValidatePVCDeleteRequest(t *testing.T) {
 				},
 			},
 			isRequiresPVCCreation: true,
-			expectedResponse:      true,
+			expectedResponse:      false,
+		},
+
+		"validate pvc if skipValidation annotations not properly set": {
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "PVC8",
+					Namespace:   "test",
+					Annotations: map[string]string{skipValidation: ""},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					VolumeName: "PV1",
+				},
+			},
+			snapshot: &snapshotapi.VolumeSnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "Snap1",
+					Namespace: "test",
+					Labels:    map[string]string{snapshotMetadataPVName: "PV1"},
+				},
+			},
+			isRequiresPVCCreation: true,
+			expectedResponse:      false,
 		},
 	}
 	for name, test := range tests {


### PR DESCRIPTION
## Pull Request template
**Why is this PR required? What issue does it fix?**:

PR required to handle PVC validation checks before starting the volume migration operations,
for example, ignore the PVC deletion if snapshots are exists.  

**What this PR does?**:
- Add skip validations checks in webhook validations via annotations:
There are some cases like volume migration where we need to delete
the old pvc and create new pvc based on CSI, in such cases we need
to ignore/skip the validations  related to snapshots .

- Ignore old snapshots delete request once migrated to CSI based volumes. Once we migrate the volumes to CSI, we have to migrate the snapshot as well, once snapshots are migrated, backend snapshot will be bind to new CSI snapshot type, and it requires clean up of the older snapshot related resources as they are no longer requried. This change will allow user to delete the snapshot of old types (not from the pools which is bind to the new csi snapshot types)

**Does this PR require any upgrade changes?**:

NO

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- Created PVC with skip annotation 
- Created snapshot and tried to delete the pvc which should allow to delete the PVC.


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [x] Commit has unit tests
- [x] Commit has integration tests
