### PR TITLE
fix(webhook): fix version comparison of webhook resources

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -275,9 +275,10 @@ func IsCurrentLessThanNewVersion(old, new string) bool {
 	for i := 0; i < len(oldVersions); i++ {
 		oldVersion, _ := strconv.Atoi(oldVersions[i])
 		newVersion, _ := strconv.Atoi(newVersions[i])
-		if oldVersion > newVersion {
-			return false
+		if oldVersion == newVersion {
+			continue
 		}
+		return oldVersion < newVersion
 	}
-	return true
+	return false
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -373,3 +373,47 @@ func TestRemoveString(t *testing.T) {
 		})
 	}
 }
+
+func TestIsCurrentLessThanNewVersion(t *testing.T) {
+	type args struct {
+		old string
+		new string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "old is less than new",
+			args: args{
+				old: "1.12.0",
+				new: "2.8.0",
+			},
+			want: true,
+		},
+		{
+			name: "old is greater than new",
+			args: args{
+				old: "2.10.0-RC2",
+				new: "2.8.0",
+			},
+			want: false,
+		},
+		{
+			name: "old is same as new",
+			args: args{
+				old: "2.8.0",
+				new: "2.8.0",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsCurrentLessThanNewVersion(tt.args.old, tt.args.new); got != tt.want {
+				t.Errorf("IsCurrentLessThanNewVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

**What this PR does?**:

This PR fixes the issue where the validatingwebhookconfiguration did not get updated the upgrading from 1.12.0 to latest versions.

```
failed to patch cspc cstor-cspc-disk-pool: Internal error occurred: failed calling webhook "admission-webhook.cstor.openebs.io": converting (v1.AdmissionReview) to (v1beta1.AdmissionReview): unknown conversion
```

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
