### PR TITLE
feat(cas-config): Add 'List' option to cas-config

### DIFF
--- a/pkg/apis/openebs.io/v1alpha1/cas_template.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_template.go
@@ -78,6 +78,8 @@ type Config struct {
 	Value string `json:"value"`
 	// Data represents an arbitrary map of key value pairs
 	Data map[string]string `json:"data"`
+	// List represents a JSON(YAML) array
+	List []string `json:"list"`
 }
 
 // RunTasks contains fields to run a set of

--- a/pkg/apis/openebs.io/v1alpha1/cas_template_keys.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_template_keys.go
@@ -230,6 +230,12 @@ const (
 	//  The corresponding value will be accessed as
 	// {{ .Policy.<PolicyName>.data }}
 	DataPTP PolicyTLPProperty = "data"
+
+	// ListPTP is the data property of the policy
+	// NOTE:
+	//  The corresponding value will be accessed as
+	// {{ .Policy.<PolicyName>.list }}
+	ListPTP PolicyTLPProperty = "list"
 )
 
 const (

--- a/pkg/apis/openebs.io/v1alpha1/cas_template_test.go
+++ b/pkg/apis/openebs.io/v1alpha1/cas_template_test.go
@@ -64,8 +64,9 @@ func TestCASConfigJSONIndent(t *testing.T) {
 				Name:    "Replicas",
 				Value:   "2",
 				Enabled: "false",
+				List:    []string{"openebs.io/cpu-node"},
 			},
-			[]string{`"name": "Replicas"`, `"value": "2"`, `"enabled": "false"`},
+			[]string{`"name": "Replicas"`, `"value": "2"`, `"enabled": "false"`, `"openebs.io/cpu-node"`},
 		},
 	}
 	for name, mock := range tests {

--- a/pkg/apis/openebs.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/openebs.io/v1alpha1/zz_generated.deepcopy.go
@@ -1003,6 +1003,11 @@ func (in *Config) DeepCopyInto(out *Config) {
 			(*out)[key] = val
 		}
 	}
+	if in.List != nil {
+		in, out := &in.List, &out.List
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

**Why is this PR required? What issue does it fix?**:
The 'List' option allows cas-config keys to accept values in the form of JSON(or YAML) arrays.
So far values can be accepted in the following forms:
1. JSON string (Value)
2. JSON object (Data)

**What this PR does?**:
This adds the List ([]string) component to the Config struct.
Also adds the ListPTP component to the PolicyTLPProperty for use with the Config's List component.

**Does this PR require any upgrade changes?**:
No.

**The following PRs depend on this:**
1. https://github.com/openebs/dynamic-localpv-provisioner/pull/102