### PR TITLE
fix(usage): add nil checks to avoid panic (#1720)

### DIFF
--- a/changelogs/unreleased/1720-kmova
+++ b/changelogs/unreleased/1720-kmova
@@ -1,0 +1,1 @@
+fix(apiserver): panic when PVC is created with name containing greater than 63 characters

--- a/cmd/provisioner-localpv/app/provisioner.go
+++ b/cmd/provisioner-localpv/app/provisioner.go
@@ -161,7 +161,11 @@ func (p *Provisioner) Delete(pv *v1.PersistentVolume) (err error) {
 			size = pv.Spec.Capacity["storage"]
 		}
 
-		sendEventOrIgnore(pv.Spec.ClaimRef.Name, pv.Name, size.String(), pvType, analytics.VolumeDeprovision)
+		pvcName := ""
+		if pv.Spec.ClaimRef != nil {
+			pvcName = pv.Spec.ClaimRef.Name
+		}
+		sendEventOrIgnore(pvcName, pv.Name, size.String(), pvType, analytics.VolumeDeprovision)
 		if pvType == "local-device" {
 			err := p.DeleteBlockDevice(pv)
 			if err != nil {

--- a/tests/artifacts/jiva-pvc-invalid-name.yaml
+++ b/tests/artifacts/jiva-pvc-invalid-name.yaml
@@ -1,8 +1,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-        name: jiva-testvolume-pvc
-        namespace: openebs
+        name: jiva-pvc-more-than-63-chars-long-due-helm-sub-chart-insallation-or-some-crazy-logic
 spec:
   storageClassName: openebs-jiva-default
   accessModes:

--- a/tests/artifacts/local-d-pvc-invalid-name.yaml
+++ b/tests/artifacts/local-d-pvc-invalid-name.yaml
@@ -1,0 +1,34 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+        name: device-pvc-more-than-63-chars-long-due-helm-sub-chart-insallation-or-some-crazy-logic
+spec:
+  storageClassName: openebs-device
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "5G"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox-device
+  namespace: default
+spec:
+  containers:
+  - command:
+       - sh
+       - -c
+       - 'date > /mnt/store1/date.txt; hostname >> /mnt/store1/hostname.txt; sync; sleep 5; sync; tail -f /dev/null;'
+    image: busybox
+    imagePullPolicy: Always
+    name: busybox
+    volumeMounts:
+    - mountPath: /mnt/store1
+      name: demo-vol1
+  volumes:
+  - name: demo-vol1
+    persistentVolumeClaim:
+      claimName: device-pvc-more-than-63-chars-long-due-helm-sub-chart-insallation-or-some-crazy-logic
+---

--- a/tests/artifacts/local-pvc-long-name.yaml
+++ b/tests/artifacts/local-pvc-long-name.yaml
@@ -1,0 +1,34 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+        name: hostpath-pvc-more-than-63-chars-long-due-helm-sub-chart-insallation-or-some-crazy-logic
+spec:
+  storageClassName: openebs-hostpath
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "5G"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox-hp
+  namespace: default
+spec:
+  containers:
+  - command:
+       - sh
+       - -c
+       - 'date > /mnt/store1/date.txt; hostname >> /mnt/store1/hostname.txt; sync; sleep 5; sync; tail -f /dev/null;'
+    image: busybox
+    imagePullPolicy: Always
+    name: busybox
+    volumeMounts:
+    - mountPath: /mnt/store1
+      name: demo-vol1
+  volumes:
+  - name: demo-vol1
+    persistentVolumeClaim:
+      claimName: hostpath-pvc-more-than-63-chars-long-due-helm-sub-chart-insallation-or-some-crazy-logic
+---


### PR DESCRIPTION
(cherry picked from commit d70090d250308f58f9e6826715124f031ee7e9fc)

Once a PVC create request is processed by the CAST,
the response is inspected to fetch the PVC name
and other details to generate an analytics log.

This was done as part of the PR: https://github.com/openebs/maya/pull/1708

This commit adds a nil check to handle the case of an error response
to avoid a panic.

Signed-off-by: kmova <kiran.mova@mayadata.io>


