### PR TITLE
fix(crd): migration from v1beta1 to v1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
     - os: linux
       arch: amd64
       env:
-        - RELEASE_TAG_DOWNSTREAM=1
+        - RELEASE_TAG_DOWNSTREAM=0
 
 services:
   - docker

--- a/tests/artifacts/crds.yaml
+++ b/tests/artifacts/crds.yaml
@@ -1,25 +1,3 @@
-/*
-Copyright 2018 The OpenEBS Authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-// TODO
-// Rename this file by removing the version suffix information
-package v1alpha1
-
-const openEBSCRDYamls = `
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -418,22 +396,3 @@ spec:
     shortNames:
     - utask
 ---
----
-`
-
-// OpenEBSCRDArtifacts returns the CRDs required for latest version
-func OpenEBSCRDArtifacts() (list artifactList) {
-	list.Items = append(list.Items, ParseArtifactListFromMultipleYamlsIf(openEBSCRDs{}, IsInstallCRDEnabled)...)
-	return
-}
-
-type openEBSCRDs struct{}
-
-// FetchYamls returns all the CRD yamls related to 0.7.0
-// in a string format
-//
-// NOTE:
-//  This is an implementation of MultiYamlFetcher
-func (o openEBSCRDs) FetchYamls() string {
-	return openEBSCRDYamls
-}


### PR DESCRIPTION
Change the version in the CRDs to v1 and make the
necessary movements of the elements to pass the
CRD v1 validations like:
- rename version to versions
- set the defaults for a specific version
- set the schema validation to `x-kubernetes-preserve-unknown-fields`

Also, this PR removes the installation of CRDs that are already
migrated to cstor CSI:
- cstorpoolinstances
- cstorvolumeclaims
- cstorvolumepolicies

Signed-off-by: kmova <kiran.mova@mayadata.io>

