### PR TITLE
fix(restore): set targetip on CVRs after restore is completed

### DIFF
--- a/changelogs/unreleased/1761-zlymeda
+++ b/changelogs/unreleased/1761-zlymeda
@@ -1,0 +1,1 @@
+fix(restore): set targetip on CVRs after restore is completed

--- a/cmd/cstor-pool-mgmt/controller/replica-controller/new_replica_controller.go
+++ b/cmd/cstor-pool-mgmt/controller/replica-controller/new_replica_controller.go
@@ -214,22 +214,6 @@ func NewCStorVolumeReplicaController(
 					return
 				}
 
-				if newCVR.ResourceVersion != oldCVR.ResourceVersion {
-					// cvr modify is not implemented
-					// hence below is commented
-					// ql.Operation = common.QOpModify
-
-					controller.recorder.Event(
-						newCVR,
-						corev1.EventTypeNormal,
-						string(common.SuccessSynced),
-						string(common.MessageModifySynced),
-					)
-
-					// no further handling needed
-					return
-				}
-
 				// finally !!!
 				// push this operation to workqueue
 				ql.Operation = common.QOpSync

--- a/tests/framework/v1alpha1/framework.go
+++ b/tests/framework/v1alpha1/framework.go
@@ -16,6 +16,7 @@ package v1alpha1
 
 import (
 	"os"
+	"strconv"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -196,6 +197,6 @@ func checkComponentStatus(namespace, lselector string, Count int) (pods *corev1.
 			Len()
 	},
 		DefaultTimeOut, DefaultPollingInterval).
-		Should(Equal(Count), "Pod count should be "+string(Count))
+		Should(Equal(Count), "Pod count should be "+strconv.Itoa(Count))
 	return
 }

