### PR TITLE
chore(upgrade): add support for upgrading to any custom tag within same version

### DIFF
--- a/pkg/apis/openebs.io/v1alpha1/versionDetails.go
+++ b/pkg/apis/openebs.io/v1alpha1/versionDetails.go
@@ -27,7 +27,7 @@ var (
 	validCurrentVersions = map[string]bool{
 		"1.0.0": true, "1.1.0": true, "1.2.0": true, "1.3.0": true,
 		"1.4.0": true, "1.5.0": true, "1.6.0": true, "1.7.0": true,
-		"1.8.0": true, "1.9.0": true, "1.10.0": true,
+		"1.8.0": true, "1.9.0": true, "1.10.0": true, "1.11.0": true,
 	}
 	validDesiredVersion = version.GetVersion()
 )


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

**Why is this PR required? What issue does it fix?**:
This PR enables the upgrade between different custom images of the same version. This will allow users to upgrade between RC builds and also the custom builds they have locally of the format `version-customTag` for example `1.11.0-mybuild`. This will be supported by 1.11.0 onwards.
Limitation: there will be no validations for the custom tag following the version.

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 