### PR TITLE
refactor(exporter): move builds to openebs-exporter repo

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -143,17 +143,16 @@ endif
 include ./buildscripts/mayactl/Makefile.mk
 include ./buildscripts/apiserver/Makefile.mk
 include ./buildscripts/upgrade/Makefile.mk
-include ./buildscripts/exporter/Makefile.mk
 include ./buildscripts/cstor-pool-mgmt/Makefile.mk
 include ./buildscripts/cstor-volume-mgmt/Makefile.mk
 include ./buildscripts/admission-server/Makefile.mk
 
 .PHONY: all
-all: compile-tests apiserver-image exporter-image pool-mgmt-image volume-mgmt-image \
+all: compile-tests apiserver-image pool-mgmt-image volume-mgmt-image \
 	   admission-server-image upgrade-image 
 
 .PHONY: all.arm64
-all.arm64: apiserver-image.arm64 exporter-image.arm64 pool-mgmt-image.arm64 volume-mgmt-image.arm64 \
+all.arm64: apiserver-image.arm64 pool-mgmt-image.arm64 volume-mgmt-image.arm64 \
            admission-server-image.arm64 upgrade-image.arm64 
 
 .PHONY: initialize

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -60,7 +60,7 @@ Images for the different components are published at the following location:
     https://hub.docker.com/r/openebs/cstor-volume-mgmt/tags <br />
     https://hub.docker.com/r/openebs/cstor-volume-mgmt-arm64/tags <br />
 
-- Maya Exporter <br />
+- Maya Exporter (Moved to https://github.com/openebs/openebs-exporter) <br />
     https://quay.io/repository/openebs/m-exporter?tab=tags <br />
     https://quay.io/repository/openebs/m-exporter-arm64?tab=tags <br />
     https://hub.docker.com/r/openebs/m-exporter/tags <br />

--- a/buildscripts/deploy.sh
+++ b/buildscripts/deploy.sh
@@ -28,7 +28,6 @@ curl --fail https://raw.githubusercontent.com/openebs/charts/gh-pages/scripts/re
 chmod +x ./buildscripts/push
 
 DIMAGE="${IMAGE_ORG}/m-apiserver${ARCH_SUFFIX}" ./buildscripts/push
-DIMAGE="${IMAGE_ORG}/m-exporter${ARCH_SUFFIX}" ./buildscripts/push
 DIMAGE="${IMAGE_ORG}/cstor-pool-mgmt${ARCH_SUFFIX}" ./buildscripts/push
 DIMAGE="${IMAGE_ORG}/cstor-volume-mgmt${ARCH_SUFFIX}" ./buildscripts/push
 DIMAGE="${IMAGE_ORG}/admission-server${ARCH_SUFFIX}" ./buildscripts/push

--- a/ci/build-maya.sh
+++ b/ci/build-maya.sh
@@ -14,7 +14,6 @@ set -e
 # a non zero exit code, which will result in a build failure.
 if [ ${CI_TAG} != "ci" ]; then
   sudo docker tag ${IMAGE_ORG}/m-apiserver:ci ${IMAGE_ORG}/m-apiserver:${CI_TAG}
-  sudo docker tag ${IMAGE_ORG}/m-exporter:ci ${IMAGE_ORG}/m-exporter:${CI_TAG}
   sudo docker tag ${IMAGE_ORG}/cstor-pool-mgmt:ci ${IMAGE_ORG}/cstor-pool-mgmt:${CI_TAG}
   sudo docker tag ${IMAGE_ORG}/cstor-volume-mgmt:ci ${IMAGE_ORG}/cstor-volume-mgmt:${CI_TAG}
 fi
@@ -23,7 +22,6 @@ fi
 #Note the quay tags are hard-coded to help with CI scripts that might use the quay.io/openebs prefix 
 # The quay images tagged here are not pushed.
 sudo docker tag ${IMAGE_ORG}/m-apiserver:ci quay.io/openebs/m-apiserver:${CI_TAG}
-sudo docker tag ${IMAGE_ORG}/m-exporter:ci quay.io/openebs/m-exporter:${CI_TAG}
 sudo docker tag ${IMAGE_ORG}/cstor-pool-mgmt:ci quay.io/openebs/cstor-pool-mgmt:${CI_TAG}
 sudo docker tag ${IMAGE_ORG}/cstor-volume-mgmt:ci quay.io/openebs/cstor-volume-mgmt:${CI_TAG}
 


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

**Why is this PR required? What issue does it fix?**:
As part of enabling multi-arch repo and deprecating the
openebs/maya repo, the maya exporter code is being
migrated to https://github.com/openebs/openebs-exporter

Disabling the travis builds on maya exporter in
the openebs/maya repository

**Does this PR require any upgrade changes?**:
No 

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 


