### PR TITLE
fix(upgrade): allow upgrades for volumes without monitor

### DIFF
--- a/pkg/apis/openebs.io/v1alpha1/versionDetails.go
+++ b/pkg/apis/openebs.io/v1alpha1/versionDetails.go
@@ -29,6 +29,7 @@ var (
 		"1.4.0": true, "1.5.0": true, "1.6.0": true, "1.7.0": true,
 		"1.8.0": true, "1.9.0": true, "1.10.0": true, "1.11.0": true,
 		"1.12.0": true, "2.0.0": true, "2.1.0": true, "2.2.0": true,
+		"2.3.0": true,
 	}
 	validDesiredVersion = strings.Split(version.GetVersion(), "-")[0]
 )

--- a/pkg/upgrade/templates/v1/cstor_target.go
+++ b/pkg/upgrade/templates/v1/cstor_target.go
@@ -44,6 +44,7 @@ var (
             ]
           {{end}}
           },
+          {{if .IsMonitorEnabled}}
           {
             "name": "maya-volume-exporter",
             "image": "{{.MExporterImage}}:{{.ImageTag}}"{{if isCurrentLessThanNewVersion .CurrentVersion "1.7.0"}},
@@ -55,6 +56,7 @@ var (
             ]
           {{end}}
           },
+          {{end}}
           {
             "name": "cstor-volume-mgmt",
             "image": "{{.VolumeMgmtImage}}:{{.ImageTag}}"{{if isCurrentLessThanNewVersion .CurrentVersion "1.7.0"}},

--- a/pkg/upgrade/templates/v1/jiva_target.go
+++ b/pkg/upgrade/templates/v1/jiva_target.go
@@ -37,11 +37,12 @@ var (
           {
             "name": "{{.ControllerContainerName}}",
             "image": "{{.ControllerImage}}:{{.ImageTag}}"
-          },
+          }{{if .IsMonitorEnabled}},
           {
             "name": "maya-volume-exporter",
             "image": "{{.MExporterImage}}:{{.ImageTag}}"
           }
+          {{end}}
         ]
       }
     }


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**:
OpenEBS provides an option to disable volume monitor which results in one less container for the m-exporter image. This PR allows upgrade to work irrespective of whether the monitor is enabled or not.

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Tested both Volume Monitor enabled and disabled for both jiva and cstor.

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
