### PR TITLE
chore(build): bump go version to 1.14.7 and allow ppc jobs to fail in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,12 @@ env:
     - MINIKUBE_HOME=$HOME
     - CHANGE_MINIKUBE_NONE_USER=true
     - KUBECONFIG=$HOME/.kube/config
+    - CAN_FAIL=true
 
 jobs:
+  allow_failures:
+    env:
+      - CAN_FAIL=true
   include:
     - os: linux
       arch: amd64
@@ -25,6 +29,7 @@ jobs:
       arch: ppc64le
       env:
         - RELEASE_TAG_DOWNSTREAM=0
+        - CAN_FAIL=true
 
 services:
   - docker
@@ -35,7 +40,7 @@ cache:
   directories:
     - $HOME/.cache/go-build
 go:
-  - 1.14.4
+  - 1.14.7
 
 addons:
   apt:


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

**Why is this PR required? What issue does it fix?**:
To bump the stable go version 1.14.7 and to ignore the PPC build job failure in travis 

**What this PR does?**:
- bump go version to 1.14.7
- Allowed ppc job to fail in the build matrix without causing the entire build to fail

**Does this PR require any upgrade changes?**:
No