### PR TITLE
fix(version): fix castemplate output runstask version suffix

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -95,7 +95,7 @@ func WithSuffixLower(given string) (suffixed string) {
 // succeeds
 func WithSuffixIf(given string, p func(string) bool) (suffixed string) {
 	if p(given) {
-		return WithSuffix(given)
+		return WithSuffixLower(given)
 	}
 	return given
 }


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

**What this PR does?**:
PR fixes the issue with output runtask version suffix  ( RC1 --> rc1) . (Changes got missed to commit earlier due to some local rebase errors and got stashed locally)

more info #1733 

```sh

Response Code from ApiServer: 500
Retrying.... 31
Logs of api-server: 
  labels:
    castName: jiva-volume-list-default-1.12.0-ee-rc1
    kubeVersion: v1.13.0
    version: 1.12.0-ee-RC1
  name: jiva-volume-list-default-1.12.0-ee-rc1
  resourceVersion: "1633"
  selfLink: /apis/openebs.io/v1alpha1/castemplates/jiva-volume-list-default-1.12.0-ee-rc1
  uid: 47c9f62e-cab7-11ea-8dde-42010a1e017c
spec:
  defaultConfig: null
  fallback: ""
  output: jiva-volume-list-output-default-1.12.0-ee-RC1
  run:
    tasks:
    - jiva-volume-list-listtargetservice-default-1.12.0-ee-rc1
    - jiva-volume-list-listtargetpod-default-1.12.0-ee-rc1
    - jiva-volume-list-listreplicapod-default-1.12.0-ee-rc1
    - jiva-volume-list-listpv-default-1.12.0-ee-rc1
  taskNamespace: openebs
}: exhausted all strategies to get runtask: failed to get runtask 'jiva-volume-list-output-default-1.12.0-ee-RC1'
```

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

After building images with a custom tag 1.11.0-ee-rc2

```sh
output: cstor-volume-create-output-default-1.12.0-ee-rc1
  run:
    tasks:
    - cstor-volume-create-getstorageclass-default-1.12.0-ee-rc1
    - cstor-volume-create-getpvc-default-1.12.0-ee-rc1
    - cstor-volume-create-listclonecstorvolumereplicacr-default-1.12.0-ee-rc1
    - cstor-volume-create-listcstorpoolcr-default-1.12.0-ee-rc1
    - cstor-volume-create-puttargetservice-default-1.12.0-ee-rc1
    - cstor-volume-create-putcstorvolumecr-default-1.12.0-ee-rc1
    - cstor-volume-create-puttargetdeployment-default-1.12.0-ee-rc1
    - cstor-volume-create-putcstorvolumereplicacr-default-1.12.0-ee-rc1
  taskNamespace: openebs
```
**Steps Performed**
- Provisioned cstor SPC
- Provisioned cstor volume
- Provisioned jiva volume
- Snapshot Jiva volume
- Deleted jiva volume
- Deleted cstor volume
- Deleted cstor SPC
- Deleted runtasks and restarted api-server, all the runtasks came back with correct version.
- Tested upgrade from 1.10.0
- Runtasks with custom version



**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
