### PR TITLE
fix(api): add ownerReference for BDC

### DIFF
--- a/pkg/algorithm/nodeselect/v1alpha1/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node.go
@@ -371,6 +371,11 @@ func (ac *Config) ClaimBlockDevice(nodeBDs *nodeBlockDevice, spc *apis.StoragePo
 			}
 			capacity := volume.ByteCount(bdObj.Spec.Capacity.Storage)
 
+			// WithOwnerReference method accepts an empty interface to enable
+			// setting of OwnerReference to other types of objects
+			var spc_owner interface{}
+			spc_owner = spc
+
 			//TODO: Move below code to some function
 			newBDCObj, err := bdc.NewBuilder().
 				WithName(bdcName).
@@ -379,7 +384,7 @@ func (ac *Config) ClaimBlockDevice(nodeBDs *nodeBlockDevice, spc *apis.StoragePo
 				WithBlockDeviceName(bdName).
 				WithHostName(hostName).
 				WithCapacity(capacity).
-				WithOwnerReference(spc).
+				WithOwnerReference(spc_owner).
 				WithFinalizer(spcv1alpha1.SPCFinalizer).
 				Build()
 

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node.go
@@ -382,7 +382,7 @@ func (ac *Config) ClaimBlockDevice(nodeBDs *nodeBlockDevice, spc *apis.StoragePo
 			// WithOwnerReference method accepts an OwnerReference object
 			// and uses it to set the owner for the BlockDeviceClaim
 			trueVal := true
-			owner := &metav1.OwnerReference{
+			owner := metav1.OwnerReference{
 				APIVersion:         OpenEBS_APIVersion,
 				Kind:               StoragePoolKind,
 				UID:                spc.ObjectMeta.UID,

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node.go
@@ -38,6 +38,10 @@ const (
 	// device.
 	// For more info : https://github.com/openebs/node-disk-manager/pull/400
 	BlockDeviceTagLabelKey = "openebs.io/block-device-tag"
+	// StoragePoolKind holds the value of StoragePoolClaim
+	StoragePoolKind = "StoragePoolClaim"
+	// APIVersion holds the value of OpenEBS version
+	OpenEBS_APIVersion = "openebs.io/v1alpha1"
 )
 
 // BDDetails holds the claimed block device details
@@ -371,10 +375,21 @@ func (ac *Config) ClaimBlockDevice(nodeBDs *nodeBlockDevice, spc *apis.StoragePo
 			}
 			capacity := volume.ByteCount(bdObj.Spec.Capacity.Storage)
 
-			// WithOwnerReference method accepts an empty interface to enable
-			// setting of OwnerReference to other types of objects
-			var spc_owner interface{}
-			spc_owner = spc
+			// Setting OwnerReference
+			if spc == nil {
+				return nil, errors.Errorf("failed to build BDC object: spc object is nil")
+			}
+			// WithOwnerReference method accepts an OwnerReference object
+			// and uses it to set the owner for the BlockDeviceClaim
+			trueVal := true
+			owner := &metav1.OwnerReference{
+				APIVersion:         OpenEBS_APIVersion,
+				Kind:               StoragePoolKind,
+				UID:                spc.ObjectMeta.UID,
+				Name:               spc.ObjectMeta.Name,
+				BlockOwnerDeletion: &trueVal,
+				Controller:         &trueVal,
+			}
 
 			//TODO: Move below code to some function
 			newBDCObj, err := bdc.NewBuilder().
@@ -384,7 +399,7 @@ func (ac *Config) ClaimBlockDevice(nodeBDs *nodeBlockDevice, spc *apis.StoragePo
 				WithBlockDeviceName(bdName).
 				WithHostName(hostName).
 				WithCapacity(capacity).
-				WithOwnerReference(spc_owner).
+				WithOwnerReference(owner).
 				WithFinalizer(spcv1alpha1.SPCFinalizer).
 				Build()
 

--- a/pkg/blockdeviceclaim/v1alpha1/build.go
+++ b/pkg/blockdeviceclaim/v1alpha1/build.go
@@ -21,6 +21,7 @@ import (
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	errors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -253,25 +254,50 @@ func (b *Builder) WithCapacity(capacity string) *Builder {
 
 // WithOwnerReference sets the OwnerReference field in BDC with required
 //fields
-func (b *Builder) WithOwnerReference(spc *apis.StoragePoolClaim) *Builder {
-	if spc == nil {
+// OwnerReference to PVC is for local-device provisioner
+func (b *Builder) WithOwnerReference(owner interface{}) *Builder {
+	if owner == nil {
 		b.errs = append(
 			b.errs,
-			errors.New("failed to build BDC object: spc object is nil"),
+			errors.New("failed to build BDC object: owner object is nil"),
 		)
 		return b
 	}
-	trueVal := true
-	reference := metav1.OwnerReference{
-		APIVersion:         APIVersion,
-		Kind:               StoragePoolKind,
-		UID:                spc.ObjectMeta.UID,
-		Name:               spc.ObjectMeta.Name,
-		BlockOwnerDeletion: &trueVal,
-		Controller:         &trueVal,
+
+	_, pvc_ok := owner.(*v1.PersistentVolumeClaim)
+	_, spc_ok := owner.(*apis.StoragePoolClaim)
+	if !(pvc_ok || spc_ok) {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build BDC object: owner is not a PVC or an SPC reference type"),
+		)
+		return b
 	}
-	b.BDC.Object.OwnerReferences = append(b.BDC.Object.OwnerReferences, reference)
-	return b
+
+	trueVal := true
+	if pvc_ok {
+		reference := metav1.OwnerReference{
+			APIVersion:         "v1",
+			Kind:               "PersistentVolumeClaim",
+			UID:                owner.(*v1.PersistentVolumeClaim).ObjectMeta.UID,
+			Name:               owner.(*v1.PersistentVolumeClaim).ObjectMeta.Name,
+			BlockOwnerDeletion: &trueVal,
+			Controller:         &trueVal,
+		}
+		b.BDC.Object.OwnerReferences = append(b.BDC.Object.OwnerReferences, reference)
+		return b
+	} else {
+		reference := metav1.OwnerReference{
+			APIVersion:         APIVersion,
+			Kind:               StoragePoolKind,
+			UID:                owner.(*apis.StoragePoolClaim).ObjectMeta.UID,
+			Name:               owner.(*apis.StoragePoolClaim).ObjectMeta.Name,
+			BlockOwnerDeletion: &trueVal,
+			Controller:         &trueVal,
+		}
+		b.BDC.Object.OwnerReferences = append(b.BDC.Object.OwnerReferences, reference)
+		return b
+	}
 }
 
 // WithFinalizer sets the finalizer field in the BDC

--- a/pkg/blockdeviceclaim/v1alpha1/build.go
+++ b/pkg/blockdeviceclaim/v1alpha1/build.go
@@ -246,8 +246,8 @@ func (b *Builder) WithCapacity(capacity string) *Builder {
 
 // WithOwnerReference sets the OwnerReference field in BDC with required
 //fields
-func (b *Builder) WithOwnerReference(owner *metav1.OwnerReference) *Builder {
-	b.BDC.Object.OwnerReferences = append(b.BDC.Object.OwnerReferences, *owner)
+func (b *Builder) WithOwnerReference(owner metav1.OwnerReference) *Builder {
+	b.BDC.Object.OwnerReferences = append(b.BDC.Object.OwnerReferences, owner)
 	return b
 }
 


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
LocalPV Device from [openebs/dynamic-localpv-provisioner](https://github.com/openebs/dynamic-localpv-provisioner) requires addition of ownerReference for the BDC to the PVC. This file is included in the vendor directory for the dynamic-localpv-provisioner repo.

The workflow involved here:
1. Add ownerReference for BDC in https://github.com/openebs/maya/tree/master/pkg/blockdeviceclaim/v1alpha1/build.go
2. Update vendoring directory in openebs/dynamic-localpv-provisioner
3. Add owner reference option in https://github.com/openebs/dynamic-localpv-provisioner/tree/master/cmd/provisioner-localpv/app/helper_blockdevice.go
4. Pass PVC to reference to getBlockDevicePath method
5. blockdeviceclaim/v1alpha1/build.go attaches owner reference.

Ref: Cleanup of stale BDCs in https://github.com/openebs/openebs/issues/3263

**What this PR does?**:
1. Changes the input signature for WithOwnerReference method to empty interface to be able to get both (*v1.PersistentVolumeClaim) and (*apis.StoragePoolClaim) as input.
2. Adds `reference` block to issue ownerReference to PVC.

Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>