### PR TITLE
refact(blockdeviceclaim-build-files): Add context argument to BDC client operations + v2.12.0 version bump

### DIFF
--- a/cmd/maya-apiserver/app/command/start.go
+++ b/cmd/maya-apiserver/app/command/start.go
@@ -17,6 +17,7 @@ limitations under the License.
 package command
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/signal"
@@ -132,7 +133,7 @@ func performPreflightChecks() error {
 
 // checks existence of NDM related CRDs
 func checkForNDMrelatedCRDs() error {
-	_, err := bdc.NewKubeClient().List(metav1.ListOptions{})
+	_, err := bdc.NewKubeClient().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return errors.Errorf("precheck for bdc failed: %v", err)
 	}

--- a/cmd/maya-apiserver/cstor-operator/spc/handler.go
+++ b/cmd/maya-apiserver/cstor-operator/spc/handler.go
@@ -273,6 +273,7 @@ func removeSPCFinalizerOnAssociatedBDC(spc *apis.StoragePoolClaim) error {
 	}
 
 	bdcList, err := bdc.NewKubeClient().WithNamespace(namespace).List(
+		context.TODO(),
 		metav1.ListOptions{
 			LabelSelector: string(apis.StoragePoolClaimCPK) + "=" + spc.Name,
 		})

--- a/pkg/algorithm/nodeselect/v1alpha1/select_node.go
+++ b/pkg/algorithm/nodeselect/v1alpha1/select_node.go
@@ -17,6 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
+	"strings"
+
 	ndmapis "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	blockdevice "github.com/openebs/maya/pkg/blockdevice/v1alpha1"
@@ -28,7 +31,6 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
-	"strings"
 )
 
 const (
@@ -185,7 +187,7 @@ func (ac *Config) selectNode(nodeBlockDeviceMap map[string]*blockDeviceList) (*n
 		// created filter and use it
 		bdcList, err = bdc.NewKubeClient().
 			WithNamespace(ac.Namespace).
-			List(metav1.ListOptions{LabelSelector: string(apis.StoragePoolClaimCPK) + "=" + ac.Spc.Name})
+			List(context.TODO(), metav1.ListOptions{LabelSelector: string(apis.StoragePoolClaimCPK) + "=" + ac.Spc.Name})
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to select node and blockdevices")
 		}
@@ -344,7 +346,7 @@ func (ac *Config) ClaimBlockDevice(nodeBDs *nodeBlockDevice, spc *apis.StoragePo
 	nodeClaimedBDs.NodeName = nodeBDs.NodeName
 	pendingBDCCount := 0
 
-	bdcObjList, err := bdcKubeclient.List(metav1.ListOptions{LabelSelector: lselector})
+	bdcObjList, err := bdcKubeclient.List(context.TODO(), metav1.ListOptions{LabelSelector: lselector})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to list block device claims for {%s}", spc.Name)
 	}
@@ -415,7 +417,7 @@ func (ac *Config) ClaimBlockDevice(nodeBDs *nodeBlockDevice, spc *apis.StoragePo
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to build block device claim for bd {%s}", bdName)
 			}
-			_, err = bdcKubeclient.Create(newBDCObj.Object)
+			_, err = bdcKubeclient.Create(context.TODO(), newBDCObj.Object)
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to create block device claim for bdc {%s}", bdcName)
 			}

--- a/pkg/apis/openebs.io/v1alpha1/versionDetails.go
+++ b/pkg/apis/openebs.io/v1alpha1/versionDetails.go
@@ -31,7 +31,7 @@ var (
 		"1.12.0": true, "2.0.0": true, "2.1.0": true, "2.2.0": true,
 		"2.3.0": true, "2.4.0": true, "2.4.1": true, "2.5.0": true,
 		"2.6.0": true, "2.7.0": true, "2.8.0": true, "2.9.0": true,
-		"2.10.0": true, "2.11.0": true,
+		"2.10.0": true, "2.11.0": true, "2.12.0": true,
 	}
 	validDesiredVersion = strings.Split(version.GetVersion(), "-")[0]
 )

--- a/pkg/blockdevice/v1alpha1/blockdevice.go
+++ b/pkg/blockdevice/v1alpha1/blockdevice.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"strings"
 
 	ndm "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
