### PR TITLE
fix(upgrade): remove quay.io as default url-prefix

### DIFF
--- a/cmd/upgrade/executor/options.go
+++ b/cmd/upgrade/executor/options.go
@@ -41,7 +41,7 @@ type UpgradeOptions struct {
 var (
 	options = &UpgradeOptions{
 		openebsNamespace: "openebs",
-		imageURLPrefix:   "quay.io/openebs/",
+		imageURLPrefix:   "",
 	}
 )
 


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

**What this PR does?**:
The upgrade job changes the image urls on pools and volumes to quay.io if the `--to-version-image-prefix` is not set
As the multi-arch images are not pushed to quay.io the upgrade may fail.

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
