### PR TITLE
feat(spc): add capability to specify allowed BD tags on SPC

### DIFF
--- a/cmd/maya-apiserver/app/server/restore_endpoint_v1alpha1.go
+++ b/cmd/maya-apiserver/app/server/restore_endpoint_v1alpha1.go
@@ -280,7 +280,6 @@ func updateRestoreStatus(clientset versioned.Interface, rst v1alpha1.CStorRestor
 
 func createVolumeForRestore(r *v1alpha1.CStorRestore) (*v1alpha1.CASVolume, error) {
 	vol := &v1alpha1.CASVolume{}
-
 	vol.Name = r.Spec.VolumeName
 	vol.Labels = map[string]string{
 		string(v1alpha1.StorageClassKey): r.Spec.StorageClass,

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node_test.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"reflect"
 	"strconv"
 	"testing"
 
@@ -543,6 +544,88 @@ func TestNodeBlockDeviceAlloter(t *testing.T) {
 			}
 			if err == nil && len(blockdeviceList.BlockDevices.Items) != test.expectedDiskListLength {
 				t.Errorf("Test case failed as the expected blockdevice list length is %d but got %d", test.expectedDiskListLength, len(blockdeviceList.BlockDevices.Items))
+			}
+		})
+	}
+}
+
+func Test_getAllowedTagMap(t *testing.T) {
+	type args struct {
+		cspcAnnotation map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]bool
+	}{
+		{
+			name: "Test case #1",
+			args: args{
+				cspcAnnotation: map[string]string{CStorBDTagAnnotationKey: "fast,slow"},
+			},
+			want: map[string]bool{"fast": true, "slow": true},
+		},
+
+		{
+			name: "Test case #2",
+			args: args{
+				cspcAnnotation: map[string]string{CStorBDTagAnnotationKey: "fast,slow"},
+			},
+			want: map[string]bool{"slow": true, "fast": true},
+		},
+
+		{
+			name: "Test case #3 -- Nil Annotations",
+			args: args{
+				cspcAnnotation: nil,
+			},
+			want: map[string]bool{},
+		},
+
+		{
+			name: "Test case #4 -- No BD tag Annotations",
+			args: args{
+				cspcAnnotation: map[string]string{"some-other-annotation-key": "awesome-openebs"},
+			},
+			want: map[string]bool{},
+		},
+
+		{
+			name: "Test case #5 -- Improper format 1",
+			args: args{
+				cspcAnnotation: map[string]string{CStorBDTagAnnotationKey: ",fast,slow,,"},
+			},
+			want: map[string]bool{"fast": true, "slow": true},
+		},
+
+		{
+			name: "Test case #6 -- Improper format 2",
+			args: args{
+				cspcAnnotation: map[string]string{CStorBDTagAnnotationKey: ",fast,slow"},
+			},
+			want: map[string]bool{"fast": true, "slow": true},
+		},
+
+		{
+			name: "Test case #7 -- Improper format 2",
+			args: args{
+				cspcAnnotation: map[string]string{CStorBDTagAnnotationKey: ",fast,,slow"},
+			},
+			want: map[string]bool{"fast": true, "slow": true},
+		},
+
+		{
+			name: "Test case #7 -- Improper format 2",
+			args: args{
+				cspcAnnotation: map[string]string{CStorBDTagAnnotationKey: "this is improper"},
+			},
+			want: map[string]bool{"this is improper": true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getAllowedTagMap(tt.args.cspcAnnotation); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getAllowedTagMap() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/blockdevice/v1alpha1/blockdevice.go
+++ b/pkg/blockdevice/v1alpha1/blockdevice.go
@@ -22,7 +22,7 @@ import (
 	ndm "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	bdc_v1alpha1 "github.com/openebs/maya/pkg/blockdeviceclaim/v1alpha1"
-	errors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -40,7 +40,15 @@ const (
 	FilterNonSparseDevices  = "filterNonSparseDevices"
 	InActiveStatus          = "Inactive"
 	FilterNonRelesedDevices = "filterNonRelesedDevices"
+	FilterNotAllowedBDTag   = "filterNotAllowedBDTag"
+
+	// BlockDeviceTagLabelKey is the key to fetch tag of a block
+	// device.
+	// For more info : https://github.com/openebs/node-disk-manager/pull/400
+	BlockDeviceTagLabelKey = "openebs.io/block-device-tag"
 )
+
+var bdFilterOptions FilterOptions
 
 // KubernetesClient is the kubernetes client which will implement block device actions/behaviours
 type KubernetesClient struct {
@@ -111,6 +119,7 @@ var filterOptionFuncMap = map[string]filterOptionFunc{
 	FilterSparseDevices:     filterSparseDevices,
 	FilterNonSparseDevices:  filterNonSparseDevices,
 	FilterNonRelesedDevices: filterNonRelesedDevices,
+	FilterNotAllowedBDTag:   filterNotAllowedBDTag,
 }
 
 // predicateFailedError returns the predicate error which is provided to this function as an argument
@@ -185,8 +194,12 @@ func checkName(db *BlockDevice) (string, bool) {
 	return "", true
 }
 
+type FilterOptions struct {
+	AllowedBDTags map[string]bool
+}
+
 // Filter adds filters on which the blockdevice has to be filtered
-func (bdl *BlockDeviceList) Filter(predicateKeys ...string) *BlockDeviceList {
+func (bdl *BlockDeviceList) Filter(filterOps *FilterOptions, predicateKeys ...string) *BlockDeviceList {
 	// Initialize filtered block device list
 	filteredBlockDeviceList := &BlockDeviceList{
 		BlockDeviceList: &ndm.BlockDeviceList{},
@@ -199,6 +212,9 @@ func (bdl *BlockDeviceList) Filter(predicateKeys ...string) *BlockDeviceList {
 	}
 	filteredBlockDeviceList = bdl
 	for _, key := range predicateKeys {
+		if key == FilterNotAllowedBDTag {
+			bdFilterOptions.AllowedBDTags = filterOps.AllowedBDTags
+		}
 		filteredBlockDeviceList = filterOptionFuncMap[key](filteredBlockDeviceList)
 	}
 	return filteredBlockDeviceList
@@ -320,6 +336,27 @@ func filterNonRelesedDevices(originalList *BlockDeviceList) *BlockDeviceList {
 	}
 	for _, device := range originalList.Items {
 		if !(device.Status.ClaimState == ndm.BlockDeviceReleased) {
+			filteredList.Items = append(filteredList.Items, device)
+		}
+	}
+	return filteredList
+}
+
+func filterNotAllowedBDTag(originalList *BlockDeviceList) *BlockDeviceList {
+	filteredList := &BlockDeviceList{
+		BlockDeviceList: &ndm.BlockDeviceList{},
+		errs:            nil,
+	}
+	for _, device := range originalList.Items {
+		value, ok := device.Labels[BlockDeviceTagLabelKey]
+		bdTag := strings.TrimSpace(value)
+		if ok {
+			if bdTag == "" || !bdFilterOptions.AllowedBDTags[bdTag] {
+				continue
+			} else {
+				filteredList.Items = append(filteredList.Items, device)
+			}
+		} else {
 			filteredList.Items = append(filteredList.Items, device)
 		}
 	}

--- a/pkg/blockdevice/v1alpha1/blockdevice.go
+++ b/pkg/blockdevice/v1alpha1/blockdevice.go
@@ -353,9 +353,8 @@ func filterNotAllowedBDTag(originalList *BlockDeviceList) *BlockDeviceList {
 		if ok {
 			if bdTag == "" || !bdFilterOptions.AllowedBDTags[bdTag] {
 				continue
-			} else {
-				filteredList.Items = append(filteredList.Items, device)
 			}
+			filteredList.Items = append(filteredList.Items, device)
 		} else {
 			filteredList.Items = append(filteredList.Items, device)
 		}

--- a/pkg/blockdevice/v1alpha1/kubernetes_client_test.go
+++ b/pkg/blockdevice/v1alpha1/kubernetes_client_test.go
@@ -68,7 +68,7 @@ func TestFilteredList(t *testing.T) {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			blockDeviceList, err := blockDeviceK8s.List(metav1.ListOptions{})
-			filtteredBlockDeviceList := blockDeviceList.Filter(FilterInactive)
+			filtteredBlockDeviceList := blockDeviceList.Filter(nil, FilterInactive)
 			gotErr := false
 			if err != nil {
 				gotErr = true

--- a/pkg/blockdevice/v1alpha1/spc_client_test.go
+++ b/pkg/blockdevice/v1alpha1/spc_client_test.go
@@ -337,7 +337,7 @@ func TestSpcClientFilteredList(t *testing.T) {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			blockDeviceList, err := test.spcClientObj.List(metav1.ListOptions{})
-			blockDeviceList = blockDeviceList.Filter(FilterInactive)
+			blockDeviceList = blockDeviceList.Filter(nil, FilterInactive)
 			gotErr := false
 			if err != nil {
 				gotErr = true

--- a/tests/cstor/cspc/provisioning/provisioning_test.go
+++ b/tests/cstor/cspc/provisioning/provisioning_test.go
@@ -45,7 +45,6 @@ func provisioningAndReconciliationTest(createCSPCObject func()) {
 		It("cStor Pools Should be Provisioned ", func() {
 			SkipTest(skipPositiveCaseIfRequired)
 			By("Preparing A CSPC Object, No Error Should Occur", createCSPCObject)
-
 			By("Creating A CSPC Object, Desired Number of CSPIs Should Be Created", verifyDesiredCSPICount)
 		})
 	})


### PR DESCRIPTION
This commit adds the capability to specify allowed BD tags on SPC via
annotations.
The annotation key is `cstor.openebs.io/allowed-bd-tags` and the allowed value
is comma-separated strings.
For example "fast,slow" is a possible value, and in this case SPC provisioner
will reject BDs that have a BD tag (`openebs.io/block-device-tag`) present on
it and the value is other than fast or slow.

Signed-off-by: Ashutosh Kumar <ashutosh.kumar@mayadata.io>