@@ -231,7 +232,7 @@ func (bdl *BlockDeviceList) GetUsableBlockDevices(spcName, namespace string) (*B
 	for _, bdObj := range bdl.Items {
 		if bdObj.Status.ClaimState == ndm.BlockDeviceClaimed {
 			bdcName := bdObj.Spec.ClaimRef.Name
-			bdcObj, err := bdcClient.Get(bdcName, metav1.GetOptions{})
+			bdcObj, err := bdcClient.Get(context.TODO(), bdcName, metav1.GetOptions{})
 			if err != nil {
 				return nil, errors.Wrapf(err,
 					"failed to get blockdeviceclaim %s details of blockdevice %s",

--- a/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim.go
+++ b/pkg/blockdeviceclaim/v1alpha1/blockdeviceclaim.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
+
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
 	ndm "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
 	"github.com/openebs/maya/pkg/util"
@@ -147,7 +149,7 @@ func (bdc *BlockDeviceClaim) AddFinalizer(finalizer string) (*ndm.BlockDeviceCla
 
 	bdcAPIObj, err := NewKubeClient(WithKubeConfigPath(bdc.configPath)).
 		WithNamespace(bdc.Object.Namespace).
-		Update(bdc.Object)
+		Update(context.TODO(), bdc.Object)
 
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to update bdc %s while adding finalizer %s",
@@ -175,7 +177,7 @@ func (bdc *BlockDeviceClaim) RemoveFinalizer(
 
 	newBDC, err := NewKubeClient(WithKubeConfigPath(bdc.configPath)).
 		WithNamespace(bdc.Object.Namespace).
-		Update(bdc.Object)
+		Update(context.TODO(), bdc.Object)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to update object while removing finalizer")
 	}

--- a/pkg/blockdeviceclaim/v1alpha1/kubernetes.go
+++ b/pkg/blockdeviceclaim/v1alpha1/kubernetes.go
@@ -43,31 +43,31 @@ type getClientsetForPathFn func(kubeConfigPath string) (clientset *clientset.Cli
 
 // listFn is a typed function that abstracts
 // listing of block device
-type listFn func(cli *clientset.Clientset, namespace string, opts metav1.ListOptions) (*apis.BlockDeviceClaimList, error)
+type listFn func(ctx context.Context, cli *clientset.Clientset, namespace string, opts metav1.ListOptions) (*apis.BlockDeviceClaimList, error)
 
 // getFn is a typed function that
 // abstracts fetching of block device
-type getFn func(cli *clientset.Clientset, namespace, name string, opts metav1.GetOptions) (*apis.BlockDeviceClaim, error)
+type getFn func(ctx context.Context, cli *clientset.Clientset, namespace, name string, opts metav1.GetOptions) (*apis.BlockDeviceClaim, error)
 
 // createFn is a typed function that abstracts
 // creation of block device
-type createFn func(cli *clientset.Clientset, namespace string, bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim, error)
+type createFn func(ctx context.Context, cli *clientset.Clientset, namespace string, bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim, error)
 
 // deleteFn is a typed function that abstracts
 // deletion of bdcs
-type deleteFn func(cli *clientset.Clientset, namespace string, name string, deleteOpts *metav1.DeleteOptions) error
+type deleteFn func(ctx context.Context, cli *clientset.Clientset, namespace string, name string, deleteOpts *metav1.DeleteOptions) error
 
 // deleteFn is a typed function that abstracts
 // deletion of bdc's collection
-type deleteCollectionFn func(cli *clientset.Clientset, namespace string, listOpts metav1.ListOptions, deleteOpts *metav1.DeleteOptions) error
+type deleteCollectionFn func(ctx context.Context, cli *clientset.Clientset, namespace string, listOpts metav1.ListOptions, deleteOpts *metav1.DeleteOptions) error
 
 // patchFn is a typed function that abstracts
 // to patch block device claim
-type patchFn func(cli *clientset.Clientset, namespace, name string, pt types.PatchType, data []byte, subresources ...string) (*apis.BlockDeviceClaim, error)
+type patchFn func(ctx context.Context, cli *clientset.Clientset, namespace, name string, pt types.PatchType, data []byte, subresources ...string) (*apis.BlockDeviceClaim, error)
 
 // updateFn is a typed function that abstracts to update
 // block device claim
-type updateFn func(cli *clientset.Clientset, namespace string, bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim, error)
+type updateFn func(ctx context.Context, cli *clientset.Clientset, namespace string, bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim, error)
 
 // make ndm clientset as singleton
 var (
@@ -133,46 +133,46 @@ func (k *Kubeclient) WithDefaults() {
 		}
 	}
 	if k.list == nil {
-		k.list = func(cli *clientset.Clientset, namespace string, opts metav1.ListOptions) (*apis.BlockDeviceClaimList, error) {
+		k.list = func(ctx context.Context, cli *clientset.Clientset, namespace string, opts metav1.ListOptions) (*apis.BlockDeviceClaimList, error) {
 			return cli.OpenebsV1alpha1().BlockDeviceClaims(namespace).
-				List(context.TODO(), opts)
+				List(ctx, opts)
 		}
 	}
 
 	if k.get == nil {
-		k.get = func(cli *clientset.Clientset, namespace, name string, opts metav1.GetOptions) (*apis.BlockDeviceClaim, error) {
+		k.get = func(ctx context.Context, cli *clientset.Clientset, namespace, name string, opts metav1.GetOptions) (*apis.BlockDeviceClaim, error) {
 			return cli.OpenebsV1alpha1().BlockDeviceClaims(namespace).
-				Get(context.TODO(), name, opts)
+				Get(ctx, name, opts)
 		}
 	}
 	if k.create == nil {
-		k.create = func(cli *clientset.Clientset, namespace string, bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim, error) {
+		k.create = func(ctx context.Context, cli *clientset.Clientset, namespace string, bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim, error) {
 			return cli.OpenebsV1alpha1().BlockDeviceClaims(namespace).
-				Create(context.TODO(), bdc, metav1.CreateOptions{})
+				Create(ctx, bdc, metav1.CreateOptions{})
 		}
 	}
 	if k.del == nil {
-		k.del = func(cli *clientset.Clientset, namespace string, name string, deleteOpts *metav1.DeleteOptions) error {
+		k.del = func(ctx context.Context, cli *clientset.Clientset, namespace string, name string, deleteOpts *metav1.DeleteOptions) error {
 			return cli.OpenebsV1alpha1().BlockDeviceClaims(namespace).
-				Delete(context.TODO(), name, *deleteOpts)
+				Delete(ctx, name, *deleteOpts)
 		}
 	}
 	if k.delCollection == nil {
-		k.delCollection = func(cli *clientset.Clientset, namespace string, listOpts metav1.ListOptions, deleteOpts *metav1.DeleteOptions) error {
+		k.delCollection = func(ctx context.Context, cli *clientset.Clientset, namespace string, listOpts metav1.ListOptions, deleteOpts *metav1.DeleteOptions) error {
 			return cli.OpenebsV1alpha1().BlockDeviceClaims(namespace).
-				DeleteCollection(context.TODO(), *deleteOpts, listOpts)
+				DeleteCollection(ctx, *deleteOpts, listOpts)
 		}
 	}
 	if k.patch == nil {
-		k.patch = func(cli *clientset.Clientset, namespace, name string, pt types.PatchType, data []byte, subresources ...string) (*apis.BlockDeviceClaim, error) {
+		k.patch = func(ctx context.Context, cli *clientset.Clientset, namespace, name string, pt types.PatchType, data []byte, subresources ...string) (*apis.BlockDeviceClaim, error) {
 			return cli.OpenebsV1alpha1().BlockDeviceClaims(namespace).
-				Patch(context.TODO(), name, pt, data, metav1.PatchOptions{}, subresources...)
+				Patch(ctx, name, pt, data, metav1.PatchOptions{}, subresources...)
 		}
 	}
 	if k.update == nil {
-		k.update = func(cli *clientset.Clientset, namespace string, bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim, error) {
+		k.update = func(ctx context.Context, cli *clientset.Clientset, namespace string, bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim, error) {
 			return cli.OpenebsV1alpha1().BlockDeviceClaims(namespace).
-				Update(context.TODO(), bdc, metav1.UpdateOptions{})
+				Update(ctx, bdc, metav1.UpdateOptions{})
 		}
 	}
 }
@@ -234,16 +234,16 @@ func (k *Kubeclient) getClientsetOrCached() (*clientset.Clientset, error) {
 
 // List returns a list of disk
 // instances present in kubernetes cluster
-func (k *Kubeclient) List(opts metav1.ListOptions) (*apis.BlockDeviceClaimList, error) {
+func (k *Kubeclient) List(ctx context.Context, opts metav1.ListOptions) (*apis.BlockDeviceClaimList, error) {
 	cli, err := k.getClientsetOrCached()
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to list bdc in namespace {%s}", k.namespace)
 	}
-	return k.list(cli, k.namespace, opts)
+	return k.list(ctx, cli, k.namespace, opts)
 }
 
 // Get returns a disk object
-func (k *Kubeclient) Get(name string, opts metav1.GetOptions) (*apis.BlockDeviceClaim, error) {
+func (k *Kubeclient) Get(ctx context.Context, name string, opts metav1.GetOptions) (*apis.BlockDeviceClaim, error) {
 	if strings.TrimSpace(name) == "" {
 		return nil, errors.New("failed to get bdc: missing bdc name")
 	}
@@ -251,11 +251,11 @@ func (k *Kubeclient) Get(name string, opts metav1.GetOptions) (*apis.BlockDevice
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get bdc {%s} in namespace {%s}", name, k.namespace)
 	}
-	return k.get(cli, k.namespace, name, opts)
+	return k.get(ctx, cli, k.namespace, name, opts)
 }
 
 // Create creates a bdc in specified namespace in kubernetes cluster
-func (k *Kubeclient) Create(bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim, error) {
+func (k *Kubeclient) Create(ctx context.Context, bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim, error) {
 	if bdc == nil {
 		return nil, errors.New("failed to create bdc: nil bdc object")
 	}
@@ -263,21 +263,21 @@ func (k *Kubeclient) Create(bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim,
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create bdc {%s} in namespace {%s}", bdc.Name, bdc.Namespace)
 	}
-	return k.create(cli, k.namespace, bdc)
+	return k.create(ctx, cli, k.namespace, bdc)
 }
 
 // DeleteCollection deletes a collection of bdc objects.
-func (k *Kubeclient) DeleteCollection(listOpts metav1.ListOptions, deleteOpts *metav1.DeleteOptions) error {
+func (k *Kubeclient) DeleteCollection(ctx context.Context, listOpts metav1.ListOptions, deleteOpts *metav1.DeleteOptions) error {
 	cli, err := k.getClientsetOrCached()
 	if err != nil {
 		return errors.Wrapf(err, "failed to delete the collection of bdcs")
 	}
-	return k.delCollection(cli, k.namespace, listOpts, deleteOpts)
+	return k.delCollection(ctx, cli, k.namespace, listOpts, deleteOpts)
 }
 
 // Delete deletes a bdc instance from the
 // kubecrnetes cluster
-func (k *Kubeclient) Delete(name string, deleteOpts *metav1.DeleteOptions) error {
+func (k *Kubeclient) Delete(ctx context.Context, name string, deleteOpts *metav1.DeleteOptions) error {
 	if strings.TrimSpace(name) == "" {
 		return errors.New("failed to delete bdc: missing bdc name")
 	}
@@ -285,11 +285,11 @@ func (k *Kubeclient) Delete(name string, deleteOpts *metav1.DeleteOptions) error
 	if err != nil {
 		return errors.Wrapf(err, "failed to delete bdc {%s} in namespace {%s}", name, k.namespace)
 	}
-	return k.del(cli, k.namespace, name, deleteOpts)
+	return k.del(ctx, cli, k.namespace, name, deleteOpts)
 }
 
 // Patch patches the block device claim if present in kubernetes cluster
-func (k *Kubeclient) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (*apis.BlockDeviceClaim, error) {
+func (k *Kubeclient) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, subresources ...string) (*apis.BlockDeviceClaim, error) {
 	if len(name) == 0 {
 		return nil, errors.New("failed to patch block device claim: missing bdc name")
 	}
@@ -297,11 +297,11 @@ func (k *Kubeclient) Patch(name string, pt types.PatchType, data []byte, subreso
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to patch bdc: {%s}", name)
 	}
-	return k.patch(cli, k.namespace, name, pt, data, subresources...)
+	return k.patch(ctx, cli, k.namespace, name, pt, data, subresources...)
 }
 
 // Update updates the block device claim if present in kubernetes cluster
-func (k *Kubeclient) Update(bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim, error) {
+func (k *Kubeclient) Update(ctx context.Context, bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim, error) {
 	if bdc == nil {
 		return nil, errors.New("failed to udpate bdc: nil bdc object")
 	}
@@ -309,5 +309,5 @@ func (k *Kubeclient) Update(bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim,
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to update bdc {%s} in namespace {%s}", bdc.Name, bdc.Namespace)
 	}
-	return k.update(cli, k.namespace, bdc)
+	return k.update(ctx, cli, k.namespace, bdc)
 }

--- a/pkg/blockdeviceclaim/v1alpha1/kubernetes_test.go
+++ b/pkg/blockdeviceclaim/v1alpha1/kubernetes_test.go
@@ -15,6 +15,7 @@
 package v1alpha1
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -38,27 +39,27 @@ func fakeGetClientsetForPathErr(fakeConfigPath string) (cli *clientset.Clientset
 	return nil, errors.New("fake error")
 }
 
-func fakeGetFnOk(cli *clientset.Clientset, name, namespace string, opts metav1.GetOptions) (*apis.BlockDeviceClaim, error) {
+func fakeGetFnOk(ctx context.Context, cli *clientset.Clientset, name, namespace string, opts metav1.GetOptions) (*apis.BlockDeviceClaim, error) {
 	return &apis.BlockDeviceClaim{}, nil
 }
 
-func fakeListFnOk(cli *clientset.Clientset, namespace string, opts metav1.ListOptions) (*apis.BlockDeviceClaimList, error) {
+func fakeListFnOk(ctx context.Context, cli *clientset.Clientset, namespace string, opts metav1.ListOptions) (*apis.BlockDeviceClaimList, error) {
 	return &apis.BlockDeviceClaimList{}, nil
 }
 
-func fakeDeleteFnOk(cli *clientset.Clientset, name, namespace string, opts *metav1.DeleteOptions) error {
+func fakeDeleteFnOk(ctx context.Context, cli *clientset.Clientset, name, namespace string, opts *metav1.DeleteOptions) error {
 	return nil
 }
 
-func fakeListFnErr(cli *clientset.Clientset, namespace string, opts metav1.ListOptions) (*apis.BlockDeviceClaimList, error) {
+func fakeListFnErr(ctx context.Context, cli *clientset.Clientset, namespace string, opts metav1.ListOptions) (*apis.BlockDeviceClaimList, error) {
 	return &apis.BlockDeviceClaimList{}, errors.New("some error")
 }
 
-func fakeGetFnErr(cli *clientset.Clientset, name, namespace string, opts metav1.GetOptions) (*apis.BlockDeviceClaim, error) {
+func fakeGetFnErr(ctx context.Context, cli *clientset.Clientset, name, namespace string, opts metav1.GetOptions) (*apis.BlockDeviceClaim, error) {
 	return &apis.BlockDeviceClaim{}, errors.New("some error")
 }
 
-func fakeDeleteFnErr(cli *clientset.Clientset, name, namespace string, opts *metav1.DeleteOptions) error {
+func fakeDeleteFnErr(ctx context.Context, cli *clientset.Clientset, name, namespace string, opts *metav1.DeleteOptions) error {
 	return errors.New("some error")
 }
 
@@ -66,19 +67,19 @@ func fakeGetClientsetErr() (clientset *clientset.Clientset, err error) {
 	return nil, errors.New("Some error")
 }
 
-func fakeCreateFnOk(cli *clientset.Clientset, namespace string, bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim, error) {
+func fakeCreateFnOk(ctx context.Context, cli *clientset.Clientset, namespace string, bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim, error) {
 	return &apis.BlockDeviceClaim{}, nil
 }
 
-func fakeCreateErr(cli *clientset.Clientset, namespace string, bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim, error) {
+func fakeCreateErr(ctx context.Context, cli *clientset.Clientset, namespace string, bdc *apis.BlockDeviceClaim) (*apis.BlockDeviceClaim, error) {
 	return nil, errors.New("failed to create BDC")
 }
 
-func fakePatchFnOk(cli *clientset.Clientset, namespace, name string, pt types.PatchType, data []byte, subresources ...string) (*apis.BlockDeviceClaim, error) {
+func fakePatchFnOk(ctx context.Context, cli *clientset.Clientset, namespace, name string, pt types.PatchType, data []byte, subresources ...string) (*apis.BlockDeviceClaim, error) {
 	return &apis.BlockDeviceClaim{}, nil
 }
 
-func fakePatchFnErr(cli *clientset.Clientset, namespace, name string, pt types.PatchType, data []byte, subresources ...string) (*apis.BlockDeviceClaim, error) {
+func fakePatchFnErr(ctx context.Context, cli *clientset.Clientset, namespace, name string, pt types.PatchType, data []byte, subresources ...string) (*apis.BlockDeviceClaim, error) {
 	return nil, errors.New("fake error")
 }
 
@@ -286,7 +287,7 @@ func TestBlockDeviceClaimList(t *testing.T) {
 				kubeConfigPath:      mock.kubeConfigPath,
 				list:                mock.list,
 			}
-			_, err := fc.List(metav1.ListOptions{})
+			_, err := fc.List(context.TODO(), metav1.ListOptions{})
 			if mock.expectedErr && err == nil {
 				t.Fatalf("Test %q failed: expected error not to be nil", name)
 			}
@@ -324,7 +325,7 @@ func TestBlockDeviceClaimGet(t *testing.T) {
 				namespace:           "default",
 				get:                 mock.get,
 			}
-			_, err := k.Get(mock.bdName, metav1.GetOptions{})
+			_, err := k.Get(context.TODO(), mock.bdName, metav1.GetOptions{})
 			if mock.expectErr && err == nil {
 				t.Fatalf("Test %q failed: expected error not to be nil", name)
 			}
@@ -363,7 +364,7 @@ func TestBlockDeviceClaimDelete(t *testing.T) {
 				namespace:           "",
 				del:                 mock.delete,
 			}
-			err := k.Delete(mock.bdName, &metav1.DeleteOptions{})
+			err := k.Delete(context.TODO(), mock.bdName, &metav1.DeleteOptions{})
 			if mock.expectErr && err == nil {
 				t.Fatalf("Test %q failed: expected error not to be nil", name)
 			}
@@ -434,7 +435,7 @@ func TestBlockDeviceClaimCreate(t *testing.T) {
 				kubeConfigPath:      mock.kubeConfigPath,
 				create:              mock.create,
 			}
-			_, err := fc.Create(mock.bdc)
+			_, err := fc.Create(context.TODO(), mock.bdc)
 			if mock.expectErr && err == nil {
 				t.Fatalf("Test %q failed: expected error not to be nil", name)
 			}
@@ -473,7 +474,7 @@ func TestBlockDeviceClaimPatch(t *testing.T) {
 			}
 			//fake data
 			data, _ := json.Marshal(mock)
-			_, err := k.Patch(mock.bdName, types.MergePatchType, data)
+			_, err := k.Patch(context.TODO(), mock.bdName, types.MergePatchType, data)
 			if mock.expectErr && err == nil {
 				t.Fatalf("Test %q failed: expected error not to be nil", name)
 			}

--- a/pkg/storagepoolclaim/v1alpha1/storagepoolclaim.go
+++ b/pkg/storagepoolclaim/v1alpha1/storagepoolclaim.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -181,6 +182,7 @@ func (spc *SPC) addSPCFinalizerOnAssociatedBDCs() error {
 	namespace := env.Get(env.OpenEBSNamespace)
 
 	bdcList, err := bdc.NewKubeClient().WithNamespace(namespace).List(
+		context.TODO(),
 		metav1.ListOptions{
 			LabelSelector: string(apis.StoragePoolClaimCPK) + "=" + spc.Object.Name,
 		})

--- a/tests/operations.go
+++ b/tests/operations.go
@@ -18,6 +18,7 @@ package tests
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strconv"
 	"time"
@@ -743,7 +744,7 @@ func (ops *Operations) GetHealthyCSPCount(spcName string, expectedCSPCount int) 
 func (ops *Operations) GetBDCCountEventually(listOptions metav1.ListOptions, expectedBDCCount int, namespace string) int {
 	var bdcCount int
 	for i := 0; i < maxRetry; i++ {
-		bdcAPIList, err := ops.BDCClient.WithNamespace(namespace).List(listOptions)
+		bdcAPIList, err := ops.BDCClient.WithNamespace(namespace).List(context.TODO(), listOptions)
 		Expect(err).To(BeNil())
 		bdcCount = len(bdcAPIList.Items)
 		if bdcCount == expectedBDCCount {
@@ -769,7 +770,7 @@ func (ops *Operations) IsSPCNotExists(spcName string) bool {
 // IsFinalizerExistsOnBDC returns true if the object with provided name contains the finalizer.
 func (ops *Operations) IsFinalizerExistsOnBDC(bdcName, finalizer string) bool {
 	for i := 0; i < maxRetry; i++ {
-		bdcObj, err := ops.BDCClient.Get(bdcName, metav1.GetOptions{})
+		bdcObj, err := ops.BDCClient.Get(context.TODO(), bdcName, metav1.GetOptions{})
 		Expect(err).To(BeNil())
 		for _, f := range bdcObj.Finalizers {
 			if f == finalizer {
@@ -801,7 +802,7 @@ func (ops *Operations) IsSPCFinalizerExistsOnSPC(spcName, spcFinalizer string) b
 func (ops *Operations) IsCSPCFinalizerExistsOnBDCs(listOptions metav1.ListOptions, cspcFinalizer string) bool {
 	for i := 0; i < maxRetry; i++ {
 		cspcFinalizerPresent := true
-		gotBDCList, err := ops.BDCClient.WithNamespace(ops.NameSpace).List(listOptions)
+		gotBDCList, err := ops.BDCClient.WithNamespace(ops.NameSpace).List(context.TODO(), listOptions)
 		Expect(err).To(BeNil())
 		for _, BDCObj := range gotBDCList.Items {
 			BDCObj := BDCObj
@@ -824,7 +825,7 @@ func (ops *Operations) IsCSPCFinalizerExistsOnBDCs(listOptions metav1.ListOption
 func (ops *Operations) IsSPCFinalizerExistsOnBDCs(listOptions metav1.ListOptions, spcFinalizer string) bool {
 	for i := 0; i < maxRetry; i++ {
 		spcFinalizerPresent := true
-		gotBDCList, err := ops.BDCClient.List(listOptions)
+		gotBDCList, err := ops.BDCClient.List(context.TODO(), listOptions)
 		Expect(err).To(BeNil())
 		for _, BDCObj := range gotBDCList.Items {
 			BDCObj := BDCObj
@@ -1004,7 +1005,7 @@ func (ops *Operations) VerifyUpgradeResultTasksIsNotFail(namespace, lselector st
 func (ops *Operations) GetBDCCount(lSelector, namespace string) int {
 	bdcList, err := ops.BDCClient.
 		WithNamespace(namespace).
-		List(metav1.ListOptions{LabelSelector: lSelector})
+		List(context.TODO(), metav1.ListOptions{LabelSelector: lSelector})
 	Expect(err).ShouldNot(HaveOccurred())
 	return len(bdcList.Items)
 }


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

**Why is this PR required? What issue does it fix?**:
To be able to pass a context.Context down the stack. Presently, the client operations wrapper fucntions derive their own context.Context from the caller's Context, without giving the caller function the option to explicitly pass a context.Context.

v2.12.0 Version Bump:
This PR also contains a commit for the v2.12.0 verion bump.

**What this PR does?**:
Adds an argument to the abstraction functions for the client-go operations in pkg/blockdeviceclaim/v1alpha1/kubernetes.go
Also passes a context.TODO() from existing callers of the functions in the repo.

v2.12.0 Version Bump:
Add entry for the v2,12.0 version bump.

**Does this PR require any upgrade changes?**:
No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
https://github.com/openebs/dynamic-localpv-provisioner/pull/74 depends on this.