### PR TITLE
refactor(localpv): move builds to dynamic-localpv-provisioner repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,8 @@ env:
     - MINIKUBE_HOME=$HOME
     - CHANGE_MINIKUBE_NONE_USER=true
     - KUBECONFIG=$HOME/.kube/config
-    - CAN_FAIL=true
 
 jobs:
-  allow_failures:
-    env:
-      - CAN_FAIL=true
   include:
     - os: linux
       arch: amd64
@@ -25,11 +21,6 @@ jobs:
       arch: arm64
       env:
         - RELEASE_TAG_DOWNSTREAM=0
-    - os: linux
-      arch: ppc64le
-      env:
-        - RELEASE_TAG_DOWNSTREAM=0
-        - CAN_FAIL=true
 
 services:
   - docker

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -142,7 +142,6 @@ endif
 
 include ./buildscripts/mayactl/Makefile.mk
 include ./buildscripts/apiserver/Makefile.mk
-include ./buildscripts/provisioner-localpv/Makefile.mk
 include ./buildscripts/upgrade/Makefile.mk
 include ./buildscripts/exporter/Makefile.mk
 include ./buildscripts/cstor-pool-mgmt/Makefile.mk
@@ -151,14 +150,11 @@ include ./buildscripts/admission-server/Makefile.mk
 
 .PHONY: all
 all: compile-tests apiserver-image exporter-image pool-mgmt-image volume-mgmt-image \
-	   admission-server-image upgrade-image provisioner-localpv-image
+	   admission-server-image upgrade-image 
 
 .PHONY: all.arm64
 all.arm64: apiserver-image.arm64 exporter-image.arm64 pool-mgmt-image.arm64 volume-mgmt-image.arm64 \
-           admission-server-image.arm64 upgrade-image.arm64 provisioner-localpv-image.arm64
-
-.PHONY: all.ppc64le
-all.ppc64le: provisioner-localpv-image.ppc64le
+           admission-server-image.arm64 upgrade-image.arm64 
 
 .PHONY: initialize
 initialize: bootstrap

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -42,7 +42,7 @@ Images for the different components are published at the following location:
     https://hub.docker.com/r/openebs/admission-server/tags <br />
     https://hub.docker.com/r/openebs/admission-server-arm64/tags <br />
 
