### PR TITLE
refact(localpv): add ENV to allow skipping leader election

### DIFF
--- a/cmd/provisioner-localpv/app/start.go
+++ b/cmd/provisioner-localpv/app/start.go
@@ -19,21 +19,26 @@ package app
 import (
 	"flag"
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/klog"
 
-	pvController "sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
-	//	pvController "github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	mKube "github.com/openebs/maya/pkg/kubernetes/client/v1alpha1"
 	"github.com/openebs/maya/pkg/util"
+	pvController "sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
 )
 
 var (
 	cmdName         = "provisioner"
 	provisionerName = "openebs.io/local"
-	usage           = fmt.Sprintf("%s", cmdName)
+	// LeaderElectionKey represents ENV for disable/enable leaderElection for
+	// localpv provisioner
+	LeaderElectionKey = "LEADER_ELECTION_ENABLED"
+	usage             = fmt.Sprintf("%s", cmdName)
 )
 
 // StartProvisioner will start a new dynamic Host Path PV provisioner
@@ -105,6 +110,7 @@ func Start(cmd *cobra.Command) error {
 		provisionerName,
 		provisioner,
 		serverVersion.GitVersion,
+		pvController.LeaderElection(isLeaderElectionEnabled()),
 	)
 	klog.V(4).Info("Provisioner started")
 	//Run the provisioner till a shutdown signal is received.
@@ -112,4 +118,25 @@ func Start(cmd *cobra.Command) error {
 	klog.V(4).Info("Provisioner stopped")
 
 	return nil
+}
+
+// isLeaderElectionEnabled returns true/false based on the ENV
+// LEADER_ELECTION_ENABLED set via provisioner deployment.
+// Defaults to true, means leaderElection enabled by default.
+func isLeaderElectionEnabled() bool {
+	leaderElection := os.Getenv(LeaderElectionKey)
+
+	var leader bool
+	switch strings.ToLower(leaderElection) {
+	default:
+		klog.Info("Leader election enabled for localpv-provisioner")
+		leader = true
+	case "y", "yes", "true":
+		klog.Info("Leader election enabled for localpv-provisioner via leaderElectionKey")
+		leader = true
+	case "n", "no", "false":
+		klog.Info("Leader election disabled for localpv-provisioner via leaderElectionKey")
+		leader = false
+	}
+	return leader
 }


### PR DESCRIPTION
commit adds the `LEADER_ELECTION_ENABLED` env to allow user
to enable/disable the leader election feature of localpv
provisioner.

If env is not configured, leader election will be enabled by
default.

cherry-pick: #1742 

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>