--- a/tests/sts/sts_suite_test.go
+++ b/tests/sts/sts_suite_test.go
@@ -17,6 +17,7 @@ package sts
 import (
 	"flag"
 	"os"
+	"strconv"
 
 	"testing"
 
@@ -43,7 +44,7 @@ const (
 	// time in seconds for the Eventually block
 	defaultPollingInterval int = 10
 	// minNodeCount is the minimum number of nodes
-	// neede to run this test
+	// needed to run this test
 	minNodeCount int = 3
 )
 
@@ -61,7 +62,7 @@ var _ = BeforeSuite(func() {
 	configPath, err := kubernetes.GetConfigPath()
 	Expect(err).ShouldNot(HaveOccurred())
 
-	// Setting the path in environemnt variable
+	// Setting the path in environment variable
 	err = os.Setenv(string(v1alpha1.KubeConfigEnvironmentKey), configPath)
 	Expect(err).ShouldNot(HaveOccurred())
 	// Getting clientset
@@ -70,6 +71,7 @@ var _ = BeforeSuite(func() {
 
 	// Checking appropriate node numbers. This test is designed to run on a 3 node cluster
 	nodes, err := cl.CoreV1().Nodes().List(v1.ListOptions{})
+	Expect(err).ShouldNot(HaveOccurred())
 	Expect(nodes.Items).Should(HaveLen(minNodeCount))
 
 	// Fetching the openebs component artifacts
@@ -159,7 +161,7 @@ var _ = BeforeSuite(func() {
 			Len()
 	},
 		defaultTimeOut, defaultPollingInterval).
-		Should(Equal(minNodeCount), "NDM pod count should be "+string(minNodeCount))
+		Should(Equal(minNodeCount), "NDM pod count should be "+strconv.Itoa(minNodeCount))
 
 	// Check for cstor storage pool pods to get created and running
 	Eventually(func() int {
@@ -174,7 +176,7 @@ var _ = BeforeSuite(func() {
 			Len()
 	},
 		defaultTimeOut, defaultPollingInterval).
-		Should(Equal(minNodeCount), "CStor pool pod count should be "+string(minNodeCount))
+		Should(Equal(minNodeCount), "CStor pool pod count should be "+strconv.Itoa(minNodeCount))
 })
 
 var _ = AfterSuite(func() {

--- a/tests/sts/sts_test.go
+++ b/tests/sts/sts_test.go
@@ -15,6 +15,8 @@
 package sts
 
 import (
+	"strconv"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	k8s "github.com/openebs/maya/pkg/client/k8s/v1alpha1"
@@ -140,7 +142,7 @@ var _ = Describe("StatefulSet", func() {
 			return pvcCount
 		},
 			defaultTimeOut, defaultPollingInterval).
-			Should(Equal(3), "PVC count should be "+string(3))
+			Should(Equal(3), "PVC count should be "+strconv.Itoa(3))
 
 		// Check for CVR to get healthy
 		Eventually(func() int {
@@ -156,7 +158,7 @@ var _ = Describe("StatefulSet", func() {
 				Len()
 		},
 			defaultTimeOut, defaultPollingInterval).
-			Should(Equal(3), "CVR count should be "+string(3))
+			Should(Equal(3), "CVR count should be "+strconv.Itoa(3))
 
 		// Check for statefulset pods to get created and running
 		Eventually(func() int {
@@ -172,7 +174,7 @@ var _ = Describe("StatefulSet", func() {
 				Len()
 		},
 			defaultTimeOut, defaultPollingInterval).
-			Should(Equal(3), "Pod count should be "+string(3))
+			Should(Equal(3), "Pod count should be "+strconv.Itoa(3))
 	})
 
 	AfterEach(func() {
@@ -267,25 +269,25 @@ var _ = Describe("StatefulSet", func() {
 				WithFilter(pvc.ContainsName(STSUnstructured.GetName())).
 				List()
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(pvcList.Len()).Should(Equal(3), "pvc count should be "+string(3))
+			Expect(pvcList.Len()).Should(Equal(3), "pvc count should be "+strconv.Itoa(3))
 
 			cvrs, err := cvr.
 				NewKubeclient(cvr.WithNamespace("")).
 				List(metav1.ListOptions{LabelSelector: replicaAntiAffinityLabel})
-			Expect(cvrs.Items).Should(HaveLen(3), "cvr count should be "+string(3))
+			Expect(cvrs.Items).Should(HaveLen(3), "cvr count should be "+strconv.Itoa(3))
 
 			poolNames := cvr.
 				NewListBuilder().
 				WithAPIList(cvrs).
 				List()
 			Expect(poolNames.GetUniquePoolNames()).
-				Should(HaveLen(3), "pool names count should be "+string(3))
+				Should(HaveLen(3), "pool names count should be "+strconv.Itoa(3))
 
 			pools, err := csp.NewKubeClient().List(metav1.ListOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
 			nodeNames := csp.ListBuilder().WithAPIList(pools).List()
 			Expect(nodeNames.GetPoolUIDs()).
-				Should(HaveLen(3), "node names count should be "+string(3))
+				Should(HaveLen(3), "node names count should be "+strconv.Itoa(3))
 		})
 
 		PIt("should co-locate the cstor volume targets with application instances", func() {


### PR DESCRIPTION
Auto-setting of targetip on CVR if openebs.io/restore-completed is found

## Pull Request template

**Why is this PR required? What issue does it fix?**:
Currently, users have to set targetip on CVRs after restore. Corresponding change in https://github.com/openebs/velero-plugin/pull/131 will mark CVRs which needs to update the targetip. Changes in this PR will check the annotation and set the targetip.


**What this PR does?**:
Sets targetip on CVRs marked with openebs.io/restore-completed annotation.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
`make test` in velero-plugin repository with changes deployed.

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_

related velero-plugin PR: https://github.com/openebs/velero-plugin/pull/131
related cstor-operators PR: https://github.com/openebs/cstor-operators/pull/198

**Checklist:**
- [x] Fixes https://github.com/openebs/velero-plugin/issues/127
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
