### PR TITLE
fix(ci): fetch the cstor base without arch suffix

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,8 +21,10 @@ _Mention if this PR is part of any design or a continuation of previous PRs_
 - [ ] Commit has unit tests
 - [ ] Commit has integration tests
 - [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
-- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
+- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/website is used to track them: 
 
+
+<!--
 
 **PLEASE REMOVE BELOW INFORMATION BEFORE SUBMITTING**
 
@@ -49,3 +51,4 @@ Where: <br />
     - chores (`version`, `build`, `log`, `travis`)
 
 - `subject` is a single line brief description of the changes made in the pull request.
+-->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -402,6 +402,13 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
 
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build & Push Image
         uses: docker/build-push-action@v2
         with:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -119,11 +119,11 @@ endif
 export DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL} --build-arg ARCH=${ARCH}
 
 # Specify the name of cstor-base image
-CSTOR_BASE_IMAGE_AMD64= ${IMAGE_ORG}/cstor-base-amd64:${BASE_TAG}
+CSTOR_BASE_IMAGE_AMD64= ${IMAGE_ORG}/cstor-base:${BASE_TAG}
 export CSTOR_BASE_IMAGE_AMD64
 
 ifeq (${CSTOR_BASE_IMAGE_ARM64}, )
-  CSTOR_BASE_IMAGE_ARM64= ${IMAGE_ORG}/cstor-base-arm64:${BASE_TAG}
+  CSTOR_BASE_IMAGE_ARM64= ${IMAGE_ORG}/cstor-base:${BASE_TAG}
   export CSTOR_BASE_IMAGE_ARM64
 endif
 


### PR DESCRIPTION
As part of tagged release, the cstor containers attempt
to pull from the corresponding tagged cstor-base. With
multi-arch builds, the base container is pushed without
a suffix. This was causing a build failure on tagged releases

Signed-off-by: kmova <kiran.mova@mayadata.io>

