### PR TITLE
feat(webhook): add validation for namspace delete requests

### DIFF
--- a/changelogs/unreleased/1754-shubham14bajpai
+++ b/changelogs/unreleased/1754-shubham14bajpai
@@ -1,0 +1,1 @@
+feat(webhook): add validation for namspace delete requests

--- a/cmd/admission-server/main.go
+++ b/cmd/admission-server/main.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/klog"
 
 	clientset "github.com/openebs/maya/pkg/client/generated/clientset/versioned"
+	ndmclientset "github.com/openebs/maya/pkg/client/generated/openebs.io/ndm/v1alpha1/clientset/internalclientset"
 	snapclientset "github.com/openebs/maya/pkg/client/generated/openebs.io/snapshot/v1/clientset/internalclientset"
 )
 
@@ -75,6 +76,12 @@ func main() {
 		klog.Fatalf("Error building openebs snapshot clientset: %s", err.Error())
 	}
 
+	// Building NDM Clientset
+	ndmClient, err := ndmclientset.NewForConfig(cfg)
+	if err != nil {
+		klog.Fatalf("Error building ndm clientset: %s", err.Error())
+	}
+
 	// Fetch a reference to the admission server deployment object
 	ownerReference, err := webhook.GetAdmissionReference()
 	if err != nil {
@@ -85,7 +92,7 @@ func main() {
 		klog.Fatal(validatorErr, "failed to initialize validation server")
 	}
 
-	wh, err := webhook.New(parameters, kubeClient, openebsClient, snapClient)
+	wh, err := webhook.New(parameters, kubeClient, openebsClient, snapClient, ndmClient)
 	if err != nil {
 		klog.Fatalf("failed to create validation webhook: %s", err.Error())
 	}

--- a/pkg/webhook/configuration.go
+++ b/pkg/webhook/configuration.go
@@ -81,6 +81,7 @@ var (
 		addCSPCDeleteRule,
 		addCVCWithUpdateRule,
 		addSPCWithDeleteRule,
+		addNSWithDeleteRule,
 	}
 	cvcRuleWithOperations = v1beta1.RuleWithOperations{
 		Operations: []v1beta1.OperationType{
@@ -100,6 +101,16 @@ var (
 			APIGroups:   []string{"*"},
 			APIVersions: []string{"*"},
 			Resources:   []string{"storagepoolclaims"},
+		},
+	}
+	nsRuleWithOperations = v1beta1.RuleWithOperations{
+		Operations: []v1beta1.OperationType{
+			v1beta1.Delete,
+		},
+		Rule: v1beta1.Rule{
+			APIGroups:   []string{"*"},
+			APIVersions: []string{"*"},
+			Resources:   []string{"namespaces"},
 		},
 	}
 )
@@ -214,6 +225,7 @@ func createValidatingWebhookConfig(
 			},
 			cvcRuleWithOperations,
 			spcRuleWithOperations,
+			nsRuleWithOperations,
 		},
 		ClientConfig: v1beta1.WebhookClientConfig{
 			Service: &v1beta1.ServiceReference{
@@ -504,6 +516,12 @@ func addCVCWithUpdateRule(config *v1beta1.ValidatingWebhookConfiguration) {
 func addSPCWithDeleteRule(config *v1beta1.ValidatingWebhookConfiguration) {
 	if util.IsCurrentLessThanNewVersion(config.Labels[string(apis.OpenEBSVersionKey)], "1.11.0") {
 		config.Webhooks[0].Rules = append(config.Webhooks[0].Rules, spcRuleWithOperations)
+	}
+}
+
+func addNSWithDeleteRule(config *v1beta1.ValidatingWebhookConfiguration) {
+	if util.IsCurrentLessThanNewVersion(config.Labels[string(apis.OpenEBSVersionKey)], "2.1.0") {
+		config.Webhooks[0].Rules = append(config.Webhooks[0].Rules, nsRuleWithOperations)
 	}
 }
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -27,6 +27,7 @@ import (
 
 	snapshot "github.com/openebs/maya/pkg/apis/openebs.io/snapshot/v1"
 	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	blockdeviceclaim "github.com/openebs/maya/pkg/blockdeviceclaim/v1alpha1"
 	clientset "github.com/openebs/maya/pkg/client/generated/clientset/versioned"
 	snapclient "github.com/openebs/maya/pkg/client/generated/openebs.io/snapshot/v1/clientset/internalclientset"
 	"github.com/pkg/errors"
@@ -421,6 +422,9 @@ func (wh *webhook) validate(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespo
 	response.Allowed = true
 	klog.Info("Admission webhook request received")
 	switch req.Kind.Kind {
+	case "Namespace":
+		klog.V(2).Infof("Admission webhook request for type %s", req.Kind.Kind)
+		return wh.validateNamespace(ar)
 	case "PersistentVolumeClaim":
 		klog.V(2).Infof("Admission webhook request for type %s", req.Kind.Kind)
 		return wh.validatePVC(ar)
@@ -450,6 +454,72 @@ func (wh *webhook) validatePVC(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRe
 	}
 	klog.V(2).Info("Admission wehbook for PVC module not " +
 		"configured for operations other than DELETE and CREATE")
+	return response
+}
+
+func (wh *webhook) validateNamespace(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
+	req := ar.Request
+	response := &v1beta1.AdmissionResponse{}
+	response.Allowed = true
+	// validates only if requested operation is CREATE or DELETE
+	if req.Operation == v1beta1.Delete {
+		return wh.validateNamespaceDeleteRequest(req)
+	}
+	klog.V(2).Info("Admission wehbook for PVC module not " +
+		"configured for operations other than DELETE")
+	return response
+}
+
+func (wh *webhook) validateNamespaceDeleteRequest(req *v1beta1.AdmissionRequest) *v1beta1.AdmissionResponse {
+	response := &v1beta1.AdmissionResponse{}
+	response.Allowed = true
+	svcLabel := "openebs.io/controller-service=jiva-controller-svc"
+
+	msg := fmt.Sprintf("either BDCs or services with the label %s exists in the namespace %s.", svcLabel, req.Name)
+
+	// ignore the Delete request of Namespace if resource name is empty
+	if req.Name == "" {
+		return response
+	}
+
+	bdcList, err := blockdeviceclaim.NewKubeClient().
+		WithNamespace(req.Name).
+		List(metav1.ListOptions{})
+	if err != nil {
+		response.Allowed = false
+		response.Result = &metav1.Status{
+			Message: fmt.Sprintf("error listing BDC in namespace %s: %v", req.Name, err.Error()),
+		}
+		return response
+	}
+
+	if len(bdcList.Items) != 0 {
+		response.Allowed = false
+		response.Result = &metav1.Status{
+			Message: msg,
+		}
+		return response
+	}
+
+	svcList, err := wh.kubeClient.CoreV1().Services(req.Name).
+		List(metav1.ListOptions{
+			LabelSelector: svcLabel,
+		})
+	if err != nil {
+		response.Allowed = false
+		response.Result = &metav1.Status{
+			Message: fmt.Sprintf("error listing svc in namespace %s: %v", req.Name, err.Error()),
+		}
+		return response
+	}
+
+	if len(svcList.Items) != 0 {
+		response.Allowed = false
+		response.Result = &metav1.Status{
+			Message: msg,
+		}
+		return response
+	}
 	return response
 }
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -465,7 +465,7 @@ func (wh *webhook) validateNamespace(ar *v1beta1.AdmissionReview) *v1beta1.Admis
 	if req.Operation == v1beta1.Delete {
 		return wh.validateNamespaceDeleteRequest(req)
 	}
-	klog.V(2).Info("Admission wehbook for PVC module not " +
+	klog.V(2).Info("Admission wehbook for Namespace module not " +
 		"configured for operations other than DELETE")
 	return response
 }


### PR DESCRIPTION
**What this PR does?**:  

This PR adds validation on the deletion of openebs namespace
to avoid
  - loss of data in case of accidental deletion of
    namespace
  - stale resources with finalizers in openebs namespace which
    maybe stuck on namespace deletion.

**Does this PR require any upgrade changes?**: 
Yes already handled in the PR itself. Tested 1.10 to latest upgrade: namespace gets added to validatingwebhookconfigurations automatically.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

Local test performed:

Both jiva and cstor volume exist
```sh
mayadata:setup$ kubectl get pvc
NAME                  STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
demo-vol-claim-2      Bound    pvc-704959f7-1632-4ab8-96f0-4a4449306418   5Gi        RWO            jiva-1r                7m31s
testclaim-busybox-0   Bound    pvc-d30a84a9-e8f6-48b0-b463-9c1ced1ba159   2G         RWO            openebs-cstor-sparse   7m11s
mayadata:setup$ kubectl delete ns openebs
Error from server: admission webhook "admission-webhook.openebs.io" denied the request: either BDCs or services with the label openebs.io/controller-service=jiva-controller-svc exists in the namespace openebs.
```

Only cstor volume exists
```sh
mayadata:setup$ kubectl get pvc
NAME                  STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
testclaim-busybox-0   Bound    pvc-d30a84a9-e8f6-48b0-b463-9c1ced1ba159   2G         RWO            openebs-cstor-sparse   8m18s
mayadata:setup$ kubectl delete ns openebs
Error from server: admission webhook "admission-webhook.openebs.io" denied the request: either BDCs or services with the label openebs.io/controller-service=jiva-controller-svc exists in the namespace openebs.
```

Only jiva volume exists
```sh
mayadata:setup$ kubectl get pvc
NAME               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
demo-vol-claim-2   Bound    pvc-e5cf0812-7a43-4ef9-9e27-f2d5b47f9991   5Gi        RWO            jiva-1r        12s
mayadata:setup$ kubectl delete ns openebs
Error from server: admission webhook "admission-webhook.openebs.io" denied the request: either BDCs or services with the label openebs.io/controller-service=jiva-controller-svc exists in the namespace openebs.
```

After deleting all volumes and pools
```sh
mayadata:setup$ kubectl delete ns openebs
namespace "openebs" deleted
```

Created a cstor & jiva volume in test namespace and deleted the namespace. The webhook did not impact the deletion and cleanup was successful.
```sh
mayadata:setup$ kubectl get pvc -n test
NAME                  STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
testclaim-busybox-0   Bound    pvc-a5dfc230-c214-406d-8cce-34084b096fae   2G         RWO            openebs-cstor-sparse   3m36s
demo-vol-claim-2      Bound    pvc-f05675e0-f712-4b60-bb88-b4b42004bcf9   5Gi        RWO            jiva-1r        50s
mayadata:setup$ kubectl delete ns test
namespace "test" deleted
```


**TODO**
Add unit test for the added webhook validation. 

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
