### PR TITLE
fix(jiva): add serviceAccount to clean up jobs

### DIFF
--- a/pkg/apis/openebs.io/v1alpha1/versionDetails.go
+++ b/pkg/apis/openebs.io/v1alpha1/versionDetails.go
@@ -30,6 +30,7 @@ var (
 		"1.8.0": true, "1.9.0": true, "1.10.0": true, "1.11.0": true,
 		"1.12.0": true, "2.0.0": true, "2.1.0": true, "2.2.0": true,
 		"2.3.0": true, "2.4.0": true, "2.4.1": true, "2.5.0": true,
+		"2.6.0": true,
 	}
 	validDesiredVersion = strings.Split(version.GetVersion(), "-")[0]
 )

--- a/pkg/install/v1alpha1/jiva_volume.go
+++ b/pkg/install/v1alpha1/jiva_volume.go
@@ -268,6 +268,8 @@ spec:
     enabled: "false"
   - name: ReplicaTolerations
     value: "none"
+  - name: ServiceAccountName
+    value: {{env "OPENEBS_SERVICE_ACCOUNT"}}
   taskNamespace: {{env "OPENEBS_NAMESPACE"}}
   run:
     tasks:
@@ -1337,6 +1339,7 @@ spec:
       {{- end }}
       template:
         spec:
+          serviceAccountName: {{ .Config.ServiceAccountName.value }}
           restartPolicy: OnFailure
           nodeSelector:
             kubernetes.io/hostname: {{ kubeNodeGetHostNameOrNodeName .ListItems.currentRepeatResource }}


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

**Why is this PR required? What issue does it fix?**:

This Pr adds the serviceAccountName to the jiva cleanup jobs while deleting a volume. 
https://github.com/openebs/openebs/issues/3331

**What this PR does?**:

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
