### PR TITLE
feat(cas-template-engine): add 'data' map key to volumeconfig alongside value and enabled

### DIFF
--- a/pkg/castemplate/v1alpha1/cas_template_engine.go
+++ b/pkg/castemplate/v1alpha1/cas_template_engine.go
@@ -66,11 +66,13 @@ func ConfigToMap(all []v1alpha1.Config) (m map[string]interface{}, err error) {
 			return nil, err
 		}
 		confHierarchy := map[string]interface{}{
-			configName: map[string]string{
+			configName: map[string]interface{}{
 				string(v1alpha1.EnabledPTP): config.Enabled,
 				string(v1alpha1.ValuePTP):   config.Value,
+				string(v1alpha1.DataPTP):    config.Data,
 			},
 		}
+
 		isMerged := util.MergeMapOfObjects(m, confHierarchy)
 		if !isMerged {
 			err = errors.Errorf("failed to transform cas config to map: failed to merge: %s", config)


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

**Why is this PR required? What issue does it fix?**:
This is required in openebs/dynamic-localpv-provisioner repo to parse the cas-template of format
```yaml
- name: XFSQuota
  enabled: true
  data: |
      SoftLimitGrace: 80
      HardLimitGrace: 85
```

**What this PR does?**:
Adds instruction to add the embedded Data component from v1alpha1.config object to the map when ConfigToMap function is called.