### PR TITLE
fix(blockdeviceclaim-build-file): Add new build function to add any BDC selectors

### DIFF
--- a/pkg/blockdeviceclaim/v1alpha1/build.go
+++ b/pkg/blockdeviceclaim/v1alpha1/build.go
@@ -17,14 +17,14 @@ limitations under the License.
 package v1alpha1
 
 import (
-	ndm "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
-
 	"strings"
 
 	errors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ndm "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
 )
 
 const (

--- a/pkg/blockdeviceclaim/v1alpha1/build.go
+++ b/pkg/blockdeviceclaim/v1alpha1/build.go
@@ -18,6 +18,9 @@ package v1alpha1
 
 import (
 	ndm "github.com/openebs/maya/pkg/apis/openebs.io/ndm/v1alpha1"
+
+	"strings"
+
 	errors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -302,5 +305,33 @@ func (b *Builder) WithBlockDeviceTag(bdTagValue string) *Builder {
 	}
 
 	b.BDC.Object.Spec.Selector.MatchLabels[bdTagKey] = bdTagValue
+	return b
+}
+
+// WithSelector appends (or creates) the BDC Label Selector
+// by setting the provided key and corresponding value
+// This will enable the NDM to pick only devices that
+// match the given label and its value.
+func (b *Builder) WithSelector(labelSelector map[string]string) *Builder {
+	if len(labelSelector) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build BDC object: missing label selector fields"),
+		)
+		return b
+	}
+
+	if b.BDC.Object.Spec.Selector == nil {
+		b.BDC.Object.Spec.Selector = &metav1.LabelSelector{}
+	}
+	if b.BDC.Object.Spec.Selector.MatchLabels == nil {
+		b.BDC.Object.Spec.Selector.MatchLabels = map[string]string{}
+	}
+
+	for key, value := range labelSelector {
+		if len(strings.TrimSpace(value)) != 0 {
+			b.BDC.Object.Spec.Selector.MatchLabels[key] = value
+		}
+	}
 	return b
 }

--- a/pkg/blockdeviceclaim/v1alpha1/build_test.go
+++ b/pkg/blockdeviceclaim/v1alpha1/build_test.go
@@ -237,9 +237,9 @@ func TestBuilderWithBlockDeviceTag(t *testing.T) {
 
 func TestBuilder_WithSelector(t *testing.T) {
 	tests := map[string]struct {
-		labelSelector map[string]string
-		ExpectedBuilder   *Builder
-		expectErr bool
+		labelSelector   map[string]string
+		ExpectedBuilder *Builder
+		expectErr       bool
 	}{
 		"Test Builder with empty labelSelector map": {
 			labelSelector: map[string]string{},


### PR DESCRIPTION
Signed-off-by: Abhishek Agarwal <abhishek.agarwal@mayadata.io>

**Why is this PR required? What issue does it fix?**:
Adds a new function to add Selectors to BDC. Currently only one fixed selector can be added to the BDC and that is `"openebs.io/block-device-tag"`.

**What this PR does?**:
The function added will allow to add any number of selector labels to the BDC by passing a map of string key and values.

**Does this PR require any upgrade changes?**:
No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [x] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 