### PR TITLE
fix(build): travis CI failure in forked Repo git error

### DIFF
--- a/buildscripts/travis-build.sh
+++ b/buildscripts/travis-build.sh
@@ -30,7 +30,8 @@ then
 	echo $GIT_COMMIT >> $SRC_REPO/GITCOMMIT
 
 	mkdir -p $DST_REPO
-	cp -R $SRC_REPO/* $DST_REPO/
+	rsync -az ${TRAVIS_BUILD_DIR}/ ${DST_REPO}/
+	export TRAVIS_BUILD_DIR=$DST_REPO
 	cd $DST_REPO
 fi
 


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

## Pull Request template

**Why is this PR required? What issue does it fix?**:
Fix for Travis CI failure in forked maya repositories, which is failed due to `Not a git repository` error after copying from forked path to actual go import path.

**What this PR does?**:
Clone the forked repo using `rsync` and set the `TRAVIS_BUILD_DIR` 

**Does this PR require any upgrade changes?**:
NA


**Checklist:**
- [x] Fixes #https://github.com/openebs/openebs/issues/3066
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