-- LocalPV Provisioner <br />
+- LocalPV Provisioner (Moved to https://github.com/openebs/dynamic-localpv-provisioner) <br />
     https://quay.io/repository/openebs/provisioner-localpv?tab=tags <br />
     https://quay.io/repository/openebs/provisioner-localpv-arm64?tab=tags <br />
     https://hub.docker.com/r/openebs/provisioner-localpv/tags <br />

--- a/buildscripts/deploy.sh
+++ b/buildscripts/deploy.sh
@@ -19,37 +19,17 @@ set -e
 ARCH=$(uname -m)
 
 if [ "${ARCH}" = "x86_64" ]; then
-  APISERVER_IMG="${IMAGE_ORG}/m-apiserver"
-  M_EXPORTER_IMG="${IMAGE_ORG}/m-exporter"
-  CSTOR_POOL_MGMT_IMG="${IMAGE_ORG}/cstor-pool-mgmt"
-  CSTOR_VOLUME_MGMT_IMG="${IMAGE_ORG}/cstor-volume-mgmt"
-  ADMISSION_SERVER_IMG="${IMAGE_ORG}/admission-server"
-  UPGRADE_IMG="${IMAGE_ORG}/m-upgrade"
-  PROVISIONER_LOCALPV="${IMAGE_ORG}/provisioner-localpv"
+  ARCH_SUFFIX=""
 elif [ "${ARCH}" = "aarch64" ]; then
-  APISERVER_IMG="${IMAGE_ORG}/m-apiserver-arm64"
-  M_EXPORTER_IMG="${IMAGE_ORG}/m-exporter-arm64"
-  CSTOR_POOL_MGMT_IMG="${IMAGE_ORG}/cstor-pool-mgmt-arm64"
-  CSTOR_VOLUME_MGMT_IMG="${IMAGE_ORG}/cstor-volume-mgmt-arm64"
-  ADMISSION_SERVER_IMG="${IMAGE_ORG}/admission-server-arm64"
-  UPGRADE_IMG="${IMAGE_ORG}/m-upgrade-arm64"
-  PROVISIONER_LOCALPV="${IMAGE_ORG}/provisioner-localpv-arm64"
-elif [ "${ARCH}" = "ppc64le" ]; then
-  PROVISIONER_LOCALPV="${IMAGE_ORG}/provisioner-localpv-ppc64le"
+  ARCH_SUFFIX="-arm64"
 fi
 
 curl --fail https://raw.githubusercontent.com/openebs/charts/gh-pages/scripts/release/buildscripts/push > ./buildscripts/push
 chmod +x ./buildscripts/push
 
-# tag and push all the images
-if [ "${ARCH}" = "ppc64le" ]; then
-  DIMAGE="${PROVISIONER_LOCALPV}" ./buildscripts/push
-else
-  DIMAGE="${APISERVER_IMG}" ./buildscripts/push
-  DIMAGE="${M_EXPORTER_IMG}" ./buildscripts/push
-  DIMAGE="${CSTOR_POOL_MGMT_IMG}" ./buildscripts/push
-  DIMAGE="${CSTOR_VOLUME_MGMT_IMG}" ./buildscripts/push
-  DIMAGE="${ADMISSION_SERVER_IMG}" ./buildscripts/push
-  DIMAGE="${UPGRADE_IMG}" ./buildscripts/push
-  DIMAGE="${PROVISIONER_LOCALPV}" ./buildscripts/push
-fi
+DIMAGE="${IMAGE_ORG}/m-apiserver${ARCH_SUFFIX}" ./buildscripts/push
+DIMAGE="${IMAGE_ORG}/m-exporter${ARCH_SUFFIX}" ./buildscripts/push
+DIMAGE="${IMAGE_ORG}/cstor-pool-mgmt${ARCH_SUFFIX}" ./buildscripts/push
+DIMAGE="${IMAGE_ORG}/cstor-volume-mgmt${ARCH_SUFFIX}" ./buildscripts/push
+DIMAGE="${IMAGE_ORG}/admission-server${ARCH_SUFFIX}" ./buildscripts/push
+DIMAGE="${IMAGE_ORG}/m-upgrade${ARCH_SUFFIX}" ./buildscripts/push

--- a/ci/build-maya.sh
+++ b/ci/build-maya.sh
@@ -17,7 +17,6 @@ if [ ${CI_TAG} != "ci" ]; then
   sudo docker tag ${IMAGE_ORG}/m-exporter:ci ${IMAGE_ORG}/m-exporter:${CI_TAG}
   sudo docker tag ${IMAGE_ORG}/cstor-pool-mgmt:ci ${IMAGE_ORG}/cstor-pool-mgmt:${CI_TAG}
   sudo docker tag ${IMAGE_ORG}/cstor-volume-mgmt:ci ${IMAGE_ORG}/cstor-volume-mgmt:${CI_TAG}
-  sudo docker tag ${IMAGE_ORG}/provisioner-localpv:ci ${IMAGE_ORG}/provisioner-localpv:${CI_TAG}
 fi
 
 #Tag the images with quay.io, since the operator can either have quay or docker images
@@ -27,7 +26,6 @@ sudo docker tag ${IMAGE_ORG}/m-apiserver:ci quay.io/openebs/m-apiserver:${CI_TAG
 sudo docker tag ${IMAGE_ORG}/m-exporter:ci quay.io/openebs/m-exporter:${CI_TAG}
 sudo docker tag ${IMAGE_ORG}/cstor-pool-mgmt:ci quay.io/openebs/cstor-pool-mgmt:${CI_TAG}
 sudo docker tag ${IMAGE_ORG}/cstor-volume-mgmt:ci quay.io/openebs/cstor-volume-mgmt:${CI_TAG}
-sudo docker tag ${IMAGE_ORG}/provisioner-localpv:ci quay.io/openebs/provisioner-localpv:${CI_TAG}
 
 ## install iscsi pkg
 echo "Installing iscsi packages"

--- a/tests/artifacts/openebs-ci.yaml
+++ b/tests/artifacts/openebs-ci.yaml
@@ -89,7 +89,7 @@ spec:
       containers:
       - name: maya-apiserver
         imagePullPolicy: IfNotPresent
-        image: quay.io/openebs/m-apiserver:ci
+        image: openebs/m-apiserver:ci
         ports:
         - containerPort: 5656
         env:
@@ -127,23 +127,23 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-          value: "quay.io/openebs/jiva:ci"
+          value: "openebs/jiva:ci"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-          value: "quay.io/openebs/jiva:ci"
+          value: "openebs/jiva:ci"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "3"
         - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
-          value: "quay.io/openebs/cstor-istgt:ci"
+          value: "openebs/cstor-istgt:ci"
         - name: OPENEBS_IO_CSTOR_POOL_IMAGE
-          value: "quay.io/openebs/cstor-pool:ci"
+          value: "openebs/cstor-pool:ci"
         - name: OPENEBS_IO_CSTOR_POOL_MGMT_IMAGE
-          value: "quay.io/openebs/cstor-pool-mgmt:ci"
+          value: "openebs/cstor-pool-mgmt:ci"
         - name: OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
-          value: "quay.io/openebs/cstor-volume-mgmt:ci"
+          value: "openebs/cstor-volume-mgmt:ci"
         - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
-          value: "quay.io/openebs/m-exporter:ci"
+          value: "openebs/m-exporter:ci"
         - name: OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE
-          value: "quay.io/openebs/m-exporter:ci"
+          value: "openebs/m-exporter:ci"
         # OPENEBS_IO_ENABLE_ANALYTICS if set to true sends anonymous usage
         # events to Google Analytics
         - name: OPENEBS_IO_ENABLE_ANALYTICS
@@ -202,7 +202,7 @@ spec:
       containers:
       - name: openebs-provisioner
         imagePullPolicy: IfNotPresent
-        image: quay.io/openebs/openebs-k8s-provisioner:ci
+        image: openebs/openebs-k8s-provisioner:ci
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
         # based on this address. This is ignored if empty.
@@ -255,7 +255,7 @@ spec:
       serviceAccountName: openebs-maya-operator
       containers:
         - name: snapshot-controller
-          image: quay.io/openebs/snapshot-controller:ci
+          image: openebs/snapshot-controller:ci
           imagePullPolicy: IfNotPresent
           env:
           - name: OPENEBS_NAMESPACE
@@ -276,7 +276,7 @@ spec:
         #- name: OPENEBS_MAYA_SERVICE_NAME
         #  value: "maya-apiserver-apiservice"
         - name: snapshot-provisioner
-          image: quay.io/openebs/snapshot-provisioner:ci
+          image: openebs/snapshot-provisioner:ci
           imagePullPolicy: IfNotPresent
           env:
           - name: OPENEBS_NAMESPACE
@@ -363,7 +363,7 @@ spec:
       hostNetwork: true
       containers:
       - name: node-disk-manager
-        image: quay.io/openebs/node-disk-manager-amd64:ci
+        image: openebs/node-disk-manager:ci
         imagePullPolicy: Always
         securityContext:
           privileged: true
@@ -448,7 +448,7 @@ spec:
       serviceAccountName: openebs-maya-operator
       containers:
         - name: node-disk-operator
-          image: quay.io/openebs/node-disk-operator-amd64:ci
+          image: openebs/node-disk-operator:ci
           imagePullPolicy: Always
           readinessProbe:
             exec:
@@ -518,7 +518,7 @@ spec:
       serviceAccountName: openebs-maya-operator
       containers:
         - name: admission-webhook
-          image: quay.io/openebs/admission-server:ci
+          image: openebs/admission-server:ci
           imagePullPolicy: IfNotPresent
           args:
             - -tlsCertFile=/etc/webhook/certs/cert.pem
@@ -576,7 +576,7 @@ spec:
       containers:
       - name: openebs-provisioner-hostpath
         imagePullPolicy: Always
-        image: quay.io/openebs/provisioner-localpv:ci
+        image: openebs/provisioner-localpv:ci
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
         # based on this address. This is ignored if empty.


### PR DESCRIPTION
As part of enabling multi-arch repo and deprecating the
openebs/maya repo, the local pv provisioner code is being
migrated to https://github.com/openebs/dynamic-localpv-provisioner

Disabling the travis builds on Local PV provisioner in
the openebs/maya repository

Signed-off-by: kmova <kiran.mova@mayadata.io>

