### PR TITLE
chore(Makefile): remove cspc,cvc,cspi based controller image builds

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -147,21 +147,15 @@ include ./buildscripts/upgrade/Makefile.mk
 include ./buildscripts/exporter/Makefile.mk
 include ./buildscripts/cstor-pool-mgmt/Makefile.mk
 include ./buildscripts/cstor-volume-mgmt/Makefile.mk
-include ./buildscripts/cspi-mgmt/Makefile.mk
-include ./buildscripts/cvc-operator/Makefile.mk
 include ./buildscripts/admission-server/Makefile.mk
-include ./buildscripts/cspc-operator/Makefile.mk
-include ./buildscripts/cspc-operator-debug/Makefile.mk
 
 .PHONY: all
 all: compile-tests apiserver-image exporter-image pool-mgmt-image volume-mgmt-image \
-	   admission-server-image cspc-operator-image cspc-operator-debug-image \
-	   cvc-operator-image cspi-mgmt-image upgrade-image provisioner-localpv-image
+	   admission-server-image upgrade-image provisioner-localpv-image
 
 .PHONY: all.arm64
 all.arm64: apiserver-image.arm64 exporter-image.arm64 pool-mgmt-image.arm64 volume-mgmt-image.arm64 \
-           admission-server-image.arm64 cspc-operator-image.arm64 upgrade-image.arm64 \
-           cvc-operator-image.arm64 cspi-mgmt-image.arm64 provisioner-localpv-image.arm64
+           admission-server-image.arm64 upgrade-image.arm64 provisioner-localpv-image.arm64
 
 .PHONY: all.ppc64le
 all.ppc64le: provisioner-localpv-image.ppc64le

--- a/buildscripts/deploy.sh
+++ b/buildscripts/deploy.sh
@@ -22,24 +22,18 @@ if [ "${ARCH}" = "x86_64" ]; then
   APISERVER_IMG="${IMAGE_ORG}/m-apiserver"
   M_EXPORTER_IMG="${IMAGE_ORG}/m-exporter"
   CSTOR_POOL_MGMT_IMG="${IMAGE_ORG}/cstor-pool-mgmt"
-  CSPI_MGMT_IMG="${IMAGE_ORG}/cspi-mgmt"
   CSTOR_VOLUME_MGMT_IMG="${IMAGE_ORG}/cstor-volume-mgmt"
   ADMISSION_SERVER_IMG="${IMAGE_ORG}/admission-server"
-  CSPC_OPERATOR_IMG="${IMAGE_ORG}/cspc-operator"
   UPGRADE_IMG="${IMAGE_ORG}/m-upgrade"
   PROVISIONER_LOCALPV="${IMAGE_ORG}/provisioner-localpv"
-  CVC_OPERATOR_IMG="${IMAGE_ORG}/cvc-operator"
 elif [ "${ARCH}" = "aarch64" ]; then
   APISERVER_IMG="${IMAGE_ORG}/m-apiserver-arm64"
   M_EXPORTER_IMG="${IMAGE_ORG}/m-exporter-arm64"
   CSTOR_POOL_MGMT_IMG="${IMAGE_ORG}/cstor-pool-mgmt-arm64"
-  CSPI_MGMT_IMG="${IMAGE_ORG}/cspi-mgmt-arm64"
   CSTOR_VOLUME_MGMT_IMG="${IMAGE_ORG}/cstor-volume-mgmt-arm64"
   ADMISSION_SERVER_IMG="${IMAGE_ORG}/admission-server-arm64"
-  CSPC_OPERATOR_IMG="${IMAGE_ORG}/cspc-operator-arm64"
   UPGRADE_IMG="${IMAGE_ORG}/m-upgrade-arm64"
   PROVISIONER_LOCALPV="${IMAGE_ORG}/provisioner-localpv-arm64"
-  CVC_OPERATOR_IMG="${IMAGE_ORG}/cvc-operator-arm64"
 elif [ "${ARCH}" = "ppc64le" ]; then
   PROVISIONER_LOCALPV="${IMAGE_ORG}/provisioner-localpv-ppc64le"
 fi
@@ -51,11 +45,8 @@ else
   DIMAGE="${APISERVER_IMG}" ./buildscripts/push
   DIMAGE="${M_EXPORTER_IMG}" ./buildscripts/push
   DIMAGE="${CSTOR_POOL_MGMT_IMG}" ./buildscripts/push
-  DIMAGE="${CSPI_MGMT_IMG}" ./buildscripts/push
   DIMAGE="${CSTOR_VOLUME_MGMT_IMG}" ./buildscripts/push
   DIMAGE="${ADMISSION_SERVER_IMG}" ./buildscripts/push
-  DIMAGE="${CSPC_OPERATOR_IMG}" ./buildscripts/push
   DIMAGE="${UPGRADE_IMG}" ./buildscripts/push
   DIMAGE="${PROVISIONER_LOCALPV}" ./buildscripts/push
-  DIMAGE="${CVC_OPERATOR_IMG}" ./buildscripts/push
 fi


### PR DESCRIPTION

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**:
Required to cleanup Makefile build and image targets no longer maintained 

**What this PR does?**:
Commit removes the cstor v1 apis based controller, cspc, cvc , cspi makefile image and builds
target which is no longer maintained in `maya` repo and migrated to `openebs/cstor-operators` repo
as part of future enhancements.


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests