### PR TITLE
fix(usage): add nil checks to avoid panic

### DIFF
--- a/changelogs/unreleased/1720-kmova
+++ b/changelogs/unreleased/1720-kmova
@@ -1,0 +1,1 @@
+fix(apiserver): panic when PVC is created with name containing greater than 63 characters

--- a/cmd/maya-apiserver/app/server/volume_endpoint_v1alpha1.go
+++ b/cmd/maya-apiserver/app/server/volume_endpoint_v1alpha1.go
@@ -85,7 +85,10 @@ func (s *HTTPServer) volumeV1alpha1SpecificRequest(resp http.ResponseWriter, req
 	switch req.Method {
 	case "POST":
 		cvol, err := volOp.create()
-		pvc := cvol.ObjectMeta.Labels["openebs.io/persistent-volume-claim"]
+		pvc := ""
+		if err != nil && cvol != nil && cvol.ObjectMeta.Labels != nil {
+			pvc = cvol.ObjectMeta.Labels["openebs.io/persistent-volume-claim"]
+		}
 		sendEventOrIgnore(cvol, pvc, usage.VolumeProvision)
 		return cvol, err
 	case "GET":

--- a/cmd/maya-apiserver/app/server/volume_endpoint_v1alpha1.go
+++ b/cmd/maya-apiserver/app/server/volume_endpoint_v1alpha1.go
@@ -55,12 +55,12 @@ type volumeAPIOpsV1alpha1 struct {
 }
 
 // sendEventOrIgnore sends anonymous volume (de)-provision events
-func sendEventOrIgnore(cvol *v1alpha1.CASVolume, pvc, method string) {
+func sendEventOrIgnore(cvol *v1alpha1.CASVolume, pvcName, method string) {
 	if menv.Truthy(menv.OpenEBSEnableAnalytics) && cvol != nil {
 		usage.New().Build().ApplicationBuilder().
 			SetVolumeType(cvol.Spec.CasType, method).
 			SetDocumentTitle(cvol.ObjectMeta.Name).
-			SetCampaignName(pvc).
+			SetCampaignName(pvcName).
 			SetLabel(usage.EventLabelCapacity).
 			SetReplicaCount(cvol.Spec.Replicas, method).
 			SetCategory(method).
@@ -85,11 +85,11 @@ func (s *HTTPServer) volumeV1alpha1SpecificRequest(resp http.ResponseWriter, req
 	switch req.Method {
 	case "POST":
 		cvol, err := volOp.create()
-		pvc := ""
+		pvcName := ""
 		if err != nil && cvol != nil && cvol.ObjectMeta.Labels != nil {
-			pvc = cvol.ObjectMeta.Labels["openebs.io/persistent-volume-claim"]
+			pvcName = cvol.ObjectMeta.Labels["openebs.io/persistent-volume-claim"]
 		}
-		sendEventOrIgnore(cvol, pvc, usage.VolumeProvision)
+		sendEventOrIgnore(cvol, pvcName, usage.VolumeProvision)
 		return cvol, err
 	case "GET":
 		return volOp.httpGet()

--- a/cmd/provisioner-localpv/app/provisioner.go
+++ b/cmd/provisioner-localpv/app/provisioner.go
@@ -161,7 +161,11 @@ func (p *Provisioner) Delete(pv *v1.PersistentVolume) (err error) {
 			size = pv.Spec.Capacity["storage"]
 		}
 
-		sendEventOrIgnore(pv.Spec.ClaimRef.Name, pv.Name, size.String(), pvType, analytics.VolumeDeprovision)
+		pvcName := ""
+		if pv.Spec.ClaimRef != nil {
+			pvcName = pv.Spec.ClaimRef.Name
+		}
+		sendEventOrIgnore(pvcName, pv.Name, size.String(), pvType, analytics.VolumeDeprovision)
 		if pvType == "local-device" {
 			err := p.DeleteBlockDevice(pv)
 			if err != nil {

--- a/tests/artifacts/jiva-pvc-invalid-name.yaml
+++ b/tests/artifacts/jiva-pvc-invalid-name.yaml
@@ -1,8 +1,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-        name: jiva-testvolume-pvc
-        namespace: openebs
+        name: jiva-pvc-more-than-63-chars-long-due-helm-sub-chart-insallation-or-some-crazy-logic
 spec:
   storageClassName: openebs-jiva-default
   accessModes:

--- a/tests/artifacts/local-d-pvc-invalid-name.yaml
+++ b/tests/artifacts/local-d-pvc-invalid-name.yaml
@@ -1,0 +1,34 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+        name: device-pvc-more-than-63-chars-long-due-helm-sub-chart-insallation-or-some-crazy-logic
+spec:
+  storageClassName: openebs-device
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "5G"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox-device
+  namespace: default
+spec:
+  containers:
+  - command:
+       - sh
+       - -c
+       - 'date > /mnt/store1/date.txt; hostname >> /mnt/store1/hostname.txt; sync; sleep 5; sync; tail -f /dev/null;'
+    image: busybox
+    imagePullPolicy: Always
+    name: busybox
+    volumeMounts:
+    - mountPath: /mnt/store1
+      name: demo-vol1
+  volumes:
+  - name: demo-vol1
+    persistentVolumeClaim:
+      claimName: device-pvc-more-than-63-chars-long-due-helm-sub-chart-insallation-or-some-crazy-logic
+---

--- a/tests/artifacts/local-pvc-long-name.yaml
+++ b/tests/artifacts/local-pvc-long-name.yaml
@@ -1,0 +1,34 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+        name: hostpath-pvc-more-than-63-chars-long-due-helm-sub-chart-insallation-or-some-crazy-logic
+spec:
+  storageClassName: openebs-hostpath
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "5G"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox-hp
+  namespace: default
+spec:
+  containers:
+  - command:
+       - sh
+       - -c
+       - 'date > /mnt/store1/date.txt; hostname >> /mnt/store1/hostname.txt; sync; sleep 5; sync; tail -f /dev/null;'
+    image: busybox
+    imagePullPolicy: Always
+    name: busybox
+    volumeMounts:
+    - mountPath: /mnt/store1
+      name: demo-vol1
+  volumes:
+  - name: demo-vol1
+    persistentVolumeClaim:
+      claimName: hostpath-pvc-more-than-63-chars-long-due-helm-sub-chart-insallation-or-some-crazy-logic
+---


### PR DESCRIPTION
Signed-off-by: kmova <kiran.mova@mayadata.io>

**Why is this PR required? What issue does it fix?**:
https://github.com/openebs/openebs/issues/3064

**What this PR does?**:
Adds nil checks to catch provisioning errors. 

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

- Verified by creating a PVC with name > 63 chars long. The output shows the following error when `kubectl describe pvc` is executed. 

   ```
   Warning  ProvisioningFailed    2s (x2 over 17s)   openebs.io/provisioner-iscsi_openebs-provisioner-684b6b8584-96kvx_261d65dd-b150-11ea-bd60-2e484c01cabe  failed to provision volume with StorageClass "openebs-jiva-default": Internal Server Error: failed to create volume
    ....
    .... snipped verbose output. 
    ....
    failed to create service: Service "pvc-f872ca1d-4bf4-453f-805f-e2fd3ed31003-ctrl-svc" is invalid: metadata.labels: Invalid value: "jiva-pvc-more-than-63-chars-long-due-helm-sub-chart-insallation-or-some-crazy-logic": must be no more than 63 characters
   ```
- Verified by creating a PVC with name < 63 chars long. Volume gets created successfully. 


**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [x] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [x] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 


